### PR TITLE
1678 Fixed SFTP filenames to not have blob folders

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -1,5 +1,6 @@
 package gov.cdc.prime.router
 
+import gov.cdc.prime.router.azure.BlobAccess
 import gov.cdc.prime.router.azure.WorkflowEngine
 import gov.cdc.prime.router.azure.db.tables.pojos.CovidResultMetadata
 import gov.cdc.prime.router.azure.db.tables.pojos.ItemLineage
@@ -867,7 +868,7 @@ class Report : Logging {
         fun formExternalFilename(header: WorkflowEngine.Header): String {
             // extract the filename from the blob url.
             val filename = if (header.reportFile.bodyUrl != null)
-                header.reportFile.bodyUrl.split("/").last()
+                BlobAccess.BlobInfo.getBlobFilename(header.reportFile.bodyUrl)
             else ""
             return if (filename.isNotEmpty())
                 filename

--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -10,9 +10,14 @@ import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.serializers.CsvSerializer
 import gov.cdc.prime.router.serializers.Hl7Serializer
 import gov.cdc.prime.router.serializers.RedoxSerializer
+import org.apache.commons.io.FilenameUtils
 import org.apache.logging.log4j.kotlin.Logging
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.net.MalformedURLException
+import java.net.URL
+import java.net.URLDecoder
+import java.nio.charset.Charset
 import java.security.MessageDigest
 
 const val defaultBlobContainerName = "reports"
@@ -28,8 +33,20 @@ class BlobAccess(
     data class BlobInfo(
         val format: Report.Format,
         val blobUrl: String,
-        val digest: ByteArray,
-    )
+        val digest: ByteArray
+    ) {
+        companion object {
+            /**
+             * Get the blob filename from a [blobUrl]
+             * @return the blob filename
+             * @throws MalformedURLException if the blob URL is malformed
+             */
+            fun getBlobFilename(blobUrl: String): String {
+                return if (blobUrl.isNotBlank())
+                    FilenameUtils.getName(URL(URLDecoder.decode(blobUrl, Charset.defaultCharset())).path) else ""
+            }
+        }
+    }
 
     /**
      * Upload the [report] to the blob store using the [action] to determine a folder as needed.  A [subfolderName]
@@ -107,7 +124,7 @@ class BlobAccess(
         val fromBytes = this.downloadBlob(fromBlobUrl)
         logger.info("Ready to copy ${fromBytes.size} bytes from $fromBlobUrl")
         val fromBlobClient = getBlobClient(fromBlobUrl) // only used to get the filename.
-        val toFilename = fromBlobClient.blobName
+        val toFilename = BlobInfo.getBlobFilename(fromBlobClient.blobName)
         logger.info("New blob filename will be $toFilename")
         val toBlobUrl = uploadBlob(toFilename, fromBytes, toBlobContainer, toBlobConnEnvVar)
         logger.info("New blob URL is $toBlobUrl")

--- a/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
+++ b/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
@@ -1,0 +1,29 @@
+package gov.cdc.prime.router.azure
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.fail
+import org.junit.jupiter.api.Test
+import java.net.MalformedURLException
+
+class BlobAccessTests {
+    @Test
+    fun `blob info filename`() {
+        var filename = BlobAccess.BlobInfo
+            .getBlobFilename("http://127.0.0.1:10000/devstoreaccount1/reports/ready/pima-az-phd.elr/filename.csv")
+        assertThat(filename).isEqualTo("filename.csv")
+
+        // This is how the URLs are returned from the Blob store
+        filename = BlobAccess.BlobInfo
+            .getBlobFilename("http://azurite:10000/devstoreaccount1/reports/ready%2Ftx-doh.elr%2Ffilename.csv")
+        assertThat(filename).isEqualTo("filename.csv")
+
+        try {
+            BlobAccess.BlobInfo.getBlobFilename("ggg://somethingweird")
+            fail("Expected malformed URL Exception")
+        } catch (e: MalformedURLException) {
+            assertThat(e).isNotNull()
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the filenames uploaded via SFTP to not have the blob folders.  I searched all the code for any other places that the blob URL was being used besides SFTP and found the BlobTransport was affected too.

To test:
1. Build and run the API.
2. Run `./gradlew testend2end` and verify in the build/sftp folder that the filenames for the received data do not contain the blob folders.

## Changes
- Fixed SFTP so filenames do not have the blob folders
- Updated blob copy method to use proper filename.  This affects the BlobTransport.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #1678 

## To Be Done

