### PR TITLE
Removed the entire response body from the data stored in action history

### DIFF
--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -183,7 +183,7 @@ class ActionHistory {
     }
 
     fun trackActionResult(httpResponseMessage: HttpResponseMessage) {
-        trackActionResult(httpResponseMessage.status.toString() + ":\n" + httpResponseMessage.body.toString())
+        trackActionResult(httpResponseMessage.status.toString())
     }
 
     fun trackActionRequestResponse(request: HttpRequestMessage<String?>, response: HttpResponseMessage) {


### PR DESCRIPTION
This PR changes the download action history so it no longer stores the verbose response.

Test Steps:
1. Do a download, then confirm that just the brief http status string (eg, "OK") appears in the action.action_response field in the database.

### Testing
- [ ] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

