### PR TITLE
Add schedule to invoke function to check whether receivers are up

### DIFF
--- a/operations/app/src/modules/function_app/main.tf
+++ b/operations/app/src/modules/function_app/main.tf
@@ -35,6 +35,10 @@ locals {
 
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = false
 
+    # Cron-like schedule for running the function app that reaches out to remote
+    # sites and verifies they're up
+    "REMOTE_CONNECTION_CHECK_SCHEDULE" = "*/5 * * * *"
+
     # App Insights
     "APPINSIGHTS_INSTRUMENTATIONKEY"                  = var.ai_instrumentation_key
     "APPINSIGHTS_PROFILERFEATURE_VERSION"             = "1.0.0"


### PR DESCRIPTION
This PR adds an application setting for invoking the function app that checks whether we can still reach receivers' SFTP sites (and possibly other destinations). See https://github.com/CDCgov/prime-reportstream/pull/2371 for details on that functionality.

Based on the existing functionapp settings this seems the right place to put data to pass through to the environment, let me know if it's not.

## Checklist

### Testing
- [x] Tested locally? (Terraform linting)
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

### Process
- [x] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [x] Updated the release notes?
- [x] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

Fixes: #1153 