### PR TITLE
made testId (internally as message_id) visible in all direct schemas

### DIFF
--- a/prime-router/docs/schema_documentation/direct-cue-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-cue-covid-19.md
@@ -695,7 +695,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 ---
 
-**Name**: message_id
+**Name**: testId
 
 **Type**: ID
 
@@ -705,7 +705,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **Documentation**:
 
-ReportStream copies value from the specimenId
+ReportStream copies value from the specimenId if none is provided by the sender.
 
 ---
 

--- a/prime-router/docs/schema_documentation/direct-direct-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-direct-covid-19.md
@@ -695,7 +695,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 ---
 
-**Name**: message_id
+**Name**: testId
 
 **Type**: ID
 
@@ -705,7 +705,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **Documentation**:
 
-ReportStream copies value from the specimenId
+ReportStream copies value from the specimenId if none is provided by the sender.
 
 ---
 

--- a/prime-router/docs/schema_documentation/direct-imagemover-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-imagemover-covid-19.md
@@ -695,7 +695,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 ---
 
-**Name**: message_id
+**Name**: testId
 
 **Type**: ID
 
@@ -705,7 +705,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **Documentation**:
 
-ReportStream copies value from the specimenId
+ReportStream copies value from the specimenId if none is provided by the sender.
 
 ---
 

--- a/prime-router/docs/schema_documentation/direct-inbios-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-inbios-covid-19.md
@@ -695,7 +695,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 ---
 
-**Name**: message_id
+**Name**: testId
 
 **Type**: ID
 
@@ -705,7 +705,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **Documentation**:
 
-ReportStream copies value from the specimenId
+ReportStream copies value from the specimenId if none is provided by the sender.
 
 ---
 

--- a/prime-router/docs/schema_documentation/direct-safehealth-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-safehealth-covid-19.md
@@ -695,7 +695,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 ---
 
-**Name**: message_id
+**Name**: testId
 
 **Type**: ID
 
@@ -705,7 +705,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **Documentation**:
 
-ReportStream copies value from the specimenId
+ReportStream copies value from the specimenId if none is provided by the sender.
 
 ---
 

--- a/prime-router/docs/schema_documentation/hhsprotect-hhsprotect-covid-19.md
+++ b/prime-router/docs/schema_documentation/hhsprotect-hhsprotect-covid-19.md
@@ -705,7 +705,7 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 
 **Documentation**:
 
-ReportStream copies value from the specimenId
+ReportStream copies value from the specimenId if none is provided by the sender.
 
 ---
 

--- a/prime-router/metadata/schemas/direct/direct-covid-19.schema
+++ b/prime-router/metadata/schemas/direct/direct-covid-19.schema
@@ -79,8 +79,9 @@ elements:
     csvFields: [{ name: serialNumber}]
 
   - name: message_id
-    documentation: ReportStream copies value from the specimenId
+    documentation: ReportStream copies value from the specimenId if none is provided by the sender.
     mapper: use(specimen_id)
+    csvFields: [{ name: testId}]
 
   - name: patient_age
     csvFields: [{ name: patientAge}]


### PR DESCRIPTION
This PR adds a missing testId header into the `direct` family of schemas.


## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

