### PR TITLE
add schema existence validation to SendReport

### DIFF
--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -146,10 +146,14 @@ class ReportFunction {
         val clientName = request.headers[CLIENT_PARAMETER] ?: request.queryParameters.getOrDefault(CLIENT_PARAMETER, "")
         if (clientName.isBlank())
             errors.add(ResultDetail.param(CLIENT_PARAMETER, "Expected a '$CLIENT_PARAMETER' query parameter"))
+
         val sender = engine.settings.findSender(clientName)
         if (sender == null)
             errors.add(ResultDetail.param(CLIENT_PARAMETER, "'$CLIENT_PARAMETER:$clientName': unknown sender"))
+
         val schema = engine.metadata.findSchema(sender?.schemaName ?: "")
+        if(sender != null && schema == null)
+            errors.add(ResultDetail.param(CLIENT_PARAMETER, "'$CLIENT_PARAMETER:${clientName}': unknown schema '${sender.schemaName}'"))
 
         val contentType = request.headers.getOrDefault(HttpHeaders.CONTENT_TYPE.lowercase(), "")
         if (contentType.isBlank()) {


### PR DESCRIPTION
This PR validates in the SendReport function if the associated schema of the sender is valid, and returns an error in the canonical json payload if necessary.

@jimduff-usds I've talked with Tom about adding extra tests for this based on the works he's doing, but he isn't planning to push anything related to that anytime soon, so maybe it's preferable to send this wo tests.

## Changes
- prime-router/src/main/kotlin/azure/ReportFunction.kt -> schema validation

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
*List potential security threats and mitigations in the PR*

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

