### PR TITLE
Turn Palo Alto on for production

### DIFF
--- a/operations/app/src/environments/configurations/prod.tfvars
+++ b/operations/app/src/environments/configurations/prod.tfvars
@@ -11,4 +11,4 @@ https_cert_names = [
 okta_redirect_url         = "https://prime.cdc.gov/download"
 aad_object_keyvault_admin = "5c6a951e-a4c2-4890-b62c-0ed8179501bb" # CT-PRIMEDATAHUBPRD-DMZ-AZ-Contributor
 
-use_cdc_managed_vnet = false
+use_cdc_managed_vnet = true

--- a/operations/app/src/modules/function_app/main.tf
+++ b/operations/app/src/modules/function_app/main.tf
@@ -22,8 +22,10 @@ locals {
     # Route storage account access through the VNET
     "WEBSITE_CONTENTOVERVNET" = 1
 
-    # Use the VNET DNS server (so we receive private endpoint URLs)
-    "WEBSITE_DNS_SERVER" = "168.63.129.16"
+    # Use the CDC DNS for everything; they have mappings for all our internal
+    # resources, so if we add a new resource we'll have to contact them (see
+    # prime-router/docs/dns.md)
+    "WEBSITE_DNS_SERVER" = "172.17.0.135"
 
     "DOCKER_REGISTRY_SERVER_URL"      = data.azurerm_container_registry.container_registry.login_server
     "DOCKER_REGISTRY_SERVER_USERNAME" = data.azurerm_container_registry.container_registry.admin_username

--- a/prime-router/docs/dns.md
+++ b/prime-router/docs/dns.md
@@ -1,0 +1,29 @@
+# DNS in Azure
+
+## Environments use CDC DNS
+
+As of November 2021 we're no longer using Azure DNS servers to lookup addresses for internal resources. Instead we're using a CDC DNS server which has the mappings for our resources -- databases, queues, storage accounts, etc -- manually entered. This means if we add new resources -- e.g., a Redis cache -- we'll need to register its IP and name with the CDC DNS server.
+
+To do so you'll need to send the mapping of IP address to name(s) to Richard Teasley. We'll need to do this **before** enabling applications to use these services to ensure the services can be reached.
+
+Different environments have unique areas in the CDC address space. These **cannot** overlap -- unlike our internal IP address spaces which use `10.0.5.x` no matter which environment you're in, the CDC-issued addresses must be 
+
+* Production - `172.17.7.0/25`
+* Staging - `172.17.6.0/25`
+* Test - `172.17.5.0/25`
+
+## VPN uses dnsmasq
+
+If you connect your development machine [to the VPN](vpn.md) you'll need to point requests for Azure resources to a small DNS server we run for this purpose. The configuration for these servers is in `operations/dnsmasq/config/{environment}/hosts.local`, and each one has a mapping of IP address (in the `10.0.5.x` address space) to Azure resource host names.
+
+Finally, you OpenVPN configuration needs to point to this DNS server. Fortunately this is already done for you -- each profile you receive when you get a VPN account has a section like:
+
+```
+dhcp-option DNS 10.0.2.4
+dhcp-option DOMAIN azure.com
+dhcp-option DOMAIN azure.net
+dhcp-option DOMAIN azurewebsites.net
+dhcp-option DOMAIN windows.net
+```
+
+So this configuration is telling your OS that requests looking up IPs under (for example) `azure.com` should go to the DNS server running at `10.0.2.4`, which is our `dnsmasq` server.


### PR DESCRIPTION
This PR flips the switch to enable the Palo Alto in production. (A retry from https://github.com/CDCgov/prime-reportstream/pull/2828)

## Deployment Checklist

- [ ] Ensure changes to CDC DNS are applied (Richard Teasley should notify us)
- [ ] Notify senders of downtime - Anshul
- [ ] Disable the release GitHub Action - Chris
- [ ] Merge this PR - Chris
- [ ] Deploy Terraform to production - Chris
    - [ ] Deploy `tf-01-network` to production
    - [ ] Deploy `tf-02-config` to production
    - [ ] Deploy `tf-03-persistent` to production
    - [ ] Deploy `tf-04-app` to production
- [ ] Verify we have App Insights logs - Jim
- [ ] Verify we have no blocked SFTP connection to senders - Jim
- [ ] Inspect Palo Alto logs to see if any unexpected traffic is blocked - Timothy
- [ ] Perform post-deployment validations - Jim
- [ ] Enable the release GitHub Action - Chris
- [ ] Notify receivers they can remove our old IP address from their firewall - Ming/Adrian