### PR TITLE
Use utf-8 chars

### DIFF
--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -567,14 +567,14 @@ class ReportFunction : Logging {
                     } else if (row == rows[i - 1] || row == rows[i - 1] + 1) {
                         isListing = true
                     } else if (isListing) {
-                        sb.append("–" + rows[i - 1].toString() + ", " + row.toString())
+                        sb.append("\u2013" + rows[i - 1].toString() + "\u002c " + row.toString())
                         isListing = false
                     } else {
-                        sb.append(", " + row.toString())
+                        sb.append("\u002c " + row.toString())
                         isListing = false
                     }
                     if (i == rows.lastIndex && isListing) {
-                        sb.append("–" + rows[rows.lastIndex].toString())
+                        sb.append("\u2013" + rows[rows.lastIndex].toString())
                     }
                 }
                 return sb.toString()


### PR DESCRIPTION
The hyphen characters are not coming through correctly in the rolled up error messages for the csv uploader:
![image](https://user-images.githubusercontent.com/87096393/135530777-0a689566-11df-43dd-95db-fec979de7a00.png)

This problem only happens on staging, I am not able to repro locally. Switching to using the unicodes for these characters may solve the problem. I'll have to see what it looks like in staging. 
