### PR TITLE
Mo/report UUID mismatch

### DIFF
--- a/prime-router/src/main/kotlin/FileNameTemplate.kt
+++ b/prime-router/src/main/kotlin/FileNameTemplate.kt
@@ -146,7 +146,7 @@ open class FileNameTemplate(
                     val e = it.first as FileNameElement
                     // if the file element type is the UUID, combine args
                     val args = if (e is FileUuid) {
-                        it.second + reportId.toString()
+                        listOf(reportId.toString())
                     } else {
                         it.second
                     }

--- a/prime-router/src/main/kotlin/FileNameTemplate.kt
+++ b/prime-router/src/main/kotlin/FileNameTemplate.kt
@@ -50,7 +50,11 @@ class FileUuid : FileNameElement {
         get() = "uuid"
 
     override fun getElementValue(args: List<String>, translatorConfig: TranslatorConfiguration?): String {
-        return UUID.randomUUID().toString()
+        return if (args.isEmpty()) {
+            UUID.randomUUID().toString()
+        } else {
+            args[0]
+        }
     }
 }
 
@@ -131,7 +135,8 @@ open class FileNameTemplate(
     val name: String? = null
 ) {
     fun getFileName(
-        translatorConfig: TranslatorConfiguration? = null
+        translatorConfig: TranslatorConfiguration? = null,
+        reportId: ReportId
     ): String {
         val fileName = StringBuilder()
         val parsedElements = fixupFileNameElements(elements)
@@ -139,7 +144,13 @@ open class FileNameTemplate(
             when (it.first) {
                 is FileNameElement -> {
                     val e = it.first as FileNameElement
-                    fileName.append(e.getElementValue(it.second, translatorConfig))
+                    // if the file element type is the UUID, combine args
+                    val args = if (e is FileUuid) {
+                        it.second + reportId.toString()
+                    } else {
+                        it.second
+                    }
+                    fileName.append(e.getElementValue(args, translatorConfig))
                 }
                 is String -> {
                     fileName.append(it.first)

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -854,7 +854,7 @@ class Report : Logging {
             val fileName = when (translationConfig) {
                 null -> "${Schema.formBaseName(schemaName)}-$id-${formatter.format(createdDateTime)}"
                 else -> metadata.fileNameTemplates[nameFormat.lowercase()].run {
-                    this?.getFileName(translationConfig)
+                    this?.getFileName(translationConfig, id)
                         ?: "${Schema.formBaseName(schemaName)}-$id-${formatter.format(createdDateTime)}"
                 }
             }

--- a/prime-router/src/test/kotlin/FileNameTemplateTests.kt
+++ b/prime-router/src/test/kotlin/FileNameTemplateTests.kt
@@ -27,6 +27,11 @@ class FileNameTemplateTests {
         elements:
           - literal(cdcprime)
     """.trimIndent()
+    private val fileIdTemplate = """
+        ---
+        elements:
+            - uuid()
+    """.trimIndent()
     private val config = mockkClass(Hl7Configuration::class).also {
         every { it.receivingApplicationName }.returns("receiving application")
         every { it.receivingFacilityName }.returns("receiving facility")
@@ -62,6 +67,13 @@ class FileNameTemplateTests {
         val fileName = mapper.readValue<FileNameTemplate>(literal)
         val actual = fileName.getFileName(reportId = reportId)
         assertThat(actual).isEqualTo("cdcprime")
+    }
+
+    @Test
+    fun `test getting file name UUID`() {
+        val fileName = mapper.readValue<FileNameTemplate>(fileIdTemplate)
+        val actual = fileName.getFileName(reportId = reportId)
+        assertThat(actual).isEqualTo(reportId.toString())
     }
 
     @Test

--- a/prime-router/src/test/kotlin/FileNameTemplateTests.kt
+++ b/prime-router/src/test/kotlin/FileNameTemplateTests.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockkClass
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -35,6 +36,7 @@ class FileNameTemplateTests {
     private val metadata = Metadata(Metadata.defaultMetadataDirectory)
     private val dateFormat = "yyyyMMdd"
     private val formatter = DateTimeFormatter.ofPattern(dateFormat)
+    private val reportId = UUID.randomUUID()
     private var formattedDate: String? = null
 
     private fun createFileName(yaml: String): FileNameTemplate {
@@ -58,7 +60,7 @@ class FileNameTemplateTests {
     @Test
     fun `test reading literal name element from yaml`() {
         val fileName = mapper.readValue<FileNameTemplate>(literal)
-        val actual = fileName.getFileName()
+        val actual = fileName.getFileName(reportId = reportId)
         assertThat(actual).isEqualTo("cdcprime")
     }
 
@@ -82,7 +84,7 @@ class FileNameTemplateTests {
         val expected = "cdcprime_yoyodyne"
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).isEqualTo(expected)
     }
@@ -99,7 +101,7 @@ class FileNameTemplateTests {
         val expected = "cdcprime_yoyodyne"
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).isEqualTo(expected)
     }
@@ -115,7 +117,7 @@ class FileNameTemplateTests {
         """.trimIndent()
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         val actualLast6 = actual.takeLast(6)
         // assert
         assertThat(actualLast6.length).isEqualTo(6)
@@ -155,7 +157,7 @@ class FileNameTemplateTests {
         val expected = expectedStartsWith.format(offsetDt)
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).isEqualTo(expected)
     }
@@ -174,7 +176,7 @@ class FileNameTemplateTests {
         val expected = expectedStartsWith.format(offsetDt)
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).startsWith(expected)
     }
@@ -200,7 +202,7 @@ class FileNameTemplateTests {
         val expected = "cdcprime_yoyodyne"
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).isEqualTo(expected)
     }
@@ -218,7 +220,7 @@ class FileNameTemplateTests {
         val expected = "CDCPRIME_YOYODYNE"
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).isEqualTo(expected)
     }
@@ -235,7 +237,7 @@ class FileNameTemplateTests {
         val expected = "CdcPrime_yoyodyne"
         val fileName = createFileName(nameElementSerialized)
         // act
-        val actual = fileName.getFileName(translatorConfig = config)
+        val actual = fileName.getFileName(translatorConfig = config, reportId = reportId)
         // assert
         assertThat(actual).isEqualTo(expected)
     }
@@ -296,7 +298,7 @@ class FileNameTemplateTests {
             every { it.receivingOrganization }.returns("laoph")
             every { it.processingModeCode }.returns("P")
         }
-        val fileName = aphlNameFormat?.getFileName(translationConfig)
+        val fileName = aphlNameFormat?.getFileName(translationConfig, reportId = reportId)
             ?: assertk.fail("error getting file name")
         assertThat(fileName).startsWith("cdcprime_cdcprime_laoph_production_production_$formattedDate")
     }
@@ -306,7 +308,7 @@ class FileNameTemplateTests {
         val key = "ohio"
         assertThat(metadata.fileNameTemplates).containsKey(key)
         val ohioNameFormat = metadata.fileNameTemplates[key]
-        val fileName = ohioNameFormat?.getFileName(null)
+        val fileName = ohioNameFormat?.getFileName(null, reportId = reportId)
             ?: assertk.fail("error getting Ohio name")
         assertThat(fileName).startsWith("CDCPRIME_$formattedDate")
     }
@@ -322,7 +324,7 @@ class FileNameTemplateTests {
         assertThat(metadata.fileNameTemplates).containsKey(key)
         // act
         val aphlNameFormat = metadata.fileNameTemplates[key]
-        val fileName = aphlNameFormat?.getFileName(config)
+        val fileName = aphlNameFormat?.getFileName(config, reportId = reportId)
             ?: assertk.fail("error getting aphl light file name")
         // assert
         assertThat(fileName).startsWith("cdcprime_laoph_production_$formattedDate")


### PR DESCRIPTION
This PR fixes an issue where the `uuid` file name element was always returning a random UUID instead of the report ID

## Changes
- Adds logic to pass in the report Id 
- Adds logic to output the report's ID from the element
- Adds a test

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
*List GitHub issues this PR fixes*
- #1419 

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
