### PR TITLE
Fix to Cue schema

### DIFF
--- a/prime-router/docs/schema_documentation/direct-cue-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-cue-covid-19.md
@@ -2148,11 +2148,11 @@ The city of the testing lab
 - [ORC-2-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.2.3)
 - [ORC-3-3](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/ORC.3.3)
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Documentation**:
 
-Expecting a CLIA number here.  eg, "10D2218834"
+Expecting a CLIA number (eg, "10D2218834"), or empty string.
 
 ---
 

--- a/prime-router/metadata/schemas/direct/cue-covid-19.schema
+++ b/prime-router/metadata/schemas/direct/cue-covid-19.schema
@@ -13,3 +13,8 @@ elements:
   - name: processing_mode_code
     default: P
 
+  - name: testing_lab_clia
+    cardinality: ZERO_OR_ONE
+    documentation: Expecting a CLIA number (eg, "10D2218834"), or empty string.
+    csvFields: [{ name: performingFacility}]
+

--- a/prime-router/src/main/kotlin/ElementErrors.kt
+++ b/prime-router/src/main/kotlin/ElementErrors.kt
@@ -15,7 +15,7 @@ data class MissingFieldMessage(
 
     companion object {
         fun new(fieldMapping: String): MissingFieldMessage {
-            return MissingFieldMessage(ResponseMsgType.MISSING, fieldMapping)
+            return MissingFieldMessage(ResponseMsgType.MISSING, "", fieldMapping)
         }
     }
 }

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -605,7 +605,7 @@ class ReportFunction : Logging {
                     }
                     if (resultDetail.row != -1) {
                         // Add 2 to account for array offset and csv header
-                        rowsByGroupingId[groupingId]?.add(resultDetail.row + 2)
+                        rowsByGroupingId[groupingId]?.add(resultDetail.row + 1)
                     }
                 }
                 it.writeArrayFieldStart(field)


### PR DESCRIPTION
- This makes the CLIA number optional in the cue schema
- Also fixes a missing error message problem
- Also fixes our line numbering so that the first row of data is "row 1", to fit with how we number HL7 files.

Tested locally, and smoke tested.

