### PR TITLE
Fix in the settings API to handle unknown properties

### DIFF
--- a/prime-router/src/main/kotlin/azure/SettingsFacade.kt
+++ b/prime-router/src/main/kotlin/azure/SettingsFacade.kt
@@ -39,7 +39,7 @@ class SettingsFacade(
         // Format OffsetDateTime as an ISO string
         mapper.registerModule(JavaTimeModule())
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        // Unknown properties in the json payload may be a new property defined in a new version of the CLI of the code
+        // Unknown properties in the payload may be caused by new versions of the CLI of the code
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 

--- a/prime-router/src/main/kotlin/azure/SettingsFacade.kt
+++ b/prime-router/src/main/kotlin/azure/SettingsFacade.kt
@@ -2,6 +2,7 @@ package gov.cdc.prime.router.azure
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -38,6 +39,8 @@ class SettingsFacade(
         // Format OffsetDateTime as an ISO string
         mapper.registerModule(JavaTimeModule())
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        // Unknown properties in the json payload may be a new property defined in a new version of the CLI of the code
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 
     override val organizations: Collection<Organization>

--- a/prime-router/src/main/kotlin/cli/SettingCommands.kt
+++ b/prime-router/src/main/kotlin/cli/SettingCommands.kt
@@ -1,5 +1,6 @@
 package gov.cdc.prime.router.cli
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -78,6 +79,9 @@ abstract class SettingCommand(
         jsonMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         yamlMapper.registerModule(JavaTimeModule())
         yamlMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        // Unknown properties in a file or a payload may be caused by newer versions of the code in the environment
+        jsonMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 
     fun getEnvironment(): Environment {


### PR DESCRIPTION
This PR fixes a bug where the settings features would not work in production. This situtation occurs when new settings properties are introduced, but not yet deployed to production. 

## Changes
- The json deserializer ignores unknown properties in the API and CLI

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Specific Security-related subjects a reviewer should pay specific attention to

- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #1916

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
