### PR TITLE
gitleaks: fix 2021-08-10 run

### DIFF
--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -133,6 +133,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
             '^#',                                                                           # Comment
             '^if vault secrets list \|',
             '^import (.)+ from (.)+',                                                       # react import statement (simplified)
+            'aad_object_keyvault_admin = "[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}"',                           # Line contains AAD Security Group SID, not a credential
             'API_ENDPOINT_HOST = "PRIME_RS_REPORTS_API_ENDPOINT_HOST",',
             'API_ENDPOINT_HOST\"\) \?: \"localhost\"',
             'API_ENDPOINT_HOST\"\) \?: \"localhost\"',


### PR DESCRIPTION
This PR fixes the 2021-08-10 gitleaks run using a robust pattern that tripped for `aad_object_keyvault_admin` due to the presence of `key` in the name.