### PR TITLE
Add GitHub Actions for automatic deployment branches (closes #1851)

### DIFF
--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set Environment Variables
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
-          echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%HH%MM%SS)
+          echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%H%M%S)
 
       - name: Output Branch Name
         # TODO: de-uniquify the branch name (this is here for testing purposes)

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -22,13 +22,14 @@ jobs:
         # 86400: seconds in a 24h time-window
         run: |
           let TOMORROWS_SECONDS_SINCE_EPOCH=$(date +%s)+86400
-          echo >> $GITHUB_ENV DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH} +%Y-%m-%d)
-          echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-${DEPLOYMENT_DATE}
+          echo >> ${GITHUB_ENV} DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH?} +%Y-%m-%d)
+          echo >> ${GITHUB_ENV} BRANCH_NAME=td/WIP-ignore-deployment-${DEPLOYMENT_DATE?}
 
       - name: Output Branch Name
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
+          cat "${GITHUB_ENV?}"
 
       - name: "Create deployment branch"
         uses: peterjgrainger/action-create-branch@v2.0.1

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -22,14 +22,15 @@ jobs:
         # 86400: seconds in a 24h time-window
         run: |
           let TOMORROWS_SECONDS_SINCE_EPOCH=$(date +%s)+86400
-          echo >> ${GITHUB_ENV} DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH?} +%Y-%m-%d)
+          DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH} +%Y-%m-%d)
+          echo >> ${GITHUB_ENV} DEPLOYMENT_DATE=${DEPLOYMENT_DATE?}
           echo >> ${GITHUB_ENV} BRANCH_NAME=td/WIP-ignore-deployment-${DEPLOYMENT_DATE?}
 
       - name: Output Branch Name
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
-          cat "${GITHUB_ENV?}"
+          cat "${GITHUB_ENV}"
 
       - name: "Create deployment branch"
         uses: peterjgrainger/action-create-branch@v2.0.1

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -32,12 +32,12 @@ jobs:
           echo "Branch name: \"${BRANCH_NAME}\""
           cat "${GITHUB_ENV}"
 
-      # - name: "Create deployment branch"
-      #   uses: peterjgrainger/action-create-branch@v2.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     branch: "${{ env.BRANCH_NAME }}"
+      - name: "Create deployment branch"
+        uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: "${{ env.BRANCH_NAME }}"
 
       - name: "Create PR from deployment branch into production"
         id: cpr

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -40,14 +40,23 @@ jobs:
           branch: "${{ env.BRANCH_NAME }}"
 
       - name: "Prepare a Pull Request from ${{ env.BRANCH_NAME }} into target branch" # TODO: Fix name
+        uses: k3rnels-actions/pr-update@v1
         id: pr
-        uses: sudoStatus200/create-sync-pr@0.3.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_BRANCH: "${{ env.BRANCH_NAME }}"
-          TARGET_BRANCH: "td/IGNORE-dest-1"     # TODO: Change this to production
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "[Deployment on $${{ env.DEPLOYMENT_DATE }}]"
+          pr_source: "${{ env.BRANCH_NAME }}"
+          pr_target: "td/IGNORE-dest-1" # TODO Change this to production
+          pr_labels: devops,chore
+          pr_assignees: td-usds
+          pr_body: |
+            ## Deployment of ${{ env.DEPLOYMENT_DATE }}
+            This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}
+
+            - Sample
+            - Other
 
       - name: "Produce Pull Request URL"
         run: |
-          echo "PR URL:       ${{ steps.pr.outputs.PULL_REQUEST_URL }}"
-          echo "PR Id:        ${{ steps.pr.outputs.PULL_REQUEST_NUMBER }}"
+          echo "PR URL:       https://github.com/CDCgov/prime-reportstream/pull/${{ steps.pr.outputs.pr_nr }}"
+          echo "PR Id:        ${{ steps.pr.outputs.pr_nr }}"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   prepare_branch:
-    name: Prepare the deployment branch
+    name: "Prepare the deployment branch and file a PR"
     runs-on: ubuntu-latest
     steps:
       - name: "Check out changes"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -15,16 +15,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Environment Variables
-        # TODO: de-uniquify the branch name (this is here for testing purposes)
         # 86400: seconds in a 24h time-window
         run: |
           let TOMORROWS_SECONDS_SINCE_EPOCH=$(date +%s)+86400
           DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH} +%Y-%m-%d)
           echo >> ${GITHUB_ENV} DEPLOYMENT_DATE=${DEPLOYMENT_DATE?}
-          echo >> ${GITHUB_ENV} BRANCH_NAME=td/WIP-ignore-deployment-${DEPLOYMENT_DATE?}
+          echo >> ${GITHUB_ENV} BRANCH_NAME=deployment/${DEPLOYMENT_DATE?}
 
       - name: Output Branch Name
-        # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
 
@@ -35,14 +33,14 @@ jobs:
         with:
           branch: "${{ env.BRANCH_NAME }}"
 
-      - name: "Prepare a Pull Request from ${{ env.BRANCH_NAME }} into target branch" # TODO: Fix name
+      - name: "Prepare a Pull Request from ${{ env.BRANCH_NAME }} into production branch"
         uses: k3rnels-actions/pr-update@v1
         id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pr_title: "Deployment of ${{ env.DEPLOYMENT_DATE }}"
           pr_source: "${{ env.BRANCH_NAME }}"
-          pr_target: "td/IGNORE-dest-1" # TODO Change this to production
+          pr_target: "production"
           pr_labels: devops,chore,deployment
           pr_assignees: td-usds
           pr_body: |

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -42,7 +42,7 @@ jobs:
           pr_source: "${{ env.BRANCH_NAME }}"
           pr_target: "production"
           pr_labels: devops,chore,deployment
-          pr_assignees: td-usds
+          # pr_assignees: td-usds
           pr_body: |
             ## Deployment of ${{ env.DEPLOYMENT_DATE }}
             This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}.

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -20,7 +20,9 @@ jobs:
       - name: Set Environment Variables
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
-          echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%H%M%S)
+          let TOMORROWS_SECONDS_SINCE_EPOCH=$(date +%s)+(60*60*24)
+          echo >> $GITHUB_ENV DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH} +%Y-%m-%d)
+          echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-${DEPLOYMENT_DATE}
 
       - name: Output Branch Name
         # TODO: de-uniquify the branch name (this is here for testing purposes)
@@ -35,10 +37,10 @@ jobs:
           branch: "${{ env.BRANCH_NAME }}"
 
       - name: "Create PR from deployment branch into production"
-        uses: poorva17/create-pr-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_BRANCH: "${{ env.BRANCH_NAME }}"
-          # NOTE: Created for the sole purpose to NOT go against production during testing
-          # TODO: Change this to 'production' once we validate that the PR is a PR and not a merge
-          BASE_BRANCH: "td/1851-target-ignore"
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: td-usds
+          title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
+          body: |
+            This PR contains the deployment for ${{ env.DEPLOYMENT_DATE }}

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -44,7 +44,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "td/1851-target-ignore"
+          base: "td/auto-branch-1851"             # TODO: make this master (the 'from')
+          branch: "td/1851-target-ignore"         # TODO: make this production (the 'to')
           assignees: td-usds
           title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
           body: |

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -37,10 +37,16 @@ jobs:
           branch: "${{ env.BRANCH_NAME }}"
 
       - name: "Create PR from deployment branch into production"
+        id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "td/1851-target-ignore"
           assignees: td-usds
           title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
           body: |
             This PR contains the deployment for ${{ env.DEPLOYMENT_DATE }}
+
+      - name: "Produce Pull Request URL"
+        run: |
+          echo "Created Pull Request: ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo >> $GITHUB_ENV $BRANCH_NAME=ignore-deployment-$(date +%Y-%m-%d)
+          echo "Branch name: \"${BRANCH_NAME}\""
 
       - name: "Create deployment branch"
         uses: peterjgrainger/action-create-branch@v2.0.1
@@ -28,9 +29,11 @@ jobs:
         with:
           branch: "${{ env.BRANCH_NAME }}"
 
-      # - name: "Create PR from deployment branch into production"
-      #   uses: poorva17/create-pr-action@main
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     HEAD_BRANCH: "${{ env.BRANCH_NAME }}"
-      #     BASE_BRANCH: "production"
+      - name: "Create PR from deployment branch into production"
+        uses: poorva17/create-pr-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: "${{ env.BRANCH_NAME }}"
+          # NOTE: Created for the sole purpose to NOT go against production during testing
+          # TODO: Change this to 'production' once we validate that the PR is a PR and not a merge
+          BASE_BRANCH: "td/1851-target-ignore"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: "td/auto-branch-1851"             # TODO: make this master (the 'from')
-          branch: "td/1851-target-ignore"         # TODO: make this production (the 'to')
+          branch: "td/1851-target-2-ignore"       # TODO: make this production (the 'to')
           assignees: td-usds
           title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
           body: |

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -18,6 +18,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Environment Variables
+        run: |
+          if [ "$GITHUB_BASE_REF" == "production" ]
+          then
+              echo "Building for the production environment."
+              echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
+              echo >> $GITHUB_ENV PREFIX=pdhprod
+          else
+              echo "Building for the test environment."
+              echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
+              echo >> $GITHUB_ENV PREFIX=pdhstaging
+          fi
+
+      - name: Set Environment Variables
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo >> $GITHUB_ENV $BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%HH%MM%SS)
@@ -26,6 +39,7 @@ jobs:
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
+          export
 
       - name: "Create deployment branch"
         uses: peterjgrainger/action-create-branch@v2.0.1

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,13 +1,10 @@
 name: "WIP - Prepare the deployment branch"
 
 on:
-  push:
-    branches:
-      - "td/auto-branch-1851"
-  # schedule:
-  #   # At 16:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
-  #   # GitHub actions run in UTC (and EDT is UTC-4)
-  #   - cron: "0 16 * * 1,3"
+  schedule:
+    # At 16:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
+    # GitHub actions run in UTC (and EDT is UTC-4)
+    - cron: "0 16 * * 1,3"
 
 jobs:
   prepare_branch:

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -47,7 +47,7 @@ jobs:
           pr_title: "Deployment on ${{ env.DEPLOYMENT_DATE }}"
           pr_source: "${{ env.BRANCH_NAME }}"
           pr_target: "td/IGNORE-dest-1" # TODO Change this to production
-          pr_labels: devops,chore
+          pr_labels: devops,chore,deployment
           pr_assignees: td-usds
           pr_body: |
             ## Deployment of ${{ env.DEPLOYMENT_DATE }}

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,9 +1,9 @@
 name: "WIP - Prepare the deployment branch"
 
 on:
-  pull_request:
+  push:
     branches:
-      - "td/1851-target-ignore"
+      - "td/auto-branch-1851"
   # schedule:
   #   # At 16:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
   #   # GitHub actions run in UTC (and EDT is UTC-4)

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -43,7 +43,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          # token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           base: "td/auto-branch-1851"             # TODO: make this master (the 'from')
           branch: "${{ env.BRANCH_NAME }}"       # TODO: make this production (the 'to')
           assignees: td-usds

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -53,8 +53,6 @@ jobs:
             ## Deployment of ${{ env.DEPLOYMENT_DATE }}
             This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}
 
-            - duplicate run
-
       - name: "Produce Pull Request URL"
         run: |
           echo "PR URL:       https://github.com/CDCgov/prime-reportstream/pull/${{ steps.pr.outputs.pr_nr }}"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -44,8 +44,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          base: "td/auto-branch-1851"             # TODO: make this master (the 'from')
-          branch: "${{ env.BRANCH_NAME }}"       # TODO: make this production (the 'to')
+          base: "${{ env.BRANCH_NAME }}" # TODO: make this master (the 'from')
+          branch: "td/IGNORE-dest-1" # TODO: make this production (the 'to')
           assignees: td-usds
           title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
           body: |

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -32,20 +32,20 @@ jobs:
           echo "Branch name: \"${BRANCH_NAME}\""
           cat "${GITHUB_ENV}"
 
-      - name: "Create deployment branch"
-        uses: peterjgrainger/action-create-branch@v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          branch: "${{ env.BRANCH_NAME }}"
+      # - name: "Create deployment branch"
+      #   uses: peterjgrainger/action-create-branch@v2.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     branch: "${{ env.BRANCH_NAME }}"
 
       - name: "Create PR from deployment branch into production"
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # token: ${{ secrets.GITHUB_TOKEN }}
           base: "td/auto-branch-1851"             # TODO: make this master (the 'from')
-          branch: "td/1851-target-2-ignore"       # TODO: make this production (the 'to')
+          branch: "${{ env.BRANCH_NAME }}"       # TODO: make this production (the 'to')
           assignees: td-usds
           title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
           body: |
@@ -53,4 +53,6 @@ jobs:
 
       - name: "Produce Pull Request URL"
         run: |
-          echo "Created Pull Request: ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "PR Operation: ${{ steps.cpr.outputs.pull-request-operation }}"
+          echo "PR URL:       ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "PR Id:        ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -21,6 +21,10 @@ jobs:
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo >> $GITHUB_ENV $BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%HH%MM%SS)
+
+      - name: Output Branch Name
+        # TODO: de-uniquify the branch name (this is here for testing purposes)
+        run: |
           echo "Branch name: \"${BRANCH_NAME}\""
 
       - name: "Create deployment branch"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -42,7 +42,7 @@ jobs:
           pr_source: "${{ env.BRANCH_NAME }}"
           pr_target: "production"
           pr_labels: devops,chore,deployment
-          # pr_assignees: td-usds
+          pr_assignees: jimduff-usds,MauriceReeves-usds,RickHawesUSDS,carlosfelix2,ronaldheft-usds
           pr_body: |
             ## Deployment of ${{ env.DEPLOYMENT_DATE }}
             This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}.

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -30,7 +30,6 @@ jobs:
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
-          cat "${GITHUB_ENV}"
 
       - name: "Create a new branch that contains the changes to go into the deployment"
         uses: peterjgrainger/action-create-branch@v2.0.1
@@ -44,14 +43,14 @@ jobs:
         id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: "Deployment on ${{ env.DEPLOYMENT_DATE }}"
+          pr_title: "Deployment of ${{ env.DEPLOYMENT_DATE }}"
           pr_source: "${{ env.BRANCH_NAME }}"
           pr_target: "td/IGNORE-dest-1" # TODO Change this to production
           pr_labels: devops,chore,deployment
           pr_assignees: td-usds
           pr_body: |
             ## Deployment of ${{ env.DEPLOYMENT_DATE }}
-            This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}
+            This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}.
 
       - name: "Produce Pull Request URL"
         run: |

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -32,27 +32,22 @@ jobs:
           echo "Branch name: \"${BRANCH_NAME}\""
           cat "${GITHUB_ENV}"
 
-      - name: "Create deployment branch"
+      - name: "Create a new branch that contains the changes to go into the deployment"
         uses: peterjgrainger/action-create-branch@v2.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: "${{ env.BRANCH_NAME }}"
 
-      - name: "Create PR from deployment branch into production"
-        id: cpr
-        uses: peter-evans/create-pull-request@v3
+      - name: "Prepare a Pull Request from ${{ env.BRANCH_NAME }} into target branch" # TODO: Fix name
+        id: pr
+        uses: sudoStatus200/create-sync-pr@0.3.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: "${{ env.BRANCH_NAME }}" # TODO: make this master (the 'from')
-          branch: "td/IGNORE-dest-1" # TODO: make this production (the 'to')
-          assignees: td-usds
-          title: "[Deployment] Deployment branch for ${{ env.DEPLOYMENT_DATE }}"
-          body: |
-            This PR contains the deployment for ${{ env.DEPLOYMENT_DATE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_BRANCH: "${{ env.BRANCH_NAME }}"
+          TARGET_BRANCH: "td/IGNORE-dest-1"     # TODO: Change this to production
 
       - name: "Produce Pull Request URL"
         run: |
-          echo "PR Operation: ${{ steps.cpr.outputs.pull-request-operation }}"
-          echo "PR URL:       ${{ steps.cpr.outputs.pull-request-url }}"
-          echo "PR Id:        ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "PR URL:       ${{ steps.pr.outputs.PULL_REQUEST_URL }}"
+          echo "PR Id:        ${{ steps.pr.outputs.PULL_REQUEST_NUMBER }}"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -44,7 +44,7 @@ jobs:
         id: pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: "[Deployment on $${{ env.DEPLOYMENT_DATE }}]"
+          pr_title: "Deployment on ${{ env.DEPLOYMENT_DATE }}"
           pr_source: "${{ env.BRANCH_NAME }}"
           pr_target: "td/IGNORE-dest-1" # TODO Change this to production
           pr_labels: devops,chore

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,4 +1,4 @@
-name: "Create a deployment branch in preparation of the upcoming scheduled deployment"
+name: "Prepare Deployment Branch"
 
 on:
   schedule:

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,4 +1,4 @@
-name: "WIP - Prepare the deployment branch"
+name: "Create a deployment branch in preparation of the upcoming scheduled deployment"
 
 on:
   schedule:

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -49,5 +49,5 @@ jobs:
 
       - name: "Produce Pull Request URL"
         run: |
-          echo "PR URL:       https://github.com/CDCgov/prime-reportstream/pull/${{ steps.pr.outputs.pr_nr }}"
-          echo "PR Id:        ${{ steps.pr.outputs.pr_nr }}"
+          echo "PR URL: https://github.com/CDCgov/prime-reportstream/pull/${{ steps.pr.outputs.pr_nr }}"
+          echo "PR Id:  ${{ steps.pr.outputs.pr_nr }}"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
 
-      - name: "Create a new branch that contains the changes to go into the deployment"
+      - name: "Create branch '${{ env.BRANCH_NAME }}' to contain the changes for the deployment on ${{ env.DEPLOYMENT_DATE }}"
         uses: peterjgrainger/action-create-branch@v2.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -19,8 +19,9 @@ jobs:
 
       - name: Set Environment Variables
         # TODO: de-uniquify the branch name (this is here for testing purposes)
+        # 86400: seconds in a 24h time-window
         run: |
-          let TOMORROWS_SECONDS_SINCE_EPOCH=$(date +%s)+(60*60*24)
+          let TOMORROWS_SECONDS_SINCE_EPOCH=$(date +%s)+86400
           echo >> $GITHUB_ENV DEPLOYMENT_DATE=$(date --date=@${TOMORROWS_SECONDS_SINCE_EPOCH} +%Y-%m-%d)
           echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-${DEPLOYMENT_DATE}
 

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -18,28 +18,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Environment Variables
-        run: |
-          if [ "$GITHUB_BASE_REF" == "production" ]
-          then
-              echo "Building for the production environment."
-              echo >> $GITHUB_ENV ACR_REPO=pdhprodcontainerregistry.azurecr.io
-              echo >> $GITHUB_ENV PREFIX=pdhprod
-          else
-              echo "Building for the test environment."
-              echo >> $GITHUB_ENV ACR_REPO=pdhstagingcontainerregistry.azurecr.io
-              echo >> $GITHUB_ENV PREFIX=pdhstaging
-          fi
-
-      - name: Set Environment Variables
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
-          echo >> $GITHUB_ENV $BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%HH%MM%SS)
+          echo >> $GITHUB_ENV BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%HH%MM%SS)
 
       - name: Output Branch Name
         # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
           echo "Branch name: \"${BRANCH_NAME}\""
-          export
 
       - name: "Create deployment branch"
         uses: peterjgrainger/action-create-branch@v2.0.1

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,4 +1,4 @@
-name: "Prepare the deployment branch"
+name: "WIP - Prepare the deployment branch"
 
 on:
   pull_request:

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -6,7 +6,7 @@ on:
       - "td/auto-branch-1851"
   # schedule:
   #   # At 16:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
-  #   # GitHub actions run in UTC
+  #   # GitHub actions run in UTC (and EDT is UTC-4)
   #   - cron: "0 16 * * 1,3"
 
 jobs:

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,0 +1,36 @@
+name: "Prepare the deployment branch"
+
+on:
+  pull_request:
+    branches:
+      - "td/auto-branch-1851"
+  # schedule:
+  #   # At 16:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
+  #   # GitHub actions run in UTC
+  #   - cron: "0 16 * * 1,3"
+
+jobs:
+  prepare_branch:
+    name: Prepare the deployment branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out changes"
+        uses: actions/checkout@v2
+
+      - name: Set Environment Variables
+        run: |
+          echo >> $GITHUB_ENV $BRANCH_NAME=ignore-deployment-$(date +%Y-%m-%d)
+
+      - name: "Create deployment branch"
+        uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: "${{ env.BRANCH_NAME }}"
+
+      # - name: "Create PR from deployment branch into production"
+      #   uses: poorva17/create-pr-action@main
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     HEAD_BRANCH: "${{ env.BRANCH_NAME }}"
+      #     BASE_BRANCH: "production"

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -53,8 +53,7 @@ jobs:
             ## Deployment of ${{ env.DEPLOYMENT_DATE }}
             This PR contains the changes that will go into the deployment scheduled for ${{ env.DEPLOYMENT_DATE }}
 
-            - Sample
-            - Other
+            - duplicate run
 
       - name: "Produce Pull Request URL"
         run: |

--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -3,7 +3,7 @@ name: "WIP - Prepare the deployment branch"
 on:
   pull_request:
     branches:
-      - "td/auto-branch-1851"
+      - "td/1851-target-ignore"
   # schedule:
   #   # At 16:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
   #   # GitHub actions run in UTC (and EDT is UTC-4)
@@ -18,8 +18,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Environment Variables
+        # TODO: de-uniquify the branch name (this is here for testing purposes)
         run: |
-          echo >> $GITHUB_ENV $BRANCH_NAME=ignore-deployment-$(date +%Y-%m-%d)
+          echo >> $GITHUB_ENV $BRANCH_NAME=td/WIP-ignore-deployment-$(date +%Y-%m-%d_%HH%MM%SS)
           echo "Branch name: \"${BRANCH_NAME}\""
 
       - name: "Create deployment branch"


### PR DESCRIPTION
This PR introduces a GitHub Action that prepares some logistics in anticipation of the scheduled deployments; these deployments happen on Tuesdays and Thursdays. The GitHub Action runs ahead of these days on the following schedule:
- Monday at 16:00 UTC (noon ET)
- Wednesday at 16:00 UTC (noon ET)

When the Action runs, it does the following:
1. A new branch called `deployment/<DEPLOYMENT_DATE>` is spun off from `master` (note that the deployment date is the date of the deployment, not the date of the branching)
2. A new PR (using the [k3rnels/pr-update](https://github.com/marketplace/actions/pr-update) action) is created and tagged with `chore`, `deployment`, `devops` to go from `deployment/<DEPLOYMENT_DATE>` (and thus effectively that snapshot from `master`@noon on the snapshot day) into `production`.

Example created PRs during testing (marked as closed because they were test PRs - note that the target branch will 404 on you because it has since been deleted):
- https://github.com/CDCgov/prime-reportstream/pull/1894
- https://github.com/CDCgov/prime-reportstream/pull/1893
- https://github.com/CDCgov/prime-reportstream/pull/1892

# Outstanding Questions
- Q: We can assign the PR to whomever we want (including multiple folks), who should that be (Mo, Jim, ...)?

This PR closes #1851.