### PR TITLE
Enhanced prime script to build fatjar if possible

### DIFF
--- a/prime-router/prime
+++ b/prime-router/prime
@@ -13,11 +13,8 @@
 #
 # This script should work on both a Mac and the Dev Docker container
 
-set -e
 version=0.1-SNAPSHOT
 fat_jar_name=prime-router-$version-all.jar
-slim_jar_name=prime-router-$version.jar
-lib_name=azure-functions/prime-data-hub-router/lib
 lib_dir=build/libs
 
 # find the jar
@@ -25,21 +22,16 @@ if [ -f $fat_jar_name ]; then
   jar=$fat_jar_name
 elif [ -f $lib_dir/$fat_jar_name ]; then
   jar=$lib_dir/$fat_jar_name
-elif [ -f $slim_jar_name ]; then
-  jar=$slim_jar_name
-  if [ ! -d $lib_name ]; then
-    echo "Could not find a $lib_name directory"
-    exit 1
-  fi
-elif [ -f $lib_dir/$slim_jar_name ]; then
-  jar=$lib_dir/$slim_jar_name
-  if [ ! -d build/$lib_name ]; then
-    echo "Could not find a target/$lib_name directory"
-    exit 1
-  fi
-else
-  echo "Could not find a prime-data-hub-router*.jar file"
-  exit 1
+
+# If the jar was not found then try to build it
+elif [ -r ./gradlew ]; then
+    bash ./gradlew fatjar
+    if [ $? -eq 0 ]; then
+        jar=$lib_dir/$fat_jar_name
+    else
+        echo "Could not find $fat_jar_name"
+        exit 1
+    fi
 fi
 
 java -Dfile.encoding=UTF8 -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -jar $jar "$@"


### PR DESCRIPTION
This PR changes the prime script to build the fatjar that is required to run the tool if gradlew is detected.  Note that the slim jar does not work locally as the Azure functions lib folder does not include certain runtimes.

To test:
1. Delete the jars from build/libs
2. From the CLI like `./prime test --run waters` and verify the fatjar is generated before running the CLI.
3. Run `./prime test --run waters` again and verify the fatjar is not generated again.

## Changes
- Updated the prime script to generate the fatjar IF gradlew is available.
-

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
Not related to an issue

## To Be Done

