### PR TITLE
1282 Fixed CLI environment overwrite issue when using Gradle

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -119,7 +119,6 @@ tasks.register<JavaExec>("primeCLI") {
     environment["POSTGRES_URL"] = dbUrl
     environment["POSTGRES_USER"] = dbUser
     environment["POSTGRES_PASSWORD"] = dbPassword
-    println(environment)
     doFirst {
         println("primeCLI Gradle task usage: gradle primeCLI --args='<args>'")
         println(

--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -116,7 +116,10 @@ tasks.register<JavaExec>("primeCLI") {
     classpath = sourceSets["main"].runtimeClasspath
     // Default arguments is to display the help
     args = listOf("-h")
-    environment = mapOf("POSTGRES_URL" to dbUrl, "POSTGRES_USER" to dbUser, "POSTGRES_PASSWORD" to dbPassword)
+    environment["POSTGRES_URL"] = dbUrl
+    environment["POSTGRES_USER"] = dbUser
+    environment["POSTGRES_PASSWORD"] = dbPassword
+    println(environment)
     doFirst {
         println("primeCLI Gradle task usage: gradle primeCLI --args='<args>'")
         println(


### PR DESCRIPTION
This PR correctly sets the environment variables when running the CLI from Gradle.  The previous way completely replaced the environment provided by the process.  This new way just adds more variables.

To test:
Run the following commands and verify that the output is using the HashicorpVaultCredentialService and not the MemoryService.
`export $(cat ./.vault/env/.env.local | xargs)`
`./gradlew primeCLI --args='create-credential --type=UserPass --persist=IGNORE--CSV --user foo --pass pass'`

The output will look like:
10:13:12.888 [main][1] INFO  gov.cdc.prime.router.credentials.**HashicorpVaultCredentialService** - CREDENTIAL UPDATE: ...

## Changes
- Set environment variables correctly in Gradle.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security

## Fixes
- #1282

## To Be Done


