### PR TITLE
Enabled local JMX port and documented use of Mission Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ prime-router/.vault/env/**
 
 gitleaks.report.json
 gitleaks.log
+prime-router/src/testLoadJmeter/results.jtl

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ prime-router/.vault/env/**
 
 gitleaks.report.json
 gitleaks.log
-prime-router/src/testLoadJmeter/results.jtl
+*.jtl

--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     ports:
       - 7071:7071 # default function port
       - 5005:5005 # Java debug port
+      - 9090:9090 # Java JMX port
     networks:
       - prime-router_build
 

--- a/prime-router/docs/getting-started/java-profiling.md
+++ b/prime-router/docs/getting-started/java-profiling.md
@@ -1,10 +1,8 @@
 # Profiling ReportStream
 
 You can use the Mission Control application to monitor and manage the ReportStream 
-Java Application.  A Java Profiler is a tool that monitors Java bytecode constructs 
-and operations at the JVM level. These code constructs and operations include object 
-creation, iterative executions (including recursive calls), method executions, 
-thread executions, and garbage collections.  
+Java Application.  Mission Control can be used as a Java Profiler to monitors Java bytecode constructs 
+and operations at the JVM level.   
 
 1. Download and run the [JDK Mission Control](https://openjdk.java.net/projects/jmc/)
 or the [Azul Missing Control](https://www.azul.com/products/components/zulu-mission-control/)

--- a/prime-router/docs/getting-started/java-profiling.md
+++ b/prime-router/docs/getting-started/java-profiling.md
@@ -1,0 +1,18 @@
+# Profiling ReportStream
+
+You can use the Mission Control application to monitor and manage the ReportStream 
+Java Application.  A Java Profiler is a tool that monitors Java bytecode constructs 
+and operations at the JVM level. These code constructs and operations include object 
+creation, iterative executions (including recursive calls), method executions, 
+thread executions, and garbage collections.  
+
+1. Download and run the [JDK Mission Control](https://openjdk.java.net/projects/jmc/)
+or the [Azul Missing Control](https://www.azul.com/products/components/zulu-mission-control/)
+   
+2. Start the ReportStream local Docker container.  This container exposes port 9090 for 
+   JMX connections.
+   
+3. Start a new connection from the Mission Control application to `localhost:9090`.
+
+Once connected, you can inspect the JVM and start Flight Recording.  For more information
+you can read [this article about using the Flight Recorder and Mission Control](https://access.redhat.com/documentation/en-us/openjdk/11/pdf/using_jdk_flight_recorder_for_jdk_mission_control/OpenJDK-11-Using_JDK_Flight_Recorder_for_JDK_Mission_Control-en-US.pdf).

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -414,6 +414,7 @@ Some useful tools for Kotlin/Java development include:
 * [KTLint](https://ktlint.github.io/): the Kotlin linter that we use to format our KT code
     * Install the [IntelliJ KLint plugin](https://plugins.jetbrains.com/plugin/15057-ktlint-unofficial-) or configure it to follow standard Kotlin conventions as follows on a mac: `cd ./prime-router && brew install ktlint && ktlint applyToIDEAProject`
 * [Microsoft VSCode](https://code.visualstudio.com/Download) with the available Kotlin extension
+* [Java Profiling in ReportStream](./getting-started/java-profiling.md)
 
 # Miscelanious subjects
 

--- a/prime-router/local.settings.json
+++ b/prime-router/local.settings.json
@@ -4,7 +4,7 @@
     "WEBSITE_RUN_FROM_PACKAGE": "1",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "FUNCTIONS_EXTENSION_VERSION": "~3",
-    "JAVA_OPTS": "-Dfile.encoding=UTF-8"
+    "JAVA_OPTS": "-Dfile.encoding=UTF-8 -Dcom.sun.management.jmxremote.rmi.port=9090 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9090 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=localhost"
   },
   "ConnectionStrings": {}
 }


### PR DESCRIPTION
This PR enables JMX in the local report stream and exposes the JMX port 9090 to be used by JConsole or Mission Control.  Also added some documentation about profiling.  Note this only works locally and will not open ports in staging or prod.

Test:
1. Use Mission Control or JConsole to connect to the JVM's JMX port.

## Changes
- Enabled JMX locally to allow for profiling.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes


## To Be Done

