### PR TITLE
Enforce TLS 1.2 and disable public access on main storage account

### DIFF
--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_storage_account" "storage_account" {
   account_replication_type = "GRS"
   min_tls_version = "TLS1_2"
   allow_blob_public_access = false
+  enable_https_traffic_only = true
 
   network_rules {
     default_action = "Deny"
@@ -124,6 +125,7 @@ resource "azurerm_storage_account" "storage_public" {
   account_replication_type = "GRS"
   min_tls_version = "TLS1_2"
   allow_blob_public_access = false
+  enable_https_traffic_only = true
 
   static_website {
     index_document = "index.html"
@@ -156,6 +158,7 @@ resource "azurerm_storage_account" "storage_partner" {
   account_replication_type = "GRS"
   min_tls_version = "TLS1_2"
   allow_blob_public_access = false
+  enable_https_traffic_only = true
 
   network_rules {
     default_action = "Deny"

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -4,6 +4,8 @@ resource "azurerm_storage_account" "storage_account" {
   location = var.location
   account_tier = "Standard"
   account_replication_type = "GRS"
+  min_tls_version = "TLS1_2"
+  allow_blob_public_access = false
 
   network_rules {
     default_action = "Deny"


### PR DESCRIPTION
This PR resolves #1287.

## Changes
- Require TLS 1.2 on the main storage account
  - Other storage accounts had this setting enabled, but we never enabled it for the main storage account
- Disallow public containers to be created in our storage account containing PHI/PII
  - This setting prevents any storage container in the future created under this storage account from being granted public access
  - We currently have no containers within this storage account with public access; we have a separate public-facing storage account
  - This will ensure we can't accidentally make our PHI/PII container public

## Checklist

### Testing
- [N/A] Tested locally?
- [N/A] Ran `quickTest all`?
- [N/A] Ran `./prime test` against local Docker ReportStream container?
- [N/A] Downloaded a file from `http://localhost:7071/api/download`?
- [N/A] Added tests?

### Security
- [N/A] Did you check for sensitive data, and remove any? 
- [N/A] Does logging contain sensitive data?  
- [N/A] Are additional approvals needed for this change?
- [N/A] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [x] Includes a summary of what a code reviewer should verify?
- [N/A] Updated the release notes?
- [N/A] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?