### PR TITLE
1471 Ignore errors that the blob already exists

### DIFF
--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
   settings:
     build: settings/.
-    command: "--wait=25 --check-last-modified prime_dev /settings/organizations-local.yml"
+    command: "--wait=20 --check-last-modified prime_dev /settings/organizations-local.yml"
     depends_on:
       - prime_dev
     volumes:

--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
   settings:
     build: settings/.
-    command: "--wait=15 --check-last-modified prime_dev /settings/organizations-local.yml"
+    command: "--wait=25 --check-last-modified prime_dev /settings/organizations-local.yml"
     depends_on:
       - prime_dev
     volumes:


### PR DESCRIPTION
This PR ignores an error that the Blob already exists.  This is not really an error for us, but can occur when concurrent calls are made to the API and those calls all try to create the Blob store at the same time.

## Changes
- ignore blob already created error

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
#1471 

## To Be Done

