### PR TITLE
Remove jest mocks for unused CdcMap component

### DIFF
--- a/frontend-react/src/pages/home/Home.test.tsx
+++ b/frontend-react/src/pages/home/Home.test.tsx
@@ -4,10 +4,6 @@ import content from "../../content/content.json";
 
 import Home from "./Home";
 
-jest.mock("@cdc/map", () => () => {
-    return <div>Map</div>;
-});
-
 describe("Home rendering", () => {
     beforeEach(() => {
         render(<Home />);

--- a/frontend-react/src/pages/home/Sections/Section.test.tsx
+++ b/frontend-react/src/pages/home/Sections/Section.test.tsx
@@ -5,12 +5,9 @@ import Section from "./Section";
 /* REFACTOR
    Is there a better way to handle mocking components when they cause
    issues running simple unit tests?
-   
+
    >>> Kevin Haube, Oct 12, 2021
 */
-jest.mock("@cdc/map", () => () => {
-    return <div>Map</div>;
-});
 
 describe("Section rendering", () => {
     const fakeSection = {


### PR DESCRIPTION
 This #2916. (My change #2837 broke the unit tests.

This PR fixes the tests by removing the jest mock for the removed component.

Opened another issue https://github.com/CDCgov/prime-reportstream/issues/2920 to have tests run as github action so it gets caught automatically.