### PR TITLE
remove Content-Security-Policy for now

### DIFF
--- a/frontend-react/public/index.html
+++ b/frontend-react/public/index.html
@@ -6,28 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="%REACT_APP_DESCRIPTION%"/>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self';
-        script-src 'self'
-          https://hss-prime-okta.com
-          https://global.oktacdn.com
-          https://www.google-analytics.com
-          https://*.in.applicationinsights.azure.com;
-        style-src 'self' 'unsafe-inline'
-          https://global.oktacdn.com
-          https://cdnjs.cloudflare.com;
-        frame-src 'self' https://hhs-prime.okta.com;
-        img-src 'self' https://hhs-prime.okta.com https://reportstream.cdc.gov data: ;
-        connect-src 'self'
-          https://www.google-analytics.com
-          https://*.in.applicationinsights.azure.com
-          https://hhs-prime.okta.com
-          https://staging.reportstream.cdc.gov/api/
-          https://staging.prime.cdc.gov/api/
-          %REACT_APP_BACKEND_URL%
-          ;"
-    />
     <link rel="apple-touch-icon" href="%REACT_APP_PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
It really should be in the header anyways.

What it was in case we want to use this as a starting point for http header cors:
```html
 <meta
      http-equiv="Content-Security-Policy"
      content="default-src 'self';
        script-src 'self'
          https://hss-prime-okta.com
          https://global.oktacdn.com
          https://www.google-analytics.com
          https://*.in.applicationinsights.azure.com;
        style-src 'self' 'unsafe-inline'
          https://global.oktacdn.com
          https://cdnjs.cloudflare.com;
        frame-src 'self' https://hhs-prime.okta.com;
        img-src 'self' https://hhs-prime.okta.com https://reportstream.cdc.gov data: ;
        connect-src 'self'
          https://www.google-analytics.com
          https://*.in.applicationinsights.azure.com
          https://hhs-prime.okta.com
          https://staging.reportstream.cdc.gov/api/
          https://staging.prime.cdc.gov/api/
          %REACT_APP_BACKEND_URL%
          ;"
    />
```