### PR TITLE
Revert move to gh actions path filter

### DIFF
--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -5,15 +5,9 @@ on:
     branches:
       - master
       - production
-    paths:
-      - 'prime-router/**'
-      - '.github/workflows/build_hub.yml'
   push:
     branches:
       - master
-    paths:
-      - 'prime-router/**'
-      - '.github/workflows/build_hub.yml'
 
 env:
   # These are for CI and not credentials of any system
@@ -21,10 +15,28 @@ env:
   DB_PASSWORD: changeIT!
 
 jobs:
+  pre_job:
+    name: Pre Job
+    runs-on: ubuntu-latest
+    outputs:
+      has_router_change: ${{ steps.skip_check.outputs.router }}
+    steps:
+      - name: "Check out changes"
+        uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: skip_check
+        with:
+          list-files: csv
+          filters: |
+            router:
+              - 'prime-router/**'
+              - '.github/workflows/build_hub.yml'
 
   build_router:
     name: Build Router
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.has_router_change == 'true' }}
     defaults:
       run:
         working-directory: prime-router
@@ -115,6 +127,8 @@ jobs:
   docker_build_test:
     name: Testing Docker Build
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.has_router_change == 'true' }}
     defaults:
       run:
         working-directory: prime-router
@@ -144,6 +158,8 @@ jobs:
   linting:
     name: Check Linting
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.has_router_change == 'true' }}
     defaults:
       run:
         working-directory: prime-router
@@ -161,6 +177,8 @@ jobs:
   docs:
     name: Check Docs
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.has_router_change == 'true' }}
     defaults:
       run:
         working-directory: prime-router


### PR DESCRIPTION
Before this a required check would not run when changes weren't made to router files. GitHub Actions isn't fully ready for mono-repos: https://github.community/t/status-check-with-path-filter/18049

This PR moves back to using https://github.com/dorny/paths-filter

Test Steps:
1. See that the check still runs
2. after this is merged the router check should pass but no heavy weight tasks should run if no router files were changed.

## Changes
- re-implement https://github.com/dorny/paths-filter

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?
