### PR TITLE
Palo Alto: Lower Environments

### DIFF
--- a/operations/app/src/modules/container_registry/data.tf
+++ b/operations/app/src/modules/container_registry/data.tf
@@ -3,3 +3,9 @@ data "azurerm_subnet" "public" {
   virtual_network_name = "${var.resource_prefix}-vnet"
   resource_group_name  = var.resource_group
 }
+
+data "azurerm_subnet" "public_subnet" {
+  name                 = "public"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}

--- a/operations/app/src/modules/container_registry/main.tf
+++ b/operations/app/src/modules/container_registry/main.tf
@@ -12,6 +12,11 @@ resource "azurerm_container_registry" "container_registry" {
       action    = "Allow"
       subnet_id = data.azurerm_subnet.public.id
     }
+
+    virtual_network {
+      action    = "Allow"
+      subnet_id = data.azurerm_subnet.public_subnet.id
+    }
   }
 
   trust_policy {

--- a/operations/app/src/modules/database/data.tf
+++ b/operations/app/src/modules/database/data.tf
@@ -15,6 +15,18 @@ data "azurerm_subnet" "endpoint_replica" {
   resource_group_name  = var.resource_group
 }
 
+data "azurerm_subnet" "endpoint_subnet_east" {
+  name                 = "endpoint"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
+data "azurerm_subnet" "endpoint_subnet_west" {
+  name                 = "endpoint"
+  virtual_network_name = "${var.resource_prefix}-West-vnet"
+  resource_group_name  = var.resource_group
+}
+
 
 // Key Vault
 

--- a/operations/app/src/modules/database/main.tf
+++ b/operations/app/src/modules/database/main.tf
@@ -50,6 +50,16 @@ module "postgres_private_endpoint" {
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
 }
 
+module "postgres_server_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_postgresql_server.postgres_server.id
+  name               = azurerm_postgresql_server.postgres_server.name
+  type               = "postgres_server"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_east.id
+}
+
 
 // Replicate Server
 
@@ -104,6 +114,16 @@ module "postgres_private_endpoint_replica" {
   resource_group     = var.resource_group
   location           = azurerm_postgresql_server.postgres_server_replica.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_replica.id
+}
+
+module "postgres_server_private_endpoint_replica" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_postgresql_server.postgres_server_replica.id
+  name               = azurerm_postgresql_server.postgres_server_replica.name
+  type               = "postgres_server"
+  resource_group     = var.resource_group
+  location           = azurerm_postgresql_server.postgres_server_replica.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_west.id
 }
 
 

--- a/operations/app/src/modules/function_app/candidate_slot.tf
+++ b/operations/app/src/modules/function_app/candidate_slot.tf
@@ -97,5 +97,5 @@ resource "azurerm_key_vault_access_policy" "slot_candidate_client_config_access_
 resource "azurerm_app_service_slot_virtual_network_swift_connection" "candidate_slot_vnet_integration" {
   slot_name      = azurerm_function_app_slot.candidate.name
   app_service_id = azurerm_function_app.function_app.id
-  subnet_id      = data.azurerm_subnet.public.id
+  subnet_id      = var.environment != "prod" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
 }

--- a/operations/app/src/modules/function_app/data.tf
+++ b/operations/app/src/modules/function_app/data.tf
@@ -6,6 +6,12 @@ data "azurerm_subnet" "public" {
   resource_group_name  = var.resource_group
 }
 
+data "azurerm_subnet" "public_subnet" {
+  name                 = "public"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
 
 // App Service Plan
 

--- a/operations/app/src/modules/function_app/main.tf
+++ b/operations/app/src/modules/function_app/main.tf
@@ -156,7 +156,7 @@ resource "azurerm_key_vault_access_policy" "functionapp_client_config_access_pol
 
 resource "azurerm_app_service_virtual_network_swift_connection" "function_app_vnet_integration" {
   app_service_id = azurerm_function_app.function_app.id
-  subnet_id      = data.azurerm_subnet.public.id
+  subnet_id      = var.environment != "prod" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
 }
 
 // Enable sticky slot settings

--- a/operations/app/src/modules/key_vault/data.tf
+++ b/operations/app/src/modules/key_vault/data.tf
@@ -6,6 +6,12 @@ data "azurerm_subnet" "endpoint" {
   resource_group_name  = var.resource_group
 }
 
+data "azurerm_subnet" "endpoint_subnet" {
+  name                 = "endpoint"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
 data "azurerm_key_vault_secret" "cyberark_ip_ingress" {
   name         = "cyberark-ip-ingress"
   key_vault_id = azurerm_key_vault.application.id

--- a/operations/app/src/modules/key_vault/main.tf
+++ b/operations/app/src/modules/key_vault/main.tf
@@ -116,6 +116,16 @@ module "application_private_endpoint" {
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
 }
 
+module "application_vault_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_key_vault.application.id
+  name               = azurerm_key_vault.application.name
+  type               = "key_vault"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+}
+
 resource "azurerm_key_vault" "app_config" {
   name = "${var.resource_prefix}-appconfig"
   # Does not include "-keyvault" due to char limits (24)
@@ -189,6 +199,16 @@ module "app_config_private_endpoint" {
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
 }
 
+module "app_config_vault_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_key_vault.app_config.id
+  name               = azurerm_key_vault.app_config.name
+  type               = "key_vault"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+}
+
 resource "azurerm_key_vault" "client_config" {
   # Does not include "-keyvault" due to char limits (24)
   name = "${var.resource_prefix}-clientconfig"
@@ -251,4 +271,14 @@ module "client_config_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+}
+
+module "client_config_vault_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_key_vault.client_config.id
+  name               = azurerm_key_vault.client_config.name
+  type               = "key_vault"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
 }

--- a/operations/app/src/modules/metabase/data.tf
+++ b/operations/app/src/modules/metabase/data.tf
@@ -6,6 +6,12 @@ data "azurerm_subnet" "public" {
   resource_group_name  = var.resource_group
 }
 
+data "azurerm_subnet" "public_subnet" {
+  name                 = "public"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
 
 // Key Vault
 

--- a/operations/app/src/modules/metabase/main.tf
+++ b/operations/app/src/modules/metabase/main.tf
@@ -47,5 +47,5 @@ resource "azurerm_app_service" "metabase" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "metabase_vnet_integration" {
   app_service_id = azurerm_app_service.metabase.id
-  subnet_id      = data.azurerm_subnet.public.id
+  subnet_id      = var.environment != "prod" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
 }

--- a/operations/app/src/modules/sftp_container/data.tf
+++ b/operations/app/src/modules/sftp_container/data.tf
@@ -6,6 +6,12 @@ data "azurerm_subnet" "container" {
   resource_group_name  = var.resource_group
 }
 
+data "azurerm_subnet" "container_subnet" {
+  name                 = "container"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
 
 // Storage Account
 

--- a/operations/app/src/modules/sftp_container/main.tf
+++ b/operations/app/src/modules/sftp_container/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_network_profile" "sftp_network_profile" {
     name = "sftp_container_network_interface"
     ip_configuration {
       name      = "sftp_container_ip_configuration"
-      subnet_id = data.azurerm_subnet.container.id
+      subnet_id = var.environment != "prod" ? data.azurerm_subnet.container_subnet.id : data.azurerm_subnet.container.id
     }
   }
 }

--- a/operations/app/src/modules/storage/candidate_slot.tf
+++ b/operations/app/src/modules/storage/candidate_slot.tf
@@ -139,7 +139,9 @@ resource "azurerm_storage_account" "storage_partner_candidate" {
 
     virtual_network_subnet_ids = [
       data.azurerm_subnet.public.id,
-      data.azurerm_subnet.endpoint.id
+      data.azurerm_subnet.endpoint.id,
+      data.azurerm_subnet.public_subnet.id,
+      data.azurerm_subnet.endpoint_subnet.id,
     ]
   }
 
@@ -184,6 +186,16 @@ module "storageaccountcandidatepartner_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+}
+
+module "storage_candidatepartner_blob_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_partner_candidate.id
+  name               = azurerm_storage_account.storage_partner_candidate.name
+  type               = "storage_account_blob"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
 }
 
 resource "azurerm_storage_container" "storage_candidate_container_hhsprotect" {

--- a/operations/app/src/modules/storage/data.tf
+++ b/operations/app/src/modules/storage/data.tf
@@ -20,6 +20,24 @@ data "azurerm_subnet" "endpoint" {
   resource_group_name  = var.resource_group
 }
 
+data "azurerm_subnet" "public_subnet" {
+  name                 = "public"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
+data "azurerm_subnet" "container_subnet" {
+  name                 = "container"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
+data "azurerm_subnet" "endpoint_subnet" {
+  name                 = "endpoint"
+  virtual_network_name = "${var.resource_prefix}-East-vnet"
+  resource_group_name  = var.resource_group
+}
+
 
 // Key Vault
 

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -20,7 +20,10 @@ resource "azurerm_storage_account" "storage_account" {
     virtual_network_subnet_ids = [
       data.azurerm_subnet.public.id,
       data.azurerm_subnet.container.id,
-      data.azurerm_subnet.endpoint.id
+      data.azurerm_subnet.endpoint.id,
+      data.azurerm_subnet.public_subnet.id,
+      data.azurerm_subnet.container_subnet.id,
+      data.azurerm_subnet.endpoint_subnet.id,
     ]
   }
 
@@ -66,6 +69,36 @@ module "storageaccount_queue_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+}
+
+module "storage_blob_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_account.id
+  name               = azurerm_storage_account.storage_account.name
+  type               = "storage_account_blob"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+}
+
+module "storage_file_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_account.id
+  name               = azurerm_storage_account.storage_account.name
+  type               = "storage_account_file"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+}
+
+module "storage_queue_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_account.id
+  name               = azurerm_storage_account.storage_account.name
+  type               = "storage_account_queue"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
 }
 
 # Point-in-time restore, soft delete, versioning, and change feed were
@@ -178,7 +211,9 @@ resource "azurerm_storage_account" "storage_partner" {
 
     virtual_network_subnet_ids = [
       data.azurerm_subnet.public.id,
-      data.azurerm_subnet.endpoint.id
+      data.azurerm_subnet.endpoint.id,
+      data.azurerm_subnet.public_subnet.id,
+      data.azurerm_subnet.endpoint_subnet.id,
     ]
   }
 
@@ -225,6 +260,16 @@ module "storageaccountpartner_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+}
+
+module "storage_partner_blob_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_partner.id
+  name               = azurerm_storage_account.storage_partner.name
+  type               = "storage_account_blob"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
 }
 
 resource "azurerm_storage_container" "storage_container_hhsprotect" {


### PR DESCRIPTION
This PR rolls out the Palo Alto egress firewall in all environments outside of production.

## Changes
- Adds private endpoints to the Palo Alto VNET for the database, storage accounts, and Key Vaults
    - These private endpoints are in addition to our existing private endpoints
    - This ensures that the resources are connected to both VNETs
- Adds firewall rules to the container registry and storage accounts to allow connections from the Palo Alto VNET
    - This is in addition to our existing VNET firewall rules, so both VNETs can connect
- Switches the Function App to the Palo Alto VNET in non-production environments
    - This will restart the Function App when deployed
- Switches Metabase to the Palo Alto VNET in non-production environments
    - This will restart Metabase when deployed
- Switch the SFTP container to the Palo Alto VNET in non-production environments
    - This will recreate the SFTP container
    - A new private IP address will be allocated in the Palo Alto VNET
    - We will need to update smoke tests to use the new IP address in lower environments

## Fixes
- Resolves #1947

## To Be Done
- Switch smoke tests to use the new SFTP container IP
    - We will not known the new IP address until after this is deployed