### PR TITLE
Remove use of azure/CLI action, run commands directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,10 +213,8 @@ jobs:
           az functionapp config access-restriction remove -g ${{ env.RESOURCE_GROUP }} -n ${{ env.PREFIX }}-functionapp --slot candidate --rule-name GitHubActionIPV4 > /dev/null 2>&1
 
       - name: Upload Static Site React
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend-react/build
+        run: |
+          az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend-react/build
 
   deploy_release_test:
     name: "Deploy Release: TEST"
@@ -305,11 +303,9 @@ jobs:
           az functionapp config access-restriction remove -g ${{ env.RESOURCE_GROUP }} -n ${{ env.PREFIX }}-functionapp --slot candidate --rule-name GitHubActionIPV4 > /dev/null 2>&1
 
       - name: Upload Static Site
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist
+        run: |
+          az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
+          az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist
 
   deploy_release_staging:
     name: "Deploy Release: STAGING"
@@ -398,11 +394,9 @@ jobs:
           az functionapp config access-restriction remove -g ${{ env.RESOURCE_GROUP }} -n ${{ env.PREFIX }}-functionapp --slot candidate --rule-name GitHubActionIPV4 > /dev/null 2>&1
 
       - name: Upload Static Site
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend-react/build
+        run: |
+          az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
+          az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend-react/build
 
   deploy_release_prod:
     name: "Deploy Release: PROD"
@@ -491,8 +485,6 @@ jobs:
           az functionapp config access-restriction remove -g ${{ env.RESOURCE_GROUP }} -n ${{ env.PREFIX }}-functionapp --slot candidate --rule-name GitHubActionIPV4 > /dev/null 2>&1
 
       - name: Upload Static Site
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
-            az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist
+        run: |
+          az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
+          az storage blob upload-batch --account-name ${{ env.PREFIX }}public -d '$web' -s frontend/dist

--- a/.github/workflows/validate_terraform.yml
+++ b/.github/workflows/validate_terraform.yml
@@ -87,14 +87,12 @@ jobs:
 
       - name: Upload Terraform Plan to Storage Account
         if: ${{ always() }} # We want to upload whatever part of the plan we have
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az storage blob upload-batch --account-name pdhstagingterraform \
-              --destination terraformplan \
-              --destination-path "${{ github.run_id }}-${{ github.sha }}" \
-              --source operations/app/plan \
-              --pattern 'staging-*'
+        run: |
+          az storage blob upload-batch --account-name pdhstagingterraform \
+            --destination terraformplan \
+            --destination-path "${{ github.run_id }}-${{ github.sha }}" \
+            --source operations/app/plan \
+            --pattern 'staging-*'
 
       - name: Directions for Downloading Plan
         if: ${{ always() }}


### PR DESCRIPTION
* Something (not sure what) changed recently in the `azure/login`action
  where the credentials are not passed properly to the `azure/CLI`
  action


Test Steps:
1. Run the `release` and `validate_terraform` actions

## Changes
- Remove use of `azure/CLI` action
