### PR TITLE
"content security policy" Path change from `/api` to `/api/`

### DIFF
--- a/frontend-react/.env
+++ b/frontend-react/.env
@@ -1,7 +1,8 @@
+; default .env.production and .env.development override values
 REACT_APP_TITLE=ReportStream Dashboard
 REACT_APP_DESCRIPTION=ReportStream Dashboard Application
 REACT_APP_ICON=https://reportstream.cdc.gov/assets/cdc-logo.svg
-REACT_APP_BACKEND_URL=https://reportstream.cdc.gov/
-REACT_APP_BASE_URL=https://reportstream.cdc.gov/
+REACT_APP_BASE_URL=https://reportstream.cdc.gov
+REACT_APP_BACKEND_URL=https://reportstream.cdc.gov/api/
 REACT_APP_IS_TRAINING_SITE=false
 INLINE_RUNTIME_CHUNK=false

--- a/frontend-react/.env.development
+++ b/frontend-react/.env.development
@@ -1,4 +1,4 @@
 REACT_APP_TITLE=ReportStream Dashboard DEV
-REACT_APP_BACKEND_URL=http://localhost:7071
+REACT_APP_BACKEND_URL=http://localhost:7071/api/
 REACT_APP_BASE_URL=http://localhost:3000
 INLINE_RUNTIME_CHUNK=false

--- a/frontend-react/.env.production
+++ b/frontend-react/.env.production
@@ -1,5 +1,6 @@
+; production overrides .env values
 REACT_APP_BASE_URL=https://reportstream.cdc.gov
-REACT_APP_BACKEND_URL=https://prime.cdc.gov/api
+REACT_APP_BACKEND_URL=https://prime.cdc.gov/api/
 REACT_APP_PUBLIC_URL=
 PUBLIC_URL=
 INLINE_RUNTIME_CHUNK=false

--- a/frontend-react/.env.staging
+++ b/frontend-react/.env.staging
@@ -1,5 +1,6 @@
+; this does NOT look like is being used by staging - need to figure out why
 REACT_APP_BASE_URL=https://staging.reportstream.cdc.gov
-REACT_APP_BACKEND_URL=https://staging.prime.cdc.gov/api
+REACT_APP_BACKEND_URL=https://staging.prime.cdc.gov/api/
 REACT_APP_PUBLIC_URL=
 PUBLIC_URL=
 INLINE_RUNTIME_CHUNK=false

--- a/frontend-react/public/index.html
+++ b/frontend-react/public/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="%REACT_APP_DESCRIPTION%"/>
-    <meta name="test" content="%REACT_APP_TEST_VALUE%" />
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self';
@@ -19,13 +18,13 @@
           https://global.oktacdn.com
           https://cdnjs.cloudflare.com;
         frame-src 'self' https://hhs-prime.okta.com;
-        img-src 'self' https://hhs-prime.okta.com https://reportstream.cdc.gov/ data: ;
+        img-src 'self' https://hhs-prime.okta.com https://reportstream.cdc.gov data: ;
         connect-src 'self'
           https://www.google-analytics.com
           https://*.in.applicationinsights.azure.com
           https://hhs-prime.okta.com
-          https://staging.reportstream.cdc.gov/api
-          https://staging.prime.cdc.gov/api
+          https://staging.reportstream.cdc.gov/api/
+          https://staging.prime.cdc.gov/api/
           %REACT_APP_BACKEND_URL%
           ;"
     />


### PR DESCRIPTION
`https://prime.cdc.gov/api` ONLY matches the `api` page... just that page. 
`https://prime.cdc.gov/api/` matches the api path and all pages under that path.

Right now the `https://staging.reportstream.cdc.gov/api/` and `https://staging.prime.cdc.gov/api/` are hard coded in the "Content-Security-Policy" because `.env.staging` isn't being used. 
```html
    <meta
      http-equiv="Content-Security-Policy"
      content="default-src 'self';
        script-src 'self'
          https://hss-prime-okta.com
          https://global.oktacdn.com
          https://www.google-analytics.com
          https://*.in.applicationinsights.azure.com;
        style-src 'self' 'unsafe-inline'
          https://global.oktacdn.com
          https://cdnjs.cloudflare.com;
        frame-src 'self' https://hhs-prime.okta.com;
        img-src 'self' https://hhs-prime.okta.com https://reportstream.cdc.gov data: ;
        connect-src 'self'
          https://www.google-analytics.com
          https://*.in.applicationinsights.azure.com
          https://hhs-prime.okta.com
          https://staging.reportstream.cdc.gov/api/
          https://staging.prime.cdc.gov/api/
          %REACT_APP_BACKEND_URL%
          ;"
    />
```

I created a bug to fix the hard coded values before we launch. https://github.com/CDCgov/prime-simplereport/issues/2469

The goal is to just get staging working for now.