### PR TITLE
Sender configuration

### DIFF
--- a/prime-router/pom.xml
+++ b/prime-router/pom.xml
@@ -516,6 +516,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>1.0.2</version>

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -41,6 +41,8 @@
         topic: covid-19
         schemaName: tpca/tpca-covid-19
         format: CSV
+        configuration:
+          processingModeCode: Q
 
   - name: az-phd
     description: Arizona PHD
@@ -731,7 +733,7 @@
         organizationName: ma-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, MA, patient_state, MA)
+          - orEquals(ordering_facility_state, MA, patient_state, MA)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -755,7 +757,7 @@
         organizationName: nh-dphs
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, NH, patient_state, NH)
+          - orEquals(ordering_facility_state, NH, patient_state, NH)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -782,7 +784,7 @@
         organizationName: al-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, AL, patient_state, AL)
+          - orEquals(ordering_facility_state, AL, patient_state, AL)
         translation:
           type: HL7
           useBatchHeaders: true
@@ -806,7 +808,7 @@
         organizationName: mi-phd
         topic: covid-19
         jurisdictionalFilter:
-          - orElse(ordering_facility_state, MI, patient_state, MI)
+          - orEquals(ordering_facility_state, MI, patient_state, MI)
         translation:
           type: HL7
           useBatchHeaders: true

--- a/prime-router/settings/organizations-local.yml
+++ b/prime-router/settings/organizations-local.yml
@@ -42,7 +42,7 @@
         schemaName: tpca/tpca-covid-19
         format: CSV
         configuration:
-          processingModeCode: Q
+          processingModeCode: T
 
   - name: az-phd
     description: Arizona PHD

--- a/prime-router/src/main/kotlin/Sender.kt
+++ b/prime-router/src/main/kotlin/Sender.kt
@@ -13,8 +13,16 @@ open class Sender(
     val format: Format,
     val topic: String,
     val schemaName: String,
+    val configuration: SenderConfiguration? = null,
 ) {
-    constructor(copy: Sender) : this(copy.name, copy.organizationName, copy.format, copy.topic, copy.schemaName)
+    constructor(copy: Sender) : this(
+        copy.name,
+        copy.organizationName,
+        copy.format,
+        copy.topic,
+        copy.schemaName,
+        copy.configuration,
+    )
 
     @get:JsonIgnore
     val fullName: String get() = "$organizationName$fullNameSeparator$name"

--- a/prime-router/src/main/kotlin/SenderConfiguration.kt
+++ b/prime-router/src/main/kotlin/SenderConfiguration.kt
@@ -1,0 +1,10 @@
+package gov.cdc.prime.router
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class SenderConfiguration
+@JsonCreator constructor(
+    val processingModeCode: String? = null,
+    val testingLabName: String? = null,
+    val testingLabCLIA: String? = null
+)

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -184,9 +184,23 @@ class ReportFunction {
                     return@mapNotNull null
                 }
                 Pair(parts[0], parts[1])
-            }.toMap()
+            }.toMap().toMutableMap()
         } else {
-            emptyMap()
+            mutableMapOf()
+        }
+
+        sender.configuration?.let {
+            if (!it.processingModeCode.isNullOrEmpty()) {
+                defaultValues["processing_mode_code"] = it.processingModeCode
+            }
+
+            if (!it.testingLabCLIA.isNullOrEmpty()) {
+                defaultValues["testing_lab_clia"] = it.testingLabCLIA
+            }
+
+            if (!it.testingLabName.isNullOrEmpty()) {
+                defaultValues["testing_lab_name"] = it.testingLabName
+            }
         }
 
         if (content.isEmpty() || errors.isNotEmpty()) {


### PR DESCRIPTION
This PR adds a sender configuration object to a sender that gets set in the organizations or settings, and then is based into the default values collection that is then used to fill in values in the report on ingestion. 

## Changes
- Adds a `SenderConfiguration` class
- Adds the object to the `Sender` class
- Adds logic to fill in the default values from `SenderConfiguration` if they're passed in

## Checklist
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from http://localhost:7071/api/download
- [ ] Updated the release notes? 
- [ ] Added tests?
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

## Fixes
*List GitHub issues this PR fixes*
- #843

