### PR TITLE
Bug Fix 2996: Broken env option on the PRIME CLI

### DIFF
--- a/prime-router/src/main/kotlin/cli/OktaCommands.kt
+++ b/prime-router/src/main/kotlin/cli/OktaCommands.kt
@@ -62,7 +62,7 @@ class LoginCommand : OktaCommand(
         .default("local", "local")
 
     override fun run() {
-        val oktaApp = Environment.get().oktaApp ?: abort("No need to login in this environment")
+        val oktaApp = Environment.get(env).oktaApp ?: abort("No need to login in this environment")
         val accessTokenFile = readAccessTokenFile()
         if (accessTokenFile != null && isValidToken(oktaApp, accessTokenFile)) {
             echo("Has a valid token until ${accessTokenFile.expiresAt}")

--- a/prime-router/src/main/kotlin/cli/SenderUtilsCommand.kt
+++ b/prime-router/src/main/kotlin/cli/SenderUtilsCommand.kt
@@ -58,7 +58,7 @@ class AddPublicKey : SingleSettingCommand(
     ).flag(default = false)
 
     override fun run() {
-        val environment = Environment.get()
+        val environment = Environment.get(env)
         val accessToken = getAccessToken(environment)
         val publicKeyFile = File(publicKeyFilename)
         if (! publicKeyFile.exists()) {
@@ -130,7 +130,7 @@ class TokenUrl : SingleSettingCommand(
     ).required()
 
     override fun run() {
-        val environment = Environment.get()
+        val environment = Environment.get(env)
         val privateKeyFile = File(privateKeyFilename)
         if (! privateKeyFile.exists()) {
             echo("Unable to fine pem file " + privateKeyFile.absolutePath)

--- a/prime-router/src/main/kotlin/cli/SettingCommands.kt
+++ b/prime-router/src/main/kotlin/cli/SettingCommands.kt
@@ -47,7 +47,7 @@ abstract class SettingCommand(
     name: String,
     help: String,
 ) : CliktCommand(name = name, help = help) {
-    private val env by option(
+    internal val env by option(
         "-e", "--env",
         metavar = "<name>",
         envvar = "PRIME_ENVIRONMENT",
@@ -311,7 +311,7 @@ abstract class SingleSettingCommandNoSettingName(
 
     override fun run() {
         // Authenticate
-        val environment = Environment.get()
+        val environment = Environment.get(env)
         val accessToken = getAccessToken(environment)
 
         // Operations
@@ -520,7 +520,7 @@ class PutMultipleSettings : SettingCommand(
         .inputStream()
 
     override fun run() {
-        val environment = Environment.get()
+        val environment = Environment.get(env)
         val accessToken = getAccessToken(environment)
         val results = putAll(environment, accessToken)
         val output = "${results.joinToString("\n")}\n"
@@ -566,7 +566,7 @@ class GetMultipleSettings : SettingCommand(
     )
 
     override fun run() {
-        val environment = Environment.get()
+        val environment = Environment.get(env)
         val accessToken = getAccessToken(environment)
         val output = getAll(environment, accessToken)
         writeOutput(output)


### PR DESCRIPTION
This PR fixes the PRIME CLI's `--env` option. This option was broken in the recent environment consolidation work. 

Test Steps:
1. Try `./prime login --env prod` 
2. Other commands that have an `--env` option

## Changes
- The PRIME CLI's environment was hardcoded to the local environment. Now use the value in the --env option to select the environment. 

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #2996 
-
## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
