### PR TITLE
Enable CI for Forks

### DIFF
--- a/.github/workflows/build_frontend.yaml
+++ b/.github/workflows/build_frontend.yaml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_frontend_change: ${{ steps.skip_check.outputs.frontend }}
-      is_fork: ${{ steps.fork_check.outputs.is_fork }}
     steps:
       - name: "Check out changes"
         uses: actions/checkout@v2
@@ -27,13 +26,11 @@ jobs:
             frontend:
               - 'frontend-react/**'
               - '.github/workflows/build_frontend.yml'
-      - id: fork_check
-        run: echo "::set-output name=is_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
 
   build_frontend:
     name: Build Frontend
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.has_frontend_change == 'true' && needs.pre_job.outputs.is_fork != 'true' }}
+    if: ${{ needs.pre_job.outputs.has_frontend_change == 'true' }}
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -48,6 +48,16 @@ jobs:
         run: |
           echo >> $GITHUB_ENV DB_USER=${POSTGRES_USER}
           echo >> $GITHUB_ENV DB_PASSWORD=${POSTGRES_PASSWORD}
+          if [ "$GITHUB_BASE_REF" == "production" ]
+          then
+              echo "Building for the production environment."
+              echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
+              echo >> $GITHUB_ENV PREFIX=pdhprod
+          else
+              echo "Building for the test environment."
+              echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
+              echo >> $GITHUB_ENV PREFIX=pdhstaging
+          fi
 
       # Appears not to be needed on GitHub (but needed when running act [https://github.com/nektos/act] locally)
       # - name: Install docker-compose

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -48,16 +48,6 @@ jobs:
         run: |
           echo >> $GITHUB_ENV DB_USER=${POSTGRES_USER}
           echo >> $GITHUB_ENV DB_PASSWORD=${POSTGRES_PASSWORD}
-          if [ "$GITHUB_BASE_REF" == "production" ]
-          then
-              echo "Building for the production environment."
-              echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
-              echo >> $GITHUB_ENV PREFIX=pdhprod
-          else
-              echo "Building for the test environment."
-              echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
-              echo >> $GITHUB_ENV PREFIX=pdhstaging
-          fi
 
       # Appears not to be needed on GitHub (but needed when running act [https://github.com/nektos/act] locally)
       # - name: Install docker-compose

--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_router_change: ${{ steps.skip_check.outputs.router }}
-      is_fork: ${{ steps.fork_check.outputs.is_fork }}
     steps:
       - name: "Check out changes"
         uses: actions/checkout@v2
@@ -27,13 +26,11 @@ jobs:
             router:
               - 'prime-router/**'
               - '.github/workflows/build_hub.yml'
-      - id: fork_check
-        run: echo "::set-output name=is_fork::${{ github.event.pull_request.head.repo.full_name != github.repository }}"
 
   build_router:
     name: Build Router
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.has_router_change == 'true' && needs.pre_job.outputs.is_fork != 'true' }}
+    if: ${{ needs.pre_job.outputs.has_router_change == 'true' }}
     runs-on: ubuntu-latest
     env:
       # These are for CI and not credentials of any system


### PR DESCRIPTION
This PR allows our CI GitHub Action to run for forks.

Originally we had disabled this because our CI build required the use of some secrets, but those limitations have since been removed.
