### PR TITLE
Speed improvements for files in UI

### DIFF
--- a/frontend/src/_includes/details_report.liquid
+++ b/frontend/src/_includes/details_report.liquid
@@ -10,7 +10,7 @@
     </ol>
   </nav>
   <h2 class="margin-top-0 margin-bottom-4">
-    <p id="download" class="margin-top-0 margin-bottom-0">Report: <span id="report-id">This is the report ID</span></p>
+    <p id="download" class="margin-top-0 margin-bottom-0">Report: <span id="report-id"></span></p>
   </h2>
 </section>
 

--- a/frontend/src/js/prime-web-receiver-pre.js
+++ b/frontend/src/js/prime-web-receiver-pre.js
@@ -248,6 +248,7 @@ async function changeOrg(event){
     debug(`org = ${event.value}`)
     window.org = event.value;
     window.sessionStorage.setItem( "oldOrg", window.org );
+    window.location.replace(`${window.location.origin}/daily-data/`);
     processOrgName();
     const details = document.querySelector("#details");
     if (details) {

--- a/frontend/src/js/prime-web-receiver-pre.js
+++ b/frontend/src/js/prime-web-receiver-pre.js
@@ -222,6 +222,7 @@ async function requestFile(reportId) {
     return window.jwt ? await axios(apiConfig(`history/report/${reportId}`))
         .then(res => res.data)
         .then(csv => {
+            debug(csv);
             // The filename to use for the download should not contain blob folders if present
             let filename = decodeURIComponent(csv.filename);
             let filenameStartIndex = filename.lastIndexOf("/");
@@ -262,8 +263,6 @@ async function changeOrg(event){
         await processReports(feed, idx);
     });
     Promise.all(promises).then(_results => debug(_results));
-
-    await processReport(await fetchReports());
 }
 
 function populateOrgDropdown() {
@@ -474,7 +473,7 @@ async function processReports(feed, idx){
         reports.forEach(_report => {
             const tBody = document.querySelector(`tBody[data-feed-name='${feed}']`);
             if (tBody) {
-                tBody.innerHTML =
+                tBody.innerHTML +=
                     `<tr>
                     <th data-title="reportId" scope="row">
                         <a href="/report-details/?${_report.reportId}" class="usa-link">${_report.reportId}</a>

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -885,6 +885,29 @@ class Report : Logging {
             }
         }
 
+        fun formExternalFilename(
+            bodyUrl: String?,
+            reportId: ReportId,
+            schemaName: String,
+            format: Format,
+            createdAt: OffsetDateTime
+        ): String {
+            // extract the filename from the blob url.
+            val filename = if (bodyUrl != null)
+                BlobAccess.BlobInfo.getBlobFilename(bodyUrl)
+            else ""
+            return filename.ifEmpty {
+                // todo: extend this to use the APHL naming convention
+                formFilename(
+                    reportId,
+                    schemaName,
+                    format,
+                    createdAt,
+                    metadata = Metadata.provideMetadata()
+                )
+            }
+        }
+
         /**
          * Takes a nullable String and trims it down to null if the string is empty
          */

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -30,8 +30,8 @@ import org.jooq.Field
 import org.jooq.JSON
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
-import org.jooq.impl.DSL.inline
 import org.jooq.impl.DSL.count
+import org.jooq.impl.DSL.inline
 import org.postgresql.Driver
 import java.sql.Connection
 import java.sql.DriverManager
@@ -628,10 +628,10 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
         val ctx = if (txn != null) DSL.using(txn) else create
         val result = ctx
             .select(
-                    COVID_RESULT_METADATA.TESTING_LAB_CLIA,
-                    COVID_RESULT_METADATA.TESTING_LAB_NAME,
-                    count(COVID_RESULT_METADATA.COVID_RESULTS_METADATA_ID).`as`("COUNT_RECORDS")
-                )
+                COVID_RESULT_METADATA.TESTING_LAB_CLIA,
+                COVID_RESULT_METADATA.TESTING_LAB_NAME,
+                count(COVID_RESULT_METADATA.COVID_RESULTS_METADATA_ID).`as`("COUNT_RECORDS")
+            )
             .from(REPORT_ANCESTORS(reportId))
             .join(COVID_RESULT_METADATA).on(REPORT_ANCESTORS.REPORT_ANCESTORS_.eq(COVID_RESULT_METADATA.REPORT_ID))
             .groupBy(


### PR DESCRIPTION
This PR removes the call to get the file header when listing the files for an organization to speed up the performance of the UI.

## Changes
- Removes the call to get the file header in order to speed up the listing of downloadable files in the UI

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
