### PR TITLE
rhood/1992-PositiveCOVID

### DIFF
--- a/prime-router/src/main/kotlin/Mappers.kt
+++ b/prime-router/src/main/kotlin/Mappers.kt
@@ -487,6 +487,7 @@ class Obx8Mapper : Mapper {
                 "720735008" -> "A" // Presumptive positive
                 "42425007" -> "N" // Equivocal
                 "260385009" -> "N" // Negative
+                "10828004" -> "A" // Positive
                 "895231008" -> "N" // Not detected in pooled specimen
                 "462371000124108" -> "A" // Detected in pooled specimen
                 "419984006" -> "N" // Inconclusive


### PR DESCRIPTION
This PR fixes a bug in Mappers.kt.  "A" for abnormal was not being set in the OBX.8 for COVID "Positive" results.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

## Changes
- Added bug fix for Positive results not setting the OBX.8 to "A" for abnormal automatically.
-

## Checklist

### Testing
- [x] Tested locally? Mappers.kt file is included in #2004 and #2008 and fully tested within these two new CSV senders schemas.
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
*List GitHub issues this PR fixes*
- #1992 

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
