### PR TITLE
Fix quicktest to no longer use the build.sh script

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -14,7 +14,7 @@ Properties that can be overriden using an environment variable only:
 Properties to control the execution and output using the Gradle -P arguments:
   forcetest - Force the running of the test regardless of changes
   showtests - Verbose output of the unit tests
-  E.g. ./build.sh -- gradle clean package -Ppg.user=myuser -Dpg.password=mypassword -Pforcetest
+  E.g. ./gradlew clean package -Ppg.user=myuser -Dpg.password=mypassword -Pforcetest
  */
 
 import org.apache.tools.ant.filters.ReplaceTokens

--- a/prime-router/prime
+++ b/prime-router/prime
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # DEPRECATED: This script has been replaced by a Gradle task.  Run
-#   ./build.sh -- gradle primeCLI --args='<args>'
+#   ./gradlew primeCLI --args='<args>'
 #
 # This script runs the CLI of the project.
 #

--- a/prime-router/quick-test.sh
+++ b/prime-router/quick-test.sh
@@ -98,7 +98,7 @@ mkdir -p $outputdir
 function run_prime_cli {
   # We need to pass the arguments as one string
   args="$@"
-  output=$(./build.sh -- gradle -q primeCLI --args="$args")
+  output=$(./gradlew -q primeCLI --args="$args")
   exit_value=$?
   echo $output
   return $exit_value


### PR DESCRIPTION
This PR reverts the invocation of gradlew in quick-test.sh instead of using build.sh