### PR TITLE
Use "to" instead of hyphen

### DIFF
--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -567,14 +567,14 @@ class ReportFunction : Logging {
                     } else if (row == rows[i - 1] || row == rows[i - 1] + 1) {
                         isListing = true
                     } else if (isListing) {
-                        sb.append("\u2013" + rows[i - 1].toString() + "\u002c " + row.toString())
+                        sb.append("&#8211;" + rows[i - 1].toString() + ", " + row.toString())
                         isListing = false
                     } else {
-                        sb.append("\u002c " + row.toString())
+                        sb.append(", " + row.toString())
                         isListing = false
                     }
                     if (i == rows.lastIndex && isListing) {
-                        sb.append("\u2013" + rows[rows.lastIndex].toString())
+                        sb.append("&#8211;" + rows[rows.lastIndex].toString())
                     }
                 }
                 return sb.toString()

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -567,14 +567,14 @@ class ReportFunction : Logging {
                     } else if (row == rows[i - 1] || row == rows[i - 1] + 1) {
                         isListing = true
                     } else if (isListing) {
-                        sb.append("&#8211;" + rows[i - 1].toString() + ", " + row.toString())
+                        sb.append(" to " + rows[i - 1].toString() + ", " + row.toString())
                         isListing = false
                     } else {
                         sb.append(", " + row.toString())
                         isListing = false
                     }
                     if (i == rows.lastIndex && isListing) {
-                        sb.append("&#8211;" + rows[rows.lastIndex].toString())
+                        sb.append(" to " + rows[rows.lastIndex].toString())
                     }
                 }
                 return sb.toString()


### PR DESCRIPTION
The hyphen characters are not coming through correctly in the rolled up error messages for the csv uploader. I've tried both the literal character, and the encoding for the hyphen and both result in the question mark character showing:
![image](https://user-images.githubusercontent.com/87096393/135530777-0a689566-11df-43dd-95db-fec979de7a00.png)

This problem only happens on staging, I am not able to repro locally. Switching to just use " to " since I've already spent too much time trying to debug!  