### PR TITLE
gitleaks workflow: output the non-sensitive log after a gitleaks run

### DIFF
--- a/.github/workflows/run_gitleaks.yaml
+++ b/.github/workflows/run_gitleaks.yaml
@@ -16,3 +16,7 @@ jobs:
 
       - name: "Run Gitleaks on a selected part of our history"
         run: .environment/gitleaks/run-gitleaks.sh --since '2021-06-01T00:00:00-0400'
+
+      - name: "Output non-sensitive log"
+        if: always()
+        run: cat "gitleaks.log"


### PR DESCRIPTION
This PR adds outputting of the `gitleaks.log` that is generated by the gitleaks to the nightly `run_gitleaks.yaml` workflow. This log file does **NOT** contain the violations themselves, but it does contain metrics about the violations, thus telling us how _bad_ the run was:
- scan duration
- commits scanned
- violation count