### PR TITLE
Adding Abbott and Lifepoint senders, directlite schema

### DIFF
--- a/prime-router/docs/schema_documentation/direct-directlite-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-directlite-covid-19.md
@@ -1,6 +1,6 @@
 
-### Schema:         direct/abbott-covid-19
-#### Description:   Abbott
+### Schema:         direct/directlite-covid-19
+#### Description:   Direct Submission to ReportStream COVID-19 flat file, Lite edition (tm)
 
 ---
 
@@ -446,7 +446,7 @@ The patient's race. There is a common valueset defined for race values, but some
 
 **PII**: No
 
-**Cardinality**: [0..1]
+**Cardinality**: [1..1]
 
 **Table**: fips-county
 
@@ -454,7 +454,7 @@ The patient's race. There is a common valueset defined for race values, but some
 
 **Documentation**:
 
-not required since this is only going to HHSProtect
+Extremely important field for routing data to states.
 
 ---
 
@@ -573,7 +573,7 @@ Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
 
 **PII**: No
 
-**Default Value**: T
+**Default Value**: P
 
 **Cardinality**: [0..1]
 
@@ -666,8 +666,6 @@ Override the base hl70136 valueset with a custom one, to handle slightly differe
 **Type**: TEXT
 
 **PII**: No
-
-**Default Value**: abbott
 
 **Cardinality**: [1..1]
 

--- a/prime-router/metadata/schemas/direct/abbott-covid-19.schema
+++ b/prime-router/metadata/schemas/direct/abbott-covid-19.schema
@@ -4,7 +4,7 @@ description: Abbott
 topic: covid-19
 trackingElement: specimen_id
 basedOn: covid-19
-extends: direct/direct-covid-19
+extends: direct/directlite-covid-19
 
 elements:
   - name: sender_id

--- a/prime-router/metadata/schemas/direct/directlite-covid-19.schema
+++ b/prime-router/metadata/schemas/direct/directlite-covid-19.schema
@@ -1,0 +1,211 @@
+---
+name: directlite-covid-19
+description: Direct Submission to ReportStream COVID-19 flat file, Lite edition (tm)
+topic: covid-19
+trackingElement: specimen_id
+basedOn: covid-19
+elements:
+
+  - name: sender_id
+    cardinality: ONE
+    csvFields: [{ name: senderId}]
+
+  - name: processing_mode_code
+    csvFields: [{name: processingModeCode}]
+
+  - name: ordered_test_code
+    documentation: eg, 94531-1
+    csvFields: [{ name: testOrdered}]
+
+  - name: ordered_test_name
+    documentation: Should be the name that matches to Test Ordered LOINC Long Name, in LIVD table
+    csvFields: [{ name: testName}]
+
+  - name: test_result
+    documentation:  eg, 260373001
+    csvFields: [{ name: testResult }]
+
+  - name: test_result_status
+    default: F
+
+  - name: placer_order_id
+    mapper: use(message_id)
+
+  - name: filler_order_id
+    mapper: use(message_id)
+
+  - name: test_performed_code
+    documentation: eg, 94558-4
+    csvFields: [{ name: testPerformed }]
+    
+  - name: test_result_date
+    documentation: eg, 20210111
+    csvFields: [{ name: testResultDate}]
+
+  - name: date_result_released
+    documentation: eg, 20210112
+    csvFields: [{ name: testReportDate}]
+
+  - name: test_kit_name_id
+    documentation: Must match LIVD column M, "Test Kit Name ID"
+    csvFields: [{ name: deviceIdentifier}]
+
+  - name: equipment_model_name
+    documentation: Required.  Must match LIVD column B, "Model". eg,  "BD Veritor System for Rapid Detection of SARS-CoV-2 & Flu A+B"
+    cardinality: ONE
+    csvFields: [{ name: deviceName}]
+
+  - name: specimen_id
+    documentation: A unique id, such as a UUID. Note - Need to override the mapper in covid-19.schema file.
+    mapper: use(specimen_id)
+    csvFields: [{ name: specimenId}]
+
+  - name: message_id
+    documentation: ReportStream copies value from the specimenId if none is provided by the sender.
+    mapper: use(specimen_id)
+    csvFields: [{ name: testId}]
+
+  - name: patient_age
+    csvFields: [{ name: patientAge}]
+
+  - name: patient_race
+    csvFields: [{ name: patientRace}]
+
+  - name: patient_ethnicity
+    documentation:  Internally, ReportStream uses hl70189 (H,N,U), but should use HHS values. (2135-2, 2186-5, UNK, ASKU). A mapping is done here, but better is to switch all of RS to HHS standard.
+    altValues:
+      - code: H
+        display: 2135-2
+      - code: N
+        display: 2186-5
+      - code: U
+        display: UNK
+      - code: U
+        display: ASKU
+    csvFields: [{ name: patientEthnicity, format: $alt}]
+
+  - name: patient_gender
+    csvFields: [{ name: patientSex}]
+
+  - name: patient_zip_code 
+    csvFields: [{ name: patientZip}]
+
+  - name: patient_county
+    csvFields: [{ name: patientCounty}]
+
+  - name: ordering_provider_id
+    documentation:  eg, "1265050918"
+    csvFields: [{ name: orderingProviderNpi}]
+
+  - name: ordering_provider_last_name
+    csvFields: [{ name: orderingProviderLname}]
+
+  - name: ordering_provider_first_name
+    csvFields: [{ name: orderingProviderFname}]
+
+  - name: ordering_provider_zip_code
+    csvFields: [{ name: orderingProviderZip}]
+
+  - name: testing_lab_clia
+    documentation: Expecting a CLIA number here.  eg, "10D2218834"
+    csvFields: [{ name: performingFacility}]
+
+  - name: testing_lab_name
+    csvFields: [{ name: performingFacilityName}]
+
+  - name: testing_lab_state
+    csvFields: [{ name: performingFacilityState}]
+
+  - name: testing_lab_zip_code
+    csvFields: [{ name: performingFacilityZip}]
+
+  - name: specimen_type
+    csvFields: [{ name: specimenSource}]
+
+  - name: patient_id
+    csvFields: [{ name: patientUniqueId}]
+
+  - name: patient_id_type
+    default: PI
+
+  - name: patient_id_hash
+    # Custom.   Needs to go into covid-19. Mimic waters here.
+    type: TEXT
+    mapper: hash(patient_id)
+    csvFields: [{ name: patientUniqueIdHash}]
+
+  - name: patient_state
+    documentation: Extremely important field for routing data to states.
+    csvFields: [{ name: patientState}]
+
+  - name: first_test
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: firstTest, format: $display}]
+
+  - name: previous_test_type
+    documentation:  Custom field. Note, value matched LIVD column "F", "Test Performed LOINC Code"
+    type: TEXT
+    csvFields: [{ name: previousTestType}]
+
+  - name: previous_test_result
+    documentation: Custom field.  Example - 260415000
+    type: CODE
+    valueSet: covid-19/test_result
+    csvFields: [{ name: previousTestResult}]
+
+  - name: employed_in_healthcare
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: healthcareEmployee, format: $display}]
+
+  - name: symptomatic_for_disease
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: symptomatic, format: $display}]
+
+  - name: symptoms_list
+    documentation:  Custom.  Just a simple text string for now. Format is symptomCode1^date1;symptomCode2^date2; ...
+    type: TEXT
+    csvFields: [{ name: symptomsList}]
+
+  - name: hospitalized
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: hospitalized, format: $display}]
+
+  - name: icu
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: symptomsIcu, format: $display}]
+
+  - name: resident_congregate_setting
+    type: CODE
+    valueSet: covid-19/yesno
+    documentation: Override the base hl70136 valueset with a custom one, to handle slightly different syntax
+    csvFields: [{ name: congregateResident, format: $display}]
+
+  - name: site_of_care
+    documentation: Custom field
+    type: CODE
+    valueSet: site_of_care
+    csvFields: [{ name: congregateResidentType}]
+
+  - name: pregnant
+    csvFields: [{ name: pregnant}]
+
+  - name: reporting_facility_name
+    mapper: use(testing_lab_name)
+
+  - name: reporting_facility_clia
+    mapper: use(testing_lab_clia)
+
+  # These fields are calculated
+  - name: test_authorized_for_otc
+  - name: test_authorized_for_home
+  - name: test_authorized_for_unproctored

--- a/prime-router/settings/prod/0049-abbott-lifepoint.yml
+++ b/prime-router/settings/prod/0049-abbott-lifepoint.yml
@@ -1,0 +1,60 @@
+# Run this:  ./prime multiple-settings set --input ./settings/staging/0050-abbott-lifepoint.yml --env staging
+---
+- name: abbott
+  description: Abbott
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: abbott
+      topic: covid-19
+      customerStatus: testing
+      schemaName: direct/abbott-covid-19
+      format: CSV
+
+- name: lifepoint
+  description: LifePoint (Ellume data)
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: lifepoint
+      topic: covid-19
+      customerStatus: testing
+      schemaName: hl7/lifepoint-covid-19
+      format: HL7
+
+- name: "hhsprotect"
+  description: "HHSProtect"
+  jurisdiction: "FEDERAL"
+  stateCode: null
+  countyName: null
+  senders: []
+  receivers:
+  - name: "elr"
+    organizationName: "hhsprotect"
+    topic: "covid-19"
+    translation: !<CUSTOM>
+      schemaName: "hhsprotect/hhsprotect-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(sender_id, SafeHealth,ImageMover,Cue,InBios,Strac,.*CueHlth.*,reddyfmc,primary,cuc-al,guc-la,abbott,lifepoint,hca)"
+    qualityFilter:
+    - "allowAll()"
+    - "doesNotMatch(processing_mode_code,T,D)"
+    reverseTheQualityFilter: false
+    deidentify: true
+    timing:
+      operation: "MERGE"
+      numberPerDay: 12
+      initialTime: "01:25"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<BLOBSTORE>
+      storageName: "PartnerStorage"
+      containerName: "hhsprotect"
+      type: "BLOBSTORE"
+    externalName: null

--- a/prime-router/settings/staging/0050-abbott-lifepoint.yml
+++ b/prime-router/settings/staging/0050-abbott-lifepoint.yml
@@ -1,0 +1,57 @@
+# Run this:  ./prime multiple-settings set --input ./settings/staging/0050-abbott-lifepoint.yml --env staging
+---
+- name: abbott
+  description: Abbott
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: abbott
+      topic: covid-19
+      customerStatus: active
+      schemaName: direct/abbott-covid-19
+      format: CSV
+  
+- name: lifepoint
+  description: LifePoint (Ellume data)
+  jurisdiction: FEDERAL
+  senders:
+    - name: default
+      organizationName: lifepoint
+      topic: covid-19
+      customerStatus: active
+      schemaName: hl7/lifepoint-covid-19
+      format: HL7
+    
+- name: "hhsprotect"
+  description: "HHSProtect"
+  jurisdiction: "FEDERAL"
+  receivers:
+  - name: "elr"
+    organizationName: "hhsprotect"
+    topic: "covid-19"
+    customerStatus: "active"
+    translation: !<CUSTOM>
+      schemaName: "hhsprotect/hhsprotect-covid-19"
+      format: "CSV"
+      defaults: {}
+      nameFormat: "STANDARD"
+      receivingOrganization: null
+      type: "CUSTOM"
+    jurisdictionalFilter:
+    - "matches(sender_id,.*SafeHealth.*,.*CueHlth.*,.*ImageMover.*,InBios,Strac,AnavasiDx,careevolution,reddyfmc,primary,abbott,lifepoint,hca)"
+    qualityFilter:
+    - "allowAll()"
+    reverseTheQualityFilter: false
+    deidentify: true
+    timing:
+      operation: "MERGE"
+      numberPerDay: 96          # every 15 minutes
+      initialTime: "00:00"
+      timeZone: "EASTERN"
+      maxReportCount: 500
+    description: ""
+    transport: !<BLOBSTORE>
+      storageName: "PartnerStorage"
+      containerName: "hhsprotect"
+      type: "BLOBSTORE"
+  


### PR DESCRIPTION
This PR adds Abbott and Lifepoint sender settings, and adds a Direct Lite base schema for Abbott.

Test Steps:
1. Execute `./prime multiple-settings` against yamlitos as described in line 1 of the files.
2. Create and submit fake Abbott data

## Changes
- abbott-covid-19.schema - change base to directlite-covid-19
- adds directlite-covid-19.schema
- adds settings/prod/0049-abbott-lifepoint.yml
- adds settings/staging/0050-abbott-lifepoint.yml

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Fixes
- #2950
