### PR TITLE
gitleaks: adding exclusion for commit that is about to come

### DIFF
--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -311,6 +311,9 @@ title = "PRIME ReportStream Gitleaks Configuration"
         "AsymmetricPrivateKey",
     ]
     [rules.allowlist]
+        files = [
+            'prime-router/docs/Suppress-gitleaks-false-positives.md',                       # Contains a sample of "what not to do"
+        ]
         commits = [
             '00bc6c1bc1f51d2375e22917e95deac6f6370694',                                     # Invalidated
             'c07433b133225d9fa04ba763df7047545a5da217',                                     # Test Keys

--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -311,8 +311,8 @@ title = "PRIME ReportStream Gitleaks Configuration"
         "AsymmetricPrivateKey",
     ]
     [rules.allowlist]
-        files = [
-            'prime-router/docs/Suppress-gitleaks-false-positives.md',                       # Contains a sample of "what not to do"
+        paths = [
+            'prime-router/docs/Suppress-gitleaks-false-positives\.md$',                       # Contains a sample of "what not to do"
         ]
         commits = [
             '00bc6c1bc1f51d2375e22917e95deac6f6370694',                                     # Invalidated


### PR DESCRIPTION
Adding a gitleaks exclusion for a commit (efb0f02fce90cd7117ff1b9e092afdd6c2a06de0 - not yet pushed up, will modify this code when it is) that is coming up... The gitleaks documentation contains some "stuff not to do" examples which obviously trip a gitleaks rule

Note that the file referenced in the exclusion is added by the commit, so it's not yet there...