### PR TITLE
Add Reddy FMC to the HHSProtect jurisdictional filter

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -1368,7 +1368,7 @@
     - name: "elr"
       organizationName: "hhsprotect"
       topic: "covid-19"
-      jurisdictionalFilter: [ "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*,Strac,InBios)" ]
+      jurisdictionalFilter: [ "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*,Strac,InBios,reddyfmc)" ]
       qualityFilter: [ "allowAll()" ]
       translation:
         type: "CUSTOM"

--- a/prime-router/settings/prod/0040-hhsprotect.yml
+++ b/prime-router/settings/prod/0040-hhsprotect.yml
@@ -1,0 +1,31 @@
+# Run ./prime receiver set --input ./settings/prod/0040-hhsprotect.yml --env prod
+# Note that the processing_mode_code filter is still set to allow both "T" and "P" data, for now, in Prod.
+---
+name: "elr"
+organizationName: "hhsprotect"
+topic: "covid-19"
+translation: !<CUSTOM>
+  schemaName: "hhsprotect/hhsprotect-covid-19"
+  format: "CSV"
+  defaults: {}
+  nameFormat: "STANDARD"
+  receivingOrganization: null
+  type: "CUSTOM"
+jurisdictionalFilter:
+- "matches(sender_id, SafeHealth,ImageMover,Cue,InBios,Strac,.*CueHlth.*,.*ImageMover.*,reddyfmc)"
+qualityFilter:
+- "allowAll()"
+- "doesNotMatch(processing_mode_code,D)"
+reverseTheQualityFilter: false
+deidentify: true
+timing:
+  operation: "MERGE"
+  numberPerDay: 12
+  initialTime: "01:25"
+  timeZone: "EASTERN"
+  maxReportCount: 500
+description: ""
+transport: !<BLOBSTORE>
+  storageName: "PartnerStorage"
+  containerName: "hhsprotect"
+  type: "BLOBSTORE"

--- a/prime-router/settings/staging/0039-hhsprotect.yml
+++ b/prime-router/settings/staging/0039-hhsprotect.yml
@@ -1,0 +1,29 @@
+# Run this:  ./prime multiple-settings set --input ./settings/staging/0039-hhsprotect.yml --env staging
+---
+name: "elr"
+organizationName: "hhsprotect"
+topic: "covid-19"
+translation: !<CUSTOM>
+  schemaName: "hhsprotect/hhsprotect-covid-19"
+  format: "CSV"
+  defaults: {}
+  nameFormat: "STANDARD"
+  receivingOrganization: null
+  type: "CUSTOM"
+jurisdictionalFilter:
+- "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*,InBios,Strac,AnavasiDx,careevolution,reddyfmc)"
+qualityFilter:
+- "allowAll()"
+reverseTheQualityFilter: false
+deidentify: true
+timing:
+  operation: "MERGE"
+  numberPerDay: 1440
+  initialTime: "00:00"
+  timeZone: "EASTERN"
+  maxReportCount: 500
+description: ""
+transport: !<BLOBSTORE>
+  storageName: "PartnerStorage"
+  containerName: "hhsprotect"
+  type: "BLOBSTORE"


### PR DESCRIPTION
This PR adds Reddy Family Medical Clinic in the jurisdictional filter for HHSProtect.

## Changes
Modified filter in organizations.yml
Added yamlitos for staging and prod

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?




## Fixes
*List GitHub issues this PR fixes*
- #1708 Onboarding of Reddy Family Medical Clinic sender
