### PR TITLE
rhood/2237-Reddy-PID-ORC-OBR-Changes

### DIFF
--- a/prime-router/docs/schema_documentation/ipatientcare-ipatientcare-covid-19.md
+++ b/prime-router/docs/schema_documentation/ipatientcare-ipatientcare-covid-19.md
@@ -172,6 +172,22 @@ This field is ignored because it does not contain a valid specimen type.  Set th
 
 ---
 
+**Name**: ResultDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: M/d/yyyy
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+ResultDate populates multiple fields.  This instance populates date_result_released.
+
+---
+
 **Name**: equipment_model_name
 
 **Type**: TABLE
@@ -657,6 +673,18 @@ Facility populates multiple fields.  This instance populates patient_id_assigner
 
 ---
 
+**Name**: patient_id_type
+
+**Type**: TEXT
+
+**PII**: No
+
+**Default Value**: PI
+
+**Cardinality**: [0..1]
+
+---
+
 **Name**: Last Name
 
 **Type**: PERSON_NAME
@@ -811,6 +839,25 @@ The patient's street address
 **Documentation**:
 
 The patient's zip code
+
+---
+
+**Name**: Accession_no
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-2-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.2.1)
+- [ORC-2-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.2.1)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ID number of the lab order from the placer
 
 ---
 

--- a/prime-router/docs/schema_documentation/ipatientcare-reddyfmc-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/ipatientcare-reddyfmc-la-covid-19.md
@@ -172,6 +172,22 @@ This field is ignored because it does not contain a valid specimen type.  Set th
 
 ---
 
+**Name**: ResultDate
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: M/d/yyyy
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+ResultDate populates multiple fields.  This instance populates date_result_released.
+
+---
+
 **Name**: equipment_model_name
 
 **Type**: TABLE
@@ -737,6 +753,18 @@ Facility populates multiple fields.  This instance populates patient_id_assigner
 
 ---
 
+**Name**: patient_id_type
+
+**Type**: TEXT
+
+**PII**: No
+
+**Default Value**: PI
+
+**Cardinality**: [0..1]
+
+---
+
 **Name**: Last Name
 
 **Type**: PERSON_NAME
@@ -891,6 +919,25 @@ The patient's street address
 **Documentation**:
 
 The patient's zip code
+
+---
+
+**Name**: Accession_no
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-2-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.2.1)
+- [ORC-2-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.2.1)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ID number of the lab order from the placer
 
 ---
 

--- a/prime-router/metadata/schemas/iPatientCare/iPatientCare-covid-19.schema
+++ b/prime-router/metadata/schemas/iPatientCare/iPatientCare-covid-19.schema
@@ -21,6 +21,9 @@ elements:
     - name: patient_id
       csvFields: [{name: MRN}]
 
+    - name: patient_id_type
+      default: "PI"
+
     - name: patient_last_name
       csvFields: [{name: Last Name}]
 
@@ -135,6 +138,9 @@ elements:
       csvFields: [{name: ResultDate, format: "M/d/yyyy"}]
       documentation: ResultDate populates multiple fields.  This instance populates test_result_report_date.
 
+    - name: date_result_released
+      csvFields: [{name: ResultDate, format: "M/d/yyyy"}]
+      documentation: ResultDate populates multiple fields.  This instance populates date_result_released.
 
     - name: test_performed_name
       csvFields: [{name: TestName}]
@@ -288,6 +294,8 @@ elements:
     - name: filler_order_id
       csvFields: [{name: Accession_no}]
 
+    - name: placer_order_id
+      csvFields: [{name: Accession_no}]
 
 
 #AOE fields


### PR DESCRIPTION
This PR contains all modifications necessary to the iPatientCare Parent schema to populate the PID.3.5, ORC.2.1 and OBR.22.1 for Reddy Family Medical Clinic.  LADOH and ADPH do not require these to be populated, but MN and NJ do.

Also multiple other fixes/changes were made as listed under "Changes" and "Fixes" below.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. If requested, I've saved the input CSV file and the HL7 output for Reddy Family Medical Clinoic.  The only step to testing is to process the CSV file and review the HL7 for the "Changes" and "Fixes" listed below.


## Changes
- Changed the iPatientcare schema to set the PID.3.5 to "PI".
- Populated date_result_released in the iPatientCare schema to set the OBR.22.
- Populated the placer_order_id with the filler_order_id because some States want the ORC.2; OBR.2; and SPM.2 populated.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?


### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
*List GitHub issues this PR fixes*
- #2237 


## To Be Done
*Create GitHub issues to track the work remaining, if any*
