### PR TITLE
1902 Do not process blank strings generated from batch submission headers

### DIFF
--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -24,7 +24,6 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Properties
 import java.util.TimeZone
-import java.util.regex.Pattern
 
 class Hl7Serializer(
     val metadata: Metadata,
@@ -135,14 +134,17 @@ class Hl7Serializer(
             if (it.startsWith("FTS"))
                 return@forEach
 
-            if (nextMessage.isNotEmpty() && it.startsWith("MSH")) {
+            if (nextMessage.isNotBlank() && it.startsWith("MSH")) {
                 deconstructStringMessage()
             }
-            nextMessage.append("$it\r")
+
+            if (it.isNotBlank()) {
+                nextMessage.append("$it\r")
+            }
         }
 
         // catch the last message
-        if (nextMessage.isNotEmpty()) {
+        if (nextMessage.isNotBlank()) {
             deconstructStringMessage()
         }
 

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -669,7 +669,6 @@ NTE|1|L|This is a final comment|RE"""
 
         val emptyHL7 = ByteArrayInputStream("".toByteArray())
         var result = serializer.readExternal(hl7SchemaName, emptyHL7, TestSource)
-        assertThat(result.warnings).isNotEmpty()
         assertThat(result.report).isNotNull()
         assertThat(result.report!!.itemCount).isEqualTo(0)
 


### PR DESCRIPTION
This PR makes sure the HL7 serializer is not generating a false warning about processing an empty message for batch payloads.  The problem was that the serializer would loop through the initial batch segments and generate a string with "\r\r" due to the appending of \r to the nextMessage variable.  The serializer would then generate a warning that it could not parse an empty message when it encountered the first true HL7 message of the batch message.  

## Changes
- Not parse a blank string.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #1902

## To Be Done
