### PR TITLE
Sanity check which login page is being used

### DIFF
--- a/frontend-react/src/pages/Login.tsx
+++ b/frontend-react/src/pages/Login.tsx
@@ -21,8 +21,9 @@ export const Login = ({ config }) => {
     };
 
     const MonitoringAlert = () => {
+        console.log("react")
         return (
-            <SiteAlert variant="info" heading="This is a U.S. government service" className="margin-bottom-3 tablet:margin-bottom-6" >
+            <SiteAlert variant="info" heading="This is a United States government service" className="margin-bottom-3 tablet:margin-bottom-6" >
                 Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties. By logging in, you are agreeing to our <Link to="/terms-of-service">terms of service.</Link>
             </SiteAlert>
         )


### PR DESCRIPTION
On staging, when navigating to /daily-data the log in screen flashes. This cannot be reproduced locally. It seems like it could be an 11ty artifact. This PR adds a console log and a subtle UI change to make it clear which login page is being flashed. 