### PR TITLE
Fix VNET peering

### DIFF
--- a/operations/app/src/modules/common/private_endpoint/main.tf
+++ b/operations/app/src/modules/common/private_endpoint/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_private_endpoint" "endpoint" {
 
   # Automatically register the private endpoint in the private DNS zones
   dynamic "private_dns_zone_group" {
-    for_each = (var.location == "eastus") ? [0] : [] # DNS not needed for peered VNET
+    for_each = [0] # DNS needed for all zones. For each block retained to keep existing resource paths.
     content {
       name                 = local.endpoint_name
       private_dns_zone_ids = [for dns_zone in data.azurerm_private_dns_zone.private_dns_cname : dns_zone.id]

--- a/operations/app/src/modules/network/old-vnet.tf
+++ b/operations/app/src/modules/network/old-vnet.tf
@@ -251,6 +251,13 @@ resource "azurerm_virtual_network_peering" "virtual_network_peer" {
   remote_virtual_network_id = azurerm_virtual_network.virtual_network_2.id
 }
 
+resource "azurerm_virtual_network_peering" "virtual_network_peer-remote" {
+  name                      = "${var.resource_prefix}-peering-remote-001"
+  resource_group_name       = var.resource_group
+  virtual_network_name      = azurerm_virtual_network.virtual_network_2.name
+  remote_virtual_network_id = azurerm_virtual_network.virtual_network.id
+}
+
 # This subnet is where the private endpoints will exist
 # They need a dedicated subnet, since Azure requires full automatic management capabilities of the ACL
 resource "azurerm_subnet" "endpoint2" {


### PR DESCRIPTION
This PR fixes our VNET peering between East and West locations. The West VNET was missing a return peering to the East VNET. In addition, the West VNET needed registered DNS records on private endpoints to support DNS lookups.
