### PR TITLE
Trying experiment to handle missing paths for a SPA

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -50,6 +50,7 @@
         "clean": "rimraf ./build",
         "start": "react-scripts start",
         "build": "craco build",
+        "postbuild": "cp build/index.html build/404.html",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "lint": "npm-run-all -p lint:eslint lint:prettier",


### PR DESCRIPTION
see https://github.com/CDCgov/prime-reportstream/issues/2952

Fix is to simply duplicate the index.html page (which hosts the SPA) to 404.html. Any 404 result should just load this page.
