### PR TITLE
MA Missing OBR-22 In Messages From STRAC

### DIFF
--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -53,6 +53,16 @@ This field is generated based on the normalcy status of the result. A = abnormal
 
 ---
 
+**Name**: date_result_released
+
+**Type**: DATETIME
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
 **Name**: equipment_model_name
 
 **Type**: TABLE

--- a/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
+++ b/prime-router/metadata/schemas/STRAC/strac-covid-19.schema
@@ -100,6 +100,9 @@ elements:
   - name: test_result_date
     csvFields: [{name: patient_results}]
 
+  - name: date_result_released
+    mapper: use(test_result_date)
+
   - name: patient_gender
     csvFields: [{name: patient_sex}]
 


### PR DESCRIPTION
This PR populates OBR-22 in messages coming from STRAC



Test Steps:
1. Generate fake data from strac
2. Run Docker
3. Submit fake data file to api
4. Verify that OBR-22 is populated

## Changes
- Added date_result_released to STRAC schema
- generatedocs

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


## Fixes
- #3022 

