### PR TITLE
Fix bug with out of State CLIA translation property

### DIFF
--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -598,11 +598,17 @@ class Hl7Serializer(
         if (!hl7Config?.cliaForOutOfStateTesting.isNullOrEmpty()) {
             val testingStateField = "OBX-24-4"
             val pathSpecTestingState = formPathSpec(testingStateField)
-            val testingState = terser.get(pathSpecTestingState)
+            var originState = terser.get(pathSpecTestingState)
+
+            if (originState.isEmpty()) {
+                val orderingStateField = "ORC-24-4"
+                val pathSpecOrderingState = formPathSpec(orderingStateField)
+                originState = terser.get(pathSpecOrderingState)
+            }
 
             val stateCode = report.destination?.let { settings.findOrganization(it.organizationName)?.stateCode }
 
-            if (!testingState.equals(stateCode)) {
+            if (!originState.equals(stateCode)) {
                 val sendingFacility = "MSH-4-2"
                 val pathSpecSendingFacility = formPathSpec(sendingFacility)
                 terser.set(pathSpecSendingFacility, hl7Config?.cliaForOutOfStateTesting)


### PR DESCRIPTION
This PR fixes a bug that occurs when when cliaForOutOfStateTesting is set to true. The codes checked the value for testing lab state. But that value can be blank. In that case the ordering facility state should be used.

## Changes
- Checks if testing lab state is blank
- if testing lab state is blank the ordering facility state is retrieved 

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `quickTest all`?
- [X] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?