### PR TITLE
Prevent multiple deployments occurring at the same time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
       - build_frontend_release
     if: github.ref == 'refs/heads/dev-rheft'
     environment: dev
+    concurrency: dev
     runs-on: ubuntu-latest
     env:
       RESOURCE_GROUP: prime-dev-rheft
@@ -191,6 +192,7 @@ jobs:
       - build_frontend_release
     if: github.ref == 'refs/heads/master'
     environment: staging
+    concurrency: staging
     runs-on: ubuntu-latest
     env:
       RESOURCE_GROUP: prime-data-hub-staging
@@ -284,6 +286,7 @@ jobs:
       - build_frontend_release
     if: github.ref == 'refs/heads/production'
     environment: prod
+    concurrency: prod
     runs-on: ubuntu-latest
     env:
       RESOURCE_GROUP: prime-data-hub-prod


### PR DESCRIPTION
This PR adds a concurrency flag to each deployment environment, to ensure that additional deployments are queued while an active deployment is in progress.

See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency
