### PR TITLE
add missed tracking of sender information

### DIFF
--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -181,6 +181,8 @@ class ReportFunction : Logging {
         val warnings: MutableList<ResultDetail> = mutableListOf()
         // The following is identical to waters (for arch reasons)
         val validatedRequest = validateRequest(workflowEngine, request)
+        // track the sending organization and client based on the header
+        actionHistory.trackActionSender(extractClientHeader(request))
         warnings += validatedRequest.warnings
         handleValidation(validatedRequest, request, actionHistory, workflowEngine)?.let {
             return it


### PR DESCRIPTION
This PR fixes tracking of sending_org and sending_org_client which was missed during the Async/split work.
