### PR TITLE
modified V17 to remove slow update sql

### DIFF
--- a/prime-router/docs/playbooks/db_flyway_repair.md
+++ b/prime-router/docs/playbooks/db_flyway_repair.md
@@ -1,0 +1,30 @@
+# Flyway Database Repair
+
+If the Flyway migrations need a repair, the following commands will resolve in each environment.
+
+## TEST
+
+```shell
+az login
+export POSTGRES_PASSWORD=$(az account get-access-token --resource-type oss-rdbms | python3 -c "import sys, json; print(json.load(sys.stdin)['accessToken'])")
+POSTGRES_URL=jdbc:postgresql://pdhtest-pgsql.postgres.database.azure.com:5432/prime_data_hub_candidate?sslmode=require POSTGRES_USER=reportstream_pgsql_admin@pdhtest-pgsql ./gradlew flywayRepair
+POSTGRES_URL=jdbc:postgresql://pdhtest-pgsql.postgres.database.azure.com:5432/prime_data_hub?sslmode=require POSTGRES_USER=reportstream_pgsql_admin@pdhtest-pgsql ./gradlew flywayRepair
+```
+
+## STAGING
+
+```shell
+az login
+export POSTGRES_PASSWORD=$(az account get-access-token --resource-type oss-rdbms | python3 -c "import sys, json; print(json.load(sys.stdin)['accessToken'])")
+POSTGRES_URL=jdbc:postgresql://pdhstaging-pgsql.postgres.database.azure.com:5432/prime_data_hub_candidate?sslmode=require POSTGRES_USER=reportstream_pgsql_admin@pdhstaging-pgsql ./gradlew flywayRepair
+POSTGRES_URL=jdbc:postgresql://pdhstaging-pgsql.postgres.database.azure.com:5432/prime_data_hub?sslmode=require POSTGRES_USER=reportstream_pgsql_admin@pdhstaging-pgsql ./gradlew flywayRepair
+```
+
+## PROD
+
+```shell
+az login
+export POSTGRES_PASSWORD=$(az account get-access-token --resource-type oss-rdbms | python3 -c "import sys, json; print(json.load(sys.stdin)['accessToken'])")
+POSTGRES_URL=jdbc:postgresql://pdhprod-pgsql.postgres.database.azure.com:5432/prime_data_hub_candidate?sslmode=require POSTGRES_USER=reportstream_pgsql_admin@pdhprod-pgsql ./gradlew flywayRepair
+POSTGRES_URL=jdbc:postgresql://pdhprod-pgsql.postgres.database.azure.com:5432/prime_data_hub?sslmode=require POSTGRES_USER=reportstream_pgsql_admin@pdhprod-pgsql ./gradlew flywayRepair
+```

--- a/prime-router/src/main/resources/db/migration/V17__add_sender_and_testkit_data_to_metadata_table.sql
+++ b/prime-router/src/main/resources/db/migration/V17__add_sender_and_testkit_data_to_metadata_table.sql
@@ -23,12 +23,3 @@ ALTER TABLE covid_result_metadata
     ADD COLUMN test_performed_loinc_code VARCHAR(512) NULL
 ;
 
-/*
- * Now back fill the sender_id using data from the report_file table.
- */
-UPDATE covid_result_metadata
-SET sender_id = subquery.sender_id
-FROM (SELECT rf.report_id, rf.sending_org || '.' || rf.sending_org_client as sender_id
-FROM report_file rf
-JOIN covid_result_metadata crm ON rf.report_id = crm.report_id) AS subquery
-WHERE covid_result_metadata.sender_id IS NULL AND covid_result_metadata.report_id = subquery.report_id;


### PR DESCRIPTION
This PR removes an update statement that was running too slowly to run inside flyway.

Users must run `./gradlew flywayRepair` before doing a build.

Test Steps:
1. Run run `./gradlew flywayRepair` before doing a build.
2. Then run run `./gradlew clean package`
3. You should get a clean build.


## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
- #2263 

## To Be Done
- Don't forget to run `./gradlew flywayRepair` before attempting a build.
