### PR TITLE
Improved DB access docs

### DIFF
--- a/prime-router/docs/azure_database_login.md
+++ b/prime-router/docs/azure_database_login.md
@@ -16,7 +16,7 @@ az account get-access-token --resource-type oss-rdbms
 
 You will receive a response that looks like:
 
-```shell
+```json
 {
   "accessToken": "token",
   "expiresOn": "2021-04-22 16:22:54.350957",

--- a/prime-router/docs/azure_database_login.md
+++ b/prime-router/docs/azure_database_login.md
@@ -28,6 +28,8 @@ You will receive a response that looks like:
 
 Copy the value from `accessToken`. This will be your password. It will expire in one hour after request. If your token expires, run this command again.
 
+After connecting using this password, your session will remain active beyond the token expiration.
+
 ## Login to PostgreSQL
 
 Using your PostgreSQL tool of choice, login with the following details:

--- a/prime-router/docs/azure_database_login.md
+++ b/prime-router/docs/azure_database_login.md
@@ -4,19 +4,19 @@ This is the process for logging into our database via Azure Active Directory.
 
 ## Login to Azure CLI
 
-```aidl
+```shell
 az login
 ```
 
 ## Request a token for Active Directory
 
-```aidl
+```shell
 az account get-access-token --resource-type oss-rdbms
 ```
 
 You will receive a response that looks like:
 
-```aidl
+```shell
 {
   "accessToken": "token",
   "expiresOn": "2021-04-22 16:22:54.350957",
@@ -26,13 +26,14 @@ You will receive a response that looks like:
 }
 ```
 
-Copy the value from `accessToken`. This will be your password and it will expire in one hour after request. If your token expires, run this command again.
+Copy the value from `accessToken`. This will be your password. It will expire in one hour after request. If your token expires, run this command again.
 
 ## Login to PostgreSQL
 
 Using your PostgreSQL tool of choice, login with the following details:
 
 * For write / schema access: `reportstream_pgsql_admin@dbservername`
+    * Only use this if you have a specific reason
 * For read-only access: `reportstream_pgsql_developer@dbservername`
 * Password: `<the accessToken from above>`
 
@@ -40,7 +41,12 @@ Note: The tool pgAdmin is not supported at this time. [Microsoft notes access to
 
 ### Example in staging
 
-```aidl
-export PGPASSWORD=<accessToken>
-psql "host=pdhstaging-pgsql.postgres.database.azure.com user=reportstream_pgsql_admin@pdhstaging-pgsql dbname=prime_data_hub sslmode=require"
+Get your access token and set as envvar `PGPASSWORD` in one go:
+```shell
+export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms | python3 -c "import sys, json; print(json.load(sys.stdin)['accessToken'])")
+```
+
+Connect to the staging database with read-only access:
+```shell
+psql "host=pdhstaging-pgsql.postgres.database.azure.com user=reportstream_pgsql_developer@pdhstaging-pgsql dbname=prime_data_hub sslmode=require"
 ```


### PR DESCRIPTION
This PR updates our DB access docs.

## Changes
- Example uses read-only connection
- Add to example a one-liner for setting and parsing the access token
- Adds notes about session expiration
- Fixes script syntax highlighting