### PR TITLE
MN - Suppresses SPM-2-1

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -961,6 +961,7 @@
         receivingApplicationOID: 2.16.840.1.114222.4.3.3.6.2.1
         receivingFacilityName: MN DOH
         receivingFacilityOID: 2.16.840.1.114222.4.1.3661
+        suppressHl7Fields: SPM-2-1
       transport:
         type: SFTP
         host: sftp

--- a/prime-router/settings/prod/0050-update-mn-doh.yml
+++ b/prime-router/settings/prod/0050-update-mn-doh.yml
@@ -1,0 +1,117 @@
+# ./prime multiple-settings set --env prod --input ./settings/prod/0050-update-mn-doh.yml
+---
+
+- name: "mn-doh"
+  description: "Minnesota Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "MN"
+  countyName: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "mn-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "MEDSS-ELR"
+        receivingApplicationOID: "2.16.840.1.114222.4.3.3.6.2.1"
+        receivingFacilityName: "MN DOH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.3661"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: SPM-2-1
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, MN, patient_state, MN)"
+      qualityFilter:
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob,ordering_provider_id,ordering_facility_name)"
+        - "isValidCLIA(testing_lab_clia)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "mdh-ftp.health.state.mn.us"
+        port: "22"
+        filePath: "./PROD"
+        credentialName: null
+        type: "SFTP"
+      externalName: "Primary Feed"
+    - name: "elr-secondary"
+      organizationName: "mn-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "MEDSS-ELR"
+        receivingApplicationOID: "2.16.840.1.114222.4.3.3.6.2.1"
+        receivingFacilityName: "MN DOH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.3661"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: SPM-2-1
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD_SECONDARY"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, MN, patient_state, MN)"
+      qualityFilter:
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob,ordering_provider_id,ordering_facility_name)"
+        - "isValidCLIA(testing_lab_clia)"
+      reverseTheQualityFilter: true
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: null
+      externalName: "OTC Feed"

--- a/prime-router/settings/staging/0050-update-mn-doh.yml
+++ b/prime-router/settings/staging/0050-update-mn-doh.yml
@@ -1,0 +1,117 @@
+# ./prime multiple-settings set --env prod --input ./settings/staging/0050-update-mn-doh.yml
+---
+
+- name: "mn-doh"
+  description: "Minnesota Department of Health"
+  jurisdiction: "STATE"
+  stateCode: "MN"
+  countyName: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "mn-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "MEDSS-ELR"
+        receivingApplicationOID: "2.16.840.1.114222.4.3.3.6.2.1"
+        receivingFacilityName: "MN DOH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.3661"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: SPM-2-1
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, MN, patient_state, MN)"
+      qualityFilter:
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob,ordering_provider_id,ordering_facility_name)"
+        - "isValidCLIA(testing_lab_clia)"
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: !<SFTP>
+        host: "mdh-ftp.health.state.mn.us"
+        port: "22"
+        filePath: "./PROD"
+        credentialName: null
+        type: "SFTP"
+      externalName: "Primary Feed"
+    - name: "elr-secondary"
+      organizationName: "mn-doh"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "MEDSS-ELR"
+        receivingApplicationOID: "2.16.840.1.114222.4.3.3.6.2.1"
+        receivingFacilityName: "MN DOH"
+        receivingFacilityOID: "2.16.840.1.114222.4.1.3661"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: SPM-2-1
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        nameFormat: "STANDARD_SECONDARY"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, MN, patient_state, MN)"
+      qualityFilter:
+        - "hasAtLeastOneOf(order_test_date,specimen_collection_date_time,test_result_date)"
+        - "hasAtLeastOneOf(patient_street,patient_zip_code,patient_phone_number,patient_email)"
+        - "hasValidDataFor(message_id,equipment_model_name,specimen_type,test_result,patient_last_name,patient_first_name,patient_dob,ordering_provider_id,ordering_facility_name)"
+        - "isValidCLIA(testing_lab_clia)"
+      reverseTheQualityFilter: true
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 100
+      description: ""
+      transport: null
+      externalName: "OTC Feed"


### PR DESCRIPTION
This PR suppresses SPM-2-1 field for MN.


## Test Steps:
1. Generate fake data for MN
2. Start Docker
3. Run this command: `./prime multiple-settings set --input settings/organizations.yml`
4. Submit the fake data to the api
5. Verify that SPM-2-1 is blank  

## Changes
- Added settings/prod/0050-update-mn-doh.yml
- Added settings/staging/0050-update-mn-doh.yml

## Checklist
- gradle test --> passed
- gradle testIntegration --> passed
- gradle testSmoke --> passed

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


## Fixes
- #3003 

