### PR TITLE
Move cue out of Training mode

### DIFF
--- a/prime-router/docs/schema_documentation/direct-cue-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-cue-covid-19.md
@@ -1424,7 +1424,7 @@ Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
 
 **PII**: No
 
-**Default Value**: T
+**Default Value**: P
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/direct/cue-covid-19.schema
+++ b/prime-router/metadata/schemas/direct/cue-covid-19.schema
@@ -11,6 +11,5 @@ elements:
     default: CueHlth
 
   - name: processing_mode_code
-    default: T
-
+    default: P
 

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -165,7 +165,7 @@ Examples:
         val problem: Boolean = when (env) {
             "staging" -> !dbEnv.contains("pdhstaging")
             "test" -> !dbEnv.contains("pdhtest")
-            "local" -> !dbEnv.contains("postgresql") && !dbEnv.contains("localhost")
+            "local" -> !dbEnv.contains("postgresql") || !dbEnv.contains("localhost")
             "prod" -> !dbEnv.contains("pdhprod")
             else -> true
         }


### PR DESCRIPTION
This PR moves Cue out of Training mode.  Also fixed a minor bug in TestReportStream

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Specific Security-related subjects a reviewer should pay specific attention to
**None apply.**

- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

