### PR TITLE
rhood/2626 Add Zip Codes

### DIFF
--- a/prime-router/metadata/tables/zip-code-data.csv
+++ b/prime-router/metadata/tables/zip-code-data.csv
@@ -5061,8 +5061,10 @@ state_fips,state,state_abbr,zipcode,county,city
 12,Florida,FL,33981,Charlotte,Port charlotte
 12,Florida,FL,33982,Charlotte,Punta gorda
 12,Florida,FL,33983,Charlotte,Punta gorda
-12,Florida,FL,33990,Lee,Cape coral centr
-12,Florida,FL,33991,Lee,Cape coral centr
+12,Florida,FL,33990,Lee,Cape Coral
+12,Florida,FL,33991,Lee,Cape Coral
+12,Florida,FL,33993,Lee,Cape Coral
+12,Florida,FL,33994,Lee,Fort Myers
 12,Florida,FL,34201,Manatee,Braden river
 12,Florida,FL,34202,Manatee,Braden river
 12,Florida,FL,34203,Manatee,Braden river


### PR DESCRIPTION
This PR adds multiple zip codes to the zip-code-data table.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. On my local RS, I processed a test file with zip codes containing those added to the .CSV file.  The Error messages for 'patient_county' null are now gone, and the HL7 message produced now includes the FIPS code in PID.11.9.


## Changes

- Updated metadata/tables/zip-code-data.csv


## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Downloaded a file from `http://localhost:7071/api/download`?
- [ ] Added tests?



### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
 - #2626 
