### PR TITLE
1827 Turn on App Insights profiling

### DIFF
--- a/operations/app/src/modules/function_app/main.tf
+++ b/operations/app/src/modules/function_app/main.tf
@@ -35,7 +35,19 @@ locals {
 
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = false
 
-    "APPINSIGHTS_INSTRUMENTATIONKEY" = var.ai_instrumentation_key
+    # App Insights
+    "APPINSIGHTS_INSTRUMENTATIONKEY"                  = var.ai_instrumentation_key
+    "APPINSIGHTS_PROFILERFEATURE_VERSION"             = "1.0.0"
+    "APPINSIGHTS_SNAPSHOTFEATURE_VERSION"             = "1.0.0"
+    "APPLICATIONINSIGHTS_CONFIGURATION_CONTENT"       = ""
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"           = ""
+    "ApplicationInsightsAgent_EXTENSION_VERSION"      = "~3"
+    "DiagnosticServices_EXTENSION_VERSION"            = "~3"
+    "InstrumentationEngine_EXTENSION_VERSION"         = "disabled"
+    "SnapshotDebugger_EXTENSION_VERSION"              = "disabled"
+    "XDT_MicrosoftApplicationInsights_BaseExtensions" = "disabled"
+    "XDT_MicrosoftApplicationInsights_Mode"           = "recommended"
+    "XDT_MicrosoftApplicationInsights_PreemptSdk"     = "disabled"
 
     "FEATURE_FLAG_SETTINGS_ENABLED" = true
   }

--- a/prime-router/host.json
+++ b/prime-router/host.json
@@ -9,5 +9,12 @@
       "batchSize": 8,
       "newBatchThreshold": 4
     }
+  },
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR flips some Function App settings to enable App Insights profiling.

Reference:
* https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-functions#how-to-enable-distributed-tracing-for-java-function-apps
* https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent
* https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json#applicationinsights

Related to #1827 