### PR TITLE
Quick fix to get staging working with `Content-Security-Policy`

### DIFF
--- a/frontend-react/public/index.html
+++ b/frontend-react/public/index.html
@@ -23,7 +23,9 @@
           https://www.google-analytics.com
           https://*.in.applicationinsights.azure.com
           https://hhs-prime.okta.com
-          %REACT_APP_BACKEND_URL% ;"
+          https://staging.prime.reportstream.cdc.gov/api
+          %REACT_APP_BACKEND_URL%
+          ;"
     />
     <link rel="apple-touch-icon" href="%REACT_APP_PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
A quick fix to get staging working again (and to see if there are other URLs that break once this is fixed).

Always allows access to https://staging.prime.reportstream.cdc.gov/api even in production. 

This needs to be fixed in a better way, but having it be runtime based versus configuration based is problematic.

see `getBaseUrl()`

related to: #2051 