### PR TITLE
1384 Added smoke test to gradle script

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -207,11 +207,15 @@ tasks.register<JavaExec>("primeCLI") {
     main = primeMainClass
     classpath = sourceSets["main"].runtimeClasspath
     // Default arguments is to display the help
-    args = listOf("-h")
     environment["POSTGRES_URL"] = dbUrl
     environment["POSTGRES_USER"] = dbUser
     environment["POSTGRES_PASSWORD"] = dbPassword
-    doFirst {
+
+    // Use arguments passed by another task in the project.extra["cliArgs"] property.
+    if (project.extra.has("cliArgs")) {
+        args = project.extra["cliArgs"] as MutableList<String>
+    } else {
+        args = listOf("-h")
         println("primeCLI Gradle task usage: gradle primeCLI --args='<args>'")
         println(
             "Usage example: gradle primeCLI --args=\"data --input-fake 50 " +
@@ -221,21 +225,25 @@ tasks.register<JavaExec>("primeCLI") {
     }
 }
 
+tasks.register("testSmoke") {
+    group = rootProject.description ?: ""
+    description = "Run the smoke tests"
+    project.extra["cliArgs"] = listOf("test")
+    finalizedBy("primeCLI")
+}
+
 tasks.register<JavaExec>("testEnd2End") {
     group = rootProject.description ?: ""
     description = "Run the end to end tests.  Requires running a Docker instance"
-    main = primeMainClass
-    classpath = sourceSets["main"].runtimeClasspath
-    args = listOf("test", "--run", "end2end")
-    environment = mapOf("POSTGRES_URL" to dbUrl, "POSTGRES_USER" to dbUser, "POSTGRES_PASSWORD" to dbPassword)
+    project.extra["cliArgs"] = listOf("test", "--run", "end2end")
+    finalizedBy("primeCLI")
 }
 
 tasks.register<JavaExec>("generateDocs") {
     group = rootProject.description ?: ""
     description = "Generate the schema documentation in markup format"
-    main = primeMainClass
-    classpath = sourceSets["main"].runtimeClasspath
-    args = listOf("generate-docs")
+    project.extra["cliArgs"] = listOf("generate-docs")
+    finalizedBy("primeCLI")
 }
 
 tasks.azureFunctionsPackage {

--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -232,14 +232,14 @@ tasks.register("testSmoke") {
     finalizedBy("primeCLI")
 }
 
-tasks.register<JavaExec>("testEnd2End") {
+tasks.register("testEnd2End") {
     group = rootProject.description ?: ""
     description = "Run the end to end tests.  Requires running a Docker instance"
     project.extra["cliArgs"] = listOf("test", "--run", "end2end")
     finalizedBy("primeCLI")
 }
 
-tasks.register<JavaExec>("generateDocs") {
+tasks.register("generateDocs") {
     group = rootProject.description ?: ""
     description = "Generate the schema documentation in markup format"
     project.extra["cliArgs"] = listOf("generate-docs")

--- a/prime-router/gradle.properties
+++ b/prime-router/gradle.properties
@@ -1,3 +1,3 @@
 # Set the character encoding when running from Gradle.
 # This affects the unit tests and runs of the primeCLI from Gradle.
-org.gradle.jvmargs="-Dfile.encoding=UTF8"
+org.gradle.jvmargs=-Dfile.encoding=UTF8 -Xmx2048M


### PR DESCRIPTION
This PR adds the smoke test to the Gradle script.  I also refactored the CLI portion a bit to be able to create other tasks to call the CLI without having to copy the full CLI task code.  I tried once again to split the gradle script, so it is not a large file, but Gradle does not have the ability to do that.  :( 

To test:
Run `./gradlew testSmoke'

## Changes
- Added testSmoke task
- A bit of refactor to make future CLI tasks simpler to make.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
#1384 

## To Be Done

