### PR TITLE
Fixing the build not picking up build failures from build.sh

### DIFF
--- a/prime-router/build.sh
+++ b/prime-router/build.sh
@@ -134,11 +134,10 @@ echo -e "${WHITE?}INFO:${PLAIN?} Running ${ACTION?} $(get_gradle_command $*) thr
 docker-compose \
   --file "${DOCKER_COMPOSE?}" \
   run "${ACTION?}" $(get_gradle_command $*)
+RC=$?
 
 # When you're done, let's make sure you have ownership again
 ensure_build_dir
-
-RC=$?
 
 popd 2>&1 1>/dev/null
 


### PR DESCRIPTION
This hotfix makes sure that the result (i.e. Return Code/RC) returned by the `build.sh` script is the return code from the invocation of the docker run.

## What happened?
As return code of the `build.sh` script, we (erroneously) used the return code (`$?` is the return code from the immediately preceding command in bash) as returned by the invocation of the call to `ensure_build_dir` whereas we _should_ have picked up the RC immediately after the call to the `docker run` invocation.
Thus the script erroneously reported success (i.e. a return code of `0` instead of non-zero, and `1` in specific) because while the `docker run` invocation correctly reported failure, the value we picked up was the return code of `ensure_build_dir` which is always `0` (i.e. success). This meant that the build pipelines sees that `0` and goes '_cool, the build succeeded_'

## What does the fix do?
The fix polls the value of `$?` immediately after the invocation of `docker run` to make sure it's _that_ RC and that it does not get reset by the call to `ensure_build_dir`.
The fix moves picking up the value of `$?` up 1 line.