### PR TITLE
Adds Clark County, OH as a download receiver

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -609,6 +609,46 @@
         filePath: ./upload
         credentialName: DEFAULT-SFTP
 
+- name: oh-clark-doh
+  description: Ohio Department of Health - Clark County
+  jurisdiction: COUNTY
+  stateCode: OH
+  countyName: Clark
+  receivers:
+    - name: elr-download
+      organizationName: oh-clark-doh
+      topic: covid-19
+      customerStatus: testing
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, OH)
+        - matches(ordering_facility_county, Clark)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        suppressQstForAoe: true
+        receivingApplicationName: OHDOH
+        receivingApplicationOID: 2.16.840.1.114222.4.1.3674
+        receivingFacilityName: OHDOH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.3674
+        reportingFacilityName: CDC PRIME
+        reportingFacilityId: 36DSMP9999
+        nameFormat: ohio
+        suppressHl7Fields: OBX-23-11
+        # turn off UNK and ASKU for this field
+        useBlankInsteadOfUnknown: patient_race
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: EASTERN
+        # transport should be null in production
+      transport:
+        type: SFTP
+        host: sftp
+        port: 22
+        filePath: ./upload
+        credentialName: DEFAULT-SFTP
+
 - name: nm-doh
   description: New Mexico Department of Health
   jurisdiction: STATE

--- a/prime-router/settings/prod/0048-setup-clarkcounty-oh-doh.yml
+++ b/prime-router/settings/prod/0048-setup-clarkcounty-oh-doh.yml
@@ -1,0 +1,34 @@
+# ./prime multiple-settings set --env prod --input ./settings/prod/0048-setup-clarkcounty-oh.yml
+---
+- name: oh-clark-doh
+  description: Ohio Department of Health - Clark County
+  jurisdiction: COUNTY
+  stateCode: OH
+  countyName: Clark
+  receivers:
+    - name: elr-download
+      organizationName: oh-clark-doh
+      topic: covid-19
+      customerStatus: testing
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, OH)
+        - matches(ordering_facility_county, Clark)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        suppressQstForAoe: true
+        receivingApplicationName: OHDOH
+        receivingApplicationOID: 2.16.840.1.114222.4.1.3674
+        receivingFacilityName: OHDOH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.3674
+        reportingFacilityName: CDC PRIME
+        reportingFacilityId: 36DSMP9999
+        nameFormat: ohio
+        suppressHl7Fields: OBX-23-11
+        # turn off UNK and ASKU for this field
+        useBlankInsteadOfUnknown: patient_race
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: EASTERN

--- a/prime-router/settings/staging/0048-setup-clarkcounty-oh-doh.yml
+++ b/prime-router/settings/staging/0048-setup-clarkcounty-oh-doh.yml
@@ -1,0 +1,34 @@
+# ./prime multiple-settings set --env prod --input ./settings/prod/0048-setup-clarkcounty-oh.yml
+---
+- name: oh-clark-doh
+  description: Ohio Department of Health - Clark County
+  jurisdiction: COUNTY
+  stateCode: OH
+  countyName: Clark
+  receivers:
+    - name: elr-download
+      organizationName: oh-clark-doh
+      topic: covid-19
+      customerStatus: testing
+      jurisdictionalFilter:
+        - matches(ordering_facility_state, OH)
+        - matches(ordering_facility_county, Clark)
+      translation:
+        type: HL7
+        useBatchHeaders: true
+        suppressQstForAoe: true
+        receivingApplicationName: OHDOH
+        receivingApplicationOID: 2.16.840.1.114222.4.1.3674
+        receivingFacilityName: OHDOH
+        receivingFacilityOID: 2.16.840.1.114222.4.1.3674
+        reportingFacilityName: CDC PRIME
+        reportingFacilityId: 36DSMP9999
+        nameFormat: ohio
+        suppressHl7Fields: OBX-23-11
+        # turn off UNK and ASKU for this field
+        useBlankInsteadOfUnknown: patient_race
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: EASTERN


### PR DESCRIPTION
This PR adds the settings files for Clark County 

** Testing Steps
1.  Add the settings locally
2.  Generate test data
3. Submit data to API and verify that Clark County is one of the destination routes

## Changes
- Adds 0048-setup-clarkcounty-oh-doh.yml file to settings/prod and to settings/staging

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

## Fixes
- #2578 
