### PR TITLE
Pc/1233 add verbose to prime settings

### DIFF
--- a/prime-router/src/main/kotlin/cli/SettingCommands.kt
+++ b/prime-router/src/main/kotlin/cli/SettingCommands.kt
@@ -314,6 +314,11 @@ abstract class SingleSettingCommandNoSettingName(
         help = "Use the JSON format instead of YAML"
     ).flag(default = false)
 
+    private val verbose by option(
+        "--verbose",
+        help = "Verbose output"
+    ).flag(default = false)
+
     override fun run() {
         // Authenticate
         val environment = getEnvironment()
@@ -337,6 +342,11 @@ abstract class SingleSettingCommandNoSettingName(
                 else
                     fromYaml(readInput(), settingType)
                 val output = put(environment, accessToken, settingType, name, payload)
+
+                if(verbose) {
+                    println("put ${settingType.toString().lowercase()} :: $payload")
+                }
+
                 writeOutput(output)
             }
             Operation.DELETE -> {
@@ -556,7 +566,7 @@ class PutMultipleSettings : SettingCommand(
             val payload = jsonMapper.writeValueAsString(receiver)
 
             if(verbose) {
-                println("""Receiver :: $receiver""")
+                println("""Receiver :: $payload""")
             }
 
             results += put(environment, accessToken, SettingType.RECEIVER, receiver.fullName, payload)

--- a/prime-router/src/main/kotlin/cli/SettingCommands.kt
+++ b/prime-router/src/main/kotlin/cli/SettingCommands.kt
@@ -510,8 +510,14 @@ class PutMultipleSettings : SettingCommand(
     name = "set",
     help = "set all settings from a 'organizations.yml' file"
 ) {
+
     override val inStream by option("-i", "--input", help = "Input from file", metavar = "<file>")
         .inputStream()
+
+    private val verbose by option(
+        "--verbose",
+        help = "Verbose output"
+    ).flag(default = false)
 
     override fun run() {
         val environment = getEnvironment()
@@ -528,16 +534,31 @@ class PutMultipleSettings : SettingCommand(
         deepOrgs.forEach { deepOrg ->
             val org = Organization(deepOrg)
             val payload = jsonMapper.writeValueAsString(org)
+
+            if(verbose) {
+                println("""Organization :: $payload""")
+            }
+
             results += put(environment, accessToken, SettingType.ORG, deepOrg.name, payload)
         }
         // Put senders
         deepOrgs.flatMap { it.senders }.forEach { sender ->
             val payload = jsonMapper.writeValueAsString(sender)
+
+            if(verbose) {
+                println("""Sender :: $payload""")
+            }
+
             results += put(environment, accessToken, SettingType.SENDER, sender.fullName, payload)
         }
         // Put receivers
         deepOrgs.flatMap { it.receivers }.forEach { receiver ->
             val payload = jsonMapper.writeValueAsString(receiver)
+
+            if(verbose) {
+                println("""Receiver :: $receiver""")
+            }
+
             results += put(environment, accessToken, SettingType.RECEIVER, receiver.fullName, payload)
         }
         return results


### PR DESCRIPTION
This PR enables the 'verbose' flag to the set commands for:

```
./prime multiple-settings set
./prime receiver set
./prime sender set
./prime organization set

```



## Changes
- cli/SettingCommands.kt -> add verbose option to **PutMultipleSettings** and **SingleSettingCommandNoSettingName**

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

