### PR TITLE
AZ Missing Lab Name and Specimen ID

### DIFF
--- a/prime-router/docs/schema_documentation/az-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19.md
@@ -452,6 +452,28 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 ---
 
+**Name**: Specimen_ID
+
+**Type**: EI
+
+**PII**: No
+
+**HL7 Fields**
+
+- [SPM-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2)
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
+
+---
+
 **Name**: Specimen_Site
 
 **Type**: CODE
@@ -655,20 +677,6 @@ An example of the ID is 03D2159846
 **Documentation**:
 
 The phone number of the testing lab
-
----
-
-**Name**: Specimen_ID
-
-**Type**: ID
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Documentation**:
-
-The specimen-id from the testing lab
 
 ---
 

--- a/prime-router/docs/schema_documentation/az-az-ihs-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-az-ihs-covid-19.md
@@ -497,6 +497,28 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 ---
 
+**Name**: Specimen_ID
+
+**Type**: EI
+
+**PII**: No
+
+**HL7 Fields**
+
+- [SPM-2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2)
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.2) 
+
+**Documentation**:
+
+A unique code for this specimen
+
+---
+
 **Name**: Specimen_Site
 
 **Type**: CODE
@@ -714,20 +736,6 @@ An example of the ID is 03D2159846
 **Documentation**:
 
 The phone number of the testing lab
-
----
-
-**Name**: Specimen_ID
-
-**Type**: ID
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Documentation**:
-
-The specimen-id from the testing lab
 
 ---
 

--- a/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
@@ -16,12 +16,7 @@ elements:
   - name: organization_name
     maxLength:  50
     type: TEXT
-    csvFields:
-    - name: organization_name
-
-  - name: testing_lab_name
-    maxLength: 50
-    type: TEXT
+    mapper: use(testing_lab_name)
     csvFields:
     - name: Lab_Name
 

--- a/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
@@ -17,6 +17,12 @@ elements:
     maxLength:  50
     type: TEXT
     csvFields:
+    - name: organization_name
+
+  - name: testing_lab_name
+    maxLength: 50
+    type: TEXT
+    csvFields:
     - name: Lab_Name
 
   - name: testing_lab_clia

--- a/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
+++ b/prime-router/metadata/schemas/AZ/az-covid-19-csv.schema
@@ -150,8 +150,7 @@ elements:
     csvFields:
     - name: Provider_Phone_Number
 
-  - name: testing_lab_specimen_id
-    mapper: use(placer_order_id)
+  - name: specimen_id
     csvFields:
     - name: Specimen_ID
 


### PR DESCRIPTION
This PR fixes the issue where OBX-23-1 was not populated. This is for AZ and their display field name is Lab_Name. Lab_Name was only being populated by test results from Simple Report and not from any other sender. At the same time, this PR fixes the issue of specimen id not being populated as well.


Test Steps:
1. Run gradle
    - test
    - integration
    - testSmoke
2. Generate fake data from Simple Report for AZ
3. Submit to api
4. Verify that Lab_Name and Speciment_ID fields are populated
5. Do steps 2 through 4 with fake data from imagemover for AZ

## Changes
- Edited az-covid-19-csv.schema
   - organization_name
   - testing_lab_specimen_id

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


## Fixes
- #2631 

