### PR TITLE
Fix nav on mobile 

### DIFF
--- a/frontend-react/src/components/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/ReportStreamHeader.tsx
@@ -6,6 +6,7 @@ import {
     Link,
     Dropdown,
     NavDropDownButton,
+    NavMenuButton,
     Menu,
 } from "@trussworks/react-uswds";
 import { useOktaAuth } from "@okta/okta-react";
@@ -147,6 +148,8 @@ const DropdownHowItWorks = () => {
 
 export const ReportStreamHeader = () => {
     const { authState } = useOktaAuth();
+    const [expanded, setExpanded] = useState(false)
+    const toggleMobileNav = (): void => setExpanded((prvExpanded) => !prvExpanded)
 
 
     let itemsMenu = [
@@ -189,8 +192,12 @@ export const ReportStreamHeader = () => {
                     <Title>
                         <a href="/">ReportStream</a>
                     </Title>
+                    <NavMenuButton onClick={toggleMobileNav} label="Menu" />
                 </div>
-                <PrimaryNav items={itemsMenu}>
+                <PrimaryNav 
+                    items={itemsMenu} 
+                    onToggleMobileNav={toggleMobileNav}
+                    mobileExpanded={expanded}>
                     <SignInOrUser />
                 </PrimaryNav>
             </div>


### PR DESCRIPTION
In `ReportStreamHeader` the `PrimaryNav` was missing expand/collapse functionality

| Collapsed | Expanded |
|-----|-----|
| ![image](https://user-images.githubusercontent.com/87096393/135007532-7f3baf61-7dd5-4303-a875-eb50fbdf2aea.png) | ![image](https://user-images.githubusercontent.com/87096393/135007551-2a1d6332-e54f-44ce-9cc8-999851634acc.png)|
