### PR TITLE
Add playbook for shutting down resources

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -179,3 +179,7 @@ make TF_ENV={dev,test,staging,prod} tf-01-network
 tf destroy
 exit
 ```
+
+**WARNING:** Removing stages beyond `04-app` will release resources that are irrecoverable. Data is preserved by Azure retention policies, but public IP addresses and other static resources may be released.
+
+Any resource that is not ephemeral is marked with a `lifecycle { prevent_destroy = true }` annotation, requiring manual intervention to tear down the resource.

--- a/prime-router/docs/playbooks/shutdown.md
+++ b/prime-router/docs/playbooks/shutdown.md
@@ -24,23 +24,25 @@ az functionapp config appsettings set --name <FUNCTION_APP_NAME>
 
 ## Disable HTTP Traffic
 
-If traffic to a given code path must be completely stopped, [the backend source can be removed from the load balancer](https://docs.microsoft.com/en-us/cli/azure/network/front-door/backend-pool?view=azure-cli-latest#az_network_front_door_backend_pool_delete).
+If traffic to a given code path must be completely stopped, [the backend route can be disabled in the load balancer](https://docs.microsoft.com/en-us/cli/azure/network/front-door/routing-rule?view=azure-cli-latest#az_network_front_door_routing_rule_update).
 
 ### From the CLI
 
 ```
-az network front-door backend-pool delete --front-door-name <FD_NAME>
-                                          --name <BE_POOL_NAME>
+az network front-door routing-rule update --front-door-name <FD_NAME>
+                                          --name <RULE_NAME>
                                           --resource-group <RESX_GROUP>
+                                          --enabled Disabled
 ```
 
 ### From the Azure Portal
 
 1. Login to Azure Portal
 2. Navigate to `prime-data-hub-*` > `Front Door Designer` within the Portal
-3. Click on the backend pool(s) to be removed
-4. From the bottom menu, select the `Delete` option
-5. Repeat for each affected backend pool
+3. Click on the routing rule(s) to be disabled
+4. From the top of the page, select the `Disabled` option under `Status`
+5. Repeat for each affected routing rule
+6. Save the Front Door configuration with the `Save` button at the top
 
 ## Delete Application Resources
 

--- a/prime-router/docs/playbooks/shutdown.md
+++ b/prime-router/docs/playbooks/shutdown.md
@@ -4,7 +4,17 @@ In the event the project needs to shutdown quickly in the response to an inciden
 
 ## Disable a Function
 
-If the scope of the shutdown can be limited to one or more Azure Functions, Functions can individually be disabled. To do this:
+If the scope of the shutdown can be limited to one or more Azure Functions, [Functions can individually be disabled](https://docs.microsoft.com/en-us/azure/azure-functions/disable-function?tabs=portal).
+
+### From the CLI
+
+```
+az functionapp config appsettings set --name <FUNCTION_APP_NAME>
+                                      --resource-group <RESOURCE_GROUP_NAME>
+                                      --settings AzureWebJobs.<FUNCTION_NAME>.Disabled=true
+```
+
+### From the Azure Portal
 
 1. Login to Azure Portal
 2. Navigate to `*-functionapp` > `Functions` within the Portal
@@ -14,7 +24,17 @@ If the scope of the shutdown can be limited to one or more Azure Functions, Func
 
 ## Disable HTTP Traffic
 
-If traffic to a given code path must be completely stopped, the backend source can be removed from the load balancer. To do this:
+If traffic to a given code path must be completely stopped, [the backend source can be removed from the load balancer](https://docs.microsoft.com/en-us/cli/azure/network/front-door/backend-pool?view=azure-cli-latest#az_network_front_door_backend_pool_delete).
+
+### From the CLI
+
+```
+az network front-door backend-pool delete --front-door-name <FD_NAME>
+                                          --name <BE_POOL_NAME>
+                                          --resource-group <RESX_GROUP>
+```
+
+### From the Azure Portal
 
 1. Login to Azure Portal
 2. Navigate to `prime-data-hub-*` > `Front Door Designer` within the Portal

--- a/prime-router/docs/playbooks/shutdown.md
+++ b/prime-router/docs/playbooks/shutdown.md
@@ -47,3 +47,5 @@ az network front-door backend-pool delete --front-door-name <FD_NAME>
 If the application must completely be removed from Azure, Terraform can destroy all application resources. To do this:
 
 1. [Follow the operations/README.md for environment tear down directions](https://github.com/CDCgov/prime-reportstream/blob/master/operations/README.md#tear-down-a-environment)
+2. Start with the app stage (`04-app`) and work backwards until the resources needed are destroyed
+3. Make note of the warning when tearing down resources that are not ephemeral

--- a/prime-router/docs/playbooks/shutdown.md
+++ b/prime-router/docs/playbooks/shutdown.md
@@ -1,0 +1,29 @@
+# Shutdown Options
+
+In the event the project needs to shutdown quickly in the response to an incident, the following options are available:
+
+## Disable a Function
+
+If the scope of the shutdown can be limited to one or more Azure Functions, Functions can individually be disabled. To do this:
+
+1. Login to Azure Portal
+2. Navigate to `*-functionapp` > `Functions` within the Portal
+3. Click on the affected function(s)
+4. From the top menu, select the `Disable` option
+5. Repeat for each affected function
+
+## Disable HTTP Traffic
+
+If traffic to a given code path must be completely stopped, the backend source can be removed from the load balancer. To do this:
+
+1. Login to Azure Portal
+2. Navigate to `prime-data-hub-*` > `Front Door Designer` within the Portal
+3. Click on the backend pool(s) to be removed
+4. From the bottom menu, select the `Delete` option
+5. Repeat for each affected backend pool
+
+## Delete Application Resources
+
+If the application must completely be removed from Azure, Terraform can destroy all application resources. To do this:
+
+1. [Follow the operations/README.md for environment tear down directions](https://github.com/CDCgov/prime-reportstream/blob/master/operations/README.md#tear-down-a-environment)


### PR DESCRIPTION
This PR adds a playbook detailing various options to stop traffic to PRIME resources.

## Changes
- Adds playbooks/shutdown.md

## Checklist

### Testing
N/A

### Specific Security-related subjects a reviewer should pay specific attention to
N/A

### Process
N/A

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
