### PR TITLE
Adds an alias for the QuickVue Rapids test kit

### DIFF
--- a/prime-router/metadata/tables/LIVD-SARS-CoV-2-2021-04-28.csv
+++ b/prime-router/metadata/tables/LIVD-SARS-CoV-2-2021-04-28.csv
@@ -3220,6 +3220,9 @@ Invalid Result (455371000124106^Invalid result^SCT or 125154007^Specimen unsatis
 Quidel Corporation,QuickVue SARS Antigen Test*,SARS-CoV-2 nucleocapsid protein antigen,anterior nares (NS) swab (697989009^Anterior nares swab^SCT),"Positive Result (260373001^Detected^SCT)
 Negative result (260415000^Not Detected^SCT)
 Invalid result (455371000124106^Invalid result^SCT or 125154007^Specimen unsatisfactory for evaluation^SCT)",95209-3,SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,95209-3,SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,,,,30014613339373,DIT,,,SARS coronavirus+SARS coronavirus 2 Ag,PrThr,Pt,Respiratory,Ord,IA.rapid,20210317,2.69
+Quidel Corporation,QuickVue Rapids,SARS-CoV-2 nucleocapsid protein antigen,anterior nares (NS) swab (697989009^Anterior nares swab^SCT),"Positive Result (260373001^Detected^SCT)
+Negative result (260415000^Not Detected^SCT)
+Invalid result (455371000124106^Invalid result^SCT or 125154007^Specimen unsatisfactory for evaluation^SCT)",95209-3,SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,95209-3,SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,,,,30014613339373,DIT,,,SARS coronavirus+SARS coronavirus 2 Ag,PrThr,Pt,Respiratory,Ord,IA.rapid,20210317,2.69
 Quidel Corporation,Sofia 2 Flu + SARS Antigen FIA*,SARS antigen result,"nasopharyngeal (NP) swab (258500001^Nasopharyngeal swab^SCT)
 nasal (NS) swab (445297001^Swab of internal nose^SCT)","Positive (260373001^Detected^SCT)
 Negative (260415000^Not Detected^SCT)


### PR DESCRIPTION
This PR adds an alias for the QuickVue Rapids test kit that doesn't currently exist in the LIVD table but SimpleReport is using as a test type.