### PR TITLE
Update @okta/okta-auth-js

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -8,7 +8,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.16",
-        "@okta/okta-auth-js": "^5.2.3",
+        "@okta/okta-auth-js": "^5.8.0",
         "@okta/okta-react": "^6.1.0",
         "@okta/okta-signin-widget": "^5.13.1",
         "@rest-hooks/hooks": "^2.0.0",

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -1617,7 +1617,7 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okta/okta-auth-js@^5.2.3":
+"@okta/okta-auth-js@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-5.8.0.tgz#e80a550e7850f3bc89ea3d6bcd6a66a95f8702f5"
   integrity sha512-gkQ3/IOlG10FsE7h3GCN38BJGv7QZqr8clh5dpmjmZ4L1xtFwoDuk1VP0iaHtxr3UhsOG/wxNx17tnFAuSjeoQ==


### PR DESCRIPTION
Updated @okta/okta-auth-js 5.2.3 -> 5.8.0
Required to get patched version json-schema further downstream

Ran and tested.