### PR TITLE
Fix for #1977: Only run terraform format check hook when there are terraform changes

### DIFF
--- a/.environment/terraform-fmt/run-terraform-fmt.sh
+++ b/.environment/terraform-fmt/run-terraform-fmt.sh
@@ -38,13 +38,22 @@ LOGFILE="terraform-fmt.log"
 
 function terraform_fmt_check() {
     note "Checking Terraform formatting."
-    make -C "${REPO_ROOT?}/operations" -f "${REPO_ROOT?}/operations/Makefile" tf-cmd TF_CMD="terraform fmt -check -recursive /app/src" > "${REPO_ROOT?}/${LOGFILE?}" 2>&1
-    return $?
+    MODIFIED_TF_FILES_COUNT=$(git status --porcelain | grep "\.tf$" | wc -l)
+    RC=0
+    if [[ ${MODIFIED_TF_FILES_COUNT?} != 0 ]]; then
+        make -C "${REPO_ROOT?}/operations" -f "${REPO_ROOT?}/operations/Makefile" tf-cmd TF_CMD="terraform fmt -check -recursive /app/src" >"${REPO_ROOT?}/${LOGFILE?}" 2>&1
+        RC=$?
+    else
+        note "Skipping this check, you made no changes to Terraform files..."
+        RC=0
+    fi
+
+    return ${RC?}
 }
 
 function terraform_fmt_fix() {
     warning "Formatting all Terraform files."
-    make -C "${REPO_ROOT?}/operations" -f "${REPO_ROOT?}/operations/Makefile" tf-cmd TF_CMD="terraform fmt -recursive /app/src" > "${REPO_ROOT?}/${LOGFILE?}" 2>&1
+    make -C "${REPO_ROOT?}/operations" -f "${REPO_ROOT?}/operations/Makefile" tf-cmd TF_CMD="terraform fmt -recursive /app/src" >"${REPO_ROOT?}/${LOGFILE?}" 2>&1
     return $?
 }
 


### PR DESCRIPTION
This fixes #1977 by only running the terraform hook if `git status --porcelain` reports files with `.tf` extension. If no such files come back from that command, then the hook tells you that it will skip the check (and reports success). If such files _were_ changed then the script will report the return code from the (containerized) `terraform fmt` invocation as it did before.

This closes #1977 