### PR TITLE
Fixed SFTP not working for local dockerless run

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -19,8 +19,10 @@ Properties to control the execution and output using the Gradle -P arguments:
 
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.FileInputStream
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Properties
 
 plugins {
     kotlin("jvm") version "1.5.21"
@@ -68,7 +70,7 @@ val dbUrl = (
 val reportsApiEndpointHost = (
     System.getenv(KEY_PRIME_RS_API_ENDPOINT_HOST)
         ?: "localhost"
-    ) as String
+    )
 
 val jooqSourceDir = "build/generated-src/jooq/src/main/java"
 val jooqPackageName = "gov.cdc.prime.router.azure.db"
@@ -335,17 +337,26 @@ tasks.azureFunctionsRun {
         "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=" +
             "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=" +
             "http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
-    environment(
-        mapOf(
-            "AzureWebJobsStorage" to devAzureConnectString,
-            "PartnerStorage" to devAzureConnectString,
-            "POSTGRES_USER" to dbUser,
-            "POSTGRES_PASSWORD" to dbPassword,
-            "POSTGRES_URL" to dbUrl,
-            "PRIME_ENVIRONMENT" to "local",
-            "VAULT_API_ADDR" to "http://localhost:8200"
-        )
+
+    val env = mutableMapOf(
+        "AzureWebJobsStorage" to devAzureConnectString,
+        "PartnerStorage" to devAzureConnectString,
+        "POSTGRES_USER" to dbUser,
+        "POSTGRES_PASSWORD" to dbPassword,
+        "POSTGRES_URL" to dbUrl,
+        "PRIME_ENVIRONMENT" to "local",
+        "VAULT_API_ADDR" to "http://localhost:8200",
+        "SFTP_HOST_OVERRIDE" to "localhost",
+        "SFTP_PORT_OVERRIDE" to "2222"
     )
+
+    // Load the vault variables
+    val file = File(".vault/env/.env.local")
+    val prop = Properties()
+    FileInputStream(file).use { prop.load(it) }
+    prop.forEach { key, value -> env[key.toString()] = value.toString().replace("\"", "") }
+
+    environment(env)
     azurefunctions.localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
 }
 

--- a/prime-router/docs/getting-started/faster-development.md
+++ b/prime-router/docs/getting-started/faster-development.md
@@ -16,8 +16,6 @@ test changes more quickly and/or save memory you can then run the Azure function
 
 ## Instructions
 ### Setup
-1. Add `sftp` to your hosts file to point to localhost or 127.0.0.1.  Alternatively, you can change all the host 
-   references of sftp to locahost in the organizations.yml file.
 1. The following commands start the database and other services needed by the Azure functions.  This is
 a one time procedure and only needs to be run at workstation startup or when you perform a clean:
 

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -39,8 +39,16 @@ class SftpTransport : ITransport, Logging {
         actionHistory: ActionHistory,
     ): RetryItems? {
         val sftpTransportType = transportType as SFTPTransportType
-        val host: String = sftpTransportType.host
-        val port: String = sftpTransportType.port
+
+        // Override the SFTP host and port only if provided and in the local environment.
+        val host: String = if ("local" == System.getenv("PRIME_ENVIRONMENT") &&
+            !System.getenv("SFTP_HOST_OVERRIDE").isNullOrBlank()
+        )
+            System.getenv("SFTP_HOST_OVERRIDE") else sftpTransportType.host
+        val port: String = if ("local" == System.getenv("PRIME_ENVIRONMENT") &&
+            !System.getenv("SFTP_PORT_OVERRIDE").isNullOrBlank()
+        )
+            System.getenv("SFTP_PORT_OVERRIDE") else sftpTransportType.port
         return try {
             if (header.content == null)
                 error("No content to sftp for report ${header.reportFile.reportId}")


### PR DESCRIPTION
This PR fixes SFTP uploads not working when running the functions outside of Docker.  This was due to 
1. Not having the environment from the vault
2. The SFTP container only exposes port 2222 and the configuration in organizations.yml points to port 22

## Changes
-  Added a way to override the SFTP host and port ONLY in the local environment

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes

## To Be Done

