### PR TITLE
Fix #2354, Exception in alt value set code causing Batch steps to fail

### DIFF
--- a/prime-router/src/main/kotlin/FakeReport.kt
+++ b/prime-router/src/main/kotlin/FakeReport.kt
@@ -147,7 +147,7 @@ class FakeDataService {
                         else -> TODO("Add this column in a table")
                     }
                 }
-                else -> TODO("Add this table")
+                else -> TODO("Add this table ${element.table}")
             }
         }
 
@@ -179,7 +179,7 @@ class FakeDataService {
             Element.Type.PERSON_NAME -> createFakeName(element)
             Element.Type.TELEPHONE -> createFakePhoneNumber(element)
             Element.Type.EMAIL -> createFakeEmail()
-            null -> error("Invalid element type for ${element.name}")
+            null -> error("Element type is null for ${element.name}")
         }
     }
 

--- a/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
+++ b/prime-router/src/main/kotlin/serializers/CsvSerializer.kt
@@ -212,7 +212,7 @@ class CsvSerializer(val metadata: Metadata) {
                             element.csvFields.map { field ->
                                 val value = report.getString(row, element.name)
                                     ?: error("Internal Error: table is missing ${element.fieldMapping} column")
-                                element.toFormatted(value, field.format)
+                                element.toFormatted(value, field.format, report.schema)
                             }
                         } else {
                             emptyList()

--- a/prime-router/src/scripts/db_one_off/1974_customer_status.sql
+++ b/prime-router/src/scripts/db_one_off/1974_customer_status.sql
@@ -18,11 +18,11 @@ where type in ('SENDER','RECEIVER')
     'az-phd','pima-az-phd','ca-scc-phd','co-phd','tx-phd','fl-phd','gu-doh','vt-doh',
     'nd-doh','la-doh','oh-doh','nm-doh','mt-doh','tx-doh','nj-doh','mn-doh','ms-doh',
     'ca-dph','ma-phd','al-phd','pa-phd','pa-chester-phd','pa-montgomery-phd','pa-philadelphia-phd',
-    'md-doh','md-phd','hhsprotect','ignore','il-phd','wa-phd','wy-phd','ak-phd','nh-dphs','all-in-one-health-ca');
+    'md-doh','md-phd','hhsprotect','ignore','il-phd','wa-phd','wy-phd','ak-phd','nh-dphs','all-in-one-health-ca','or-phd');
 
 -- set testing senders and receivers to 'testing'
 update setting
 set values = jsonb_set(values, '{customerStatus}', '"testing"', true)
 where type in ('SENDER','RECEIVER')
-  and  values ->> 'organizationName' in ('wi-dph','tn-doh','de-dph','ct-phd','ny-phd','or-phd');
+  and  values ->> 'organizationName' in ('wi-dph','tn-doh','de-dph','ct-phd','ny-phd','fl-hillsborough-phd');
 


### PR DESCRIPTION
Currently the Batch step does the final transformation of data from our in-memory format into the format desired by the Receiver. However, these transforms can create errors and warnings, as we discovered with ticket #2354.  In this bug, the code throws an Exception, which kills the Batch immediately , and prevents all associated data from going to the state, just because of one invalid value.

So, obviously the Exception is Bad, but then the question is: what to do with these errors and warnings?   The solution here for #2354 is an improvement -a message logged, labelled as an "Exception" so that our notification tools can pick it up.  However, then the value is turned to an empty string, and processing continues.

Since this is a stopgap solution, I've documented a path to a proper fix.   See #2571 and #2572 .

## Test Steps:
If you go to the bug ticket and scroll way down, you'll see the Steps to Reproduce.   If you do those, then the test passes if, instead of an Exception, you now get a nasty error message like this in the logs:

## Changes
- In addition to the above fix, there's some tweaks to the "parallel" test, and a last minute tweak to our customerActive script (already run in prod, so this is just documenting after the fact)

### Testing
- [X ] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?

## Fixes
- #2354 

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #2571 
- #2572 
