### PR TITLE
added two new equipment_model_name to Pima Schema as temp fix

### DIFF
--- a/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
@@ -35,6 +35,8 @@ ID Now|Molecular
 BinaxNOW COVID-19 Ag Card|Antigen
 LumiraDx SARS-CoV-2 Ag Test*|Antigen
 Sofia 2 SARS Antigen FIA|Antigen
+Sofia 2 Flu + SARS Antigen FIA*|Antigen
+Sienna-Clarity COVID-19 Antigen Rapid Test Cassette*|Antigen
 
 **Documentation**:
 

--- a/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/pima-az-covid-19-csv.schema
@@ -53,6 +53,10 @@ elements:
         code: "LumiraDx SARS-CoV-2 Ag Test*"
       - display: Antigen
         code: Sofia 2 SARS Antigen FIA
+      - display: Antigen
+        code: Sofia 2 Flu + SARS Antigen FIA*
+      - display: Antigen
+        code: Sienna-Clarity COVID-19 Antigen Rapid Test Cassette*
     csvFields:
     - name: Device_type
       format: $alt


### PR DESCRIPTION
This PR adds a couple values to the alt value set for device_type in Pima schema.

Tested by running similar data thru and did not see the exception.

Test Steps:
1. Generate fake pdi data for AZ, and set the equipment_model_name to both unknown (not in Pima alt valueset) and good values.

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## To Be Done
- The rest of #2354 - this is only a partial fix for 2354.

