### PR TITLE
rhood/2607 CUC - Add RightSign Antibody Test

### DIFF
--- a/prime-router/docs/schema_documentation/experity-cuc-al-covid-19.md
+++ b/prime-router/docs/schema_documentation/experity-cuc-al-covid-19.md
@@ -1045,7 +1045,7 @@ Translate multiple inbound Y/N/U AOE values to RS values
 **Reference URL**:
 [https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
 
-**Table**: LIVD-SARS-CoV-2-2021-04-28
+**Table**: LIVD-SARS-CoV-2-2021-09-29
 
 **Table Column**: Model
 
@@ -2155,8 +2155,6 @@ Translate multiple inbound Y/N/U AOE values to RS values
 
 **Format**: $alt
 
-**Default Value**: 99999999
-
 **Cardinality**: [0..1]
 
 **Alt Value Sets**
@@ -2165,6 +2163,7 @@ Code | Display
 ---- | -------
 Sofia SARS Antigen FIA_Quidel Corporation|Sofia SARS Antigen FIA
 10811877011269|Abbott-ID NOW COVID-19 (Molecular)
+RightSign COVID-19 IgG/IgM Rapid Test Cassette_Hangzhou Biotest Biotech Co., Ltd.|RightSign COVID-19 IgG/IgM Rapid Test Cassette
 COVID-19 IgG/IgM Rapid Test Cassette (Whole Blood/Serum/Plasma)_Healgen Scientific LLC|Healgen COVID-19 IgG IgM Rapid Test
 
 ---

--- a/prime-router/docs/schema_documentation/experity-experity-covid-19.md
+++ b/prime-router/docs/schema_documentation/experity-experity-covid-19.md
@@ -1045,7 +1045,7 @@ Translate multiple inbound Y/N/U AOE values to RS values
 **Reference URL**:
 [https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
 
-**Table**: LIVD-SARS-CoV-2-2021-04-28
+**Table**: LIVD-SARS-CoV-2-2021-09-29
 
 **Table Column**: Model
 

--- a/prime-router/docs/schema_documentation/experity-guc-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/experity-guc-la-covid-19.md
@@ -1045,7 +1045,7 @@ Translate multiple inbound Y/N/U AOE values to RS values
 **Reference URL**:
 [https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
 
-**Table**: LIVD-SARS-CoV-2-2021-04-28
+**Table**: LIVD-SARS-CoV-2-2021-09-29
 
 **Table Column**: Model
 
@@ -2154,8 +2154,6 @@ Translate multiple inbound Y/N/U AOE values to RS values
 **PII**: No
 
 **Format**: $alt
-
-**Default Value**: 99999999
 
 **Cardinality**: [0..1]
 

--- a/prime-router/metadata/schemas/Experity/CUC-AL-covid-19.schema
+++ b/prime-router/metadata/schemas/Experity/CUC-AL-covid-19.schema
@@ -18,7 +18,6 @@ elements:
 
     - name: test_kit_name_id
       type: CODE
-      default: 99999999
       csvFields: [{name: Ordered_test_description, format: $alt}]
       altValues:
 # Used with the test_performed_code to assign the LOINC: 95209-3 and set the Device ID on the outbound HL7
@@ -27,6 +26,9 @@ elements:
 # Used with the test_performed_code to assign the LOINC: 94534-5 and set the Device ID on the outbound HL7
         - code: 10811877011269
           display: "Abbott-ID NOW COVID-19 (Molecular)"
+# Used with the test_performed_code to assign the LOINC: 94508-9 or 94507-1 for IgM or IgG, and set the Device ID on the outbound HL7
+        - code: "RightSign COVID-19 IgG/IgM Rapid Test Cassette_Hangzhou Biotest Biotech Co., Ltd."
+          display: "RightSign COVID-19 IgG/IgM Rapid Test Cassette"
 # Used with the test_performed_code to assign the LOINC: 94508-9 or 94507-1 for IgM or IgG, and set the Device ID on the outbound HL7
         - code: "COVID-19 IgG/IgM Rapid Test Cassette (Whole Blood/Serum/Plasma)_Healgen Scientific LLC"
           display: "Healgen COVID-19 IgG IgM Rapid Test"

--- a/prime-router/metadata/schemas/Experity/GUC-LA-covid-19.schema
+++ b/prime-router/metadata/schemas/Experity/GUC-LA-covid-19.schema
@@ -18,7 +18,6 @@ elements:
 
     - name: test_kit_name_id
       type: CODE
-      default: 99999999
       csvFields: [{name: Ordered_test_description, format: $alt}]
       altValues:
 # This should translate to LOINC: 94558-4

--- a/prime-router/metadata/schemas/Experity/experity-covid-19.schema
+++ b/prime-router/metadata/schemas/Experity/experity-covid-19.schema
@@ -272,11 +272,8 @@ elements:
       default: N
 
 
-#this lookup is in the covid-19 schema, but doesn't appear to be done in practice (?)
+# Appears this RS field must be set even if it is not being used for the LIVD table lookup
     - name: equipment_model_name
-      table: LIVD-SARS-CoV-2-2021-04-28
-      tableColumn: Model
-      mapper: livdLookup()
 
 
 #unused fields - these are added here to suppress warnings.


### PR DESCRIPTION
This PR contains modifications to the Compass Urgent Care Schema to add the RightSign Anitbody Test.  It also includes changes to the remove the unused Default value from the test_kit_name_id.

- Populate the OBX.3.1 with LOINC Code: 94507-1 for the IgG result.
- Populate the OBX3.1 with LOINC Code: 94508-9 for the IgM result.
- Populate the OBX.17.1 with "RightSign COVID-19 IgG/IgM Rapid Test Cassette_Hangzhou Biotest Biotech Co., Ltd._EUA" for both the IgG and IgM results.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. Re-run the test file with RightSign Antibody results for CUC.  Validate the OBX.3 and OBX.17.


## Changes
- Added the RightSign Antibody Test to the altValues for test_kit_name_id.
- Removed the Default value for the test_kit_name_id


## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?


### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
*List GitHub issues this PR fixes*
- #2607 


## To Be Done
*Create GitHub issues to track the work remaining, if any*
