### PR TITLE
GitHub run_gitleaks Action Fix

### DIFF
--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -175,6 +175,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'val redoxKey = \"apiKey\"',                                                    # Environment variable name, not value
             'val secretEnvName = \"REDOX_SECRET\"',                                         # Environment variable name, not value
             'var keymap = require\(',
+            'var tokenSigningSecret = "UVD4QOJ3H295Zi9Ayl3ySuoXNKiE8WYuOsaXOZfug3dwTUVBC1ZIKRPpG5LEyZDZ"',         # Invalidated
             'xox[baprs]-([0-9a-zA-Z]{10,48})',
         ]
         paths = [

--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -34,11 +34,14 @@ title = "PRIME ReportStream Gitleaks Configuration"
         regexes = [
             '(?i)@cdc.local',
             '(?i)@email.com',
+            '(?i)@example.com',
             '(?i)@organization.tld',
             '(?i)a@cdc.gov',
             '(?i)adhelpdsk@cdc.gov',
+            '(?i)cbrown@cdc.gov',
+            '(?i)cglodosky@cdc.gov',
             '(?i)data@cdc.gov',
-            '(?i)e.ripley@weylandyutani.com',
+            '(?i)e.ripley@weyland(-)?yutani.com',
             '(?i)jbrush@avantecenters.com',
             '(?i)jj@phd.gov',
             '(?i)joe.jones@az.pima.gov',
@@ -46,10 +49,17 @@ title = "PRIME ReportStream Gitleaks Configuration"
             '(?i)noreply@cdc.gov',
             '(?i)prime@cdc.gov',
             '(?i)qom6@cdc.gov',
+            '(?i)qop5@cdc.gov',
             '(?i)qtv1@cdc.gov',
+            '(?i)que3@cdc.gov',
             '(?i)qva8@cdc.gov',
+            '(?i)qwp3@cdc.gov',
             '(?i)reportstream@cdc.gov',
+            '(?i)rhawes@cdc.gov',
+            '(?i)rheft@cdc.gov',
+            '(?i)support@(prime.)?cdc.gov',
             '(?i)support@simplereport.gov',
+            '(?i)surveillanceplatform@cdc.gov',
             '(?i)usds@cdc.gov',
             '(?i)usds@omb.eop.gov',
         ]
@@ -67,12 +77,14 @@ title = "PRIME ReportStream Gitleaks Configuration"
         ]
         regexes = [
             '(?i)e\.g\. ',                                      # The value 'e.g.' means 'example'
-            'pdhstaging-pgsql\.postgres\.database\.azure\.com', # Not a secret
-            'DB_USER=prime',                                    # Not real
-            'DB_PASSWORD=mypass(word)?',                        # Not real
+            '(?i)pass=pass',
             '(prime|changeIT!)',                                # Default cred, this is allowed (too broad??)
-            'HOST=localhost',                                   # Default cred, this is allowed (too broad??)
+            '^# ',                                              # Comment
+            'DB_PASSWORD=mypass(word)?',                        # Not real
+            'DB_USER=prime',                                    # Not real
             'gpgkey=https:\/\/packages\.microsoft\.com\/keys\/microsoft\.asc\" \| tee \/etc\/yum\.repos\.d\/azure-cli\.repo',
+            'HOST=localhost',                                   # Default cred, this is allowed (too broad??)
+            'pdhstaging-pgsql\.postgres\.database\.azure\.com', # Not a secret
         ]
 
 [[rules]]
@@ -86,9 +98,14 @@ title = "PRIME ReportStream Gitleaks Configuration"
     [rules.allowlist]
         regexes = [
             ' by option\(\"',
+            '!function\(',                                                                  # ignore this ugly thing
             '.user\(\s*\"USER\"\s*\)$',
             '''(?i)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]''',
+            '"[a-zA-Z0-9]*Authentications"',
             '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}',
+            '(apiConfig|\.json_rest_api)\(',                                                # function call
+            '(apid|api_prefix)\s+',
+            '(password|user): String = "test',
             '(patterns_to_match|key_permissions)\s*=',                                      # Terraform artifacts
             '(prime|changeIT!)',                                                            # Default cred, this is allowed (too broad??)
             '(resource|data) \"azurerm',                                                    # Terraform azure data or resource
@@ -97,39 +114,50 @@ title = "PRIME ReportStream Gitleaks Configuration"
             '\"user\":\"user1\",(\s)*\"pass\":\"pass1\"',
             '\s*=\s*validateUser\s*\(',
             '\s+KEY_VAULT_NAME\s*=\s*\"',
-            '^import (.)+ from (.)+;',                                                      # react import statement (simplified)
-            'apiConfig\(',                                                                  # function call
-            'apid\s+',
+            '^#',                                                                           # Comment
+            '^if vault secrets list \|',
+            '^import (.)+ from (.)+',                                                       # react import statement (simplified)
+            'API_ENDPOINT_HOST = "PRIME_RS_REPORTS_API_ENDPOINT_HOST",',
+            'API_ENDPOINT_HOST\"\) \?: \"localhost\"',
+            'api_url:',
+            'apiKey: \"some_key\"',
             'apiVersion',
-            'className=',                                                                   # this is HTML
+            'azure_key_vault_certificate_secret_version',                                   # Terraform artifact
+            'class(Name)?=',                                                                # this is HTML
+            'const val [A-Z]+_KEY_ALIAS = \"as2ohp\"',
             'const val apiPath = \"',
             'export USERNAME=\"client\"',
             'it\.key\.contains\(',                                                          # iterator key access
-            'KeyVaultSecret\(\"',                                                            # You are doing the right hting
+            'key(\s)*=(=)?(\s)*"(daily|docs|noModifier|noValue|receiver|security|user)"',
+            'key=value',
+            'KeyVaultSecret\(\"',                                                           # You are doing the right hting
+            'let key of \[',
+            'map-has-key',
+            'mock_secret',
             'MockResponse\(',                                                               # Explicitly listed as Mock
+            'password\" : \"text\"',
+            'Password=\"\"',                                                                # Empty anyway
             'PrincipalLevel\.USER',
-            'private const val oktaAuthorizePath = \"/oauth2/default/v1/authorize\"',
-            'private const val oktaUserInfoPath = \"/oauth2/default/v1/userinfo\"',
-            'rsa_key_(2048|4096)\s*=\s*\"pdh(prod|test|staging)-((2048|4096)-)?key\"',      # Terraform artifacts
+            'private const val CREDENTIAL_KEY_PREFIX = "credential/"',
+            'private const val okta([a-zA-Z0-9]+)Path = "/oauth2/default/v1/',
+            'private val redoxSecret = \"secret\"',
+            'rsa_key_(2048|4096)\s*=\s*\"(pdh(prod|test|staging|)|rkh-dev)-((2048|4096)-)?key\"',     # Terraform artifacts
             'SECRET_STORAGE_METHOD(\")?\s=',                                                # Method, not a secret
             'secretClient\.getSecret\(\"',
             'SecretHelper\.getSecretService\(\)\.fetchSecret\(',                            # You are fetching the secret properly
             'secretService getProperty \"',
             'secretService\.fetchSecret\(',                                                 # You are fetching the secret properly
+            'user = if \(',
+            'USER" to dbUser,',
+            'userAgent',
             'val (user|password)Variable = \"POSTGRES_(USER|PASSWORD)\"$',                  # Literal value
+            'val key = \"(ohio|aphl(_light)?|as2ohp)\"',                                    # not really secrets
             'val KEY_DB_(USER|PASSWORD|URL) = (\"|\\\")DB_(USER|URL|PASSWORD)(\"|\\\")',    # contained verbatim 'DB_(USER|PASSWORD|URL)'
-            'val KEY_PRIME_RS_API_ENDPOINT_HOST = ',                                        # Setting of the name of an environment variable name
+            'val KEY_PRIME_RS_(REPORTS_)?API_ENDPOINT_HOST = \"',                           # Setting of the name of an environment variable name
             'val redoxAuthPath = \"/auth/authenticate\"',
             'val redoxKey = \"apiKey\"',                                                    # Environment variable name, not value
             'val secretEnvName = \"REDOX_SECRET\"',                                         # Environment variable name, not value
             'xox[baprs]-([0-9a-zA-Z]{10,48})',
-            'private val redoxSecret = \"secret\"',
-            'val key = \"(ohio|aphl(_light)?|as2ohp)\"',                                    # not really secrets
-            'apiKey: \"some_key\"',
-            'API_ENDPOINT_HOST\"\) \?: \"localhost\"',
-            '!function\(',                                                                  # ignore this ugly thing
-            'Password=\"\"',                                                                # Empty anyway
-            'const val RECEIVER_KEY_ALIAS = \"as2ohp\"',
         ]
         paths = [
             '.terraform/modules/',
@@ -171,10 +199,13 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'prime-router/settings/(staging|prod)/',
         ]
         regexes = [
+            '([0-1])\.0\.0\.0',
             '\d+\.\d+\.\d+\.\d+\.',                     # Fix for bug in regex (allows trailing dots)
-            '0\.0\.0\.0',
+            '1\.1\.1\.1',                               # Public DNS
             '10\.(\d+\.){2}\d+',                        # Cheapo 10.0.0.0/8 range
             '127\.(\d+\.){2}\d+',                       # Cheapo 127.0.0.0/8 range
+            '165.225.48.87',                            # zScaler
+            '172\.(1[6-9]|2[0-9]|3[0-1])\.',            # 172.16.0.0/12 (172.16.0.0.0 -> 172.31.255.255) range is private
             'receivingApplicationOID',
             'receivingFacilityOID',
             'reportingFacilityId',
@@ -212,9 +243,10 @@ title = "PRIME ReportStream Gitleaks Configuration"
     ]
     [rules.allowlist]
         regexes = [
+            '00KPnlSG2vpP3VtKDlv5lsrYXhGEpnXmP1VABopqIX',                       # Expired/invalidated
             '658195889000001-1e837a04-7d87-4498-ac86-1476354ed257',
             'remote azuregateway-[a-f0-9]*(-[a-f0-9]+)*\.vpn\.azure\.com 443',
-            'zh\:1c8d7003aeccab39bfc9451415cef045428a5332eec4a5e5a7c0337946658f7c',
+            'zh\:',
         ]
 
 [[rules]]

--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -300,6 +300,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
     [rules.allowlist]
         commits = [
             '00bc6c1bc1f51d2375e22917e95deac6f6370694',                                     # Invalidated
+            'c07433b133225d9fa04ba763df7047545a5da217',                                     # Test Keys
         ]
 
 [[rules]]

--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -137,6 +137,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'const val [A-Z]+_KEY_ALIAS = \"as2ohp\"',
             'const val apiPath = \"',
             'const val oldApi = "/api/reports"',
+            'const val tokenApi =  "/api/token"',
             'const val watersApi = "',
             'export USERNAME=\"client\"',
             'FindSenderKeyInSettings\(',
@@ -165,6 +166,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'secretService\.fetchSecret\(',                                                 # You are fetching the secret properly
             'user = if \(',
             'USER" to dbUser,',
+            'user\)\.isEqualTo\("user"',
             'userAgent',
             'val (user|password)Variable = \"POSTGRES_(USER|PASSWORD)\"$',                  # Literal value
             'val exampleKeyId = "',

--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -36,12 +36,14 @@ title = "PRIME ReportStream Gitleaks Configuration"
             '(?i)@email.com',
             '(?i)@example.com',
             '(?i)@organization.tld',
+            '(?i)@users.noreply.github.com',
             '(?i)a@cdc.gov',
             '(?i)adhelpdsk@cdc.gov',
             '(?i)cbrown@cdc.gov',
             '(?i)cglodosky@cdc.gov',
             '(?i)data@cdc.gov',
             '(?i)e.ripley@weyland(-)?yutani.com',
+            '(?i)hello@cypress.io',
             '(?i)jbrush@avantecenters.com',
             '(?i)jj@phd.gov',
             '(?i)joe.jones@az.pima.gov',
@@ -97,14 +99,20 @@ title = "PRIME ReportStream Gitleaks Configuration"
     ]
     [rules.allowlist]
         regexes = [
+            ' \* \(The older version of this API is "/api/reports"\)',
+            ' \* since this auth (has|uses) a ',
             ' by option\(\"',
             '!function\(',                                                                  # ignore this ugly thing
             '.user\(\s*\"USER\"\s*\)$',
             '''(?i)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]''',
             '"[a-zA-Z0-9]*Authentications"',
+            '(?i)"(localnoauth)": "(true|false)"',                                          # json
+            '(?i)create type task_action as enum',
             '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}',
             '(apiConfig|\.json_rest_api)\(',                                                # function call
             '(apid|api_prefix)\s+',
+            '(capture|passive): popKey\(handler, ',
+            '(const|private) val TOKEN_SIGNING_SECRET_NAME = "TokenSigningSecret"',
             '(password|user): String = "test',
             '(patterns_to_match|key_permissions)\s*=',                                      # Terraform artifacts
             '(prime|changeIT!)',                                                            # Default cred, this is allowed (too broad??)
@@ -112,6 +120,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
             '\.containsKey\(',
             '\"user(\d)*\", \"pass(\d)*\"',                                                 # Not real creds
             '\"user\":\"user1\",(\s)*\"pass\":\"pass1\"',
+            '\s*//\s*(.)*auth(.)*',                                                         # Comment
             '\s*=\s*validateUser\s*\(',
             '\s+KEY_VAULT_NAME\s*=\s*\"',
             '^#',                                                                           # Comment
@@ -122,16 +131,23 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'api_url:',
             'apiKey: \"some_key\"',
             'apiVersion',
+            'authenticationType == "',
             'azure_key_vault_certificate_secret_version',                                   # Terraform artifact
             'class(Name)?=',                                                                # this is HTML
             'const val [A-Z]+_KEY_ALIAS = \"as2ohp\"',
             'const val apiPath = \"',
+            'const val oldApi = "/api/reports"',
+            'const val watersApi = "',
             'export USERNAME=\"client\"',
+            'FindSenderKeyInSettings\(',
+            'if \(key !== "query"',
             'it\.key\.contains\(',                                                          # iterator key access
+            'key.((starts|ends)With|substr)\(',
             'key(\s)*=(=)?(\s)*"(daily|docs|noModifier|noValue|receiver|security|user)"',
             'key=value',
             'KeyVaultSecret\(\"',                                                           # You are doing the right hting
             'let key of \[',
+            'localAuth [=!]= ',
             'map-has-key',
             'mock_secret',
             'MockResponse\(',                                                               # Explicitly listed as Mock
@@ -151,12 +167,14 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'USER" to dbUser,',
             'userAgent',
             'val (user|password)Variable = \"POSTGRES_(USER|PASSWORD)\"$',                  # Literal value
+            'val exampleKeyId = "',
             'val key = \"(ohio|aphl(_light)?|as2ohp)\"',                                    # not really secrets
             'val KEY_DB_(USER|PASSWORD|URL) = (\"|\\\")DB_(USER|URL|PASSWORD)(\"|\\\")',    # contained verbatim 'DB_(USER|PASSWORD|URL)'
             'val KEY_PRIME_RS_(REPORTS_)?API_ENDPOINT_HOST = \"',                           # Setting of the name of an environment variable name
             'val redoxAuthPath = \"/auth/authenticate\"',
             'val redoxKey = \"apiKey\"',                                                    # Environment variable name, not value
             'val secretEnvName = \"REDOX_SECRET\"',                                         # Environment variable name, not value
+            'var keymap = require\(',
             'xox[baprs]-([0-9a-zA-Z]{10,48})',
         ]
         paths = [
@@ -210,6 +228,10 @@ title = "PRIME ReportStream Gitleaks Configuration"
             'receivingFacilityOID',
             'reportingFacilityId',
         ]
+        commits = [
+            '0ee9f13f676e2ba8abf7bd9629a80ca32c5fa27c',
+            'fe2561d9165ad7602cd6e867bd4e70eca10f7413',
+        ]
 
 [[rules]]
     description = "IPv6 addresses"
@@ -243,7 +265,8 @@ title = "PRIME ReportStream Gitleaks Configuration"
     ]
     [rules.allowlist]
         regexes = [
-            '00KPnlSG2vpP3VtKDlv5lsrYXhGEpnXmP1VABopqIX',                       # Expired/invalidated
+            '//# sourceMappingURL=data:application/json;charset=utf-8;base64,',             # base64 encoding
+            '00KPnlSG2vpP3VtKDlv5lsrYXhGEpnXmP1VABopqIX',                                   # Expired/invalidated
             '658195889000001-1e837a04-7d87-4498-ac86-1476354ed257',
             'remote azuregateway-[a-f0-9]*(-[a-f0-9]+)*\.vpn\.azure\.com 443',
             'zh\:',
@@ -271,6 +294,10 @@ title = "PRIME ReportStream Gitleaks Configuration"
         "key",
         "AsymmetricPrivateKey",
     ]
+    [rules.allowlist]
+        commits = [
+            '00bc6c1bc1f51d2375e22917e95deac6f6370694',                                     # Invalidated
+        ]
 
 [[rules]]
     description = "SendGrid API Key"

--- a/.environment/gitleaks/run-gitleaks.sh
+++ b/.environment/gitleaks/run-gitleaks.sh
@@ -9,6 +9,7 @@ function usage() {
     echo "Options:"
     echo "    --no-git          Scans your current working directory as is (i.e. pretends it isn't a git repo)"
     echo "    --depth <int>     Scans the <int> (topologically) last commits of the repository"
+    echo "    --since <datespc> Scans the commits since a date (format: 'YYYY-mm-DD[THH:MM:SS-OFFSET]'"
     echo "    --help|-h         Shows this help and exits successfully"
     echo ""
     echo "Examples:"
@@ -49,6 +50,7 @@ LOGFILE="gitleaks.log"
 REPO_CONFIG_PATH=".environment/gitleaks/gitleaks-config.toml"
 
 function scan_uncommitted() {
+    note "Scanning your suggested changes."
     # NOTE: ironically, the switch to scan your staged (i.e. to be committed) changes is to use the --unstaged switch
     docker run \
         -v "${REPO_ROOT?}:${CONTAINER_SOURCE_LOCATION?}" \
@@ -65,6 +67,7 @@ function scan_uncommitted() {
 }
 
 function scan_no_git() {
+    note "Scanning the current state of the repository."
     docker run \
         -v "${REPO_ROOT?}:${CONTAINER_SOURCE_LOCATION?}" \
         "${GITLEAKS_IMG_NAME?}" \
@@ -82,6 +85,7 @@ function scan_no_git() {
 
 function scan_x_last_commits() {
     DEPTH=${1}
+    note "Scanning the last ${DEPTH?} commits."
 
     docker run \
         -v "${REPO_ROOT?}:${CONTAINER_SOURCE_LOCATION?}" \
@@ -98,6 +102,25 @@ function scan_x_last_commits() {
     return ${RC?}
 }
 
+function scan_since() {
+    SINCE=${1}
+    note "Scanning all commits since ${SINCE?}."
+
+    docker run \
+        -v "${REPO_ROOT?}:${CONTAINER_SOURCE_LOCATION?}" \
+        "${GITLEAKS_IMG_NAME?}" \
+        --path="${CONTAINER_SOURCE_LOCATION?}" \
+        --repo-config-path="${REPO_CONFIG_PATH?}" \
+        --report="${CONTAINER_SOURCE_LOCATION?}/${REPORT_JSON?}" \
+        $(if [[ ${VERBOSE?} != 0 ]]; then echo "--verbose"; else echo ""; fi) \
+        --commit-since "${SINCE?}" \
+        2>"${LOGFILE?}"
+
+    RC=$?
+
+    return ${RC?}
+}
+
 # Parse arguments
 HAS_UNRECOGNIZED=0
 
@@ -107,27 +130,39 @@ RUNMODE_STAGED_UNCOMMITTED="uncommitted"
 RUNMODE_NO_GIT="no-git"
 RUNMODE_DEPTH="depth"
 RUNMODE_DEPTH_VALUE=""
+RUNMODE_SINCE="since"
+RUNMODE_SINCE_VALUE=""
 while [[ ! -z "${1}" ]]; do
     case "${1}" in
-    "--${RUNMODE_DEPTH}")
+    "--${RUNMODE_DEPTH?}" | "--${RUNMODE_SINCE?}")
         if [[ ! -z "${SELECTED_RUNMODE?}" ]]; then
-            warning "The previously specified run-mode '${SELECTED_RUNMODE?}' will be overridden by the latest run-mode '${RUNMODE_DEPTH?}'."
+            warning "The previously specified run-mode '${SELECTED_RUNMODE?}' will be overridden by the latest run-mode '${1:2}'."
         fi
-        SELECTED_RUNMODE="${RUNMODE_DEPTH?}"
+        SELECTED_RUNMODE="${1:2}"
 
         if [[ -z "${2}" || "${2:0:1}" == "--" ]]; then
-            error "The depth to scan since (for '${RUNMODE_DEPTH?}' mode) is not defined."
+            error "The value for run-mode '${1:2}' is not defined."
             exit 1
         else
-            RUNMODE_DEPTH_VALUE="${2}"
+            case "${SELECTED_RUNMODE?}" in
+            "${RUNMODE_DEPTH?}")
+                RUNMODE_DEPTH_VALUE="${2}"
+                ;;
+            "${RUNMODE_SINCE?}")
+                RUNMODE_SINCE_VALUE="${2}"
+                ;;
+            *)
+                error "'${SELECTED_RUNMODE}' is not yet handled"
+                ;;
+            esac
 
             # We used an extra argument, shift that
             shift
         fi
         ;;
-    "--${RUNMODE_NO_GIT}")
+    "--${RUNMODE_NO_GIT?}")
         if [[ ! -z "${SELECTED_RUNMODE?}" ]]; then
-            warning "The previously specified run-mode '${SELECTED_RUNMODE?}' will be overridden by the latest run-mode '${RUNMODE_NO_GIT?}'."
+            warning "The previously specified run-mode '${SELECTED_RUNMODE?}' will be overridden by the latest run-mode '${1:2}'."
         fi
         SELECTED_RUNMODE="${RUNMODE_NO_GIT?}"
         ;;
@@ -157,7 +192,6 @@ if [[ -z "${SELECTED_RUNMODE?}" ]]; then
     SELECTED_RUNMODE="${RUNMODE_STAGED_UNCOMMITTED?}"
 fi
 
-note "Scanning your suggested changes."
 RC=1 # Nothing done, fail
 case "${SELECTED_RUNMODE?}" in
 "${RUNMODE_DEPTH?}")
@@ -166,6 +200,10 @@ case "${SELECTED_RUNMODE?}" in
     ;;
 "${RUNMODE_NO_GIT}")
     scan_no_git
+    RC=$?
+    ;;
+"${RUNMODE_SINCE?}")
+    scan_since "${RUNMODE_SINCE_VALUE?}"
     RC=$?
     ;;
 "${RUNMODE_STAGED_UNCOMMITTED?}")

--- a/.environment/gitleaks/run-gitleaks.sh
+++ b/.environment/gitleaks/run-gitleaks.sh
@@ -20,8 +20,11 @@ function usage() {
     echo "  $ ${0} --no-git"
     echo "      Runs gitleaks over the current state of the repository"
     echo ""
-    echo "  $ VERBOSE=1 ${0} --since abcd1234"
-    echo "      Runs gitleaks on the commits in your repository since abcd1234 while setting the VERBOSE flag"
+    echo "  $ ${0} --depth 10"
+    echo "      Runs gitleaks on the 10 (topologically) last commits"
+    echo ""
+    echo "  $ VERBOSE=1 ${0} --since '2021-06-01'"
+    echo "      Runs gitleaks on the commits in your repository since June 1st, 2021 while setting the VERBOSE flag"
     echo ""
     echo ""
 }

--- a/.github/workflows/run_gitleaks.yaml
+++ b/.github/workflows/run_gitleaks.yaml
@@ -14,9 +14,5 @@ jobs:
           # Fetch the full history
           fetch-depth: 0
 
-      # NOTE: we /had/ violations in the past that have been corrected,
-      # we do not want to have those false positives every single time
-      # The specified 'since' commit is a LKG (Last Known Good)
-      # See also git show <hash>
       - name: "Run Gitleaks on a selected part of our history"
-        run: .environment/gitleaks/run-gitleaks.sh --since baff524ad9d35a8dbab6e9c60a1789c6702f90a7
+        run: .environment/gitleaks/run-gitleaks.sh --depth 1000

--- a/.github/workflows/run_gitleaks.yaml
+++ b/.github/workflows/run_gitleaks.yaml
@@ -15,4 +15,4 @@ jobs:
           fetch-depth: 0
 
       - name: "Run Gitleaks on a selected part of our history"
-        run: .environment/gitleaks/run-gitleaks.sh --depth 1000
+        run: .environment/gitleaks/run-gitleaks.sh --since '2021-06-01T00:00:00-0400'


### PR DESCRIPTION
This PR changes how we run gitleaks on a schedule and fixes #1760 (linked issue for auto-close).
Scanning between commits is not reliable (yet) when there are multiple branches involved. When it's all in a single branch, then the tool can easily figure things out, but as soon as you have multiple, the tool ends up scanning an undeterministic subset of the entire history.

The fix for this is to scan since an LKG (Last Known Good) that is a date instead.

This PR introduces 2 new runmodes to the run-gitleaks script:
- `--since <datespec>`: scans commits that are created on or after this date
- `--depth <int>`: scans the last <int> commits from `HEAD` backwards

The `run_gitleaks.yml` GitHub action has been modified to use the `--since` version which now records an LKG date of the last time we had a leak. It currently uses `2021-06-01` as LKG date which at this contains roughly ~1500 commits:
```bash
$ .environment/gitleaks/run-gitleaks.sh --since '2021-06-01'; cat gitleaks.log 
Gitleaks> info: Scanning all commits since 2021-06-01.
time="2021-07-30T17:57:48Z" level=info msg="opening /repo\n"
time="2021-07-30T17:59:16Z" level=info msg="scan time: 1 minute 27 seconds 751 milliseconds 724 microseconds"
time="2021-07-30T17:59:16Z" level=info msg="commits scanned: 1457"
time="2021-07-30T17:59:16Z" level=info msg="No leaks found"
```

Lastly, this PR also whitelists some additional findings in the code that are false positives.