### PR TITLE
Suppress OBX-18 For VT

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -543,6 +543,18 @@
         receivingFacilityName: VDH
         receivingFacilityOID: 2.16.840.1.114222.4.1.185
 
+      timing:
+        operation: MERGE
+        numberPerDay: 1440 # Every minute
+        initialTime: 00:00
+        timeZone: CENTRAL
+      transport:
+        type: SFTP
+        host: sftp
+        port: 22
+        filePath: ./upload
+        credentialName: DEFAULT-SFTP
+
 - name: nd-doh
   description: North Dakota Department of Health
   jurisdiction: STATE
@@ -858,7 +870,7 @@
         receivingFacilityOID: 2.16.840.1.114222.4.1.185
         truncateHDNamespaceIds: true
         usePid14ForPatientEmail: true
-        suppressHl7Fields: OBX-18
+        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4
       transport:
         type: SFTP
         host: sftp

--- a/prime-router/settings/prod/0049-update-vt-doh.yml
+++ b/prime-router/settings/prod/0049-update-vt-doh.yml
@@ -1,0 +1,123 @@
+# ./prime multiple-settings set --env prod --input ./settings/prod/0049-update-vt-doh.yml
+---
+- name: "vt-doh"
+  description: "Vermont Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "VT"
+  countyName: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "vt-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "NBS"
+        receivingApplicationOID: "2.16.840.1.114222.4.1.185.1"
+        receivingFacilityName: "VDH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.185"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: null
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: true
+        usePid14ForPatientEmail: true
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, VT, patient_state, VT)"
+      qualityFilter:
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "isValidCLIA(testing_lab_clia,reporting_facility_clia)"
+        - "doesNotMatch(processing_mode_code,T,D)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 12
+        initialTime: "01:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "gs-sftp.ahs.state.vt.us"
+        port: "22"
+        filePath: "./Prod/ToVDH/"
+        credentialName: null
+        type: "SFTP"
+      externalName: null
+    - name: "elr-secondary"
+      organizationName: "vt-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "NBS"
+        receivingApplicationOID: "2.16.840.1.114222.4.1.185.1"
+        receivingFacilityName: "VDH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.185"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: true
+        usePid14ForPatientEmail: true
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD_SECONDARY"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, VT, patient_state, VT)"
+      qualityFilter:
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "isValidCLIA(testing_lab_clia,reporting_facility_clia)"
+        - "doesNotMatch(processing_mode_code,T,D)"
+      reverseTheQualityFilter: true
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 12
+        initialTime: "01:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "gs-sftp.ahs.state.vt.us"
+        port: "22"
+        filePath: "./Test/ToVDH/"
+        credentialName: null
+        type: "SFTP"
+      externalName: null

--- a/prime-router/settings/staging/0049-update-vt-doh.yml
+++ b/prime-router/settings/staging/0049-update-vt-doh.yml
@@ -1,0 +1,123 @@
+# ./prime multiple-settings set --env prod --input ./settings/staging/0049-update-vt-doh.yml
+---
+- name: "vt-doh"
+  description: "Vermont Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "VT"
+  countyName: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "vt-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "NBS"
+        receivingApplicationOID: "2.16.840.1.114222.4.1.185.1"
+        receivingFacilityName: "VDH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.185"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: true
+        usePid14ForPatientEmail: true
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, VT, patient_state, VT)"
+      qualityFilter:
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "isValidCLIA(testing_lab_clia,reporting_facility_clia)"
+        - "doesNotMatch(processing_mode_code,T,D)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 12
+        initialTime: "01:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "gs-sftp.ahs.state.vt.us"
+        port: "22"
+        filePath: "./Prod/ToVDH/"
+        credentialName: null
+        type: "SFTP"
+      externalName: null
+    - name: "elr-secondary"
+      organizationName: "vt-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "NBS"
+        receivingApplicationOID: "2.16.840.1.114222.4.1.185.1"
+        receivingFacilityName: "VDH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.185"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: null
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: true
+        usePid14ForPatientEmail: true
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD_SECONDARY"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, VT, patient_state, VT)"
+      qualityFilter:
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "isValidCLIA(testing_lab_clia,reporting_facility_clia)"
+        - "doesNotMatch(processing_mode_code,T,D)"
+      reverseTheQualityFilter: true
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 12
+        initialTime: "01:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "gs-sftp.ahs.state.vt.us"
+        port: "22"
+        filePath: "./Test/ToVDH/"
+        credentialName: null
+        type: "SFTP"
+      externalName: null


### PR DESCRIPTION
This PR suppresses HL7 field OBX-18 for VT. 



Test Steps:
1. Make sure your docker containers are running and type this command: 
   - `./prime multiple-settings set --input settings/organizations.yml`
2. Generate fake test data for VT
    - `./prime data --input-fake 5 --input-schema primedatainput/pdi-covid-19 --output-format CSV --output <FILE PATH> --target-states VT`
3. Submit fake data to api
    - `curl -X POST -H 'client: simple_report' -H 'Content-Type: text/csv' --data-binary '@<FILE PATH>' localhost:7071/api/reports`
4. Verify that OBX-18 is blank
    - Go to build/sftp folder 
    - Open the newly generated HL7 file and verify that OBX-18 is blank

## Changes
- Edits org file for vt-doh by adding `suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4` to the translation property
- adds 0049-update-vt-doh.yml to settings/prod/ and to settings/staging/


## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?



## Fixes
- #2881 





