### PR TITLE
Switch /daily-data to a NavLink

### DIFF
--- a/frontend-react/src/components/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/ReportStreamHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from "@trussworks/react-uswds";
 import { useOktaAuth } from "@okta/okta-react";
 import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
 import { useResource } from "rest-hooks";
 import OrganizationResource from "../resources/OrganizationResource";
 import { permissionCheck, reportReceiver } from "../webreceiver-utils";
@@ -162,13 +163,14 @@ export const ReportStreamHeader = () => {
     if (authState !== null && authState.isAuthenticated) {
         if (reportReceiver(authState)) {
             itemsMenu.splice(0, 0,
-                <Link href="/daily-data"
+                <NavLink 
+                    to="/daily-data"
                     key="daily"
                     data-attribute="hidden"
                     hidden={true}
                     className="usa-nav__link">
                     <span>Daily data</span>
-                </Link>
+                </NavLink>
             );
         }
 


### PR DESCRIPTION
This PR changs the /daily-data page to function as part of the single page app. Previously we've been making page requests to load this page. 

This has 2 benefits
- Load speeds will be faster
- This will hopefully solve the bug where the log in screen flashes on navigation. There is a change this is flashing since while the app waits for the server request to be made, temporarily it seems like the user is not logged in. This bug is not reproducible locally so we won't know until it is in staging