### PR TITLE
Primary Health to production

### DIFF
--- a/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19-hl7.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/az-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-az-covid-19.md
@@ -607,6 +607,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/az-az-ihs-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-az-ihs-covid-19.md
@@ -666,6 +666,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
+++ b/prime-router/docs/schema_documentation/az-pima-az-covid-19.md
@@ -950,6 +950,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/ca-ca-scc-covid-19.md
+++ b/prime-router/docs/schema_documentation/ca-ca-scc-covid-19.md
@@ -138,6 +138,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 ---
 
@@ -797,6 +798,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/co-co-covid-19-redox.md
@@ -1612,6 +1612,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/covid-19-redox.md
@@ -1612,6 +1612,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/covid-19.md
+++ b/prime-router/docs/schema_documentation/covid-19.md
@@ -2883,6 +2883,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-abbott-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-abbott-covid-19.md
@@ -546,6 +546,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -956,6 +957,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-anavasidx-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-anavasidx-covid-19.md
@@ -696,6 +696,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1570,6 +1571,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2029,6 +2031,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
@@ -2885,6 +2885,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-cue-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-cue-covid-19.md
@@ -696,6 +696,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1570,6 +1571,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2029,6 +2031,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-direct-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-direct-covid-19.md
@@ -696,6 +696,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1570,6 +1571,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2027,6 +2029,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-directlite-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-directlite-covid-19.md
@@ -546,6 +546,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -954,6 +955,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-hca-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-hca-covid-19.md
@@ -2885,6 +2885,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-imagemover-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-imagemover-covid-19.md
@@ -696,6 +696,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1570,6 +1571,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2029,6 +2031,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-inbios-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-inbios-covid-19.md
@@ -696,6 +696,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1570,6 +1571,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2029,6 +2031,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/direct-safehealth-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-safehealth-covid-19.md
@@ -696,6 +696,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1570,6 +1571,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2029,6 +2031,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/fl-fl-covid-19.md
+++ b/prime-router/docs/schema_documentation/fl-fl-covid-19.md
@@ -2519,6 +2519,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/fl-fl-hillsborough-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/fl-fl-hillsborough-covid-19-csv.md
@@ -1057,6 +1057,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/gu-gu-covid-19.md
+++ b/prime-router/docs/schema_documentation/gu-gu-covid-19.md
@@ -2509,6 +2509,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/hhsprotect-hhsprotect-covid-19.md
+++ b/prime-router/docs/schema_documentation/hhsprotect-hhsprotect-covid-19.md
@@ -698,6 +698,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -1574,6 +1575,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 
@@ -2033,6 +2035,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
@@ -2883,6 +2883,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/hl7-lifepoint-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-lifepoint-covid-19.md
@@ -2904,6 +2904,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
@@ -2885,6 +2885,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
@@ -1,5 +1,5 @@
 
-### Schema:         direct/primary-covid-19
+### Schema:         hl7/primary-covid-19
 #### Description:   Primary Diagnostics, Inc, schema
 
 ---
@@ -2185,7 +2185,7 @@ pointer/link to the unique id of a previously submitted result.  Usually blank. 
 
 **PII**: No
 
-**Default Value**: T
+**Default Value**: P
 
 **Cardinality**: [0..1]
 
@@ -2885,6 +2885,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/la-la-covid-19.md
+++ b/prime-router/docs/schema_documentation/la-la-covid-19.md
@@ -2888,6 +2888,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19-csv.md
@@ -1057,6 +1057,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/mt-mt-covid-19.md
+++ b/prime-router/docs/schema_documentation/mt-mt-covid-19.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/nd-nd-covid-19.md
+++ b/prime-router/docs/schema_documentation/nd-nd-covid-19.md
@@ -2519,6 +2519,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/nm-nm-covid-19-csv.md
+++ b/prime-router/docs/schema_documentation/nm-nm-covid-19-csv.md
@@ -437,6 +437,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 ---
 
@@ -1717,6 +1718,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/nm-nm-covid-19.md
+++ b/prime-router/docs/schema_documentation/nm-nm-covid-19.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/oh-oh-covid-19.md
+++ b/prime-router/docs/schema_documentation/oh-oh-covid-19.md
@@ -2549,6 +2549,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/or-or-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/or-or-covid-19-hl7.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-hl7.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19-redox.md
@@ -1654,6 +1654,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/pa-pa-covid-19.md
+++ b/prime-router/docs/schema_documentation/pa-pa-covid-19.md
@@ -368,6 +368,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -1765,6 +1765,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/standard-standard-covid-19.md
+++ b/prime-router/docs/schema_documentation/standard-standard-covid-19.md
@@ -2883,6 +2883,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/strac-strac-covid-19.md
+++ b/prime-router/docs/schema_documentation/strac-strac-covid-19.md
@@ -936,6 +936,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 260373001|Detected
 260415000|Not detected
 455371000124106|Invalid result

--- a/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
+++ b/prime-router/docs/schema_documentation/tpca-tpca-covid-19.md
@@ -911,6 +911,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/tx-tx-covid-19.md
+++ b/prime-router/docs/schema_documentation/tx-tx-covid-19.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/vt-vt-covid-19.md
+++ b/prime-router/docs/schema_documentation/vt-vt-covid-19.md
@@ -2887,6 +2887,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/docs/schema_documentation/waters-waters-covid-19.md
+++ b/prime-router/docs/schema_documentation/waters-waters-covid-19.md
@@ -812,6 +812,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 ---
 
@@ -1182,6 +1183,7 @@ Code | Display
 840535000|Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
 840534001|Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
 373121007|Test not done
+82334004|Indeterminate
 
 **Documentation**:
 

--- a/prime-router/metadata/schemas/HL7/primary-covid-19.schema
+++ b/prime-router/metadata/schemas/HL7/primary-covid-19.schema
@@ -10,4 +10,4 @@ elements:
     default: primary
 
   - name: processing_mode_code
-    default: T
+    default: P

--- a/prime-router/metadata/valuesets/covid-19.valuesets
+++ b/prime-router/metadata/valuesets/covid-19.valuesets
@@ -101,6 +101,8 @@
       version: 20200309
     - code: 373121007
       display: Test not done
+    - code: 82334004
+      display: Indeterminate 
 
 - name: covid-19/order
   system: LOINC

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -236,7 +236,7 @@
       organizationName: primary
       topic: covid-19
       customerStatus: active
-      schemaName: direct/primary-covid-19
+      schemaName: hl7/primary-covid-19
       format: HL7
 
 - name: "johns_hopkins"

--- a/prime-router/settings/prod/0052-primary.yml
+++ b/prime-router/settings/prod/0052-primary.yml
@@ -1,0 +1,11 @@
+# Run this:  ./prime multiple-settings set --input ./settings/prod/0052-primary.yml --env prod
+---
+- name: primary
+  description: Primary.Health
+  jurisdiction: FEDERAL
+  senders:
+  - name: default
+    organizationName: primary
+    topic: covid-19
+    schemaName: hl7/primary-covid-19
+    format: HL7

--- a/prime-router/settings/staging/0052-primary.yml
+++ b/prime-router/settings/staging/0052-primary.yml
@@ -1,0 +1,11 @@
+# Run this:  ./prime multiple-settings set --input ./settings/staging/0052-primary.yml --env staging
+---
+- name: primary
+  description: Primary.Health
+  jurisdiction: FEDERAL
+  senders:
+  - name: default
+    organizationName: primary
+    topic: covid-19
+    schemaName: hl7/primary-covid-19
+    format: HL7

--- a/prime-router/src/main/kotlin/Mappers.kt
+++ b/prime-router/src/main/kotlin/Mappers.kt
@@ -520,6 +520,7 @@ class Obx8Mapper : Mapper {
                 "840535000" -> "A" // Antibody to severe acute respiratory syndrome coronavirus 2 (substance)
                 "840534001" -> "A" // Severe acute respiratory syndrome coronavirus 2 vaccination (procedure)
                 "373121007" -> "N" // Test not done
+                "82334004" -> "N" // Indeterminate
                 else -> null
             }
         }


### PR DESCRIPTION
This PR completes the go live steps for Primary Health.  It sets processing_mode_code to "P" and adds SNOMED value 82334004 "Indeterminate" to the covid-19/test_result value set.  

Test Steps:
1. Send Primary data file with 82334004 as value for test_result.  Message properly routes and produces no warnings for test_result.

## Changes
- Add code/display to covid-19/test_result value set in covid-19.valuesets
- Add value to 'when' list in OBX-8 mapper
- Change Primary schema processing_mode_code from "T" to "P"
- Moves Primary schema location from /schemas/direct/ to /schemas/hl7
- Updates all the schema documentation markdown files (due to new result value)

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

## Fixes
- #2803