### PR TITLE
sender-tools/2384: retrieve sender organization information when sender name is 'default'

### DIFF
--- a/frontend-react/src/webreceiver-utils.ts
+++ b/frontend-react/src/webreceiver-utils.ts
@@ -44,7 +44,9 @@ const senderClient = (authState: AuthState | null) => {
 
         // should end up like "ignore.ignore_waters" from "DHSender_ignore.ignore-waters" from Okta.
         // This is used on the RS side to validate the user claims, so, it need the underscores ("_")
-        return `${organizationName}.${claimsSenderOrganizationArray[1]}`;
+        // The ternary checks if there is anything after the "." in the group name, if not, it leaves it blank
+        // i.e. if the sender name is "DHSender_all-in-one-health-ca", there will be no "."
+        return `${organizationName}${claimsSenderOrganizationArray[1] ? `.${claimsSenderOrganizationArray[1]}` : ''}`;
     }
     return '';
 }

--- a/frontend-react/src/webreceiver-utils.ts
+++ b/frontend-react/src/webreceiver-utils.ts
@@ -46,7 +46,8 @@ const senderClient = (authState: AuthState | null) => {
         // This is used on the RS side to validate the user claims, so, it need the underscores ("_")
         // The ternary checks if there is anything after the "." in the group name, if not, it leaves it blank
         // i.e. if the sender name is "DHSender_all-in-one-health-ca", there will be no "."
-        return `${organizationName}${claimsSenderOrganizationArray[1] ? `.${claimsSenderOrganizationArray[1]}` : ''}`;
+        const senderName = claimsSenderOrganizationArray[1] ? `.${claimsSenderOrganizationArray[1]}` : ''
+        return `${organizationName}${senderName}`;
     }
     return '';
 }


### PR DESCRIPTION
This PR retrieve sender organization information when sender name is 'default'

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
pre-req: be part of a sender group in Okta that has a sender name of "default", i.e. "DHSender_all-in-one-health-ca"
1. log in to ReportStream
2. browse to /upload
3. that's it! you should see organization data coming through and the page shouldn't be blank
4. bonus: join a group in Okta like "DHSender_ignore.ignore-waters", then execute  steps 1-3

## Changes
- retrieve sender organization information when sender name is 'default'

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
