### PR TITLE
rhood/2350 Onboarding All-In-One-Health

### DIFF
--- a/prime-router/docs/schema_documentation/experity-cuc-al-covid-19.md
+++ b/prime-router/docs/schema_documentation/experity-cuc-al-covid-19.md
@@ -1547,10 +1547,12 @@ H|Hispanic or Latino
 H|Hispanic
 H|Latino
 H|Mex. Amer./Hispanic
+H|H
 N|Non Hispanic or Latino
 N|Non Hispanic
 N|Not Hispanic or Latino
 N|Not Hispanic
+N|N
 U|Unknown
 U|U
 U|UNK

--- a/prime-router/docs/schema_documentation/experity-experity-covid-19.md
+++ b/prime-router/docs/schema_documentation/experity-experity-covid-19.md
@@ -1547,10 +1547,12 @@ H|Hispanic or Latino
 H|Hispanic
 H|Latino
 H|Mex. Amer./Hispanic
+H|H
 N|Non Hispanic or Latino
 N|Non Hispanic
 N|Not Hispanic or Latino
 N|Not Hispanic
+N|N
 U|Unknown
 U|U
 U|UNK

--- a/prime-router/docs/schema_documentation/experity-guc-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/experity-guc-la-covid-19.md
@@ -1547,10 +1547,12 @@ H|Hispanic or Latino
 H|Hispanic
 H|Latino
 H|Mex. Amer./Hispanic
+H|H
 N|Non Hispanic or Latino
 N|Non Hispanic
 N|Not Hispanic or Latino
 N|Not Hispanic
+N|N
 U|Unknown
 U|U
 U|UNK

--- a/prime-router/docs/schema_documentation/non-standard-all-in-one-health-ca-covid-19.md
+++ b/prime-router/docs/schema_documentation/non-standard-all-in-one-health-ca-covid-19.md
@@ -1,0 +1,1174 @@
+
+### Schema:         non-standard/all-in-one-health-ca-covid-19
+#### Description:   all-in-one-health - CSV lab report schema
+
+---
+
+**Name**: Language
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Notes
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Ok To Contact Patient
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Patient County
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Provider Facility Name
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Result
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Test Name
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
+**Name**: Date Reported
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: yyyymmdd
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: equipment_model_name
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-04-28
+
+**Table Column**: Model
+
+---
+
+**Name**: Facility CLIA
+
+**Type**: ID_CLIA
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Accession Number
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-3-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.3.1)
+- [ORC-3-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.3.1)
+- [SPM-2-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2.2)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Accension number
+
+---
+
+**Name**: message_id
+
+**Type**: ID
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+unique id to track the usage of the message
+
+---
+
+**Name**: Date Test Ordered
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: yyyymmdd
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Facility City
+
+**Type**: CITY
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the facility which the test was ordered from
+
+---
+
+**Name**: Facility Name
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the facility which the test was ordered from
+
+---
+
+**Name**: Facility Phone
+
+**Type**: TELEPHONE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the facility which the test was ordered from
+
+---
+
+**Name**: Facility State
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the facility which the test was ordered from
+
+---
+
+**Name**: Facility Street Address
+
+**Type**: STREET
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The address of the facility which the test was ordered from
+
+---
+
+**Name**: Facility Zip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the facility which the test was ordered from
+
+---
+
+**Name**: Provider City
+
+**Type**: CITY
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the provider
+
+---
+
+**Name**: Provider First Name
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-16-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.16.3)
+- [ORC-12-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.12.3)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The first name of the provider who ordered the test
+
+---
+
+**Name**: Provider ID/ NPI
+
+**Type**: ID_NPI
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-16-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.16.1)
+- [ORC-12-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.12.1)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ordering provider’s National Provider Identifier
+
+---
+
+**Name**: Provider Last Name
+
+**Type**: PERSON_NAME
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-16-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.16.2)
+- [ORC-12-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.12.2)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The last name of provider who ordered the test
+
+---
+
+**Name**: Provider Phone Number
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**HL7 Fields**
+
+- [OBR-17](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.17)
+- [ORC-14](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.14)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the provider
+
+---
+
+**Name**: Provider State
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state of the provider
+
+---
+
+**Name**: Provider Street Address
+
+**Type**: STREET
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address of the provider
+
+---
+
+**Name**: Provider ZIP
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The zip code of the provider
+
+---
+
+**Name**: Patient City
+
+**Type**: CITY
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's city
+
+---
+
+**Name**: patient_county
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Table**: zip-code-data
+
+**Table Column**: county
+
+---
+
+**Name**: Patient Date Of Birth
+
+**Type**: DATE
+
+**PII**: Yes
+
+**Format**: yyyymmdd
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's date of birth. Default format is yyyyMMdd.
+
+Other states may choose to define their own formats.
+
+
+---
+
+**Name**: Ethnicity
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**Default Value**: U
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+H|Hispanic or Latino
+H|Hispanic
+H|Latino
+H|Mex. Amer./Hispanic
+H|H
+N|Non Hispanic or Latino
+N|Non Hispanic
+N|Not Hispanic or Latino
+N|Not Hispanic
+N|N
+U|Unknown
+U|U
+U|UNK
+U|Black
+U|White
+U|African American
+U|NULL
+U|Patient Declines
+
+**Documentation**:
+
+Translate multiple inbound ethnicity values to RS / OMB values
+
+---
+
+**Name**: Patient First Name
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's first name
+
+---
+
+**Name**: Patient Sex
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: $display
+
+**Default Value**: U
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+F|Female
+F|F
+M|Male
+M|M
+U|U
+U|UNK
+U|UNKNOWN
+O|O
+O|Other
+O|OTH
+A|A
+A|Ambiguous
+
+**Documentation**:
+
+Translate multiple inbound Gender values to RS values
+
+---
+
+**Name**: Patient Identifier
+
+**Type**: TEXT
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ID for the patient within one of the reporting entities for this lab result. It could be the
+the patient ID from the testing lab, the oder placer, the ordering provider, or even within the PRIME system itself.
+
+
+---
+
+**Name**: Ordering_facility_name
+
+**Type**: HD
+
+**PII**: No
+
+**HL7 Fields**
+
+- [PID-3-4](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.4)
+- [PID-3-6-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.6.2)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the assigner of the patient_id field. Typically we use the name of the ordering facility
+
+---
+
+**Name**: patient_id_type
+
+**Type**: TEXT
+
+**PII**: No
+
+**Default Value**: PI
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient Last Name
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+The patient's last name
+
+---
+
+**Name**: Patient Middle Initial
+
+**Type**: PERSON_NAME
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Patient Phone Number
+
+**Type**: TELEPHONE
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's phone number with area code
+
+---
+
+**Name**: Race
+
+**Type**: CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+1002-5|American Indian or Alaska Native
+2028-9|Asian
+2054-5|Black or African American
+2076-8|Native Hawaiian or Other Pacific Islander
+2106-3|White
+2131-1|Other
+UNK|Unknown
+ASKU|Asked, but unknown
+
+**Documentation**:
+
+The patient's race. There is a common valueset defined for race values, but some states may choose to define different code/value combinations.
+
+
+---
+
+**Name**: Patient State
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [1..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The patient's state
+
+---
+
+**Name**: Patient Street Address
+
+**Type**: STREET
+
+**PII**: Yes
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's street address
+
+---
+
+**Name**: Patient Zip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The patient's zip code
+
+---
+
+**Name**: Specimen ID
+
+**Type**: ID
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-2-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.2.1)
+- [ORC-2-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.2.1)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The ID number of the lab order from the placer
+
+---
+
+**Name**: processing_mode_code
+
+**Type**: CODE
+
+**PII**: No
+
+**Default Value**: P
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+D|Debugging
+P|Production
+T|Training
+
+**Documentation**:
+
+P, D, or T for Production, Debugging, or Training
+
+---
+
+**Name**: Facility CLIA
+
+**Type**: ID_CLIA
+
+**PII**: No
+
+**HL7 Fields**
+
+- [MSH-4-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/MSH.4.2)
+- [PID-3-4-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.4.2)
+- [PID-3-6-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.6.2)
+- [SPM-2-1-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2.1.3)
+- [SPM-2-2-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2.2.3)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's CLIA
+
+---
+
+**Name**: Facility Name
+
+**Type**: TEXT
+
+**PII**: No
+
+**HL7 Fields**
+
+- [MSH-4-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/MSH.4.1)
+- [PID-3-4-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.4.1)
+- [PID-3-6-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.6.1)
+- [SPM-2-1-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2.1.2)
+- [SPM-2-2-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2.2.2)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The reporting facility's name
+
+---
+
+**Name**: sender_id
+
+**Type**: TEXT
+
+**PII**: No
+
+**Default Value**: all-in-one-health-ca
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+ID name of org that is sending this data to ReportStream.  Suitable for provenance or chain of custody tracking.  Not to be confused with sending_application, in which ReportStream acts as the 'sender' to the downstream jurisdiction.
+
+---
+
+**Name**: Specimen Collection Date
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: yyyymmdd
+
+**HL7 Fields**
+
+- [OBR-7](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.7)
+- [OBR-8](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.8)
+- [OBX-14](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBX.14)
+- [SPM-17-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.17.1)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The date which the specimen was collected. The default format is yyyyMMddHHmmsszz
+
+
+---
+
+**Name**: Specimen Type
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+445297001|Swab of internal nose
+258500001|Nasopharyngeal swab
+871810001|Mid-turbinate nasal swab
+697989009|Anterior nares swab
+258411007|Nasopharyngeal aspirate
+429931000124105|Nasal aspirate
+258529004|Throat swab
+119334006|Sputum specimen
+119342007|Saliva specimen
+258607008|Bronchoalveolar lavage fluid sample
+119364003|Serum specimen
+119361006|Plasma specimen
+440500007|Dried blood spot specimen
+258580003|Whole blood sample
+122555007|Venous blood specimen
+119297000|Blood specimen
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
+---
+
+**Name**: Device Identifier
+
+**Type**: TEXT
+
+**PII**: No
+
+**Default Value**: 99999999
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2-2021-08-11
+
+**Table Column**: Testkit Name ID
+
+**Documentation**:
+
+Follows guidence for OBX-17 as defined in the HL7 Confluence page
+
+---
+
+**Name**: Test Code
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: LIVD-SARS-CoV-2-2021-08-11
+
+**Table Column**: Test Performed LOINC Code
+
+**Documentation**:
+
+The LOINC code of the test performed. This is a standardized coded value describing the test
+
+---
+
+**Name**: Result Code
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+260373001|Detected
+260415000|Not detected
+720735008|Presumptive positive
+10828004|Positive
+42425007|Equivocal
+260385009|Negative
+895231008|Not detected in pooled specimen
+462371000124108|Detected in pooled specimen
+419984006|Inconclusive
+125154007|Specimen unsatisfactory for evaluation
+455371000124106|Invalid result
+840539006|Disease caused by sever acute respiratory syndrome coronavirus 2 (disorder)
+840544004|Suspected disease caused by severe acute respiratory coronavirus 2 (situation)
+840546002|Exposure to severe acute respiratory syndrome coronavirus 2 (event)
+840533007|Severe acute respiratory syndrome coronavirus 2 (organism)
+840536004|Antigen of severe acute respiratory syndrome coronavirus 2 (substance)
+840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
+840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
+373121007|Test not done
+
+**Documentation**:
+
+The result of the test performed. For IgG, IgM and CT results that give a numeric value put that here.
+
+---
+
+**Name**: Result Date
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: yyyymmdd
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Date Reported
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: yyyymmdd
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: Test_result_status
+
+**Type**: CODE
+
+**PII**: No
+
+**Default Value**: F
+
+**HL7 Fields**
+
+- [OBR-25-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.25.1)
+- [OBX-11-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBX.11.1)
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display
+---- | -------
+A|Some, but not all, results available
+C|Corrected, final
+F|Final results
+I|No results available; specimen received, procedure incomplete
+M|Corrected, not final
+N|Procedure completed, results pending
+O|Order received; specimen not yet received
+P|Preliminary
+R|Results stored; not yet verified
+S|No results available; procedure scheduled, but not done
+X|No results available; Order canceled
+Y|No order on record for this test
+Z|No record of this patient
+
+**Documentation**:
+
+The test result status, which is different from the test result itself. Per the valueset, this indicates if
+the test result is in some intermediate status, is a correction, or is the final result.
+
+
+---
+
+**Name**: Facility State
+
+**Type**: CITY
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The city of the testing lab
+
+---
+
+**Name**: Facility CLIA
+
+**Type**: ID_CLIA
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-2-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.2.3)
+- [OBR-3-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.3.3)
+- [OBX-15-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBX.15.1)
+- [OBX-23-10](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBX.23.10)
+- [ORC-2-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.2.3)
+- [ORC-3-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.3.3)
+
+**Cardinality**: [1..1]
+
+**Documentation**:
+
+CLIA Number from the laboratory that sends the message to DOH
+
+An example of the ID is 03D2159846
+
+
+---
+
+**Name**: Facility CLIA
+
+**Type**: ID
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+Typically this will be the same as the `testing_lab_clia`, but potentially could not be.
+
+---
+
+**Name**: Facility Name
+
+**Type**: TEXT
+
+**PII**: No
+
+**HL7 Fields**
+
+- [OBR-2-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.2.2)
+- [OBR-3-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBR.3.2)
+- [OBX-15-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBX.15.2)
+- [OBX-23-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/OBX.23.1)
+- [ORC-2-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.2.2)
+- [ORC-3-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.3.2)
+- [PID-3-4-1](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/PID.3.4.1)
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The name of the laboratory which performed the test, can be the same as the sending facility name
+
+---
+
+**Name**: Facility Phone
+
+**Type**: TELEPHONE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The phone number of the testing lab
+
+---
+
+**Name**: Specimen Received Date
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Format**: yyyymmdd
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The received date time for the specimen. This field is very important to many states for their HL7,
+but for most of our senders, the received date time is the same as the collected date time. Unfortunately,
+setting them to the same time breaks many validation rules. Most ELR systems apparently look for them to
+be offset, so this field takes the `specimen_collection_date_time` field and offsets it by a small amount.
+
+
+---
+
+**Name**: Facility Zip
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: fips-county
+
+**Table Column**: State
+
+**Documentation**:
+
+The state for the testing lab
+
+---
+
+**Name**: Facility Street Address
+
+**Type**: STREET
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The street address for the testing lab
+
+---
+
+**Name**: Facility Zip
+
+**Type**: POSTAL_CODE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+The postal code for the testing lab
+
+---

--- a/prime-router/docs/schema_documentation/non-standard-all-in-one-health-ca-covid-19.md
+++ b/prime-router/docs/schema_documentation/non-standard-all-in-one-health-ca-covid-19.md
@@ -88,6 +88,20 @@ This field is ignored.
 
 ---
 
+**Name**: Specimen Site
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Documentation**:
+
+This field is ignored.
+
+---
+
 **Name**: Test Name
 
 **Type**: TEXT
@@ -108,7 +122,7 @@ This field is ignored.
 
 **PII**: No
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **Cardinality**: [0..1]
 
@@ -182,7 +196,7 @@ unique id to track the usage of the message
 
 **PII**: No
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **Cardinality**: [0..1]
 
@@ -446,7 +460,7 @@ The patient's city
 
 **PII**: Yes
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **Cardinality**: [0..1]
 
@@ -817,7 +831,7 @@ ID name of org that is sending this data to ReportStream.  Suitable for provenan
 
 **PII**: No
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **HL7 Fields**
 
@@ -956,7 +970,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **PII**: No
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **Cardinality**: [0..1]
 
@@ -968,7 +982,7 @@ The result of the test performed. For IgG, IgM and CT results that give a numeri
 
 **PII**: No
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **Cardinality**: [0..1]
 
@@ -1113,7 +1127,7 @@ The phone number of the testing lab
 
 **PII**: No
 
-**Format**: yyyymmdd
+**Format**: yyyyMMdd
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/non-standard/all-in-one-health-ca-covid-19.schema
+++ b/prime-router/metadata/schemas/non-standard/all-in-one-health-ca-covid-19.schema
@@ -61,7 +61,7 @@ elements:
       csvFields: [{name: Patient Phone Number}]
 
     - name: patient_dob
-      csvFields: [{name: Patient Date Of Birth, format: "yyyymmdd"}]
+      csvFields: [{name: Patient Date Of Birth, format: "yyyyMMdd"}]
 
     - name: patient_gender
       type: CODE
@@ -90,22 +90,22 @@ elements:
 
 # Specimen/Order Info
     - name: specimen_collection_date_time
-      csvFields: [{name: Specimen Collection Date, format: "yyyymmdd"}]
+      csvFields: [{name: Specimen Collection Date, format: "yyyyMMdd"}]
 
     - name: order_test_date
-      csvFields: [{name: Date Test Ordered, format: "yyyymmdd"}]
+      csvFields: [{name: Date Test Ordered, format: "yyyyMMdd"}]
 
     - name: testing_lab_specimen_received_datetime
-      csvFields: [{name: Specimen Received Date, format: "yyyymmdd"}]
+      csvFields: [{name: Specimen Received Date, format: "yyyyMMdd"}]
 
     - name: test_result_date
-      csvFields: [{name: Result Date, format: "yyyymmdd"}]
+      csvFields: [{name: Result Date, format: "yyyyMMdd"}]
 
     - name: date_result_released
-      csvFields: [{name: Date Reported, format: "yyyymmdd"}]
+      csvFields: [{name: Date Reported, format: "yyyyMMdd"}]
 
     - name: test_result_report_date
-      csvFields: [{name: Date Reported, format: "yyyymmdd"}]
+      csvFields: [{name: Date Reported, format: "yyyyMMdd"}]
 
     - name: test_result
       type: TEXT
@@ -286,4 +286,9 @@ elements:
     - name: Notes_Ignore
       type: TEXT
       csvFields: [{name: Notes}]
+      documentation: This field is ignored.
+
+    - name: Specimen_Site_Ignore
+      type: TEXT
+      csvFields: [{name: Specimen Site}]
       documentation: This field is ignored.

--- a/prime-router/metadata/schemas/non-standard/all-in-one-health-ca-covid-19.schema
+++ b/prime-router/metadata/schemas/non-standard/all-in-one-health-ca-covid-19.schema
@@ -1,0 +1,289 @@
+# One-off Schema for All-In-One-Health in California
+# This schema is to be used to parse the standard CSV from the Sender
+# Created by Rick Hood
+# Last Update: 09/24/2021
+#
+name: all-in-one-health-ca-covid-19
+topic: covid-19
+description: all-in-one-health - CSV lab report schema
+basedOn: covid-19
+
+elements:
+
+    - name: sender_id
+      default: all-in-one-health-ca
+
+    - name: processing_mode_code
+      default: P
+
+
+#demographics
+    - name: patient_id
+      csvFields: [{name: Patient Identifier}]
+
+    - name: patient_id_assigner
+      csvFields: [{name: Ordering_facility_name}]
+
+    - name: patient_id_type
+      default: "PI"
+
+    - name: patient_last_name
+      csvFields: [{name: Patient Last Name}]
+
+    - name: patient_middle_name
+      csvFields: [{name: Patient Middle Initial}]
+
+    - name: patient_first_name
+      csvFields: [{name: Patient First Name}]
+
+    - name: patient_street
+      csvFields: [{name: Patient Street Address}]
+
+#    - name: patient_street2
+#      csvFields: [{name: Patient_street2}]
+
+    - name: patient_city
+      csvFields: [{name: Patient City}]
+
+    - name: patient_state
+      csvFields: [{name: Patient State}]
+
+    - name: patient_zip_code
+      csvFields: [{name: Patient Zip}]
+
+    - name: patient_county
+      type: TABLE
+      table: zip-code-data
+      tableColumn: county
+      mapper: zipCodeToCounty(patient_zip_code)
+
+    - name: patient_phone_number
+      csvFields: [{name: Patient Phone Number}]
+
+    - name: patient_dob
+      csvFields: [{name: Patient Date Of Birth, format: "yyyymmdd"}]
+
+    - name: patient_gender
+      type: CODE
+      valueSet: sender-automation/gender
+      documentation: Translate multiple inbound Gender values to RS values
+      csvFields: [{ name: Patient Sex, format: $display}]
+      default: U
+
+    - name: patient_ethnicity
+      type: CODE
+      valueSet: sender-automation/ethnicity
+      documentation: Translate multiple inbound ethnicity values to RS / OMB values
+      csvFields: [{ name: Ethnicity, format: $display}]
+      default: U
+
+    - name: patient_race
+      csvFields: [{name: Race}]
+
+#    - name: patient_race
+#      type: CODE
+#      valueSet: sender-automation/race
+#      documentation: Translate multiple inbound Race values to RS / OMB values
+#      csvFields: [{ name: Race, format: $display}]
+#      default: UNK
+
+
+# Specimen/Order Info
+    - name: specimen_collection_date_time
+      csvFields: [{name: Specimen Collection Date, format: "yyyymmdd"}]
+
+    - name: order_test_date
+      csvFields: [{name: Date Test Ordered, format: "yyyymmdd"}]
+
+    - name: testing_lab_specimen_received_datetime
+      csvFields: [{name: Specimen Received Date, format: "yyyymmdd"}]
+
+    - name: test_result_date
+      csvFields: [{name: Result Date, format: "yyyymmdd"}]
+
+    - name: date_result_released
+      csvFields: [{name: Date Reported, format: "yyyymmdd"}]
+
+    - name: test_result_report_date
+      csvFields: [{name: Date Reported, format: "yyyymmdd"}]
+
+    - name: test_result
+      type: TEXT
+      csvFields: [{name: Result Code}]
+
+#    - name: test_result
+#      type: CODE
+#      valueSet: sender-automation/test_result
+#      documentation: Translate multiple inbound Test Result values to RS values
+#      csvFields: [{ name: Result Code, format: $display}]
+
+    - name: test_result_status
+      csvFields: [{name: Test_result_status}]
+      default: F
+
+    - name: filler_order_id
+      csvFields: [{name: Accession Number}]
+
+    - name: placer_order_id
+      csvFields: [{name: Specimen ID}]
+
+    - name: specimen_type
+      type: TEXT
+      csvFields: [{name: Specimen Type}]
+
+#    - name: specimen_type
+#      type: CODE
+#      valueSet: sender-automation/specimen_type
+#      documentation: Translate inbound text to outbound SNOMED Codes
+#      csvFields: [{ name: Specimen Type, format: $display}]
+
+#    - name: specimen_source_site_code
+#      type: CODE
+#      valueSet: sender-automation/specimen_source_site_code
+#      documentation: Translate inbound text to outbound SNOMED Codes
+#      csvFields: [{ name: Specimen Site, format: $display}]
+
+    - name: test_performed_code
+      type: TEXT
+      csvFields: [{name: Test Code}]
+
+    - name: test_kit_name_id
+      type: TEXT
+      default: 99999999
+      csvFields: [{name: Device Identifier}]
+
+
+# Ordering provider
+    - name: ordering_provider_id
+      csvFields: [{name: Provider ID/ NPI}]
+
+    - name: ordering_provider_first_name
+      csvFields: [{name: Provider First Name}]
+
+    - name: ordering_provider_last_name
+      csvFields: [{name: Provider Last Name}]
+
+#    - name: ordering_provider_lastfirst_name
+#      mapper: concat(ordering_provider_last_name, ordering_provider_first_name )
+
+    - name: ordering_provider_street
+      csvFields: [{name: Provider Street Address}]
+
+#    - name: ordering_provider_street2
+#      csvFields: [{name: Ordering_provider_street2}]
+
+    - name: ordering_provider_city
+      csvFields: [{name: Provider City}]
+
+    - name: ordering_provider_state
+      csvFields: [{name: Provider State}]
+
+    - name: ordering_provider_zip_code
+      csvFields: [{name: Provider ZIP}]
+
+    - name: ordering_provider_phone_number
+      csvFields: [{name: Provider Phone Number}]
+
+#ordering facility + reporting facility name
+    - name: reporting_facility_name
+      csvFields: [{name: Facility Name}]
+
+    - name: ordering_facility_name
+      csvFields: [{name: Facility Name}]
+
+    - name: ordering_facility_street
+      csvFields: [{name: Facility Street Address}]
+
+    - name: ordering_facility_city
+      csvFields: [{name: Facility City}]
+
+    - name: ordering_facility_state
+      csvFields: [{name: Facility State}]
+
+    - name: ordering_facility_zip_code
+      csvFields: [{name: Facility Zip}]
+
+    - name: ordering_facility_phone_number
+      csvFields: [{name: Facility Phone}]
+
+
+#testing lab
+    - name: testing_lab_name
+      csvFields: [{name: Facility Name}]
+
+    - name: testing_lab_street
+      csvFields: [{name: Facility Street Address}]
+
+    - name: testing_lab_city
+      csvFields: [{name: Facility State}]
+
+    - name: testing_lab_state
+      csvFields: [{name: Facility Zip}]
+
+    - name: testing_lab_zip_code
+      csvFields: [{name: Facility Zip}]
+
+    - name: testing_lab_phone_number
+      csvFields: [{name: Facility Phone}]
+
+
+#CLIA
+    - name: testing_lab_clia
+      csvFields: [{name: Facility CLIA}]
+
+    - name: testing_lab_id
+      csvFields: [{name: Facility CLIA}]
+
+    - name: reporting_facility_clia
+      csvFields: [{name: Facility CLIA}]
+
+    - name: filler_clia
+      csvFields: [{name: Facility CLIA}]
+
+# Concatenated fields
+    - name: message_id
+      mapper: concat(filler_order_id, test_performed_code)
+
+
+#this lookup is in the covid-19 schema, but doesn't appear to be done in practice (?)
+    - name: equipment_model_name
+      table: LIVD-SARS-CoV-2-2021-04-28
+      tableColumn: Model
+      mapper: livdLookup()
+
+
+#unused fields - these are added here to suppress warnings.
+    - name: Patient_County_Ignore
+      type: TEXT
+      csvFields: [{name: Patient County}]
+      documentation: This field is ignored.
+
+    - name: Language_Ignore
+      type: TEXT
+      csvFields: [{name: Language}]
+      documentation: This field is ignored.
+
+    - name: Ok To Contact Patient_Ignore
+      type: TEXT
+      csvFields: [{name: Ok To Contact Patient}]
+      documentation: This field is ignored.
+
+    - name: ProviderFacilityName_Ignore
+      type: TEXT
+      csvFields: [{name: Provider Facility Name}]
+      documentation: This field is ignored.
+
+    - name: Test Name_Ignore
+      type: TEXT
+      csvFields: [{name: Test Name}]
+      documentation: This field is ignored.
+
+    - name: Result_Ignore
+      type: TEXT
+      csvFields: [{name: Result}]
+      documentation: This field is ignored.
+
+    - name: Notes_Ignore
+      type: TEXT
+      csvFields: [{name: Notes}]
+      documentation: This field is ignored.

--- a/prime-router/metadata/tables/zip-code-data.csv
+++ b/prime-router/metadata/tables/zip-code-data.csv
@@ -1999,6 +1999,7 @@ state_fips,state,state_abbr,zipcode,county,city
 6,California,CA,90806,Los Angeles,Signal hill
 6,California,CA,90807,Los Angeles,Signal hill
 6,California,CA,90808,Los Angeles,Long beach
+6,California,CA,90809,Los Angeles,Long beach
 6,California,CA,90810,Los Angeles,Carson
 6,California,CA,90813,Los Angeles,Long beach
 6,California,CA,90814,Los Angeles,Long beach

--- a/prime-router/metadata/valuesets/sender-automation.valuesets
+++ b/prime-router/metadata/valuesets/sender-automation.valuesets
@@ -120,6 +120,8 @@
       display: Latino
     - code: H
       display: Mex. Amer./Hispanic
+    - code: H
+      display: H
     - code: N
       display: Non Hispanic or Latino
     - code: N
@@ -128,6 +130,8 @@
       display: Not Hispanic or Latino
     - code: N
       display: Not Hispanic
+    - code: N
+      display: N
     - code: U
       display: Unknown
     - code: U

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -224,6 +224,16 @@
       schemaName: experity/cuc-al-covid-19
       format: CSV
 
+- name: all-in-one-health-ca
+  description: All-In-One Health CSV lab report schema, California
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: all-in-one-health-ca
+      topic: covid-19
+      schemaName: non-standard/all-in-one-health-ca-covid-19
+      format: CSV
+
 - name: az-phd
   description: Arizona PHD
   jurisdiction: STATE

--- a/prime-router/settings/prod/0046-all-in-one-health-ca.yml
+++ b/prime-router/settings/prod/0046-all-in-one-health-ca.yml
@@ -1,0 +1,11 @@
+# Run this:  ./prime multiple-settings set --input ./settings/prod/0046-all-in-one-health-ca.yml --env prod
+---
+- name: all-in-one-health-ca
+  description: All-In-One Health CSV lab report schema, California
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: all-in-one-health-ca
+      topic: covid-19
+      schemaName: non-standard/all-in-one-health-ca-covid-19
+      format: CSV

--- a/prime-router/settings/staging/0046-all-in-one-health-ca.yml
+++ b/prime-router/settings/staging/0046-all-in-one-health-ca.yml
@@ -1,0 +1,11 @@
+# Run this:  ./prime multiple-settings set --input ./settings/staging/0046-all-in-one-health-ca.yml --env staging
+---
+- name: all-in-one-health-ca
+  description: All-In-One Health CSV lab report schema, California
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: all-in-one-health-ca
+      topic: covid-19
+      schemaName: non-standard/all-in-one-health-ca-covid-19
+      format: CSV


### PR DESCRIPTION
This PR adds a Schema for All-In-One-Health onboarding.  Note, there is no parent/child schema setup for this Sender, so this Schema is stored in a new folder for non-standard one-off schemas under /non-standard/.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. This is still in testing, so testing will continue in Staging.

## Changes
- Adds the Schema for the Sender All-In-One-Health.
- Added All-In-One-Health to the organizations.yml
- Added yamlitos to Staging & Prod for All-In-One-Health
- Updated sender-automation.valuesets - Added "H" and "N" to the valueset list.
- Updated Zip CSV with one CA missing zip code.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?


### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
*List GitHub issues this PR fixes*
- #2350 


## To Be Done
*Create GitHub issues to track the work remaining, if any*

