### PR TITLE
1390: make all permissions match from Okta -> ReportStream

### DIFF
--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -70,7 +70,6 @@ const App = () => {
                         <ReportStreamHeader />
                         <Switch>
                             <Route path="/" exact={true} component={Home} />
-                            <SecureRoute path="/daily" component={Daily} />
                             <Route path="/about" component={About} />
                             <Route
                                 path="/how-it-works"

--- a/frontend-react/src/components/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/ReportStreamHeader.tsx
@@ -110,9 +110,6 @@ export const ReportStreamHeader = () => {
     ];
 
     let itemsMenu = [
-        <Link href="/daily" id="daily" className="usa-nav__link">
-            <span>Daily data</span>
-        </Link>,
         <Link href="/about" id="docs" className="usa-nav__link">
             <span>About</span>
         </Link>,

--- a/frontend-react/src/pages/Upload.tsx
+++ b/frontend-react/src/pages/Upload.tsx
@@ -280,7 +280,7 @@ export const Upload = () => {
                         id="upload-csv-input"
                         name="upload-csv-input"
                         aria-describedby="upload-csv-input-label"
-                        accept="text/csv"
+                        accept=".csv, text/csv"
                         onChange={(e) => handleChange(e)}
                         required
                     />

--- a/prime-router/src/main/kotlin/tokens/OktaAuthentication.kt
+++ b/prime-router/src/main/kotlin/tokens/OktaAuthentication.kt
@@ -51,6 +51,7 @@ class OktaAuthentication(private val minimumLevel: PrincipalLevel = PrincipalLev
     fun checkAccess(
         request: HttpRequestMessage<String?>,
         organizationName: String,
+        oktaSender: Boolean = false,
         block: (AuthenticatedClaims) -> HttpResponseMessage
     ): HttpResponseMessage {
         try {
@@ -66,7 +67,7 @@ class OktaAuthentication(private val minimumLevel: PrincipalLevel = PrincipalLev
                 logger.error("Wrong Authentication Verifier being used: ${claimVerifier::class} for $host")
                 return HttpUtilities.unauthorizedResponse(request)
             }
-            val claims = claimVerifier.checkClaims(accessToken, minimumLevel, organizationName)
+            val claims = claimVerifier.checkClaims(accessToken, minimumLevel, organizationName, oktaSender)
             if (claims == null) {
                 logger.info("Invalid Authorization Header: ${request.httpMethod}:${request.uri.path}")
                 return HttpUtilities.unauthorizedResponse(request, invalidClaim)


### PR DESCRIPTION
This PR makes all permissions match from Okta -> ReportStream

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

## Changes
- ReportStream API/waters: replacing all underscores with dashes when receiving the client name from the header
- ReportStream API OktaAuthentication: added a oktaSender flag to indicate what group prefix we are expecting from the front end to indicate whether the user is sending or receiving data
- ReportStream frontend-react: removed duplicated /daily route
- ReportStream frontend-react removed duplicated /daily link from navigation bar - we are now only using the permission-based link

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `quickTest all`?
- [ ] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Specific Security-related subjects a reviewer should pay specific attention to

- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
