### PR TITLE
Add missing `REACT_APP_PUBLIC_URL`

### DIFF
--- a/frontend-react/.env.development
+++ b/frontend-react/.env.development
@@ -1,4 +1,5 @@
 REACT_APP_TITLE=ReportStream Dashboard DEV
 REACT_APP_BACKEND_URL=http://localhost:7071/api/
 REACT_APP_BASE_URL=http://localhost:3000
+REACT_APP_PUBLIC_URL=
 INLINE_RUNTIME_CHUNK=false


### PR DESCRIPTION
The `REACT_APP_PUBLIC_URL` variable is used to build the path the manifest file. It needs to be set to empty for local dev setup.

This small PR also tests my setup for signing git commits.
