### PR TITLE
Fix documentation after introduction of site_of_care

### DIFF
--- a/prime-router/docs/schema_documentation/or-or-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/or-or-covid-19-hl7.md
@@ -2369,6 +2369,20 @@ The name and OID for the application sending information to the receivers
 
 ---
 
+**Name**: site_of_care
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The type of facility providing care (Hospital, Nursing Home, etc.).
+
+---
+
 **Name**: specimen_collection_date_time
 
 **Type**: DATETIME


### PR DESCRIPTION
This PR fixes the `or-or-covid-19-hl7.md` schema documentation file after introduction of site_of_care