### PR TITLE
fix: DNS records cannot be registered against multiple private endpoints

### DIFF
--- a/operations/app/src/modules/common/private_endpoint/main.tf
+++ b/operations/app/src/modules/common/private_endpoint/main.tf
@@ -59,20 +59,11 @@ resource "azurerm_private_endpoint" "endpoint" {
 
   # Automatically register the private endpoint in the private DNS zones
   dynamic "private_dns_zone_group" {
-    for_each = [0] # DNS needed for all zones. For each block retained to keep existing resource paths.
+    for_each = var.create_dns_record ? [0] : []
     content {
       name                 = local.endpoint_name
       private_dns_zone_ids = [for dns_zone in data.azurerm_private_dns_zone.private_dns_cname : dns_zone.id]
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      # Added the subnet id to new private endpoints to avoid collisions, but we don't want to rename existing endpoints
-      name,
-      private_service_connection[0].name,
-      private_dns_zone_group[0].name,
-    ]
   }
 }
 

--- a/operations/app/src/modules/common/private_endpoint/variables.tf
+++ b/operations/app/src/modules/common/private_endpoint/variables.tf
@@ -27,3 +27,8 @@ variable "endpoint_subnet_id" {
   type        = string
   description = "Private Endpoint Subnet ID"
 }
+
+variable "create_dns_record" {
+  type        = bool
+  description = "If the private endpoint should be associated via DNS. For resources with multiple private endpoints, DNS can only be registered against a single VNET. If this is enabled against multiple VNETs, Azure will silently and unpredictably overwrite DNS records."
+}

--- a/operations/app/src/modules/database/main.tf
+++ b/operations/app/src/modules/database/main.tf
@@ -48,6 +48,7 @@ module "postgres_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "postgres_server_private_endpoint" {
@@ -58,6 +59,7 @@ module "postgres_server_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_east.id
+  create_dns_record  = false
 }
 
 
@@ -114,6 +116,7 @@ module "postgres_private_endpoint_replica" {
   resource_group     = var.resource_group
   location           = azurerm_postgresql_server.postgres_server_replica.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_replica.id
+  create_dns_record  = true
 }
 
 module "postgres_server_private_endpoint_replica" {
@@ -124,6 +127,7 @@ module "postgres_server_private_endpoint_replica" {
   resource_group     = var.resource_group
   location           = azurerm_postgresql_server.postgres_server_replica.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_west.id
+  create_dns_record  = false
 }
 
 

--- a/operations/app/src/modules/database/main.tf
+++ b/operations/app/src/modules/database/main.tf
@@ -51,21 +51,21 @@ module "postgres_private_endpoint" {
   create_dns_record  = true
 }
 
-module "postgres_server_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_postgresql_server.postgres_server.id
-  name               = azurerm_postgresql_server.postgres_server.name
-  type               = "postgres_server"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_east.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.postgres_private_endpoint
-  ]
-}
+//module "postgres_server_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_postgresql_server.postgres_server.id
+//  name               = azurerm_postgresql_server.postgres_server.name
+//  type               = "postgres_server"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_east.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.postgres_private_endpoint
+//  ]
+//}
 
 
 // Replicate Server
@@ -124,21 +124,21 @@ module "postgres_private_endpoint_replica" {
   create_dns_record  = true
 }
 
-module "postgres_server_private_endpoint_replica" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_postgresql_server.postgres_server_replica.id
-  name               = azurerm_postgresql_server.postgres_server_replica.name
-  type               = "postgres_server"
-  resource_group     = var.resource_group
-  location           = azurerm_postgresql_server.postgres_server_replica.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_west.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.postgres_private_endpoint_replica
-  ]
-}
+//module "postgres_server_private_endpoint_replica" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_postgresql_server.postgres_server_replica.id
+//  name               = azurerm_postgresql_server.postgres_server_replica.name
+//  type               = "postgres_server"
+//  resource_group     = var.resource_group
+//  location           = azurerm_postgresql_server.postgres_server_replica.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_west.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.postgres_private_endpoint_replica
+//  ]
+//}
 
 
 // User Administration

--- a/operations/app/src/modules/database/main.tf
+++ b/operations/app/src/modules/database/main.tf
@@ -60,6 +60,11 @@ module "postgres_server_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_east.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.postgres_private_endpoint
+  ]
 }
 
 
@@ -128,6 +133,11 @@ module "postgres_server_private_endpoint_replica" {
   location           = azurerm_postgresql_server.postgres_server_replica.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet_west.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.postgres_private_endpoint_replica
+  ]
 }
 
 

--- a/operations/app/src/modules/function_app/candidate_slot.tf
+++ b/operations/app/src/modules/function_app/candidate_slot.tf
@@ -97,5 +97,5 @@ resource "azurerm_key_vault_access_policy" "slot_candidate_client_config_access_
 resource "azurerm_app_service_slot_virtual_network_swift_connection" "candidate_slot_vnet_integration" {
   slot_name      = azurerm_function_app_slot.candidate.name
   app_service_id = azurerm_function_app.function_app.id
-  subnet_id      = var.environment != "prod" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
+  subnet_id      = var.environment == "dev" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
 }

--- a/operations/app/src/modules/function_app/main.tf
+++ b/operations/app/src/modules/function_app/main.tf
@@ -156,7 +156,7 @@ resource "azurerm_key_vault_access_policy" "functionapp_client_config_access_pol
 
 resource "azurerm_app_service_virtual_network_swift_connection" "function_app_vnet_integration" {
   app_service_id = azurerm_function_app.function_app.id
-  subnet_id      = var.environment != "prod" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
+  subnet_id      = var.environment == "dev" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
 }
 
 // Enable sticky slot settings

--- a/operations/app/src/modules/key_vault/main.tf
+++ b/operations/app/src/modules/key_vault/main.tf
@@ -126,6 +126,11 @@ module "application_vault_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.application_private_endpoint
+  ]
 }
 
 resource "azurerm_key_vault" "app_config" {
@@ -211,6 +216,11 @@ module "app_config_vault_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.app_config_private_endpoint
+  ]
 }
 
 resource "azurerm_key_vault" "client_config" {
@@ -287,4 +297,9 @@ module "client_config_vault_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.client_config_private_endpoint
+  ]
 }

--- a/operations/app/src/modules/key_vault/main.tf
+++ b/operations/app/src/modules/key_vault/main.tf
@@ -117,21 +117,21 @@ module "application_private_endpoint" {
   create_dns_record  = true
 }
 
-module "application_vault_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_key_vault.application.id
-  name               = azurerm_key_vault.application.name
-  type               = "key_vault"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.application_private_endpoint
-  ]
-}
+//module "application_vault_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_key_vault.application.id
+//  name               = azurerm_key_vault.application.name
+//  type               = "key_vault"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.application_private_endpoint
+//  ]
+//}
 
 resource "azurerm_key_vault" "app_config" {
   name = "${var.resource_prefix}-appconfig"
@@ -207,21 +207,21 @@ module "app_config_private_endpoint" {
   create_dns_record  = true
 }
 
-module "app_config_vault_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_key_vault.app_config.id
-  name               = azurerm_key_vault.app_config.name
-  type               = "key_vault"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.app_config_private_endpoint
-  ]
-}
+//module "app_config_vault_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_key_vault.app_config.id
+//  name               = azurerm_key_vault.app_config.name
+//  type               = "key_vault"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.app_config_private_endpoint
+//  ]
+//}
 
 resource "azurerm_key_vault" "client_config" {
   # Does not include "-keyvault" due to char limits (24)
@@ -288,18 +288,18 @@ module "client_config_private_endpoint" {
   create_dns_record  = true
 }
 
-module "client_config_vault_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_key_vault.client_config.id
-  name               = azurerm_key_vault.client_config.name
-  type               = "key_vault"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.client_config_private_endpoint
-  ]
-}
+//module "client_config_vault_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_key_vault.client_config.id
+//  name               = azurerm_key_vault.client_config.name
+//  type               = "key_vault"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.client_config_private_endpoint
+//  ]
+//}

--- a/operations/app/src/modules/key_vault/main.tf
+++ b/operations/app/src/modules/key_vault/main.tf
@@ -114,6 +114,7 @@ module "application_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "application_vault_private_endpoint" {
@@ -124,6 +125,7 @@ module "application_vault_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 resource "azurerm_key_vault" "app_config" {
@@ -197,6 +199,7 @@ module "app_config_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "app_config_vault_private_endpoint" {
@@ -207,6 +210,7 @@ module "app_config_vault_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 resource "azurerm_key_vault" "client_config" {
@@ -271,6 +275,7 @@ module "client_config_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "client_config_vault_private_endpoint" {
@@ -281,4 +286,5 @@ module "client_config_vault_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }

--- a/operations/app/src/modules/metabase/main.tf
+++ b/operations/app/src/modules/metabase/main.tf
@@ -47,5 +47,5 @@ resource "azurerm_app_service" "metabase" {
 
 resource "azurerm_app_service_virtual_network_swift_connection" "metabase_vnet_integration" {
   app_service_id = azurerm_app_service.metabase.id
-  subnet_id      = var.environment != "prod" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
+  subnet_id      = var.environment == "dev" ? data.azurerm_subnet.public_subnet.id : data.azurerm_subnet.public.id
 }

--- a/operations/app/src/modules/network/main.tf
+++ b/operations/app/src/modules/network/main.tf
@@ -25,7 +25,7 @@ module "subnet_addresses" {
     },
     {
       name     = "endpoint"
-      new_bits = 3
+      new_bits = 2
     },
   ]
 }

--- a/operations/app/src/modules/sftp_container/main.tf
+++ b/operations/app/src/modules/sftp_container/main.tf
@@ -31,7 +31,7 @@ resource "azurerm_container_group" "sftp_container" {
   location            = var.location
   resource_group_name = var.resource_group
   ip_address_type     = "Private"
-  network_profile_id  = var.environment != "prod" ? azurerm_network_profile.sftp_vnet_network_profile.id : azurerm_network_profile.sftp_network_profile.id
+  network_profile_id  = var.environment == "dev" ? azurerm_network_profile.sftp_vnet_network_profile.id : azurerm_network_profile.sftp_network_profile.id
   os_type             = "Linux"
   restart_policy      = "Always"
 
@@ -67,6 +67,7 @@ resource "azurerm_container_group" "sftp_container" {
     // Workaround. TF thinks this is a new resource after import
     ignore_changes = [
       container[0].volume[0],
+      network_profile_id,
     ]
   }
 }

--- a/operations/app/src/modules/storage/candidate_slot.tf
+++ b/operations/app/src/modules/storage/candidate_slot.tf
@@ -240,21 +240,21 @@ module "storageaccountcandidatepartner_blob_private_endpoint" {
   create_dns_record  = true
 }
 
-module "storage_candidatepartner_blob_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_storage_account.storage_partner_candidate.id
-  name               = azurerm_storage_account.storage_partner_candidate.name
-  type               = "storage_account_blob"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.storageaccountcandidatepartner_blob_private_endpoint
-  ]
-}
+//module "storage_candidatepartner_blob_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_storage_account.storage_partner_candidate.id
+//  name               = azurerm_storage_account.storage_partner_candidate.name
+//  type               = "storage_account_blob"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.storageaccountcandidatepartner_blob_private_endpoint
+//  ]
+//}
 
 resource "azurerm_storage_container" "storage_candidate_container_hhsprotect" {
   name                 = "hhsprotect"

--- a/operations/app/src/modules/storage/candidate_slot.tf
+++ b/operations/app/src/modules/storage/candidate_slot.tf
@@ -48,6 +48,7 @@ module "storageaccount_candidate_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storageaccount_candidate_file_private_endpoint" {
@@ -58,6 +59,7 @@ module "storageaccount_candidate_file_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storageaccount_candidate_queue_private_endpoint" {
@@ -68,6 +70,40 @@ module "storageaccount_candidate_queue_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
+}
+
+module "storage_candidate_blob_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_account_candidate.id
+  name               = azurerm_storage_account.storage_account_candidate.name
+  type               = "storage_account_blob"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
+}
+
+module "storage_candidate_file_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_account_candidate.id
+  name               = azurerm_storage_account.storage_account_candidate.name
+  type               = "storage_account_file"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
+}
+
+module "storage_candidate_queue_private_endpoint" {
+  source             = "../common/private_endpoint"
+  resource_id        = azurerm_storage_account.storage_account_candidate.id
+  name               = azurerm_storage_account.storage_account_candidate.name
+  type               = "storage_account_queue"
+  resource_group     = var.resource_group
+  location           = var.location
+  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 resource "azurerm_storage_management_policy" "retention_policy_candidate" {
@@ -186,6 +222,7 @@ module "storageaccountcandidatepartner_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storage_candidatepartner_blob_private_endpoint" {
@@ -196,6 +233,7 @@ module "storage_candidatepartner_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 resource "azurerm_storage_container" "storage_candidate_container_hhsprotect" {

--- a/operations/app/src/modules/storage/candidate_slot.tf
+++ b/operations/app/src/modules/storage/candidate_slot.tf
@@ -82,6 +82,11 @@ module "storage_candidate_blob_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccount_candidate_blob_private_endpoint
+  ]
 }
 
 module "storage_candidate_file_private_endpoint" {
@@ -93,6 +98,11 @@ module "storage_candidate_file_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccount_candidate_file_private_endpoint
+  ]
 }
 
 module "storage_candidate_queue_private_endpoint" {
@@ -104,6 +114,11 @@ module "storage_candidate_queue_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccount_candidate_queue_private_endpoint
+  ]
 }
 
 resource "azurerm_storage_management_policy" "retention_policy_candidate" {
@@ -234,6 +249,11 @@ module "storage_candidatepartner_blob_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccountcandidatepartner_blob_private_endpoint
+  ]
 }
 
 resource "azurerm_storage_container" "storage_candidate_container_hhsprotect" {

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -74,53 +74,53 @@ module "storageaccount_queue_private_endpoint" {
   create_dns_record  = true
 }
 
-module "storage_blob_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_storage_account.storage_account.id
-  name               = azurerm_storage_account.storage_account.name
-  type               = "storage_account_blob"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
+//module "storage_blob_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_storage_account.storage_account.id
+//  name               = azurerm_storage_account.storage_account.name
+//  type               = "storage_account_blob"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.storageaccount_blob_private_endpoint
+//  ]
+//}
 
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.storageaccount_blob_private_endpoint
-  ]
-}
+//module "storage_file_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_storage_account.storage_account.id
+//  name               = azurerm_storage_account.storage_account.name
+//  type               = "storage_account_file"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.storageaccount_file_private_endpoint
+//  ]
+//}
 
-module "storage_file_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_storage_account.storage_account.id
-  name               = azurerm_storage_account.storage_account.name
-  type               = "storage_account_file"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.storageaccount_file_private_endpoint
-  ]
-}
-
-module "storage_queue_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_storage_account.storage_account.id
-  name               = azurerm_storage_account.storage_account.name
-  type               = "storage_account_queue"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.storageaccount_queue_private_endpoint
-  ]
-}
+//module "storage_queue_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_storage_account.storage_account.id
+//  name               = azurerm_storage_account.storage_account.name
+//  type               = "storage_account_queue"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.storageaccount_queue_private_endpoint
+//  ]
+//}
 
 # Point-in-time restore, soft delete, versioning, and change feed were
 # enabled in the portal as terraform does not currently support this.
@@ -284,21 +284,21 @@ module "storageaccountpartner_blob_private_endpoint" {
   create_dns_record  = true
 }
 
-module "storage_partner_blob_private_endpoint" {
-  source             = "../common/private_endpoint"
-  resource_id        = azurerm_storage_account.storage_partner.id
-  name               = azurerm_storage_account.storage_partner.name
-  type               = "storage_account_blob"
-  resource_group     = var.resource_group
-  location           = var.location
-  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
-  create_dns_record  = false
-
-  depends_on = [
-    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
-    module.storageaccountpartner_blob_private_endpoint
-  ]
-}
+//module "storage_partner_blob_private_endpoint" {
+//  source             = "../common/private_endpoint"
+//  resource_id        = azurerm_storage_account.storage_partner.id
+//  name               = azurerm_storage_account.storage_partner.name
+//  type               = "storage_account_blob"
+//  resource_group     = var.resource_group
+//  location           = var.location
+//  endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+//  create_dns_record  = false
+//
+//  depends_on = [
+//    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+//    module.storageaccountpartner_blob_private_endpoint
+//  ]
+//}
 
 resource "azurerm_storage_container" "storage_container_hhsprotect" {
   name                 = "hhsprotect"

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -83,6 +83,11 @@ module "storage_blob_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccount_blob_private_endpoint
+  ]
 }
 
 module "storage_file_private_endpoint" {
@@ -94,6 +99,11 @@ module "storage_file_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccount_file_private_endpoint
+  ]
 }
 
 module "storage_queue_private_endpoint" {
@@ -105,6 +115,11 @@ module "storage_queue_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccount_queue_private_endpoint
+  ]
 }
 
 # Point-in-time restore, soft delete, versioning, and change feed were
@@ -278,6 +293,11 @@ module "storage_partner_blob_private_endpoint" {
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
   create_dns_record  = false
+
+  depends_on = [
+    # Prevent unexpected order-of-operations by placing a hard dependency against the current private endpoint
+    module.storageaccountpartner_blob_private_endpoint
+  ]
 }
 
 resource "azurerm_storage_container" "storage_container_hhsprotect" {

--- a/operations/app/src/modules/storage/main.tf
+++ b/operations/app/src/modules/storage/main.tf
@@ -49,6 +49,7 @@ module "storageaccount_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storageaccount_file_private_endpoint" {
@@ -59,6 +60,7 @@ module "storageaccount_file_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storageaccount_queue_private_endpoint" {
@@ -69,6 +71,7 @@ module "storageaccount_queue_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storage_blob_private_endpoint" {
@@ -79,6 +82,7 @@ module "storage_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 module "storage_file_private_endpoint" {
@@ -89,6 +93,7 @@ module "storage_file_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 module "storage_queue_private_endpoint" {
@@ -99,6 +104,7 @@ module "storage_queue_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 # Point-in-time restore, soft delete, versioning, and change feed were
@@ -260,6 +266,7 @@ module "storageaccountpartner_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint.id
+  create_dns_record  = true
 }
 
 module "storage_partner_blob_private_endpoint" {
@@ -270,6 +277,7 @@ module "storage_partner_blob_private_endpoint" {
   resource_group     = var.resource_group
   location           = var.location
   endpoint_subnet_id = data.azurerm_subnet.endpoint_subnet.id
+  create_dns_record  = false
 }
 
 resource "azurerm_storage_container" "storage_container_hhsprotect" {


### PR DESCRIPTION
This PR fixes multiple private endpoints overwriting DNS records within the same resource group.

Azure [only allows one private DNS zone per resource group](https://dev.to/kaiwalter/using-azure-private-links-and-private-dns-zones-with-globally-distributed-resources-4ce3), so when using multiple private endpoints in the same resource group, only one can register a DNS record against a private DNS zone. Allowing them all to registered a DNS record creates unpredictable results.