### PR TITLE
1913 Added sender and testkit data to metadata table

### DIFF
--- a/prime-router/src/main/resources/db/migration/V17__add_sender_and_testkit_data_to_metadata_table.sql
+++ b/prime-router/src/main/resources/db/migration/V17__add_sender_and_testkit_data_to_metadata_table.sql
@@ -1,0 +1,34 @@
+/*
+ * The Flyway tool applies this migration to create the database.
+ *
+ * Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+ * use VARCHAR(63) for names in organization and schema
+ *
+ * Copy a version of this comment into the next migration
+ *
+ */
+
+/*
+ * The vw_results_by_county_lat_long view was manually created in prod, so we need to drop it first.
+ * Another PR will add the view back in the repo.
+ */
+DROP VIEW IF EXISTS public.vw_results_by_county_lat_long;
+
+/*
+ * Add several new columns to the covid_result_metadata table to track sender ID and testkit.
+ */
+ALTER TABLE covid_result_metadata
+    ADD COLUMN sender_id VARCHAR(512) NULL,
+    ADD COLUMN test_kit_name_id VARCHAR(512) NULL,
+    ADD COLUMN test_performed_loinc_code VARCHAR(512) NULL
+;
+
+/*
+ * Now back fill the sender_id using data from the report_file table.
+ */
+UPDATE covid_result_metadata
+SET sender_id = subquery.sender_id
+FROM (SELECT rf.report_id, rf.sending_org || '.' || rf.sending_org_client as sender_id
+FROM report_file rf
+JOIN covid_result_metadata crm ON rf.report_id = crm.report_id) AS subquery
+WHERE covid_result_metadata.sender_id IS NULL AND covid_result_metadata.report_id = subquery.report_id;


### PR DESCRIPTION
This PR adds sender ID and testkit information to the metadata table.

Test steps:
1. Update your database by running `./gradlew package`. This will update the DB and regenerate the Java database files.
2. Run ReportStream
3. Run the smoke tests to generate data - `./gradlew testsmoke`
4. Inspect the covid_result_metadata table and verify the sender_id, test_kit_name_id and test_performed_loinc_code columns are present.
5. Inspect the sender_id data and verify that the sender ID is populated. 

I tested this further as follows:
1. Database in V16, ran data, updated to V17, verified SQL populates existing rows with sender ID.
2. Database in V16, no data, updated to V17, ran data and verified data inserted to table and sender ID added when running with code for #1913

## Changes
- Added sender_id, test_kit_name_id and test_performed_loinc_code columns to metadata table
- Drop the manually added vw_results_by_county_lat_long view (which is in prod) before altering the table.  This view will be added in another PR.
- Try to populate any sender IDs we can find report data on.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `quickTest all`?
- [x] Ran `./prime test` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [x] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Fixes
- #1913

## To Be Done

