### PR TITLE
Remove call to get blob body

### DIFF
--- a/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
@@ -216,7 +216,11 @@ open class BaseHistoryFunction : Logging {
                 }
                 val header =
                     try {
-                        workflowEngine.fetchHeader(it.reportId, adminOrg ?: authClaims.organization)
+                        workflowEngine.fetchHeader(
+                            it.reportId,
+                            adminOrg ?: authClaims.organization,
+                            fetchBlobBody = false
+                        )
                     } catch (ex: Exception) {
                         context.logger.severe("Unable to find file for ${it.reportId} ${ex.message}")
                         null

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -440,13 +440,14 @@ class WorkflowEngine(
         reportFile: ReportFile,
         itemLineages: List<ItemLineage>?,
         organization: Organization?,
-        receiver: Receiver?
+        receiver: Receiver?,
+        fetchBlobBody: Boolean = true
     ): Header {
         val schema = if (reportFile.schemaName != null)
             metadata.findSchema(reportFile.schemaName)
         else null
 
-        val content = if (reportFile.bodyUrl != null)
+        val content = if (reportFile.bodyUrl != null && fetchBlobBody)
             blob.downloadBlob(reportFile.bodyUrl)
         else null
         return Header(task, reportFile, itemLineages, organization, receiver, schema, content)
@@ -455,6 +456,7 @@ class WorkflowEngine(
     fun fetchHeader(
         reportId: ReportId,
         organization: Organization,
+        fetchBlobBody: Boolean = true
     ): Header {
         val reportFile = db.fetchReportFile(reportId, organization)
         val task = db.fetchTask(reportId)
@@ -465,7 +467,7 @@ class WorkflowEngine(
         // todo remove this sanity check
         ActionHistory.sanityCheckReport(task, reportFile, false)
         val itemLineages = db.fetchItemLineagesForReport(reportId, reportFile.itemCount)
-        return createHeader(task, reportFile, itemLineages, organization, receiver)
+        return createHeader(task, reportFile, itemLineages, organization, receiver, fetchBlobBody)
     }
 
     /**

--- a/prime-router/src/main/kotlin/cli/tests/WatersAuthTests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/WatersAuthTests.kt
@@ -18,7 +18,7 @@ import gov.cdc.prime.router.tokens.DatabaseJtiCache
 import gov.cdc.prime.router.tokens.SenderUtils
 import java.io.File
 import java.time.OffsetDateTime
-import java.util.*
+import java.util.UUID
 
 /**
  *

--- a/prime-router/src/main/kotlin/transport/RedoxTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RedoxTransport.kt
@@ -68,8 +68,8 @@ class RedoxTransport() : ITransport, SecretManagement {
                 val itemId = "${header.reportFile.reportId}-$index"
                 val sendResult = when {
                     (retryItems == null) ||
-                        RetryToken.isAllItems(retryItems)
-                        || retryItems.contains(index.toString())
+                        RetryToken.isAllItems(retryItems) ||
+                        retryItems.contains(index.toString())
                     -> {
                         attemptedCount++
                         try {


### PR DESCRIPTION
This PR adds flag that stops the history functions from downloading the blob body.

## Changes
- Adds flag to remove the call to download the blob body
-

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue