### PR TITLE
1676 Fixed incorrect filename for blob copy

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -242,16 +242,18 @@ tasks.register<JavaExec>("primeCLI") {
     environment[KEY_PRIME_RS_API_ENDPOINT_HOST] = reportsApiEndpointHost
 
     // Use arguments passed by another task in the project.extra["cliArgs"] property.
-    if (project.extra.has("cliArgs")) {
-        args = project.extra["cliArgs"] as MutableList<String>
-    } else {
-        args = listOf("-h")
-        println("primeCLI Gradle task usage: gradle primeCLI --args='<args>'")
-        println(
-            "Usage example: gradle primeCLI --args=\"data --input-fake 50 " +
-                "--input-schema waters/waters-covid-19 --output-dir ./ --target-states CA " +
-                "--target-counties 'Santa Clara' --output-format CSV\""
-        )
+    doFirst {
+        if (project.extra.has("cliArgs")) {
+            args = project.extra["cliArgs"] as MutableList<String>
+        } else if (args.isNullOrEmpty()) {
+            args = listOf("-h")
+            println("primeCLI Gradle task usage: gradle primeCLI --args='<args>'")
+            println(
+                "Usage example: gradle primeCLI --args=\"data --input-fake 50 " +
+                    "--input-schema waters/waters-covid-19 --output-dir ./ --target-states CA " +
+                    "--target-counties 'Santa Clara' --output-format CSV\""
+            )
+        }
     }
 }
 

--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -123,8 +123,7 @@ class BlobAccess(
     fun copyBlob(fromBlobUrl: String, toBlobContainer: String, toBlobConnEnvVar: String): String {
         val fromBytes = this.downloadBlob(fromBlobUrl)
         logger.info("Ready to copy ${fromBytes.size} bytes from $fromBlobUrl")
-        val fromBlobClient = getBlobClient(fromBlobUrl) // only used to get the filename.
-        val toFilename = BlobInfo.getBlobFilename(fromBlobClient.blobName)
+        val toFilename = BlobInfo.getBlobFilename(fromBlobUrl)
         logger.info("New blob filename will be $toFilename")
         val toBlobUrl = uploadBlob(toFilename, fromBytes, toBlobContainer, toBlobConnEnvVar)
         logger.info("New blob URL is $toBlobUrl")


### PR DESCRIPTION
This PR fixes a bug in the BlobCopy method that was introduced as part of #1678.  It was using the incorrect call to get the filename.

Test:
1. Run the waters test `gradle primecli --args="test --run waters"` and verify the test passes.
2. Look at the container output and verify the filename of the blob copy shows as expected.

## Changes
- Use correct URL to get the filename
- Minor updates to gradle file to not show usage of primeCLI.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
#1678 

## To Be Done

