### PR TITLE
Bg 1828 ca onboarding

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -1007,6 +1007,7 @@
         receivingFacilityOID: 2.16.840.1.114222.4.1.214104
         suppressAoe: true
         truncateHDNamespaceIds: true
+        cliaForOutOfStateTesting: CDPH000075
       transport:
         type: SFTP
         host: sftp
@@ -1033,6 +1034,7 @@
         receivingFacilityName: CDPH CA REDIE
         receivingFacilityOID: 2.16.840.1.114222.4.3.3 .10.1.1
         messageProfileId: PHLabReport-Batch^^2.16.840.1.113883.9.10^ISO
+        cliaForOutOfStateTesting: CDPH000076
       transport:
         type: SFTP
         host: sftp

--- a/prime-router/src/main/kotlin/TranslatorConfiguration.kt
+++ b/prime-router/src/main/kotlin/TranslatorConfiguration.kt
@@ -77,6 +77,7 @@ data class Hl7Configuration
     val truncateHDNamespaceIds: Boolean = false,
     val usePid14ForPatientEmail: Boolean = false,
     val convertTimestampToDateTime: String? = null,
+    val cliaForOutOfStateTesting: String? = null,
     val phoneNumberFormatting: PhoneNumberFormatting = PhoneNumberFormatting.STANDARD,
     // pass this around as a property now
     val processingModeCode: String? = null,

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -517,7 +517,7 @@ class WorkflowEngine(
         }
 
         val hl7Serializer: Hl7Serializer by lazy {
-            Hl7Serializer(metadata)
+            Hl7Serializer(metadata, settings)
         }
 
         val redoxSerializer: RedoxSerializer by lazy {

--- a/prime-router/src/main/kotlin/cli/FileUtilities.kt
+++ b/prime-router/src/main/kotlin/cli/FileUtilities.kt
@@ -1,11 +1,7 @@
 package gov.cdc.prime.router.cli
 
 import com.github.ajalt.clikt.output.TermUi.echo
-import gov.cdc.prime.router.FakeReport
-import gov.cdc.prime.router.FileSource
-import gov.cdc.prime.router.Metadata
-import gov.cdc.prime.router.Report
-import gov.cdc.prime.router.Sender
+import gov.cdc.prime.router.*
 import gov.cdc.prime.router.serializers.CsvSerializer
 import gov.cdc.prime.router.serializers.Hl7Serializer
 import gov.cdc.prime.router.serializers.RedoxSerializer
@@ -16,6 +12,7 @@ class FileUtilities {
     companion object {
         fun createFakeFile(
             metadata: Metadata,
+            settings: SettingsProvider,
             sender: Sender,
             count: Int,
             targetStates: String? = null,
@@ -32,7 +29,7 @@ class FileUtilities {
                 targetCounties,
                 locale
             )
-            return writeReportToFile(report, format, metadata, directory, null)
+            return writeReportToFile(report, format, metadata, directory, null, settings)
         }
 
         fun createFakeReport(
@@ -56,6 +53,7 @@ class FileUtilities {
         fun writeReportsToFile(
             reports: List<Pair<Report, Report.Format>>,
             metadata: Metadata,
+            settings: SettingsProvider,
             outputDir: String?,
             outputFileName: String?,
         ) {
@@ -74,7 +72,7 @@ class FileUtilities {
                         listOf(Pair(report, format))
                     }
                 }.forEach { (report, format) ->
-                    val outputFile = writeReportToFile(report, format, metadata, outputDir, outputFileName)
+                    val outputFile = writeReportToFile(report, format, metadata, outputDir, outputFileName, settings)
                     echo(outputFile.absolutePath)
                 }
         }
@@ -85,6 +83,7 @@ class FileUtilities {
             metadata: Metadata,
             outputDir: String?,
             outputFileName: String?,
+            settings: SettingsProvider
         ): File {
             val outputFile = if (outputFileName != null) {
                 File(outputFileName)
@@ -105,7 +104,7 @@ class FileUtilities {
             }
 
             val csvSerializer = CsvSerializer(metadata)
-            val hl7Serializer = Hl7Serializer(metadata)
+            val hl7Serializer = Hl7Serializer(metadata, settings)
             val redoxSerializer = RedoxSerializer(metadata)
             outputFile.outputStream().use {
                 when (format) {

--- a/prime-router/src/main/kotlin/cli/tests/Hl7Tests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/Hl7Tests.kt
@@ -25,6 +25,7 @@ class Hl7Ingest : CoolTest() {
         ugly("Starting $name Test: send ${sender.fullName} data to $allGoodCounties")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             sender,
             itemCount,
             receivingStates,

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -644,6 +644,7 @@ class End2End : CoolTest() {
         val fakeItemCount = allGoodReceivers.size * options.items
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             fakeItemCount,
             receivingStates,
@@ -685,6 +686,7 @@ class Merge : CoolTest() {
         ugly("Starting merge test:  Merge ${options.submits} reports, each of which sends to $allGoodCounties")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             fakeItemCount,
             receivingStates,
@@ -723,6 +725,7 @@ class Hl7Null : CoolTest() {
         ugly("Starting hl7null Test: test of many threads all doing database interactions, but no sends. ")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             fakeItemCount,
             receivingStates,
@@ -842,6 +845,7 @@ class Strac : CoolTest() {
         val fakeItemCount = allGoodReceivers.size * options.items
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             stracSender,
             fakeItemCount,
             receivingStates,
@@ -898,6 +902,7 @@ class StracPack : CoolTest() {
         )
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             stracSender,
             options.items,
             receivingStates,
@@ -945,6 +950,7 @@ class Waters : CoolTest() {
         ugly("Starting Waters: sending ${options.items} Waters items to ${blobstoreReceiver.name} receiver")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             watersSender,
             options.items,
             receivingStates,
@@ -1032,6 +1038,7 @@ class HammerTime : CoolTest() {
         ugly("Starting Hammertime Test: $description")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             options.items,
             receivingStates,
@@ -1081,6 +1088,7 @@ class Garbage : CoolTest() {
         val fakeItemCount = allGoodReceivers.size * options.items
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             emptySender,
             fakeItemCount,
             receivingStates,
@@ -1161,6 +1169,7 @@ class QualityFilter : CoolTest() {
         val fakeItemCount = 5
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             emptySender,
             fakeItemCount,
             receivingStates,
@@ -1178,6 +1187,7 @@ class QualityFilter : CoolTest() {
         ugly("\nTest a QualityFilter that allows some data through")
         val file2 = FileUtilities.createFakeFile(
             metadata,
+            settings,
             emptySender,
             fakeItemCount,
             receivingStates,
@@ -1195,6 +1205,7 @@ class QualityFilter : CoolTest() {
         ugly("\nTest a QualityFilter that allows NO data through.")
         val file3 = FileUtilities.createFakeFile(
             metadata,
+            settings,
             emptySender,
             fakeItemCount,
             receivingStates,
@@ -1212,6 +1223,7 @@ class QualityFilter : CoolTest() {
         ugly("\nTest the REVERSE of the QualityFilter that allows some data through")
         val file4 = FileUtilities.createFakeFile(
             metadata,
+            settings,
             emptySender,
             fakeItemCount,
             receivingStates,
@@ -1239,6 +1251,7 @@ class Huge : CoolTest() {
         ugly("Starting huge Test: Attempting to send a report with $fakeItemCount items. This is terrapin slow.")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             fakeItemCount,
             receivingStates,
@@ -1274,6 +1287,7 @@ class TooBig : CoolTest() {
         ugly("Starting toobig test: Attempting to send a report with $fakeItemCount items. This is slllooooowww.")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             fakeItemCount,
             receivingStates,
@@ -1316,6 +1330,7 @@ class DbConnections : CoolTest() {
         ugly("Starting dbconnections Test: test of many threads attempting to sftp ${options.items} HL7s.")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             options.items,
             receivingStates,
@@ -1364,6 +1379,7 @@ class BadSftp : CoolTest() {
         ugly("Starting badsftp Test: test that our code handles sftp connectivity problems")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             options.items,
             receivingStates,
@@ -1469,6 +1485,7 @@ class InternationalContent : CoolTest() {
         ugly("Starting $name Test: send ${simpleRepSender.fullName} data to $receiverName")
         val file = FileUtilities.createFakeFile(
             metadata,
+            settings,
             simpleRepSender,
             1,
             receivingStates,
@@ -1558,6 +1575,7 @@ class SantaClaus : CoolTest() {
 
             val file = FileUtilities.createFakeFile(
                 metadata = metadata,
+                settings = settings,
                 sender = sender,
                 count = states.size,
                 format = if (sender.format == Sender.Format.CSV) Report.Format.CSV else Report.Format.HL7_BATCH,

--- a/prime-router/src/main/kotlin/cli/tests/WatersAuthTests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/WatersAuthTests.kt
@@ -94,6 +94,7 @@ class WatersAuth : CoolTest() {
         // create a fake report
         fakeReportFile = FileUtilities.createFakeFile(
             metadata,
+            settings,
             sender = savedSender,
             count = 1,
             format = Report.Format.CSV,

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -586,7 +586,6 @@ class Hl7Serializer(val metadata: Metadata) : Logging {
         // after all values have been set or blanked, check for values that need replacement
         // isNotEmpty returns true only when a value exists. Whitespace only is considered a value
         replaceValue.forEach { element ->
-
             var pathSpec = formPathSpec(element.key)
             val valueInMessage = terser.get(pathSpec) ?: ""
             if (valueInMessage.isNotEmpty()) {

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -12,17 +12,7 @@ import ca.uhn.hl7v2.parser.CanonicalModelClassFactory
 import ca.uhn.hl7v2.parser.EncodingNotSupportedException
 import ca.uhn.hl7v2.parser.ModelClassFactory
 import ca.uhn.hl7v2.util.Terser
-import gov.cdc.prime.router.Element
-import gov.cdc.prime.router.ElementAndValue
-import gov.cdc.prime.router.FileSettings
-import gov.cdc.prime.router.Hl7Configuration
-import gov.cdc.prime.router.Mapper
-import gov.cdc.prime.router.Metadata
-import gov.cdc.prime.router.Report
-import gov.cdc.prime.router.ResultDetail
-import gov.cdc.prime.router.Schema
-import gov.cdc.prime.router.Source
-import gov.cdc.prime.router.ValueSet
+import gov.cdc.prime.router.*
 import org.apache.logging.log4j.kotlin.Logging
 import java.io.InputStream
 import java.io.OutputStream
@@ -35,7 +25,10 @@ import java.time.format.DateTimeFormatter
 import java.util.Properties
 import java.util.TimeZone
 
-class Hl7Serializer(val metadata: Metadata) : Logging {
+class Hl7Serializer(
+    val metadata: Metadata,
+    val settings: SettingsProvider
+) : Logging {
     data class Hl7Mapping(
         val mappedRows: Map<String, List<String>>,
         val rows: List<RowResult>,
@@ -573,7 +566,6 @@ class Hl7Serializer(val metadata: Metadata) : Logging {
             val pathSpecTestingState = formPathSpec(testingStateField)
             val testingState = terser.get(pathSpecTestingState)
 
-            val settings = FileSettings(FileSettings.defaultSettingsDirectory)
             val stateCode = report.destination?.let { settings.findOrganization(it.organizationName)?.stateCode }
 
             if (!testingState.equals(stateCode)) {

--- a/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
+++ b/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
@@ -49,7 +49,7 @@ class WorkflowEngineTests {
             metadata,
             settings,
             csvSerializer = CsvSerializer(metadata),
-            hl7Serializer = Hl7Serializer(metadata),
+            hl7Serializer = Hl7Serializer(metadata, settings),
             redoxSerializer = RedoxSerializer(metadata),
             db = accessSpy,
             blob = blobMock,

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -17,6 +17,7 @@ import ca.uhn.hl7v2.model.v251.message.ORU_R01
 import ca.uhn.hl7v2.parser.CanonicalModelClassFactory
 import ca.uhn.hl7v2.util.Terser
 import gov.cdc.prime.router.Element
+import gov.cdc.prime.router.FileSettings
 import gov.cdc.prime.router.FileSource
 import gov.cdc.prime.router.Hl7Configuration
 import gov.cdc.prime.router.Metadata
@@ -55,10 +56,11 @@ class Hl7SerializerTests {
 
     init {
         val metadata = Metadata("./metadata")
+        val settings = FileSettings("./settings")
         val inputStream = File("./src/test/unit_test_files/fake-pdi-covid-19.csv").inputStream()
         covid19Schema = metadata.findSchema(hl7SchemaName) ?: fail("Could not find target schema")
         csvSerializer = CsvSerializer(metadata)
-        serializer = Hl7Serializer(metadata)
+        serializer = Hl7Serializer(metadata, settings)
         testReport = csvSerializer.readExternal("primedatainput/pdi-covid-19", inputStream, TestSource).report ?: fail()
         sampleHl7Message = """MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|||20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO
 SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME ReportStream|0.1-SNAPSHOT||20210210
@@ -212,7 +214,8 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test XTN phone decoding`() {
         val metadata = Metadata("./metadata")
-        val serializer = Hl7Serializer(metadata)
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
         val mockSegment = mockk<Segment>()
         val emptyPhoneField = mockk<XTN>()
@@ -305,7 +308,8 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test XTN email decoding`() {
         val metadata = Metadata("./metadata")
-        val serializer = Hl7Serializer(metadata)
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
         val mockSegment = mockk<Segment>()
         val emailField = mockk<XTN>()
@@ -349,7 +353,8 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test date time decoding`() {
         val metadata = Metadata("./metadata")
-        val serializer = Hl7Serializer(metadata)
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
         val mockSegment = mockk<Segment>()
         val mockTS = mockk<TS>()
@@ -532,7 +537,8 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test terser spec generator`() {
         val metadata = Metadata("./metadata")
-        val serializer = Hl7Serializer(metadata)
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         assertThat(serializer.getTerserSpec("MSH-1-1")).isEqualTo("/MSH-1-1")
         assertThat(serializer.getTerserSpec("PID-1")).isEqualTo("/.PID-1")
         assertThat(serializer.getTerserSpec("")).isEqualTo("/.")
@@ -541,8 +547,9 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test setTelephoneComponents for patient`() {
         val metadata = Metadata("./metadata")
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
-        val serializer = Hl7Serializer(metadata)
         every { mockTerser.set(any(), any()) } returns Unit
         every { mockTerser.get("/PATIENT_RESULT/PATIENT/PID-13(0)-2") } returns ""
 
@@ -569,8 +576,9 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test setTelephoneComponents for facility`() {
         val metadata = Metadata("./metadata")
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
-        val serializer = Hl7Serializer(metadata)
         every { mockTerser.set(any(), any()) } returns Unit
 
         val facilityPathSpec = serializer.formPathSpec("ORC-23")
@@ -601,8 +609,9 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test setCliaComponents`() {
         val metadata = Metadata("./metadata")
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
-        val serializer = Hl7Serializer(metadata)
         every { mockTerser.set(any(), any()) } returns Unit
 
         serializer.setCliaComponent(
@@ -619,8 +628,9 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test setCliaComponents in HD`() {
         val metadata = Metadata("./metadata")
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
         val mockTerser = mockk<Terser>()
-        val serializer = Hl7Serializer(metadata)
         every { mockTerser.set(any(), any()) } returns Unit
         val hl7Field = "ORC-3-3"
         val value = "dummy"
@@ -640,7 +650,8 @@ NTE|1|L|This is a final comment|RE"""
     @Test
     fun `test incorrect HL7 content`() {
         val metadata = Metadata("./metadata")
-        val serializer = Hl7Serializer(metadata)
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(metadata, settings)
 
         val emptyHL7 = ByteArrayInputStream("".toByteArray())
         var result = serializer.readExternal(hl7SchemaName, emptyHL7, TestSource)

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -109,6 +109,7 @@ NTE|1|L|This is a final comment|RE"""
             every { it.reportingFacilityName }.returns(null)
             every { it.reportingFacilityId }.returns(null)
             every { it.reportingFacilityIdType }.returns(null)
+            every { it.cliaForOutOfStateTesting }.returns(null)
         }
         val receiver = mockkClass(Receiver::class).also {
             every { it.translation }.returns(hl7Config)
@@ -603,10 +604,28 @@ NTE|1|L|This is a final comment|RE"""
         val serializer = Hl7Serializer(metadata)
         every { mockTerser.set(any(), any()) } returns Unit
 
+        val hl7Config = mockkClass(Hl7Configuration::class).also {
+            every { it.replaceValue }.returns(emptyMap())
+            every { it.format }.returns(Report.Format.HL7)
+            every { it.useTestProcessingMode }.returns(false)
+            every { it.suppressQstForAoe }.returns(false)
+            every { it.suppressAoe }.returns(false)
+            every { it.suppressHl7Fields }.returns(null)
+            every { it.useBlankInsteadOfUnknown }.returns(null)
+            every { it.convertTimestampToDateTime }.returns(null)
+            every { it.truncateHDNamespaceIds }.returns(false)
+            every { it.phoneNumberFormatting }.returns(Hl7Configuration.PhoneNumberFormatting.STANDARD)
+            every { it.usePid14ForPatientEmail }.returns(false)
+            every { it.reportingFacilityName }.returns(null)
+            every { it.reportingFacilityId }.returns(null)
+            every { it.reportingFacilityIdType }.returns(null)
+            every { it.cliaForOutOfStateTesting }.returns(null)
+        }
         serializer.setCliaComponent(
             mockTerser,
             "XYZ",
-            "OBX-23-10"
+            "OBX-23-10",
+            hl7Config
         )
 
         verify {
@@ -623,10 +642,29 @@ NTE|1|L|This is a final comment|RE"""
         val hl7Field = "ORC-3-3"
         val value = "dummy"
 
+        val hl7Config = mockkClass(Hl7Configuration::class).also {
+            every { it.replaceValue }.returns(emptyMap())
+            every { it.format }.returns(Report.Format.HL7)
+            every { it.useTestProcessingMode }.returns(false)
+            every { it.suppressQstForAoe }.returns(false)
+            every { it.suppressAoe }.returns(false)
+            every { it.suppressHl7Fields }.returns(null)
+            every { it.useBlankInsteadOfUnknown }.returns(null)
+            every { it.convertTimestampToDateTime }.returns(null)
+            every { it.truncateHDNamespaceIds }.returns(false)
+            every { it.phoneNumberFormatting }.returns(Hl7Configuration.PhoneNumberFormatting.STANDARD)
+            every { it.usePid14ForPatientEmail }.returns(false)
+            every { it.reportingFacilityName }.returns(null)
+            every { it.reportingFacilityId }.returns(null)
+            every { it.reportingFacilityIdType }.returns(null)
+            every { it.cliaForOutOfStateTesting }.returns(null)
+        }
+
         serializer.setCliaComponent(
             mockTerser,
             value,
-            hl7Field
+            hl7Field,
+            hl7Config
         )
 
         verify {

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -20,8 +20,8 @@ import gov.cdc.prime.router.Element
 import gov.cdc.prime.router.FileSource
 import gov.cdc.prime.router.Hl7Configuration
 import gov.cdc.prime.router.Metadata
-import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.Receiver
+import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.Schema
 import gov.cdc.prime.router.TestSource
 import io.mockk.every
@@ -605,27 +605,6 @@ NTE|1|L|This is a final comment|RE"""
         val serializer = Hl7Serializer(metadata)
         every { mockTerser.set(any(), any()) } returns Unit
 
-        val hl7Config = mockkClass(Hl7Configuration::class).also {
-            every { it.replaceValue }.returns(emptyMap())
-            every { it.format }.returns(Report.Format.HL7)
-            every { it.useTestProcessingMode }.returns(false)
-            every { it.suppressQstForAoe }.returns(false)
-            every { it.suppressAoe }.returns(false)
-            every { it.suppressHl7Fields }.returns(null)
-            every { it.useBlankInsteadOfUnknown }.returns(null)
-            every { it.convertTimestampToDateTime }.returns(null)
-            every { it.truncateHDNamespaceIds }.returns(false)
-            every { it.phoneNumberFormatting }.returns(Hl7Configuration.PhoneNumberFormatting.STANDARD)
-            every { it.usePid14ForPatientEmail }.returns(false)
-            every { it.reportingFacilityName }.returns(null)
-            every { it.reportingFacilityId }.returns(null)
-            every { it.reportingFacilityIdType }.returns(null)
-            every { it.cliaForOutOfStateTesting }.returns(null)
-        }
-        val receiver = mockkClass(Receiver::class).also {
-            every { it.translation }.returns(hl7Config)
-            every { it.format }.returns(Report.Format.HL7)
-        }
         serializer.setCliaComponent(
             mockTerser,
             "XYZ",
@@ -645,29 +624,6 @@ NTE|1|L|This is a final comment|RE"""
         every { mockTerser.set(any(), any()) } returns Unit
         val hl7Field = "ORC-3-3"
         val value = "dummy"
-
-        val hl7Config = mockkClass(Hl7Configuration::class).also {
-            every { it.replaceValue }.returns(emptyMap())
-            every { it.format }.returns(Report.Format.HL7)
-            every { it.useTestProcessingMode }.returns(false)
-            every { it.suppressQstForAoe }.returns(false)
-            every { it.suppressAoe }.returns(false)
-            every { it.suppressHl7Fields }.returns(null)
-            every { it.useBlankInsteadOfUnknown }.returns(null)
-            every { it.convertTimestampToDateTime }.returns(null)
-            every { it.truncateHDNamespaceIds }.returns(false)
-            every { it.phoneNumberFormatting }.returns(Hl7Configuration.PhoneNumberFormatting.STANDARD)
-            every { it.usePid14ForPatientEmail }.returns(false)
-            every { it.reportingFacilityName }.returns(null)
-            every { it.reportingFacilityId }.returns(null)
-            every { it.reportingFacilityIdType }.returns(null)
-            every { it.cliaForOutOfStateTesting }.returns(null)
-        }
-
-        val receiver = mockkClass(Receiver::class).also {
-            every { it.translation }.returns(hl7Config)
-            every { it.format }.returns(Report.Format.HL7)
-        }
 
         serializer.setCliaComponent(
             mockTerser,

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -109,11 +109,12 @@ NTE|1|L|This is a final comment|RE"""
             every { it.reportingFacilityName }.returns(null)
             every { it.reportingFacilityId }.returns(null)
             every { it.reportingFacilityIdType }.returns(null)
-            every { it.cliaForOutOfStateTesting }.returns(null)
+            every { it.cliaForOutOfStateTesting }.returns("1234FAKECLIA")
         }
         val receiver = mockkClass(Receiver::class).also {
             every { it.translation }.returns(hl7Config)
             every { it.format }.returns(Report.Format.HL7)
+            every { it.organizationName }.returns("ca-dph")
         }
 
         val testReport = csvSerializer.readExternal(schema, inputStream, listOf(TestSource), receiver).report ?: fail()
@@ -621,11 +622,14 @@ NTE|1|L|This is a final comment|RE"""
             every { it.reportingFacilityIdType }.returns(null)
             every { it.cliaForOutOfStateTesting }.returns(null)
         }
+        val receiver = mockkClass(Receiver::class).also {
+            every { it.translation }.returns(hl7Config)
+            every { it.format }.returns(Report.Format.HL7)
+        }
         serializer.setCliaComponent(
             mockTerser,
             "XYZ",
-            "OBX-23-10",
-            hl7Config
+            "OBX-23-10"
         )
 
         verify {
@@ -660,11 +664,15 @@ NTE|1|L|This is a final comment|RE"""
             every { it.cliaForOutOfStateTesting }.returns(null)
         }
 
+        val receiver = mockkClass(Receiver::class).also {
+            every { it.translation }.returns(hl7Config)
+            every { it.format }.returns(Report.Format.HL7)
+        }
+
         serializer.setCliaComponent(
             mockTerser,
             value,
-            hl7Field,
-            hl7Config
+            hl7Field
         )
 
         verify {

--- a/prime-router/src/testIntegration/kotlin/datatests/TranslationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/datatests/TranslationTests.kt
@@ -41,6 +41,11 @@ class TranslationTests {
     private val metadata = Metadata("./metadata")
 
     /**
+     * The settings
+     */
+    private val settings = FileSettings("./settings")
+
+    /**
      * The translator
      */
     private val translator = Translator(metadata, FileSettings(FileSettings.defaultSettingsDirectory))
@@ -221,7 +226,7 @@ class TranslationTests {
 
             return when (format) {
                 Report.Format.HL7 -> {
-                    val readResult = Hl7Serializer(metadata).readExternal(
+                    val readResult = Hl7Serializer(metadata, settings).readExternal(
                         schema.name,
                         input,
                         TestSource
@@ -263,8 +268,8 @@ class TranslationTests {
         ): InputStream {
             val outputStream = ByteArrayOutputStream()
             when (format) {
-                Report.Format.HL7_BATCH -> Hl7Serializer(metadata).writeBatch(report, outputStream)
-                Report.Format.HL7 -> Hl7Serializer(metadata).write(report, outputStream)
+                Report.Format.HL7_BATCH -> Hl7Serializer(metadata, settings).writeBatch(report, outputStream)
+                Report.Format.HL7 -> Hl7Serializer(metadata, settings).write(report, outputStream)
                 Report.Format.INTERNAL -> CsvSerializer(metadata).writeInternal(report, outputStream)
                 else -> CsvSerializer(metadata).write(report, outputStream)
             }


### PR DESCRIPTION
This PR adds a property to the translation configuration to chance the CLIA number for testing completed outside the state of the receiver.

## Changes
- Property added to HL7 Configuration (cliaForOutOfStateTesting) accepting a string value
- Reviews the StateCode set in the organizations.yml for the receiver against the Performing Organization State (OBX-24.4) value. When those values are different, the replacement CLIA is set only in MSH-4.2.
- Set the property for California's primary feed and secondary feed

## Checklist

### Testing
- [X] Tested locally?
- [x] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [X] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
*List GitHub issues this PR fixes*
- #1828 
- #1788 

