### PR TITLE
Setting the working directory should do the trick

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,12 +396,8 @@ jobs:
       - name: Upload Static Site
         working-directory: .
         run: |
-          ls -al
-          ls -al ..
-          find . -type f
-      # 2021-11-04 CW - Disabling to enable other production deploys to happen
-      #     az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
-      #     az storage blob upload-batch --account-name ${{ env.PREFIX }}public -s frontend-react/build -d '$web' --debug
+          az storage blob delete-batch --account-name ${{ env.PREFIX }}public -s '$web'
+          az storage blob upload-batch --account-name ${{ env.PREFIX }}public -s frontend-react/build -d '$web' --debug
 
   deploy_release_prod:
     name: "Deploy Release: PROD"


### PR DESCRIPTION
* Toward the top of the `release.yml` there's a default setting for  `run | working-directory`, which is why this wasn't working, and also why this was succeeding previously with the `azure/CLI` action (that default didn't apply).