### PR TITLE
NavLink for home page

### DIFF
--- a/frontend-react/src/components/header/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/header/ReportStreamHeader.tsx
@@ -58,7 +58,7 @@ export const ReportStreamHeader = () => {
                     <div className="usa-logo" id="basic-logo">
                         <Title>
                             <em className="usa-logo__text font-sans-md">
-                                <a href="/" title="Home" aria-label="Home">ReportStream</a>
+                                <NavLink to="/" title="Home" aria-label="Home">ReportStream</NavLink>
                             </em>
                         </Title>
                     </div>


### PR DESCRIPTION
Use NavLink for the RS logo in header so that a page request isn't made