### PR TITLE
Consolidate error and warning messages for the CSV uploader

### DIFF
--- a/frontend-react/src/pages/Upload.tsx
+++ b/frontend-react/src/pages/Upload.tsx
@@ -225,14 +225,18 @@ export const Upload = () => {
                             </p>
                         </div>
                     </div>
-                    <table>
-                        <tr>
-                            <th>Requested Edit</th>
-                            <th>Areas Containing the Requested Edit</th>
-                        </tr>
-                        {consolidatedErrors.map((e, i) => {
-                            return (<tr key={i}><td>{e['message']}</td><td>{e['rows']}</td></tr>)
-                        })}
+                    <table className="usa-table usa-table--borderless">
+                        <thead>
+                            <tr>
+                                <th>Requested Edit</th>
+                                <th>Areas Containing the Requested Edit</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {consolidatedErrors.map((e, i) => {
+                                return (<tr key={i}><td>{e['message']}</td><td>{e['rows']}</td></tr>)
+                            })}
+                        </tbody>
                     </table>
                 </div>
             )}
@@ -249,14 +253,18 @@ export const Upload = () => {
                             </p>
                         </div>
                     </div>
-                    <table>
-                        <tr>
-                            <th>Requested Edit</th>
-                            <th>Areas Containing the Requested Edit</th>
-                        </tr>
-                        {consolidatedWarnings.map((e, i) => {
-                            return (<tr key={i}><td>{e['message']}</td><td>{e['rows']}</td></tr>)
-                        })}
+                    <table className="usa-table usa-table--borderless">
+                        <thead>
+                            <tr>
+                                <th>Requested Edit</th>
+                                <th>Areas Containing the Requested Edit</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {consolidatedWarnings.map((e, i) => {
+                                return (<tr key={i}><td>{e['message']}</td><td>{e['rows']}</td></tr>)
+                            })}
+                        </tbody>
                     </table>
                 </div>
             )}

--- a/prime-router/src/main/kotlin/ElementErrors.kt
+++ b/prime-router/src/main/kotlin/ElementErrors.kt
@@ -30,7 +30,7 @@ data class InvalidDateMessage(
     }
 
     override fun groupingId(): String {
-        return fieldMapping
+        return fieldMapping + formattedValue
     }
 
     companion object {
@@ -50,7 +50,7 @@ data class InvalidCodeMessage(
     }
 
     override fun groupingId(): String {
-        return fieldMapping
+        return fieldMapping + formattedValue
     }
 
     companion object {
@@ -70,7 +70,7 @@ data class InvalidPhoneMessage(
     }
 
     override fun groupingId(): String {
-        return fieldMapping
+        return fieldMapping + formattedValue
     }
 
     companion object {
@@ -90,7 +90,7 @@ data class InvalidPostalMessage(
     }
 
     override fun groupingId(): String {
-        return fieldMapping
+        return fieldMapping + formattedValue
     }
 
     companion object {
@@ -110,7 +110,7 @@ data class UnsupportedHDMessage(
     }
 
     override fun groupingId(): String {
-        return fieldMapping
+        return fieldMapping + formattedValue
     }
 
     companion object {
@@ -134,7 +134,7 @@ data class UnsupportedEIMessage(
     }
 
     override fun groupingId(): String {
-        return fieldMapping
+        return fieldMapping + formattedValue
     }
 
     companion object {

--- a/prime-router/src/main/kotlin/ResultDetail.kt
+++ b/prime-router/src/main/kotlin/ResultDetail.kt
@@ -9,7 +9,9 @@ package gov.cdc.prime.router
 data class ResultDetail(
     val scope: DetailScope,
     val id: String,
-    val responseMessage: ResponseMessage, val row: Int = -1) {
+    val responseMessage: ResponseMessage,
+    val row: Int = -1
+) {
     /**
      * @property REPORT scope for the detail
      * @property ITEM scope for the detail

--- a/prime-router/src/main/kotlin/ResultDetail.kt
+++ b/prime-router/src/main/kotlin/ResultDetail.kt
@@ -4,6 +4,7 @@ package gov.cdc.prime.router
  * @property scope of the result detail
  * @property id of the result (depends on scope)
  * @property details of the result
+ * @property row of csv related to message (set to -1 if not applicable)
  */
 data class ResultDetail(val scope: DetailScope, val id: String, val responseMessage: ResponseMessage, val row: Int) {
     /**
@@ -18,19 +19,19 @@ data class ResultDetail(val scope: DetailScope, val id: String, val responseMess
 
     companion object {
         fun report(message: ResponseMessage): ResultDetail {
-            return ResultDetail(DetailScope.REPORT, "", message)
+            return ResultDetail(DetailScope.REPORT, "", message, -1)
         }
 
-        fun item(id: String, message: ResponseMessage): ResultDetail {
-            return ResultDetail(DetailScope.ITEM, id, message)
+        fun item(id: String, message: ResponseMessage, row: Int): ResultDetail {
+            return ResultDetail(DetailScope.ITEM, id, message, row)
         }
 
         fun param(id: String, message: ResponseMessage): ResultDetail {
-            return ResultDetail(DetailScope.PARAMETER, id, message)
+            return ResultDetail(DetailScope.PARAMETER, id, message, -1)
         }
 
         fun translation(id: String, message: ResponseMessage): ResultDetail {
-            return ResultDetail(DetailScope.TRANSLATION, id, message)
+            return ResultDetail(DetailScope.TRANSLATION, id, message, -1)
         }
     }
 }

--- a/prime-router/src/main/kotlin/ResultDetail.kt
+++ b/prime-router/src/main/kotlin/ResultDetail.kt
@@ -5,7 +5,7 @@ package gov.cdc.prime.router
  * @property id of the result (depends on scope)
  * @property details of the result
  */
-data class ResultDetail(val scope: DetailScope, val id: String, val responseMessage: ResponseMessage) {
+data class ResultDetail(val scope: DetailScope, val id: String, val responseMessage: ResponseMessage, val row: Int) {
     /**
      * @property REPORT scope for the detail
      * @property ITEM scope for the detail

--- a/prime-router/src/main/kotlin/ResultDetail.kt
+++ b/prime-router/src/main/kotlin/ResultDetail.kt
@@ -6,7 +6,10 @@ package gov.cdc.prime.router
  * @property details of the result
  * @property row of csv related to message (set to -1 if not applicable)
  */
-data class ResultDetail(val scope: DetailScope, val id: String, val responseMessage: ResponseMessage, val row: Int) {
+data class ResultDetail(
+    val scope: DetailScope,
+    val id: String,
+    val responseMessage: ResponseMessage, val row: Int = -1) {
     /**
      * @property REPORT scope for the detail
      * @property ITEM scope for the detail

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -581,8 +581,8 @@ class ReportFunction : Logging {
                 }
                 it.writeEndArray()
             }
-            writeConsolidatedArray("errorsConsolidated", result.errors)
-            writeConsolidatedArray("warningsConsolidated", result.warnings)
+            writeConsolidatedArray("consolidatedErrors", result.errors)
+            writeConsolidatedArray("consolidatedWarnings", result.warnings)
         }
         return outStream.toString()
     }

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -564,7 +564,7 @@ class ReportFunction : Logging {
                     if (i == 0) {
                         sb.append(row.toString())
                     } else {
-                        if (row == rows[i-1] + 1) {
+                        if (row == rows[i-1] || row == rows[i-1] + 1) {
                             isListing = true
                         } else {
                             if (isListing) {
@@ -575,6 +575,9 @@ class ReportFunction : Logging {
                             sb.append(row.toString())
                             isListing = false
                         }
+                    }
+                    if (i == rows.lastIndex && isListing) {
+                        sb.append("–" + rows[rows.lastIndex].toString())
                     }
                 }
                 return sb.toString()

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -555,6 +555,31 @@ class ReportFunction : Logging {
             writeDetailsArray("errors", result.errors)
             writeDetailsArray("warnings", result.warnings)
 
+            fun createRowsDescription(rows: MutableList<Int>?): String {
+                if (rows == null || rows.isEmpty()) return ""
+                rows.sort()
+                val sb = StringBuilder().append("Rows: ")
+                var isListing = false
+                rows.forEachIndexed { i, row ->
+                    if (i == 0) {
+                        sb.append(row.toString())
+                    } else {
+                        if (row == rows[i-1] + 1) {
+                            isListing = true
+                        } else {
+                            if (isListing) {
+                                sb.append("–" + rows[i-1].toString() + ", ")
+                            } else {
+                                sb.append(", ")
+                            }
+                            sb.append(row.toString())
+                            isListing = false
+                        }
+                    }
+                }
+                return sb.toString()
+            }
+
             fun writeConsolidatedArray(field: String, array: List<ResultDetail>) {
                 val messagesAndRows = hashMapOf<String, MutableList<Int>>()
                 array.forEach { resultDetail ->
@@ -574,9 +599,7 @@ class ReportFunction : Logging {
                 messagesAndRows.keys.forEach { message ->
                     it.writeStartObject()
                     it.writeStringField("message", message)
-                    val rows =
-                        if (messagesAndRows[message]?.size == 0) "" else "Rows: " + messagesAndRows[message].toString()
-                    it.writeStringField("rows", rows)
+                    it.writeStringField("rows", createRowsDescription(messagesAndRows[message]))
                     it.writeEndObject()
                 }
                 it.writeEndArray()

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -576,8 +576,9 @@ class ReportFunction : Logging {
                     val areaEffected = 
                         if (messagesAndRows[message]?.size == 0) "" else "Rows: " + messagesAndRows[message].toString()
                     it.writeStringField("areaEffected", areaEffected)
-                    it.writeEndArray()
+                    it.writeEndObject()
                 }
+                it.writeEndArray()
             }
             writeConsolidatedArray("errorsConsolidated", result.errors)
             writeConsolidatedArray("warningsConsolidated", result.warnings)

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -562,15 +562,20 @@ class ReportFunction : Logging {
                     if (messagesAndRows.containsKey(groupingId)) {
                         messagesAndRows[groupingId]?.add(resultDetail.row)
                     } else {
-                        messagesAndRows[groupingId] = mutableListOf(resultDetail.row)
+                        if (resultDetail.row == -1) {
+                            messagesAndRows[groupingId] = mutableListOf()
+                        } else {
+                            messagesAndRows[groupingId] = mutableListOf(resultDetail.row)
+                        }
                     }
                 }
                 it.writeArrayFieldStart(field)
                 messagesAndRows.keys.forEach { message -> 
                     it.writeStartObject()
                     it.writeStringField("message", message)
-                    it.writeArrayFieldStart("rows")
-                    it.writeArray(messagesAndRows[message]?.toTypedArray(), 0, 0)
+                    val areaEffected = 
+                        if (messagesAndRows[message]?.size == 0) "" else "Rows: " + messagesAndRows[message].toString()
+                    it.writeStringField("areaEffected", areaEffected)
                     it.writeEndArray()
                 }
             }

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -565,7 +565,8 @@ class ReportFunction : Logging {
                         if (resultDetail.row == -1) {
                             messagesAndRows[groupingId] = mutableListOf()
                         } else {
-                            messagesAndRows[groupingId] = mutableListOf(resultDetail.row)
+                            // Add 2 to account for array offset and csv header
+                            messagesAndRows[groupingId] = mutableListOf(resultDetail.row + 2)
                         }
                     }
                 }
@@ -573,9 +574,9 @@ class ReportFunction : Logging {
                 messagesAndRows.keys.forEach { message ->
                     it.writeStartObject()
                     it.writeStringField("message", message)
-                    val areaEffected =
+                    val rows =
                         if (messagesAndRows[message]?.size == 0) "" else "Rows: " + messagesAndRows[message].toString()
-                    it.writeStringField("areaEffected", areaEffected)
+                    it.writeStringField("rows", rows)
                     it.writeEndObject()
                 }
                 it.writeEndArray()

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -588,7 +588,8 @@ class ReportFunction : Logging {
                 array.forEach { resultDetail ->
                     val groupingId = resultDetail.responseMessage.groupingId()
                     if (messagesAndRows.containsKey(groupingId)) {
-                        messagesAndRows[groupingId]?.add(resultDetail.row)
+                        // Add 2 to account for array offset and csv header
+                        messagesAndRows[groupingId]?.add(resultDetail.row + 2)
                     } else {
                         if (resultDetail.row == -1) {
                             messagesAndRows[groupingId] = mutableListOf()

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -557,7 +557,7 @@ class ReportFunction : Logging {
 
             fun writeConsolidatedArray(field: String, array: List<ResultDetail>) {
                 val messagesAndRows = hashMapOf<String, MutableList<Int>>()
-                array.forEach { resultDetail -> 
+                array.forEach { resultDetail ->
                     val groupingId = resultDetail.responseMessage.groupingId()
                     if (messagesAndRows.containsKey(groupingId)) {
                         messagesAndRows[groupingId]?.add(resultDetail.row)
@@ -570,10 +570,10 @@ class ReportFunction : Logging {
                     }
                 }
                 it.writeArrayFieldStart(field)
-                messagesAndRows.keys.forEach { message -> 
+                messagesAndRows.keys.forEach { message ->
                     it.writeStartObject()
                     it.writeStringField("message", message)
-                    val areaEffected = 
+                    val areaEffected =
                         if (messagesAndRows[message]?.size == 0) "" else "Rows: " + messagesAndRows[message].toString()
                     it.writeStringField("areaEffected", areaEffected)
                     it.writeEndObject()

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -586,16 +586,16 @@ class ReportFunction : Logging {
             fun writeConsolidatedArray(field: String, array: List<ResultDetail>) {
                 val messagesAndRows = hashMapOf<String, MutableList<Int>>()
                 array.forEach { resultDetail ->
-                    val groupingId = resultDetail.responseMessage.groupingId()
-                    if (messagesAndRows.containsKey(groupingId)) {
+                    val groupingMsg = resultDetail.responseMessage.detailMsg()
+                    if (messagesAndRows.containsKey(groupingMsg)) {
                         // Add 2 to account for array offset and csv header
-                        messagesAndRows[groupingId]?.add(resultDetail.row + 2)
+                        messagesAndRows[groupingMsg]?.add(resultDetail.row + 2)
                     } else {
                         if (resultDetail.row == -1) {
-                            messagesAndRows[groupingId] = mutableListOf()
+                            messagesAndRows[groupingMsg] = mutableListOf()
                         } else {
                             // Add 2 to account for array offset and csv header
-                            messagesAndRows[groupingId] = mutableListOf(resultDetail.row + 2)
+                            messagesAndRows[groupingMsg] = mutableListOf(resultDetail.row + 2)
                         }
                     }
                 }

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -564,10 +564,10 @@ class ReportFunction : Logging {
                 rows.forEachIndexed { i, row ->
                     if (i == 0) {
                         sb.append(row.toString())
-                    } else if (row == rows[i-1] || row == rows[i-1] + 1) {
+                    } else if (row == rows[i - 1] || row == rows[i - 1] + 1) {
                         isListing = true
                     } else if (isListing) {
-                        sb.append("–" + rows[i-1].toString() + ", " + row.toString())
+                        sb.append("–" + rows[i - 1].toString() + ", " + row.toString())
                         isListing = false
                     } else {
                         sb.append(", " + row.toString())

--- a/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
+++ b/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
@@ -145,8 +145,8 @@ class CsvSerializer(val metadata: Metadata) {
             var trackingId = if (trackingColumn != null) result.row[trackingColumn] else ""
             if (trackingId.isEmpty())
                 trackingId = "row$index"
-            errors.addAll(result.errors.map { ResultDetail.item(trackingId, it) })
-            warnings.addAll(result.warnings.map { ResultDetail.item(trackingId, it) })
+            errors.addAll(result.errors.map { ResultDetail.item(trackingId, it, index) })
+            warnings.addAll(result.warnings.map { ResultDetail.item(trackingId, it, index) })
             if (result.errors.isEmpty()) {
                 result.row
             } else {


### PR DESCRIPTION
## Context
When there are error and/or warning during CSV uploading, each one is listed in the UI. This can become verbose and unfriendly to the end user. The solution is to consolidate these messages as shown in [these mocks](https://www.figma.com/file/ctpYEoOBWGkUnk9cmXzVp2/ReportStream-Submitter-Front-End?node-id=980%3A3216)

Tech specs proposal detailed here: https://app.zenhub.com/workspaces/prime-data-hub-5ff4833beb3e08001a4cacae/issues/cdcgov/prime-reportstream/1966

## Changes
- Introduces a `ResponseMessage` interface that `ResultDetail` uses instead of a `String` for the message
- Creates data classes for each error type that implement `ResponseMessage`
- Creates a generic `ResponseMsgType` all HL7 serialization warnings/errors since these do not need consolidation
- Adds new fields `consolidatedErrors` and `consolidatedWarnings` to the waters api response that contain the consolidated messages


## Test Steps:
1. Create an upload csv with known problems (for example, using the test-waters-data.csv, make the patientAge column blank)
2. Upload csv in the csv uploader
3. Verify that the errors/warnings are conolidated

### Before
![image](https://user-images.githubusercontent.com/87096393/134450676-98cd4b4e-2e74-4666-8496-2bc6e7c6548b.png)

### After
![image](https://user-images.githubusercontent.com/87096393/134710043-d0fe4808-bd11-4a6a-8113-f151613119a3.png)
