### PR TITLE
Fix check for toomanycols smoke test

### DIFF
--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -1207,7 +1207,7 @@ class TooManyCols : CoolTest() {
         try {
             val tree = jacksonObjectMapper().readTree(json)
             val firstError = (tree["errors"][0]) as ObjectNode
-            if (firstError["details"].textValue().contains("columns")) {
+            if (firstError["message"].textValue().contains("columns")) {
                 return good("toomanycols Test passed.")
             } else {
                 return bad("***toomanycols Test FAILED***:  did not find the error.")


### PR DESCRIPTION
Before this a change to the json error response didn't match the smoke test.

Test Steps:
1. see that the toomanycols smoke test now passes

## Changes
- update the check in the toomanycols test to look at the `message` key in the errors list.
