### PR TITLE
Secondary feeds for OH, LA, VT

### DIFF
--- a/prime-router/settings/prod/0031-oh-la-la.yml
+++ b/prime-router/settings/prod/0031-oh-la-la.yml
@@ -100,3 +100,53 @@
       port: "22"
       filePath: "./Test/ToVDH/"
       type: "SFTP"
+
+- name: "oh-doh"
+  description: "Ohio Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "OH"
+  countyName: null
+  receivers:
+  - name: "elr-secondary"
+    organizationName: "oh-doh"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: "OHDOH"
+      receivingApplicationOID: "2.16.840.1.114222.4.1.3674"
+      receivingFacilityName: "OHDOH"
+      receivingFacilityOID: "2.16.840.1.114222.4.1.3674"
+      messageProfileId: null
+      reportingFacilityName: "CDC PRIME"
+      reportingFacilityId: "36DSMP9999"
+      reportingFacilityIdType: null
+      suppressQstForAoe: true
+      suppressHl7Fields: "OBX-23-11"
+      suppressAoe: false
+      defaultAoeToUnknown: false
+      useBlankInsteadOfUnknown: "patient_race"
+      truncateHDNamespaceIds: false
+      usePid14ForPatientEmail: false
+      convertTimestampToDateTime: null
+      processingModeCode: null
+      nameFormat: "OHIO"
+      receivingOrganization: null
+      type: "HL7"
+    jurisdictionalFilter:
+    - "orEquals(ordering_facility_state, OH, patient_state, OH)"
+    qualityFilter: []
+    reverseTheQualityFilter: true
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 12
+      initialTime: "01:15"
+      timeZone: "EASTERN"
+      maxReportCount: 100
+    description: ""
+    transport: !<SFTP>
+      host: "156.63.28.72"
+      port: "4022"
+      filePath: "CDC-ELR/TestFiles"
+      type: "SFTP"

--- a/prime-router/settings/prod/0031-oh-la-la.yml
+++ b/prime-router/settings/prod/0031-oh-la-la.yml
@@ -1,4 +1,4 @@
-# Run this with   ./prime multiple-settings set --input ./settings/prod/0031-vt-la.yml --env prod
+# Run this with   ./prime multiple-settings set --input ./settings/prod/0031-oh-la-la.yml --env prod
 ---
 - name: "la-doh"
   description: "Louisiana Department of Health"

--- a/prime-router/settings/prod/0031-vt-la.yml
+++ b/prime-router/settings/prod/0031-vt-la.yml
@@ -1,0 +1,102 @@
+# Run this with   ./prime multiple-settings set --input ./settings/prod/0031-vt-la.yml --env prod
+---
+- name: "la-doh"
+  description: "Louisiana Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "LA"
+  countyName: null
+  receivers:
+  - name: "elr-secondary"
+    organizationName: "la-doh"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: "LA-ELR"
+      receivingApplicationOID: null
+      receivingFacilityName: "LADOH"
+      receivingFacilityOID: null
+      messageProfileId: null
+      reportingFacilityName: null
+      reportingFacilityId: null
+      reportingFacilityIdType: null
+      suppressQstForAoe: false
+      suppressHl7Fields: null
+      suppressAoe: false
+      defaultAoeToUnknown: false
+      useBlankInsteadOfUnknown: null
+      truncateHDNamespaceIds: false
+      usePid14ForPatientEmail: false
+      convertTimestampToDateTime: null
+      processingModeCode: "P"
+      nameFormat: "APHL"
+      receivingOrganization: "LAOPH"
+      type: "HL7"
+    jurisdictionalFilter:
+    - "orEquals(ordering_facility_state, LA, patient_state, LA)"
+    qualityFilter: []
+    reverseTheQualityFilter: true
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 12
+      initialTime: "01:15"
+      timeZone: "EASTERN"
+      maxReportCount: 100
+    description: ""
+    transport: !<SFTP>
+      host: "204.58.124.41"
+      port: "22"
+      filePath: "./TEST"
+      type: "SFTP"
+
+- name: "vt-doh"
+  description: "Vermont Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "VT"
+  countyName: null
+  senders: []
+  receivers:
+  - name: "elr-secondary"
+    organizationName: "vt-doh"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: "NBS"
+      receivingApplicationOID: "2.16.840.1.114222.4.1.185.1"
+      receivingFacilityName: "VDH"
+      receivingFacilityOID: "2.16.840.1.114222.4.1.185"
+      messageProfileId: null
+      reportingFacilityName: null
+      reportingFacilityId: null
+      reportingFacilityIdType: null
+      suppressQstForAoe: false
+      suppressHl7Fields: null
+      suppressAoe: false
+      defaultAoeToUnknown: false
+      useBlankInsteadOfUnknown: null
+      truncateHDNamespaceIds: false
+      usePid14ForPatientEmail: false
+      convertTimestampToDateTime: null
+      processingModeCode: null
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "HL7"
+    jurisdictionalFilter:
+    - "orEquals(ordering_facility_state, VT, patient_state, VT)"
+    qualityFilter: []
+    reverseTheQualityFilter: true
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 12
+      initialTime: "01:15"
+      timeZone: "EASTERN"
+      maxReportCount: 100
+    description: ""
+    transport: !<SFTP>
+      host: "gs-sftp.ahs.state.vt.us"
+      port: "22"
+      filePath: "./Test/ToVDH/"
+      type: "SFTP"

--- a/prime-router/settings/staging/0028-tn-mi.yml
+++ b/prime-router/settings/staging/0028-tn-mi.yml
@@ -1,0 +1,102 @@
+---
+- name: "tn-doh"
+  description: "Tennessee Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "TN"
+  countyName: null
+  senders: []
+  receivers:
+  - name: "elr-secondary"
+    organizationName: "tn-doh"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: "tdh-ELR"
+      receivingApplicationOID: "2.16.840.1.113883.3.773.1.1.3"
+      receivingFacilityName: "TDH"
+      receivingFacilityOID: "2.16.840.1.113883.3.773"
+      messageProfileId: null
+      reportingFacilityName: null
+      reportingFacilityId: null
+      reportingFacilityIdType: null
+      suppressQstForAoe: false
+      suppressHl7Fields: null
+      suppressAoe: false
+      defaultAoeToUnknown: false
+      useBlankInsteadOfUnknown: null
+      truncateHDNamespaceIds: false
+      usePid14ForPatientEmail: false
+      convertTimestampToDateTime: null
+      processingModeCode: null
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "HL7"
+    jurisdictionalFilter:
+    - "orEquals(ordering_facility_state, TN, patient_state, TN)"
+    qualityFilter: []
+    reverseTheQualityFilter: true
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 100
+    description: ""
+    transport: !<SFTP>
+      host: "10.0.2.4"
+      port: "22"
+      filePath: "./upload"
+      type: "SFTP"
+
+- name: "mi-phd"
+  description: "Michigan Public Health Department"
+  jurisdiction: "STATE"
+  stateCode: "MI"
+  countyName: null
+  senders: []
+  receivers:
+  - name: "elr-secondary"
+    organizationName: "mi-phd"
+    topic: "covid-19"
+    translation: !<HL7>
+      useTestProcessingMode: false
+      useBatchHeaders: true
+      receivingApplicationName: "MDSS"
+      receivingApplicationOID: "2.16.840.1.114222.4.3.2.2.3.161.1.6377"
+      receivingFacilityName: "MDSS"
+      receivingFacilityOID: "2.16.840.1.114222.4.3.2.2.3.161.1.6377"
+      messageProfileId: null
+      reportingFacilityName: null
+      reportingFacilityId: null
+      reportingFacilityIdType: null
+      suppressQstForAoe: false
+      suppressHl7Fields: null
+      suppressAoe: false
+      defaultAoeToUnknown: false
+      useBlankInsteadOfUnknown: null
+      truncateHDNamespaceIds: false
+      usePid14ForPatientEmail: false
+      convertTimestampToDateTime: null
+      processingModeCode: null
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "HL7"
+    jurisdictionalFilter:
+    - "orEquals(ordering_facility_state, MI, patient_state, MI)"
+    qualityFilter: []
+    reverseTheQualityFilter: true
+    deidentify: false
+    timing:
+      operation: "MERGE"
+      numberPerDay: 1440
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<SFTP>
+      host: "10.0.2.4"
+      port: "22"
+      filePath: "./upload"
+      type: "SFTP"


### PR DESCRIPTION
This PR submits setting changes for new receivers for secondary data to OH, LA, and VT.

## Changes
- No code changes
- The new receivers were created by doing a `get` of the existing `elr` receivers in Prod and only these changes were made:
-- the name of the new receiver is `elr-secondary`
-- changed the `reverseTheQualityFilter` flag to `true`
-- the sftp directory is changed.

MUST tell LA, VT, and OH we are doing this before the command is run in PROD.

## Checklist

I did not run any tests below because there are no code changes.   however, I uploaded the receivers into my local reportstreeam just to make sure there were no syntax errors.  It worked.

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Security
- [ ] Did you check for sensitive data, and remove any? 
- [ ] Does logging contain sensitive data?  
- [ ] Are additional approvals needed for this change?
- [ ] Are there potential vulnerabilities or licensing issues with any new dependencies introduced?

### Process
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Security
- no issues known
- 
## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue 

