### PR TITLE
Okta widget img path now reflects React release image path

### DIFF
--- a/frontend-react/src/oktaConfig.ts
+++ b/frontend-react/src/oktaConfig.ts
@@ -13,7 +13,7 @@ const oktaAuthConfig: OktaAuthOptions = {
 };
 
 const oktaSignInConfig = {
-    logo: "https://reportstream.cdc.gov/assets/img/cdc-logo.svg",
+    logo: "/assets/cdc-logo.svg",
     language: "en",
     features: {
         registration: false, // Disable self-service registration flow

--- a/frontend-react/src/utils/UserUtils.ts
+++ b/frontend-react/src/utils/UserUtils.ts
@@ -11,7 +11,7 @@ function clearGlobalContext(): void {
 }
 
 function logout(oktaAuth: OktaAuth): void {
-    if (oktaAuth.authStateManager._authState.isAuthenticated) {
+    if (oktaAuth?.authStateManager?._authState?.isAuthenticated) {
         clearGlobalContext();
         oktaAuth.signOut();
     }


### PR DESCRIPTION
This PR fixes the CDC logo img path for the Okta login widget

Test Steps:
1. pull branch
2. `yarn` and `yarn start` (also have prime-router running)
3. click login and observe the OktaSigninWidget

## Changes
- CDC logo now appears on login widget
- Fixed build error thrown by TS in `UserUtils`

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
