### PR TITLE
Tweak Azure retry policy

### DIFF
--- a/prime-router/host.json
+++ b/prime-router/host.json
@@ -6,7 +6,15 @@
   },
   "extensions": {
     "queues": {
-      "batchSize": 8
+      "batchSize": 8,
+      "maxDequeueCount": 5,
+      "visibilityTimeout": "01:30:00"
     }
+  },
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 5,
+    "minimumInterval": "00:00:01",
+    "maximumInterval": "00:01:00"
   }
 }


### PR DESCRIPTION
This PR modifies our Azure queue retry policy to retry more often and more spaces apart.

_Note: This PR cannot be merged until we remove our custom retry logic._

## Changes
- Modifies the function retry logic from zero retries to five, exponentially increasing time between retries (from 1 second to 60 seconds) ([function retry docs](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages?tabs=java))
- Modified the queue retry logic from five immediate retries to five retries with an hour and half wait in between ([queue retry docs](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue#host-json))

[According to the Azure documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages?tabs=java#using-retry-support-on-top-of-trigger-resilience), function retries can be used alongside queue retries, for a hybrid retry approach:
> The function app retry policy is independent of any retries or resiliency that the trigger provides. The function retry policy will only layer on top of a trigger resilient retry. For example, if using Azure Service Bus, by default queues have a message delivery count of 10. The default delivery count means after 10 attempted deliveries of a queue message, Service Bus will dead-letter the message. You can define a retry policy for a function that has a Service Bus trigger, but the retries will layer on top of the Service Bus delivery attempts.
>
> For instance, if you used the default Service Bus delivery count of 10, and defined a function retry policy of 5. The message would first dequeue, incrementing the service bus delivery account to 1. If every execution failed, after five attempts to trigger the same message, that message would be marked as abandoned. Service Bus would immediately requeue the message, it would trigger the function and increment the delivery count to 2. Finally, after 50 eventual attempts (10 service bus deliveries * five function retries per delivery), the message would be abandoned and trigger a dead-letter on service bus.

With the above logic, a worst case retry scenario would look like:

1. Retry 5 times (over about 3 minutes)
2. Wait 1 hour 30 minutes
3. Retry 5 times (over about 3 minutes)
4. Wait 1 hour 30 minutes
5. Retry 5 times (over about 3 minutes)
6. Wait 1 hour 30 minutes
7. Retry 5 times (over about 3 minutes)
8. Wait 1 hour 30 minutes
9. Retry 5 times (over about 3 minutes)

Total time the send function is retrying: ~6 hours 15 minutes

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

