### PR TITLE
2587 Added CRUD REST API Smoke Test

### DIFF
--- a/.environment/gitleaks/gitleaks-config.toml
+++ b/.environment/gitleaks/gitleaks-config.toml
@@ -135,6 +135,7 @@ title = "PRIME ReportStream Gitleaks Configuration"
             '(patterns_to_match|key_permissions)\s*=',                                      # Terraform artifacts
             '(prime|changeIT!)',                                                            # Default cred, this is allowed (too broad??)
             '(resource|data) \"azurerm',                                                    # Terraform azure data or resource
+            '/api/settings',
             '/api/token',
             '\.containsKey\(',
             '\"user(\d)*\", \"pass(\d)*\"',                                                 # Not real creds

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -54,7 +54,8 @@ class Report : Logging {
         CSV("csv", "text/csv"), // A CSV format the follows the csvFields
         HL7("hl7", "application/hl7-v2", true), // HL7 with one result per file
         HL7_BATCH("hl7", "application/hl7-v2"), // HL7 with BHS and FHS headers
-        REDOX("redox", "text/json", true); // Redox format
+        REDOX("redox", "text/json", true), // Redox format
+        JSON("json", "application/json"); // JSON Payload
         // FHIR
 
         companion object {

--- a/prime-router/src/main/kotlin/azure/HttpUtilities.kt
+++ b/prime-router/src/main/kotlin/azure/HttpUtilities.kt
@@ -29,6 +29,7 @@ class HttpUtilities {
         const val oldApi = "/api/reports"
         const val watersApi = "/api/waters"
         const val tokenApi = "/api/token"
+        const val organizationApi = "/api/settings/organizations"
 
         fun okResponse(
             request: HttpRequestMessage<String?>,
@@ -302,6 +303,158 @@ class HttpUtilities {
                 } catch (e: IOException) {
                     // HttpUrlStatus treats not-success codes as IOExceptions.
                     // I found that the returned json is secretly still here:
+                    errorStream?.bufferedReader()?.readText()
+                        ?: this.responseMessage
+                }
+                return responseCode to response
+            }
+        }
+
+        /**
+         * A generic function to GET data to a particular Prime ReportStream Environment,
+         * as if from Organization.
+         * Returns Pair(Http response code, json response text)
+         */
+        fun getOrganization(
+            environment: ReportStreamEnv,
+            orgName: String,
+            sendingOrgClient: Sender,
+            key: String?
+        ): Pair<Int, String> {
+            val headers = mutableListOf<Pair<String, String>>()
+            headers.add("Content-Type" to Report.Format.JSON.mimeType)
+            headers.add("Authorization" to "Bearer dummy")
+            val clientStr = sendingOrgClient.organizationName +
+                if (sendingOrgClient.name.isNotBlank()) ".${sendingOrgClient.name}" else ""
+            headers.add("client" to clientStr)
+            if (key == null && environment == ReportStreamEnv.TEST)
+                error("key is required for Test environment")
+            if (key != null)
+                headers.add("x-functions-key" to key)
+            val url = environment.urlPrefix + organizationApi + "/" + orgName
+            return getHttp(url, headers)
+        }
+
+        /**
+         * A generic function that gets data from a URL <address>.
+         * Returns a Pair (HTTP response code, text of the response)
+         */
+        fun getHttp(urlStr: String, headers: List<Pair<String, String>>? = null): Pair<Int, String> {
+            val urlObj = URL(urlStr)
+            with(urlObj.openConnection() as HttpURLConnection) {
+                requestMethod = "GET"
+                doOutput = true
+                doInput = true
+                headers?.forEach {
+                    addRequestProperty(it.first, it.second)
+                }
+                val response = try {
+                    inputStream.bufferedReader().readText()
+                } catch (e: IOException) {
+                    // HttpUrlStatus treats not-success codes as IOExceptions.
+                    // I found that the returned json is secretly still here:
+                    errorStream?.bufferedReader()?.readText()
+                        ?: this.responseMessage
+                }
+                return responseCode to response
+            }
+        }
+
+        /**
+         * A generic function to PUT data to a particular Prime ReportStream Environment,
+         * as if from Organization.
+         * Returns Pair(Http response code, json response text)
+         */
+        fun createOrganization(
+            environment: ReportStreamEnv,
+            bytes: ByteArray,
+            orgName: String,
+            sendingOrgClient: Sender,
+            key: String?,
+        ): Pair<Int, String> {
+            val headers = mutableListOf<Pair<String, String>>()
+            headers.add("Content-Type" to Report.Format.JSON.mimeType)
+            headers.add("Authorization" to "Bearer dummy")
+            val clientStr = sendingOrgClient.organizationName +
+                if (sendingOrgClient.name.isNotBlank()) ".${sendingOrgClient.name}" else ""
+            headers.add("client" to clientStr)
+            if (key == null && environment == ReportStreamEnv.TEST)
+                error("key is required for Test environment")
+            if (key != null)
+                headers.add("x-functions-key" to key)
+            val url = environment.urlPrefix + organizationApi + "/" + orgName
+            return putHttp(url, bytes, headers)
+        }
+
+        /**
+         * A generic function that puts data from a URL <address>.
+         * Returns a Pair (HTTP response code, text of the response)
+         */
+        fun putHttp(urlStr: String, bytes: ByteArray, headers: List<Pair<String, String>>? = null): Pair<Int, String> {
+            val urlObj = URL(urlStr)
+            with(urlObj.openConnection() as HttpURLConnection) {
+                requestMethod = "PUT"
+                doOutput = true
+                doInput = true
+                headers?.forEach {
+                    addRequestProperty(it.first, it.second)
+                }
+                outputStream.use {
+                    it.write(bytes)
+                }
+                val response = try {
+                    inputStream.bufferedReader().readText()
+                } catch (e: IOException) {
+                    // HttpUrlStatus treats not-success codes as IOExceptions.
+                    // I found that the returned json is secretly still here:
+                    errorStream?.bufferedReader()?.readText()
+                        ?: this.responseMessage
+                }
+                return responseCode to response
+            }
+        }
+
+        /**
+         * A generic function to DELETE organization from a particular Prime ReportStream Environment,
+         * as if from Organization.
+         * Returns Pair(Http response code, json response text)
+         */
+        fun deleteOrganization(
+            environment: ReportStreamEnv,
+            orgName: String,
+            sendingOrgClient: Sender,
+            key: String?,
+        ): Pair<Int, String> {
+            val headers = mutableListOf<Pair<String, String>>()
+            headers.add("Content-Type" to Report.Format.JSON.mimeType)
+            headers.add("Authorization" to "Bearer dummy")
+            val clientStr = sendingOrgClient.organizationName +
+                if (sendingOrgClient.name.isNotBlank()) ".${sendingOrgClient.name}" else ""
+            headers.add("client" to clientStr)
+            if (key == null && environment == ReportStreamEnv.TEST)
+                error("key is required for Test environment")
+            if (key != null)
+                headers.add("x-functions-key" to key)
+            val url = environment.urlPrefix + organizationApi + "/" + orgName
+            return deleteHttp(url, headers)
+        }
+
+        /**
+         * A generic function that puts data from a URL <address>.
+         * Returns a Pair (HTTP response code, text of the response)
+         */
+        fun deleteHttp(urlStr: String, headers: List<Pair<String, String>>? = null): Pair<Int, String> {
+            val urlObj = URL(urlStr)
+            with(urlObj.openConnection() as HttpURLConnection) {
+                requestMethod = "DELETE"
+                doOutput = true
+                doInput = true
+                headers?.forEach {
+                    addRequestProperty(it.first, it.second)
+                }
+                val response = try {
+                    inputStream.bufferedReader().readText()
+                } catch (e: IOException) {
                     errorStream?.bufferedReader()?.readText()
                         ?: this.responseMessage
                 }


### PR DESCRIPTION
Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sure your new test has a good readable but brief description.2587 Added CRUD REST API Smoke Test

Background
We have no "end to end" system level tests nor smoke tests of the Settings REST API functions. That's a gap in our testing, which we can start to address with this ticket.

Acceptance Criteria
This work is done when there is a new test in TestReportStream.kt, that uses the Settings API to do the following:
1. Do a 'get' to confirm that no organization exists called 'dummy'.
2. CREATE: Do a 'set' to submit an Organization called 'dummy'
3. READ: Do a 'get' to confirm that 'dummy' now exists, and that it has correct fields.
4. UPDATE: Do a 'set' to submit a modification of the 'dummy' organization, with some minor tweak
5. Do another 'get' to confirm you get back the new/modified version of 'dummy'
6. DELETE: Do a 'delete' to remove 'dummy'
7. Re-run step 1, to confirm that it's gone.
That covers full 'CRUD' for Organizations.

Run ./prime test --list to make sur…

This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
-

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
