### PR TITLE
Fixes the /report-details page refresh bug

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -35,7 +35,6 @@
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",
         "react-idle-timer": "^4.6.4",
-        "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "rest-hooks": "^6.1.7",
         "rimraf": "^3.0.2",

--- a/frontend-react/src/components/header/OrgDropdown.tsx
+++ b/frontend-react/src/components/header/OrgDropdown.tsx
@@ -1,6 +1,6 @@
 import { Dropdown } from "@trussworks/react-uswds";
 import { CSSProperties, useState } from "react";
-import { useHistory } from "react-router";
+import { useHistory } from "react-router-dom";
 import { useResource } from "rest-hooks";
 
 import OrganizationResource from "../../resources/OrganizationResource";

--- a/frontend-react/src/pages/daily/Table/ReportLink.tsx
+++ b/frontend-react/src/pages/daily/Table/ReportLink.tsx
@@ -47,7 +47,7 @@ function ReportLink(props: Props) {
                 .then((res) => res.json())
                 .then((report) => {
                     // The filename to use for the download should not contain blob folders if present
-                    let filename = decodeURIComponent(report.filename);
+                    let filename = decodeURIComponent(report.fileName);
                     let filenameStartIndex = filename.lastIndexOf("/");
                     if (
                         filenameStartIndex >= 0 &&

--- a/frontend-react/src/pages/details/Details.tsx
+++ b/frontend-react/src/pages/details/Details.tsx
@@ -25,6 +25,10 @@ function useQuery(): { readonly [key: string]: string } {
 
 const DetailsContent = () => {
     const queryMap = useQuery();
+    /* TODO:
+        Ensure there is a persisted reportId in localStorage to default
+        to if it cannot be found as a query param
+    */
     const reportId = queryMap?.["reportId"] || "";
     const report = useResource(ReportResource.detail(), { reportId: reportId });
 
@@ -36,7 +40,7 @@ const DetailsContent = () => {
                 fallbackComponent={() => <ErrorPage type="message" />}
             >
                 <Suspense fallback={<Spinner />}>
-                    <FacilitiesTable reportId={report?.reportId || ""} />
+                    <FacilitiesTable reportId={reportId} />
                 </Suspense>
             </NetworkErrorBoundary>
             <HipaaNotice />

--- a/frontend-react/src/pages/details/Details.tsx
+++ b/frontend-react/src/pages/details/Details.tsx
@@ -25,10 +25,6 @@ function useQuery(): { readonly [key: string]: string } {
 
 const DetailsContent = () => {
     const queryMap = useQuery();
-    /* TODO:
-        Ensure there is a persisted reportId in localStorage to default
-        to if it cannot be found as a query param
-    */
     const reportId = queryMap?.["reportId"] || "";
     const report = useResource(ReportResource.detail(), { reportId: reportId });
 

--- a/frontend-react/src/pages/details/FacilitiesTable.tsx
+++ b/frontend-react/src/pages/details/FacilitiesTable.tsx
@@ -2,15 +2,15 @@ import { useResource } from "rest-hooks";
 
 import FacilityResource from "../../resources/FacilityResource";
 
-interface Props {
+interface FacilitiesTableProps {
     /* REQUIRED
     Passing in a report allows this component to map through the facilities property
     to display a row per facility on the FaclitiesTable. */
     reportId: string;
 }
 
-function FacilitiesTable(props: Props) {
-    const { reportId }: Props = props;
+function FacilitiesTable(props: FacilitiesTableProps) {
+    const { reportId }: FacilitiesTableProps = props;
     const facilities: FacilityResource[] = useResource(
         FacilityResource.list(),
         { reportId: reportId }

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -10557,7 +10557,7 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.2.1, react-router@^5.2.0:
+react-router@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
   integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==

--- a/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
@@ -317,12 +317,30 @@ open class BaseHistoryFunction : Logging {
             else {
                 val filename = Report.formExternalFilename(header)
                 val mimeType = Report.Format.safeValueOf(header.reportFile.bodyFormat).mimeType
+                val report = ReportView.Builder()
+                    .reportId(header.reportFile.reportId.toString())
+                    .sent(header.reportFile.createdAt.toEpochSecond() * 1000)
+                    .via(header.reportFile.bodyFormat)
+                    .total(header.reportFile.itemCount.toLong())
+                    .fileType(header.reportFile.bodyFormat)
+                    .type("ELR")
+                    .expires(header.reportFile.createdAt.plusDays(DAYS_TO_SHOW).toEpochSecond() * 1000)
+                    .receivingOrg(header.reportFile.receivingOrg)
+                    .receivingOrgSvc(header.reportFile.receivingOrgSvc)
+                    .sendingOrg(header.reportFile.sendingOrg ?: "")
+                    .displayName(
+                        if (header.reportFile.externalName.isNullOrBlank()) header.reportFile.receivingOrgSvc
+                        else header.reportFile.externalName
+                    )
+                    .content(String(header.content))
+                    .fileName(filename)
+                    .mimeType(mimeType)
+                    .build()
 
-                val fileReturn = FileReturn(String(header.content), filename, mimeType)
                 response = request
                     .createResponseBuilder(HttpStatus.OK)
                     .header("Content-Type", "application/json")
-                    .body(fileReturn)
+                    .body(report)
                     .build()
 
                 val actionHistory = ActionHistory(TaskAction.download, context)


### PR DESCRIPTION
This PR fixes the error(s?) created by refreshing the `/daily-data` page. Firstly, the `facilities` call receives the reportId due to a parameter change in the `Details` component. Next, the `getReportById` call accessed via the `/history/report/{reportId}` endpoint now returns the full report (sans facilities) to match our front-end needs.

Test Steps:
1. pull most recent 
2. `cd prime-router; docker-compose down; ./gradlew clean build; docker-compose up`
    `cd ../frontend-react; yarn; yarn start`
3. Login and navigate to a details page for a report (note: You may need to add a new report to your local db since rebuilding seems to erase blob storage. It does not erase the result from showing up on your `/daily-data` page, however, so be weary of impending `404`s)
4. Refresh the page and ensure both the reportId call and facilities call both pass the id properly and return with content and `200`s. The reportId call will appear as the reportId in your Network tab, and facilities will appear as facilities.
![Screenshot from 2021-11-19 15-14-03](https://user-images.githubusercontent.com/4022304/142686035-1ccac4b0-057b-4c71-b867-630ffffe53b8.png)
5. Ensure all data is mapped accordingly in the UI

## Changes
- `getReportById` now returns a full report body, an upgrade from only returning content, filename, and filetype
-  `FacilitiesTable` is now receiving the `reportId` directly from the query parameter rather than relying on a fetched/cached report to provide it (this fixed the query param not being passed to the `facilities` call)

## Checklist

### Testing
- [X] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [X] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #3011 

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | **33**        | [15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r2219p~t~'211x)~(d~'r1yeif~t~'33x)~(d~'r1jrid~t~'o3)~(d~'r1e9lv~t~'4i2)~(d~'r1e9vm~t~'4rr)~(d~'r1ea5q~t~'8j)~(d~'r1e8t1~t~'ue)~(d~'r1eakw~t~'bl)~(d~'r1eay5~t~'bm)~(d~'r1jrue~t~'a5)~(d~'r1pe5t~t~'14)~(d~'r1levv~t~'76nf)~(d~'r1cb6x~t~'j6)~(d~'r1cbwy~t~'m5)~(d~'r29jy1~t~'7i0y)~(d~'r29k35~t~'1l)~(d~'r29k4r~t~'37)~(d~'r2bni2~t~'5uv)~(d~'r2beah~t~'58v)~(d~'r2dmpd~t~'93)~(d~'r2dme6~t~'48du)~(d~'r2dncq~t~'iz)~(d~'r2dk5n~t~'fj)~(d~'r2op0l~t~'fd)~(d~'r2oq3n~t~'ch)~(d~'r2opoi~t~'ks)~(d~'r2oojb~t~'fk)~(d~'r2oo1i~t~'6ry)~(d~'r2movr~t~'b9ho)~(d~'r2moys~t~'b9kp)~(d~'r2mrtc~t~'4h)~(d~'r2oslt~t~'f7xu)~(d~'r2qmoh~t~'fk)~(d~'r2otta~t~'2dcn)~(d~'r2qm4i~t~'91u)~(d~'r2osyj~t~'28zv)~(d~'r2dnak~t~'or)~(d~'r2twb8~t~'1etl)~(d~'r2u161~t~'1mo))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 25             |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=7e738137344cf037bf10302fe4bf1da88e55226c&v=4" width="20"></a> | MauriceReeves-usds | 32            | [16h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r1y7um~t~'1sji)~(d~'r1y9eg~t~'1u3v)~(d~'r21xa7~t~'4e9)~(d~'r23qbd~t~'2t)~(d~'r1p7wv~t~'1fu)~(d~'r1y86m~t~'av)~(d~'r1ye5i~t~'l4)~(d~'r1ya4l~t~'11)~(d~'r1y9qa~t~'wip)~(d~'r1yedu~t~'2zc)~(d~'r1n4nl~t~'2o0)~(d~'r1wlxu~t~'1p6)~(d~'r1ncbg~t~'1oy5)~(d~'r1nfv1~t~'19k)~(d~'r29e8i~t~'78zv)~(d~'r29e6y~t~'5k3y)~(d~'r1yezf~t~'1flw)~(d~'r29e4s~t~'4viy)~(d~'r29e5m~t~'4zrn)~(d~'r2gqu9~t~'3cdy)~(d~'r2gqsv~t~'17n5)~(d~'r2mlni~t~'58nc)~(d~'r1ydjr~t~'1dac)~(d~'r2gqti~t~'1i17)~(d~'r2mluh~t~'b6ge)~(d~'r2mlha~t~'5ui)~(d~'r29e9q~t~'5d81)~(d~'r2pzyo~t~'15o0)~(d~'r2o37b~t~'27q)~(d~'r2doob~t~'dpl)~(d~'r1wcyx~t~'52ls)~(d~'r2pzdh~t~'1qy)~(d~'r2rual~t~'1pbs)~(d~'r2gqvu~t~'62hn))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 13             |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 29            | [1h 6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r1qnmc~t~'1doa)~(d~'r1whfp~t~'1fr)~(d~'r1wq74~t~'88w)~(d~'r1jlpk~t~'23)~(d~'r1r6z1~t~'no)~(d~'r1pubv~t~'s)~(d~'r1ptkw~t~'mny)~(d~'r1e7r0~t~'1uz)~(d~'r1lh6f~t~'1w)~(d~'r29gtt~t~'3edm)~(d~'r2d69n~t~'18d)~(d~'r2d6md~t~'1gh)~(d~'r2of07~t~'9o)~(d~'r2h24e~t~'19n)~(d~'r2h370~t~'5j)~(d~'r2mulc~t~'314)~(d~'r2mum0~t~'31s)~(d~'r2muoq~t~'34i)~(d~'r2mty3~t~'ebb)~(d~'r2mwwq~t~'bcmi)~(d~'r2mwxj~t~'9nyb)~(d~'r2mwzl~t~'9kua)~(d~'r2q773~t~'cw8d)~(d~'r2muxy~t~'kchs)~(d~'r2mv74~t~'kcqy)~(d~'r2mv8s~t~'kcsm)~(d~'r2schs~t~'1pa)~(d~'r2qefq~t~'f6)~(d~'r2qeq5~t~'pl)~(d~'r2qerc~t~'qs)~(d~'r2ruul~t~'101)~(d~'r2rzdk~t~'13e4)~(d~'r2mu1x~t~'1ip)~(d~'r2pzle~t~'5at)~(d~'r2pzr3~t~'5gi)~(d~'r2qedb~t~'3ua)~(d~'r2tp4t~t~'3k60))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 8              |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 27            | [8h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r23xe1~t~'2hjv)~(d~'r1wdg0~t~'4z5f)~(d~'r1l68j~t~'o1r)~(d~'r1l68u~t~'o22)~(d~'r1lkex~t~'4va)~(d~'r1lksq~t~'593)~(d~'r1lkty~t~'5ab)~(d~'r1lkwa~t~'5cn)~(d~'r1ll1i~t~'5hv)~(d~'r1ll2d~t~'5iq)~(d~'r1n06k~t~'1301)~(d~'r1l77h~t~'6q0x)~(d~'r1l6lj~t~'14k0)~(d~'r1l6mt~t~'14la)~(d~'r1l6pf~t~'14nw)~(d~'r1l6uv~t~'14tc)~(d~'r2031m~t~'3f7r)~(d~'r23wq2~t~'1l79)~(d~'r246pr~t~'s6)~(d~'r246z2~t~'11h)~(d~'r2b5zo~t~'17n7)~(d~'r2d4z4~t~'fl)~(d~'r2d66q~t~'10u)~(d~'r202ya~t~'sgj)~(d~'r20307~t~'sig)~(d~'r2d7md~t~'yo)~(d~'r1x0il~t~'96)~(d~'r2048h~t~'11c8)~(d~'r20byg~t~'1927)~(d~'r20c1h~t~'mw)~(d~'r20c5n~t~'r2)~(d~'r20ctm~t~'1f1)~(d~'r20d1w~t~'1nb)~(d~'r2djxw~t~'6y3)~(d~'r1bxqx~t~'1ga)~(d~'r1bxss~t~'1i5)~(d~'r2o5zo~t~'2e)~(d~'r2ml48~t~'9a5i)~(d~'r2q97e~t~'cy8o)~(d~'r1wd8m~t~'52vh)~(d~'r22cmu~t~'dow)~(d~'r2q06x~t~'g)~(d~'r2qcc0~t~'1ihh)~(d~'r2rv2m~t~'182)~(d~'r2rv2q~t~'186)~(d~'r2di02~t~'1tl)~(d~'r2dim1~t~'2fk)~(d~'r2mc1j~t~'1z0g)~(d~'r23x1g~t~'29z)~(d~'r2dgfw~t~'3xt)~(d~'r2scre~t~'228d)~(d~'r2sdwg~t~'23df)~(d~'r206nu~t~'3jn)~(d~'r20707~t~'3w0)~(d~'r2074w~t~'40p)~(d~'r2bb9d~t~'7b2t)~(d~'r2twr0~t~'1pbc)~(d~'r2tw63~t~'1eog)~(d~'r2tw6x~t~'1epa)~(d~'r2tw9t~t~'1es6)~(d~'r2tweg~t~'1ewt)~(d~'r2twfc~t~'1exp)~(d~'r2twj3~t~'1f1g)~(d~'r2d2wj~t~'2eic)~(d~'r2d2yd~t~'2ek6)))) | **134**        |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 21            | [37m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r1yho7~t~'31)~(d~'r21wn6~t~'nqo)~(d~'r21ws4~t~'nvm)~(d~'r224pg~t~'1r3)~(d~'r1cp8s~t~'394)~(d~'r1pdoc~t~'3po1)~(d~'r1lmk8~t~'1bv6)~(d~'r1ngag~t~'1nhf)~(d~'r1pdyu~t~'118)~(d~'r1pdge~t~'3pfs)~(d~'r1wach~t~'1hho)~(d~'r229x5~t~'311)~(d~'r2gq9s~t~'354l)~(d~'r2gqgl~t~'3diq)~(d~'r2mrpn~t~'2p)~(d~'r24598~t~'1ot)~(d~'r2h267~t~'1bg)~(d~'r2h5mm~t~'1o)~(d~'r2h5ea~t~'5q)~(d~'r2h33t~t~'2c)~(d~'r2sen7~t~'6p)~(d~'r2sens~t~'fd)~(d~'r2seuw~t~'e)~(d~'r2sf3m~t~'a))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 4              |
| <a href="https://github.com/sean-usds"><img src="https://avatars.githubusercontent.com/u/87096393?u=90127e88c4ff845b6a754d10151b10a5158562ff&v=4" width="20"></a>          | sean-usds          | 21            | [2h 14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'87096393~n~'sean-usds)~p~30~r~(~(d~'r1wy68~t~'d54)~(d~'r1wtb6~t~'7gcy)~(d~'r1yjq3~t~'23yi)~(d~'r1yjsi~t~'a)~(d~'r20lh2~t~'1a6)~(d~'r1lo9g~t~'2p)~(d~'r1pick~t~'67n)~(d~'r1lns6~t~'7dyl)~(d~'r1k6tl~t~'5x6s)~(d~'r1k6vm~t~'6erj)~(d~'r1kbh8~t~'13)~(d~'r1k997~t~'5zg0)~(d~'r2bfk9~t~'er)~(d~'r2d6of~t~'1ij)~(d~'r2btm6~t~'46l)~(d~'r2dc5j~t~'7m)~(d~'r2dcq1~t~'14z5)~(d~'r2mhsn~t~'971y)~(d~'r2gwsm~t~'48n)~(d~'r1yt7c~t~'1ob)~(d~'r2twyx~t~'3k0q))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 16            | [17h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r1zylq~t~'1fql)~(d~'r22cqq~t~'3tg)~(d~'r1bvvu~t~'12om)~(d~'r1jbvm~t~'53n6)~(d~'r2n47j~t~'ho)~(d~'r29qy3~t~'5ovb)~(d~'r2a7vd~t~'73i)~(d~'r1bx3q~t~'t3)~(d~'r2mp63~t~'9nme)~(d~'r2movm~t~'b9hj)~(d~'r2puoy~t~'10ea)~(d~'r1wc9f~t~'51wa)~(d~'r1y5bv~t~'1c0y)~(d~'r1y5j4~t~'1c87)~(d~'r2pw9g~t~'gblh)~(d~'r23zoi~t~'4x1)~(d~'r29u0m~t~'5eac)~(d~'r20k6z~t~'hst)~(d~'r20krr~t~'idl)~(d~'r2tkxk~t~'302l)~(d~'r2touj~t~'16j)~(d~'r2tkqx~t~'1kah)~(d~'r2tysp~t~'3ttw))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 14             |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 12            | [11h 35m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r223rm~t~'23ju)~(d~'r224y4~t~'2nx)~(d~'r229ly~t~'oo)~(d~'r1nj15~t~'d1v)~(d~'r1nj7o~t~'d8e)~(d~'r1nkee~t~'ef4)~(d~'r1ov4y~t~'w6w)~(d~'r1y2dg~t~'1ejl)~(d~'r224er~t~'2ho)~(d~'r29g58~t~'7e85)~(d~'r2bdzd~t~'4xr)~(d~'r2bev2~t~'1m)~(d~'r21thr~t~'1bnt)~(d~'r21wcq~t~'1eis)~(d~'r29rkq~t~'5phy)~(d~'r2grt6~t~'3etd)~(d~'r2h3pm~t~'7u)~(d~'r2m8sb~t~'52qk)~(d~'r2m92p~t~'530y)~(d~'r2rwr2~t~'fx)~(d~'r2qel8~t~'ko)~(d~'r2dfi3~t~'300)~(d~'r2oabv~t~'1igz)~(d~'r2q0xk~t~'6mz)~(d~'r2tm3y~t~'1pu)~(d~'r29rh7~t~'5ran)~(d~'r2d6ws~t~'96q8)~(d~'r2d7bg~t~'974w)~(d~'r2tsy0~t~'1bgd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 50             |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 9             | [4h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r1xcih~t~'1e)~(d~'r2bdxb~t~'4vp)~(d~'r2mt2k~t~'haa)~(d~'r2ou7r~t~'8m)~(d~'r2ow0j~t~'beu)~(d~'r2owa9~t~'bok)~(d~'r2sp2w~t~'f5o8)~(d~'r2qq41~t~'idj)~(d~'r2rvbi~t~'1w6)~(d~'r2s8yz~t~'f8i))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 4              |
| <a href="https://github.com/ronaldheft-usds"><img src="https://avatars.githubusercontent.com/u/52176593?u=be6fa1049b61315b4ab5ba3189e9f111f726db5d&v=4" width="20"></a>    | ronaldheft-usds    | 9             | [1h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'52176593~n~'ronaldheft-usds)~p~30~r~(~(d~'r22bw6~t~'fn)~(d~'r22bxa~t~'gr)~(d~'r220wp~t~'4f)~(d~'r1wt04~t~'4rk)~(d~'r1njbq~t~'dcg)~(d~'r1qxj2~t~'5w9)~(d~'r1nj4g~t~'5og)~(d~'r1p9s8~t~'a0p)~(d~'r1e4g5~t~'91)~(d~'r1nddx~t~'b6)~(d~'r1njsn~t~'7eg))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 7              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 7             | [1h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r1lrrz~t~'uz)~(d~'r20563~t~'1def)~(d~'r2bqfo~t~'103)~(d~'r2gya9~t~'11)~(d~'r22mhg~t~'fgj)~(d~'r241bx~t~'1ub0)~(d~'r2dek4~t~'3tf)~(d~'r2mldj~t~'6tq)~(d~'r2mlfq~t~'6vx)~(d~'r2mr1r~t~'1tw)~(d~'r22mrf~t~'4b9)~(d~'r22msa~t~'4c4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 6              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 4             | [**14m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r23pax~t~'r7)~(d~'r246w1~t~'j5)~(d~'r244b7~t~'74)~(d~'r23x3c~t~'16d))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 3             | [1h 5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r23rf5~t~'16l)~(d~'r1ykc7~t~'308)~(d~'r1jm6z~t~'dsv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 3             | [13h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r2bwwi~t~'br0d)~(d~'r2moeo~t~'jr)~(d~'r2bqtd~t~'12f6))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 1              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [3h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r245z0~t~'1ug7)~(d~'r245za~t~'1ugh)~(d~'r245zg~t~'1ugn)~(d~'r249ow~t~'1y63)~(d~'r24exs~t~'907)~(d~'r24eyd~t~'90s)~(d~'r24eyn~t~'912)~(d~'r24f5c~t~'97r)~(d~'r29jrp~t~'54vj)~(d~'r2bb5a~t~'1cst)~(d~'r2gywn~t~'6co)~(d~'r2moyq~t~'23m)~(d~'r2mvv7~t~'40b))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 10             |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 2             | [2h 25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r1nmzw~t~'7d4)~(d~'r2mtil~t~'62o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 2             | [4d 21h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r1whb7~t~'i15e)~(d~'r2be17~t~'4zl))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [5d 2h 55m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r2ms4x~t~'9h67)~(d~'r2mso5~t~'9hpf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 2              |