### PR TITLE
Adding send_info action type

### DIFF
--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -67,7 +67,7 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
                 val serviceName = receiver.fullName
                 val nextRetryItems = mutableListOf<String>()
                 if (receiver.transport == null) {
-                    actionHistory.setActionType(TaskAction.send_error)
+                    actionHistory.setActionType(TaskAction.send_warning)
                     actionHistory.trackActionResult("Not sending $inputReportId to $serviceName: No transports defined")
                 } else {
                     val retryItems = retryToken?.items
@@ -130,6 +130,7 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
             if (nextRetryCount >= maxRetryCount) {
                 // Stop retrying and just put the task into an error state
                 val msg = "All retries failed.  Send Error report for: $reportId to $serviceName"
+                actionHistory.setActionType(TaskAction.send_error)
                 actionHistory.trackActionResult(msg)
                 context.logger.info(msg)
                 ReportEvent(Event.EventAction.SEND_ERROR, reportId)
@@ -142,6 +143,7 @@ class SendFunction(private val workflowEngine: WorkflowEngine = WorkflowEngine()
                 val msg = "Send Failed.  Will retry sending report: $reportId to $serviceName}" +
                     " in $waitMinutes minutes and $randomSeconds seconds at $nextRetryTime"
                 context.logger.info(msg)
+                actionHistory.setActionType(TaskAction.send_warning)
                 actionHistory.trackActionResult(msg)
                 ReportEvent(Event.EventAction.SEND, reportId, nextRetryTime, nextRetryToken)
             }

--- a/prime-router/src/main/kotlin/transport/AS2Transport.kt
+++ b/prime-router/src/main/kotlin/transport/AS2Transport.kt
@@ -82,7 +82,7 @@ class AS2Transport : ITransport, Logging {
                 val msg = "FAILED AS2 upload of inputReportId $reportId to $as2Info (orgService = $receiverFullName);" +
                     "Retry all items; Exception: ${t.javaClass.canonicalName} ${t.localizedMessage}"
                 context.logger.warning(msg)
-                actionHistory.setActionType(TaskAction.send_error)
+                actionHistory.setActionType(TaskAction.send_warning)
                 actionHistory.trackActionResult(msg)
                 RetryToken.allItems
             } else {

--- a/prime-router/src/main/kotlin/transport/BlobStoreTransport.kt
+++ b/prime-router/src/main/kotlin/transport/BlobStoreTransport.kt
@@ -45,7 +45,7 @@ class BlobStoreTransport(val workflowEngine: WorkflowEngine) : ITransport {
                     "$blobTransportType ($envVar:$storageName)" +
                     ", Exception: ${t.localizedMessage}"
             context.logger.warning(msg)
-            actionHistory.setActionType(TaskAction.send_error)
+            actionHistory.setActionType(TaskAction.send_warning)
             actionHistory.trackActionResult(msg)
             RetryToken.allItems
         }

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -100,7 +100,7 @@ class RedoxTransport() : ITransport, SecretManagement {
             if (successCount == 0) {
                 nextRetryItems = (retryItems ?: RetryToken.allItems) as MutableList<String>
                 // If even one redox message got through, we'll call that 'send' rather than send_error
-                actionHistory.setActionType(TaskAction.send_error)
+                actionHistory.setActionType(TaskAction.send_warning)
             }
         } finally {
             val statusStr = when {

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -86,7 +86,7 @@ class SftpTransport : ITransport, Logging {
                     "$sftpTransportType (orgService = ${header.receiver?.fullName ?: "null"})" +
                     ", Exception: ${t.localizedMessage}"
             context.logger.warning(msg)
-            actionHistory.setActionType(TaskAction.send_error)
+            actionHistory.setActionType(TaskAction.send_warning)
             actionHistory.trackActionResult(msg)
             RetryToken.allItems
         }

--- a/prime-router/src/main/resources/db/migration/V18__add_send_info_to_action_type.sql
+++ b/prime-router/src/main/resources/db/migration/V18__add_send_info_to_action_type.sql
@@ -1,0 +1,21 @@
+/*
+ * The Flyway tool applies this migration to create the database.
+ *
+ * Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+ * use VARCHAR(63) for names in organization and schema
+ *
+ * Copy a version of this comment into the next migration
+ *
+ */
+
+/*
+  Add new actions 'resend' and 'rebatch', and fix the current task table to use it.
+ */
+ALTER TABLE task        ALTER COLUMN next_action TYPE VARCHAR(255);
+ALTER TABLE report_file ALTER COLUMN next_action TYPE VARCHAR(255);
+ALTER TABLE action      ALTER COLUMN action_name TYPE VARCHAR(255);
+DROP TYPE IF EXISTS task_action;
+CREATE TYPE task_action AS ENUM ('receive', 'translate', 'batch', 'send', 'download', 'wipe', 'batch_error', 'send_error', 'wipe_error', 'none', 'resend', 'rebatch', 'token_auth', 'token_error', 'send_warning');
+ALTER TABLE task        ALTER COLUMN next_action TYPE task_action USING next_action::task_action;
+ALTER TABLE report_file ALTER COLUMN next_action TYPE task_action USING next_action::task_action;
+ALTER TABLE action      ALTER COLUMN action_name TYPE task_action USING action_name::task_action;


### PR DESCRIPTION
This PR ...

## Changes
- Migrate `task_action` type to include a `send_warning` value
- Use `send_warning` for action history in the case where a receiver has no transports defined.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [x] Added tests?

## Fixes
*List GitHub issues this PR fixes*
- #1973 

Open review questions:
- Any better name suggestions than `send_info`?
- Is the migration kosher?

---

To explore this locally, change the ignore.CSV transport to have a bogus `host`. Update the `maxRetries = 2` in SendFunction.kt and run end to end tests. You may also have to `@Ignore` a couple of unit tests to pass `gradlew package`. This will populate the action table with a series of `send_warning` and then `send_error` pairs.