### PR TITLE
Adds yamlitos for CA quality filter change

### DIFF
--- a/prime-router/settings/prod/0033-ca-quality-filter.yml
+++ b/prime-router/settings/prod/0033-ca-quality-filter.yml
@@ -1,0 +1,90 @@
+---
+- name: "ca-scc-phd"
+  description: "Public Health Department - Santa Clara, California"
+  jurisdiction: "COUNTY"
+  stateCode: "CA"
+  countyName: "Santa Clara"
+  senders: []
+  receivers:
+    - name: "elr-download"
+      organizationName: "ca-scc-phd"
+      topic: "covid-19"
+      translation: !<CUSTOM>
+        schemaName: "ca/ca-scc-covid-19"
+        format: "CSV"
+        defaults: {}
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "CUSTOM"
+      jurisdictionalFilter:
+        - "matches(ordering_facility_state, CA)"
+        - "matches(ordering_facility_county, Santa Clara)"
+      qualityFilter:
+        - "doesNotMatch(processing_mode_code,T,D)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: null
+
+- name: "ca-dph"
+  description: "California Department of Public Health"
+  jurisdiction: "STATE"
+  stateCode: "CA"
+  countyName: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "ca-dph"
+      topic: "covid-19"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: null
+        receivingApplicationOID: null
+        receivingFacilityName: null
+        receivingFacilityOID: null
+        messageProfileId: null
+        reportingFacilityName: null
+        reportingFacilityId: null
+        suppressQstForAoe: false
+        suppressHl7Fields: null
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        processingModeCode: null
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, CA, patient_state, CA)"
+      qualityFilter:
+        - "doesNotMatch(processing_mode_code,T,D)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "ecgpe.healthtechnologygroup.com"
+        port: "22"
+        filePath: "./in/simple/HL7"
+        type: "SFTP"

--- a/prime-router/settings/staging/0030-ca-quality-filter.yml
+++ b/prime-router/settings/staging/0030-ca-quality-filter.yml
@@ -1,0 +1,90 @@
+---
+- name: "ca-scc-phd"
+  description: "Public Health Department - Santa Clara, California"
+  jurisdiction: "COUNTY"
+  stateCode: "CA"
+  countyName: "Santa Clara"
+  senders: []
+  receivers:
+    - name: "elr-download"
+      organizationName: "ca-scc-phd"
+      topic: "covid-19"
+      translation: !<CUSTOM>
+        schemaName: "ca/ca-scc-covid-19"
+        format: "CSV"
+        defaults: {}
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "CUSTOM"
+      jurisdictionalFilter:
+        - "matches(ordering_facility_state, CA)"
+        - "matches(ordering_facility_county, Santa Clara)"
+      qualityFilter:
+        - "doesNotMatch(processing_mode_code,T,D)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1440
+        initialTime: "00:00"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: null
+
+- name: "ca-dph"
+  description: "California Department of Public Health"
+  jurisdiction: "STATE"
+  stateCode: "CA"
+  countyName: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "ca-dph"
+      topic: "covid-19"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: null
+        receivingApplicationOID: null
+        receivingFacilityName: null
+        receivingFacilityOID: null
+        messageProfileId: null
+        reportingFacilityName: null
+        reportingFacilityId: null
+        suppressQstForAoe: false
+        suppressHl7Fields: null
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        processingModeCode: null
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, CA, patient_state, CA)"
+      qualityFilter:
+        - "doesNotMatch(processing_mode_code,T,D)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1440
+        initialTime: "00:00"
+        timeZone: "EASTERN"
+        maxReportCount: 500
+      description: ""
+      transport: !<SFTP>
+        host: "10.0.2.4"
+        port: "22"
+        filePath: "./upload"
+        type: "SFTP"


### PR DESCRIPTION
This PR adds yamlitos that update the quality filter for CA and Santa Clara that removes the CLIA quality filter check

## Changes
- Adds a yamlito for production that removes the CLIA format check from the default quality filter
- Adds a yamlito for staging that removes the CLIA format check from the default quality filter

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
*List GitHub issues this PR fixes*
- #1380 

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #1381

