### PR TITLE
Changed to use docker-compose

### DIFF
--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -369,7 +369,7 @@ When invoked with `--prune-volumes`, this script will also reset your PostgreSQL
 ## Resetting the Database
 1. Stop your ReportStream container if it is running.
     ```bash
-    docker compose down
+    docker-compose down
     ```
 1. Run the following command to delete all ReportStream related tables from the database and recreate them.  This
 is very useful to reset your database to a clean state.  Note that the database will be re-populated the


### PR DESCRIPTION
This PR changes `docker compose` to `docker-compose` in the getting started document.  This is relates to PR https://github.com/CDCgov/prime-reportstream/pull/1843, but it was merged before completing all requested changes.