### PR TITLE
Move the download-artifact step to just before the upload one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,12 +330,6 @@ jobs:
           name: prime-router-build-${{ github.run_id }}
           path: prime-router/build
 
-      - name: Download Frontend Artifact (React)
-        uses: actions/download-artifact@v2
-        with:
-          name: static_website_react-${{ github.run_id }}
-          path: frontend-react/build
-
       - name: Build Docker Image
         run: docker build . --file Dockerfile --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:latest --tag ${{ env.ACR_REPO }}/${{ env.PREFIX }}:${{ github.sha }}
 
@@ -393,8 +387,16 @@ jobs:
         run: |
           az functionapp config access-restriction remove -g ${{ env.RESOURCE_GROUP }} -n ${{ env.PREFIX }}-functionapp --slot candidate --rule-name GitHubActionIPV4 > /dev/null 2>&1
 
+      - name: Download Frontend Artifact (React)
+        uses: actions/download-artifact@v2
+        with:
+          name: static_website_react-${{ github.run_id }}
+          path: frontend-react/build
+
       - name: Upload Static Site
-        run: find . -type f
+        run: |
+          ls -al
+          find . -type f
       # 2021-11-04 CW - Disabling to enable other production deploys to happen
       #     az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
       #     az storage blob upload-batch --account-name ${{ env.PREFIX }}public -s frontend-react/build -d '$web' --debug


### PR DESCRIPTION
* This is to see if any intervening step is mucking with the current working directory, or is cleaning up files/directories behind the scenes.