### PR TITLE
Adds user password option for the two key file auths

### DIFF
--- a/prime-router/src/main/kotlin/cli/CredentialsCli.kt
+++ b/prime-router/src/main/kotlin/cli/CredentialsCli.kt
@@ -55,8 +55,18 @@ class CredentialsCli : CredentialManagement, CliktCommand(
     override fun run() {
         val credential = when (val it = type) {
             is UserPassCredentialOptions -> UserPassCredential(it.user, it.pass)
-            is UserPemCredentialOptions -> UserPemCredential(it.user, it.file.readText(Charsets.UTF_8), it.filePass)
-            is UserPpkCredentialOptions -> UserPpkCredential(it.user, it.file.readText(Charsets.UTF_8), it.filePass)
+            is UserPemCredentialOptions -> UserPemCredential(
+                it.user,
+                it.file.readText(Charsets.UTF_8),
+                it.filePass,
+                it.pass
+            )
+            is UserPpkCredentialOptions -> UserPpkCredential(
+                it.user,
+                it.file.readText(Charsets.UTF_8),
+                it.filePass,
+                it.pass
+            )
             is UserJksCredentialOptions -> {
                 val jksEncoded = Base64.getEncoder().encodeToString(it.file.readBytes())
                 UserJksCredential(it.user, jksEncoded, it.filePass, it.privateAlias, it.trustAlias)
@@ -91,12 +101,20 @@ class UserPemCredentialOptions : CredentialConfig("Options for credential type '
     val user by option("--pem-user", help = "Username to authenticate alongside the PEM").prompt(default = "")
     val file by option("--pem-file", help = "Path to the PEM file").file(mustExist = true).required()
     val filePass by option("--pem-file-pass", help = "Password to decrypt the PEM").prompt(default = "")
+    val pass by option(
+        "--pem-user-pass",
+        help = "The password to use to login with the user if the SFTP server is using partial auth"
+    ).prompt(default = "")
 }
 
 class UserPpkCredentialOptions : CredentialConfig("Options for credential type 'UserPpk'") {
     val user by option("--ppk-user", help = "Username to authenticate alongside the PPK").prompt(default = "")
     val file by option("--ppk-file", help = "Path to the PPK file").file(mustExist = true).required()
     val filePass by option("--ppk-file-pass", help = "Password to decrypt the PPK (optional)").prompt(default = "")
+    val pass by option(
+        "--ppk-user-pass",
+        help = "The password to use to login with the user if the SFTP server is using partial auth"
+    ).prompt(default = "")
 }
 
 class UserJksCredentialOptions : CredentialConfig("Options for credential type 'UserJks'") {

--- a/prime-router/src/main/kotlin/credentials/Credential.kt
+++ b/prime-router/src/main/kotlin/credentials/Credential.kt
@@ -1,5 +1,6 @@
 package gov.cdc.prime.router.credentials
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -16,9 +17,19 @@ data class UserPassCredential(val user: String, val pass: String) : Credential()
 /**
  * A PPK credential. Can be used for SFTP transports.
  */
-data class UserPpkCredential(val user: String, val key: String, val keyPass: String) : Credential(), SftpCredential
+data class UserPpkCredential(
+    val user: String,
+    val key: String,
+    val keyPass: String,
+    val pass: String? = null,
+) : Credential(), SftpCredential
 
-data class UserPemCredential(val user: String, val key: String, val keyPass: String) : Credential(), SftpCredential
+data class UserPemCredential(
+    val user: String,
+    val key: String,
+    val keyPass: String,
+    val pass: String? = null,
+) : Credential(), SftpCredential
 
 /**
  * A credential that is saved in a Java Key Store (JKS)

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -20,6 +20,9 @@ import net.schmizz.sshj.sftp.RemoteResourceFilter
 import net.schmizz.sshj.sftp.StatefulSFTPClient
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
+import net.schmizz.sshj.userauth.method.AuthMethod
+import net.schmizz.sshj.userauth.method.AuthPassword
+import net.schmizz.sshj.userauth.method.AuthPublickey
 import net.schmizz.sshj.userauth.password.PasswordUtils
 import net.schmizz.sshj.xfer.InMemorySourceFile
 import net.schmizz.sshj.xfer.LocalSourceFile
@@ -122,7 +125,11 @@ class SftpTransport : ITransport, Logging {
                             true -> key.init(keyContents)
                             false -> key.init(keyContents, PasswordUtils.createOneOff(credential.keyPass.toCharArray()))
                         }
-                        sshClient.authPublickey(credential.user, key)
+                        val authProviders = mutableListOf<AuthMethod>(AuthPublickey(key))
+                        if (StringUtils.isNotBlank(credential.pass) && credential.pass != null) {
+                            authProviders.add(AuthPassword(PasswordUtils.createOneOff(credential.pass.toCharArray())))
+                        }
+                        sshClient.auth(credential.user, authProviders)
                     }
                     is UserPpkCredential -> {
                         val key = PuTTYKeyFile()
@@ -131,7 +138,11 @@ class SftpTransport : ITransport, Logging {
                             true -> key.init(keyContents)
                             false -> key.init(keyContents, PasswordUtils.createOneOff(credential.keyPass.toCharArray()))
                         }
-                        sshClient.authPublickey(credential.user, key)
+                        val authProviders = mutableListOf<AuthMethod>(AuthPublickey(key))
+                        if (StringUtils.isNotBlank(credential.pass) && credential.pass != null) {
+                            authProviders.add(AuthPassword(PasswordUtils.createOneOff(credential.pass.toCharArray())))
+                        }
+                        sshClient.auth(credential.user, authProviders)
                     }
                     else -> error("Unknown SftpCredential ${credential::class.simpleName}")
                 }


### PR DESCRIPTION
This PR adds the ability for our PEM and PPK file auth to also accept a user password in addition to the file password. This is used by DE as part of what is called "partial authentication," where you need to authenticate with both a key file AND a password. Authenticating with either individually is not supported. Our existing code base did not support this.

## Changes
- Adds a user pass property for both the PEM and PPK file types and logic to chain the auth 

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [x] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
*List GitHub issues this PR fixes*
- #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #2175 
