### PR TITLE
Settings uploader waits for API to be available

### DIFF
--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -108,7 +108,7 @@ services:
 
   settings:
     build: settings/.
-    command: "--wait=20 --check-last-modified prime_dev /settings/organizations.yml"
+    command: "--check-last-modified prime_dev /settings/organizations.yml"
     depends_on:
       - prime_dev
     volumes:


### PR DESCRIPTION
This PR makes the settings python script wait for the API to be available.  This should fix the problem with the settings container starting earlier than the API.  If after a number of retries the API is still not available then the script exists with an error.  The --conn-retries can be used to set the number of retries, and each retry has a wait time of 5 secs.

Test Steps:
1. Delete the `prime-router_settings` image from your Docker system.  This will regenerate the container with the new python script.
2. Run `docker compose up`
3. Look at the output logs.  Locate the settings container logs and verify the script waits until the API is running.

## Changes
-  settings python script wait for the API to be available

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #2546 

## To Be Done

