### PR TITLE
Include preferred language in pdi schema

### DIFF
--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -686,6 +686,20 @@ The patient's phone number with area code
 
 ---
 
+**Name**: Patient_preferred_language
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's preferred language
+
+---
+
 **Name**: Patient_race
 
 **Type**: CODE

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -92,6 +92,12 @@ elements:
   - name: patient_ethnicity
     csvFields: [{name: Patient_ethnicity}]
 
+  - name: patient_preferred_language
+    documentation: The patient's preferred language
+    cardinality: ZERO_OR_ONE
+    csvFields: [{name: Patient_preferred_language}]
+    type: TEXT
+
   - name: patient_street
     csvFields: [{name: Patient_street}]
 


### PR DESCRIPTION

This PR Adds the patients preferred language as a text field to the SimpleReport schema.

## Changes
- Creates a TEXT type entry in the simple report schema named `patient_preferred_language`. This will be populated from the csv header `Patient_preferred_language`

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #1748 
