### PR TITLE
rhood/2382-Add Zip Codes

### DIFF
--- a/prime-router/metadata/tables/zip-code-data.csv
+++ b/prime-router/metadata/tables/zip-code-data.csv
@@ -152,6 +152,7 @@ state_fips,state,state_abbr,zipcode,county,city
 1,Alabama,AL,35471,Pickens,Mc shan
 1,Alabama,AL,35473,Pickens,Mc shan
 1,Alabama,AL,35474,Tuscaloosa,Northport
+1,Alabama,AL,35475,Tuscaloosa,Northport
 1,Alabama,AL,35476,Tuscaloosa,Northport
 1,Alabama,AL,35477,Sumter,Panola
 1,Alabama,AL,35478,Tuscaloosa,Peterson
@@ -528,6 +529,7 @@ state_fips,state,state_abbr,zipcode,county,city
 1,Alabama,AL,36574,Baldwin,Seminole
 1,Alabama,AL,36575,Mobile,Semmes
 1,Alabama,AL,36576,Baldwin,Silverhill
+1,Alabama,AL,36577,Baldwin,Spanish Fort
 1,Alabama,AL,36578,Baldwin,Stapleton
 1,Alabama,AL,36579,Baldwin,Stockton
 1,Alabama,AL,36580,Baldwin,Summerdale
@@ -617,6 +619,9 @@ state_fips,state,state_abbr,zipcode,county,city
 1,Alabama,AL,36792,Bibb,Randolph
 1,Alabama,AL,36793,Bibb,Lawley
 1,Alabama,AL,36801,Lee,Opelika
+1,Alabama,AL,36802,Lee,Opelika
+1,Alabama,AL,36803,Lee,Opelika
+1,Alabama,AL,36804,Lee,Opelika
 1,Alabama,AL,36830,Lee,Auburn
 1,Alabama,AL,36832,Lee,Auburn
 1,Alabama,AL,36849,Lee,Auburn
@@ -1046,6 +1051,7 @@ state_fips,state,state_abbr,zipcode,county,city
 4,Arizona,AZ,85375,Maricopa,Sun city west
 4,Arizona,AZ,85381,Maricopa,Peoria
 4,Arizona,AZ,85382,Maricopa,Peoria
+4,Arizona,AZ,85383,Maricopa,Peoria
 4,Arizona,AZ,85390,Maricopa,Wickenburg
 4,Arizona,AZ,85501,Gila,Globe
 4,Arizona,AZ,85530,Graham,Bylas
@@ -2180,6 +2186,7 @@ state_fips,state,state_abbr,zipcode,county,city
 6,California,CA,92054,San Diego,Oceanside
 6,California,CA,92056,San Diego,Oceanside
 6,California,CA,92057,San Diego,Oceanside
+6,California,CA,92058,San Diego,Oceanside
 6,California,CA,92059,San Diego,Pala
 6,California,CA,92060,San Diego,Palomar mountain
 6,California,CA,92061,San Diego,Pauma valley
@@ -2889,6 +2896,7 @@ state_fips,state,state_abbr,zipcode,county,city
 6,California,CA,94971,Marin,Tomales
 6,California,CA,94972,Sonoma,Valley ford
 6,California,CA,94973,Marin,Woodacre
+6,California,CA,94998,Marin,Novato
 6,California,CA,95002,Santa Clara,Alviso
 6,California,CA,95003,Santa Cruz,Aptos
 6,California,CA,95004,Monterey,Aromas
@@ -4314,6 +4322,7 @@ state_fips,state,state_abbr,zipcode,county,city
 12,Florida,FL,32009,Nassau,Bryceville
 12,Florida,FL,32011,Nassau,Callahan
 12,Florida,FL,32013,Lafayette,Day
+12,Florida,FL,32025,Columbia,Lake City
 12,Florida,FL,32033,St Johns,Elkton
 12,Florida,FL,32034,Nassau,Amelia island
 12,Florida,FL,32038,Columbia,Fort white
@@ -5226,6 +5235,12 @@ state_fips,state,state_abbr,zipcode,county,city
 13,Georgia,GA,30036,DeKalb,Decatur
 13,Georgia,GA,30037,DeKalb,Decatur
 13,Georgia,GA,30038,DeKalb,Lithonia
+13,Georgia,GA,30039,Gwinnett,Snellville
+13,Georgia,GA,30040,Forsyth,Cumming
+13,Georgia,GA,30041,Forsyth,Cumming
+13,Georgia,GA,30042,Gwinnett,Lawrenceville
+13,Georgia,GA,30043,Gwinnett,Lawrenceville
+13,Georgia,GA,30044,Gwinnett,Lawrenceville
 13,Georgia,GA,30058,DeKalb,Centerville gwin
 13,Georgia,GA,30060,Cobb,Marietta
 13,Georgia,GA,30061,Cobb,Marietta
@@ -14751,6 +14766,7 @@ state_fips,state,state_abbr,zipcode,county,city
 28,Mississippi,MS,39531,Harrison,Biloxi
 28,Mississippi,MS,39532,Harrison,North bay
 28,Mississippi,MS,39540,Harrison,Diberville
+28,Mississippi,MS,39552,Jackson,Escatawpa
 28,Mississippi,MS,39553,Jackson,Gautier
 28,Mississippi,MS,39555,Jackson,Hurley
 28,Mississippi,MS,39556,Hancock,Kiln
@@ -16822,6 +16838,9 @@ state_fips,state,state_abbr,zipcode,county,city
 32,Nevada,NV,89131,Clark,Las vegas
 32,Nevada,NV,89134,Clark,Las vegas
 32,Nevada,NV,89135,Clark,Las vegas
+32,Nevada,NV,89136,Clark,Las vegas
+32,Nevada,NV,89137,Clark,Las vegas
+32,Nevada,NV,89138,Clark,Las vegas
 32,Nevada,NV,89139,Clark,Las vegas
 32,Nevada,NV,89191,Clark,Nellis a f b
 32,Nevada,NV,89301,White Pine,Ely
@@ -18334,6 +18353,8 @@ state_fips,state,state_abbr,zipcode,county,city
 36,New york,NY,11237,Kings,Brooklyn
 36,New york,NY,11238,Kings,Brooklyn
 36,New york,NY,11239,Kings,Brooklyn
+36,New york,NY,11247,Kings,Brooklyn
+36,New york,NY,11249,Kings,Brooklyn
 36,New york,NY,11354,Queens,Flushing
 36,New york,NY,11355,Queens,Flushing
 36,New york,NY,11356,Queens,College point
@@ -24884,6 +24905,9 @@ state_fips,state,state_abbr,zipcode,county,city
 45,South carolina,SC,29113,Orangeburg,Norway
 45,South carolina,SC,29114,Florence,Olanta
 45,South carolina,SC,29115,Orangeburg,Orangeburg
+45,South carolina,SC,29116,Orangeburg,Orangeburg
+45,South carolina,SC,29117,Orangeburg,Orangeburg
+45,South carolina,SC,29118,Orangeburg,Orangeburg
 45,South carolina,SC,29122,Newberry,Peak
 45,South carolina,SC,29123,Lexington,Pelion
 45,South carolina,SC,29124,Aiken,Perry
@@ -25019,6 +25043,7 @@ state_fips,state,state_abbr,zipcode,county,city
 45,South carolina,SC,29482,Charleston,Sullivans island
 45,South carolina,SC,29483,Dorchester,Summerville
 45,South carolina,SC,29485,Dorchester,Summerville
+45,South carolina,SC,29486,Berkeley,Summerville
 45,South carolina,SC,29487,Charleston,Wadmalaw island
 45,South carolina,SC,29488,Colleton,Ritter
 45,South carolina,SC,29492,Berkeley,Wando
@@ -27099,6 +27124,7 @@ state_fips,state,state_abbr,zipcode,county,city
 48,Texas,TX,77388,Harris,Spring
 48,Texas,TX,77389,Harris,Spring
 48,Texas,TX,77396,Harris,Humble
+48,Texas,TX,77399,Polk,Livingston
 48,Texas,TX,77401,Harris,Bellaire
 48,Texas,TX,77406,Ft Bend,Richmond
 48,Texas,TX,77412,Colorado,Altair


### PR DESCRIPTION
This PR adds multiple zip codes to the zip-code-data table.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. On my local RS, I processed a test file with zip codes containing those added to the .CSV file.  The Error messages for 'patient_county' null are now gone, and the HL7 message produced now includes the FIPS code in PID.11.9.


## Changes

- Updated metadata/tables/zip-code-data.csv


## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?



### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
 - #2382 
