### PR TITLE
Add pre-commit hook that fails if docker is not running

### DIFF
--- a/.environment/docker/check-docker.sh
+++ b/.environment/docker/check-docker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+docker ps > /dev/null 2>&1
+
+DOCKER_RC=$?
+
+if [[ $DOCKER_RC -eq 0 ]]; then
+  exit 0
+else
+  echo "Docker is not running. Docker is required to run ReportStream's Git hook. Please start Docker and retry."
+  exit 1
+fi

--- a/.environment/pre-commit.runner.sh
+++ b/.environment/pre-commit.runner.sh
@@ -25,6 +25,14 @@ function error() {
     return 1
 }
 
+# Run the docker check first and bail immediately if it fails, as some other
+# checks depend on it.
+${REPO_ROOT}/.environment/docker/check-docker.sh
+DOCKER_RC=$?
+if [[ $DOCKER_RC -ne 0 ]]; then
+  exit 1
+fi
+
 echo "> Running pre-commit hooks"
 
 for item in ${CHECKS_TO_RUN[*]}; do

--- a/prime-router/docs/getting_started.md
+++ b/prime-router/docs/getting_started.md
@@ -113,6 +113,11 @@ The most useful gradle tasks are:
 
 We make use of git hooks in this repository and rely on them for certain levels of protections against CI/CD failures and other incidents. Install/activate these hooks by invoking either `prime-router/cleanslate.sh` or by directly invoking `.environment/githooks.sh install`. This is a _repository-level_ setting, you _must_ activate the git hooks in every clone on every device you have.
 
+### pre-commit: Docker
+
+The first hook we'll invoke is to ensure Docker is running. If it's not we'll short-circuit the remainder of the hooks and let you know why.
+
+
 ### pre-commit: Gitleaks
 
 Gitleaks is one of the checks that are run as part of the `pre-commit` hook. It must pass successfully for the commit to proceed (i.e. for the commit to actually happen, failure will prevent the commit from being made and will leave your staged files in staged status). Gitleaks scans files that are marked as "staged" (i.e. `git add`) for known patterns of secrets or keys.
@@ -126,6 +131,16 @@ When gitleaks reports leaks/violations, the right course of action is typically 
 This tool can also be manually invoked through `.environment/gitleaks/run-gitleaks.sh` which may be useful to validate the lack of leaks without the need of risking a commit. Invoke the tool with `--help` to find out more about its different run modes.
 
 See [Allow-listing Gitleaks False Positives](allowlist-gitleaks-false-positives.md) for more details on how to prevent False Positives!
+
+### pre-commit: Terraform formatting
+
+If you've changed any terraform files in your commit we'll run
+`terraform fmt -check` against the directory of files. If any file's format is invalid 
+the pre-commit hook will fail. You may be able to fix the issues with:
+
+```
+$ .environment/terraform-fmt/run-terraform-fmt.sh --fix
+```
 
 ## Updating schema documentation
 You must run the schema document generator after a schema file is updated.  The updated documents are stored in


### PR DESCRIPTION
This PR adds a pre-commit hook that checks if Docker is running. If not it bails out of the pre-commit process so as not to provide misleading output. For example, the `run-gitleaks.sh` depends on Docker running and will fail with a message that you're checking in bad code, but if you look at the log it's actually just complaining about Docker not being available.

Test Steps:
1. Make a trivial change to your repo. Add the change but don't commit it.
2. Stop Docker via whatever works for you (Docker Desktop, systemd, etc.)
3. Try to commit your change. The commit should fail with:
```
$ git commit -m 'My dummy commit'
Docker is not running. Please start it and retry.
```
4. Restart Docker. The commit should now succeed with something like:
```
$ git commit -m 'My dummy commit'
> Running pre-commit hooks
   - .../prime-reportstream/.environment/gitleaks/run-gitleaks.sh
Gitleaks> info: Scanning your suggested changes.
   - .../prime-reportstream/.environment/terraform-fmt/run-terraform-fmt.sh
terraform-fmt> info: Checking Terraform formatting.
terraform-fmt> info: Skipping this check, you made no changes to Terraform files...
OK> pre-commit hooks passed!
...
```

## Changes
- Add short-circuiting Docker check to `.environment/pre-commit.runner.sh`

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

### Process
- [x] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?

## Fixes
- #2337 
