### PR TITLE
Fixes issue with the new truncation logic truncating fields it should not be

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -537,6 +537,7 @@
         receivingFacilityOID: 2.16.840.1.114222.4.1.185
         truncateHDNamespaceIds: true
         usePid14ForPatientEmail: true
+        truncateHl7Fields: OBX-23-1
         suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3
         replaceValue:
           MSH-3-1: CDC PRIME - Atlanta,

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -1165,7 +1165,12 @@ class Hl7Serializer(
         terser.set(formPathSpec("OBX-24-2", aoeRep), report.getStringByHl7Field(row, "OBX-24-2"))
         terser.set(formPathSpec("OBX-24-3", aoeRep), report.getStringByHl7Field(row, "OBX-24-3"))
         terser.set(formPathSpec("OBX-24-4", aoeRep), report.getStringByHl7Field(row, "OBX-24-4"))
-        terser.set(formPathSpec("OBX-24-5", aoeRep), report.getStringByHl7Field(row, "OBX-24-5"))
+        // OBX-24-5 is a postal code as well. pad this for now
+        // TODO: come up with a better way to repeat these segments
+        terser.set(
+            formPathSpec("OBX-24-5", aoeRep),
+            report.getStringByHl7Field(row, "OBX-24-5")?.padStart(5, '0')
+        )
         terser.set(formPathSpec("OBX-24-9", aoeRep), report.getStringByHl7Field(row, "OBX-24-9"))
         // check for the OBX-23-6 value. it needs to be split apart
         val testingLabIdAssigner = report.getString(row, "testing_lab_id_assigner")

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -1248,17 +1248,24 @@ class Hl7Serializer(
     }
 
     /**
-     * Calculate for [hl7Field] and [value] the length to truncate the value according to the
+     * Calculate for [hl7Field] and [value] the length to truncate the value according to theld.
      * truncation rules in [hl7Config]. The [terser] is used to determine the HL7 specification length.
      */
     internal fun getMaxLength(hl7Field: String, value: String, hl7Config: Hl7Configuration?, terser: Terser): Int? {
+        // get the fields to truncate
+        val hl7TruncationFields = hl7Config
+            ?.truncateHl7Fields
+            ?.uppercase()
+            ?.split(",")
+            ?.map { it.trim() }
+            ?: emptyList()
         return when {
             // This special case takes into account special rules needed by jurisdiction
             hl7Config?.truncateHDNamespaceIds == true && hl7Field in HD_FIELDS_LOCAL -> {
                 getTruncationLimitWithEncoding(value, HD_TRUNCATION_LIMIT)
             }
             // For the fields listed here use the hl7 max length
-            hl7Config?.truncateHl7Fields?.contains(hl7Field) == true -> {
+            hl7Field in hl7TruncationFields -> {
                 getHl7MaxLength(hl7Field, terser)
             }
             // In general, don't truncate. The thinking is that

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -1248,7 +1248,7 @@ class Hl7Serializer(
     }
 
     /**
-     * Calculate for [hl7Field] and [value] the length to truncate the value according to theld.
+     * Calculate for [hl7Field] and [value] the length to truncate the value according to the
      * truncation rules in [hl7Config]. The [terser] is used to determine the HL7 specification length.
      */
     internal fun getMaxLength(hl7Field: String, value: String, hl7Config: Hl7Configuration?, terser: Terser): Int? {

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -686,7 +686,7 @@ NTE|1|L|This is a final comment|RE"""
         assertThat(serializer.getHl7MaxLength("OBX-18", emptyTerser)).isEqualTo(22)
         assertThat(serializer.getHl7MaxLength("OBX-18-1", emptyTerser)).isEqualTo(199)
         assertThat(serializer.getHl7MaxLength("OBX-19", emptyTerser)).isEqualTo(26)
-
+        assertThat(serializer.getHl7MaxLength("OBX-23-1", emptyTerser)).isEqualTo(50)
         // Test that a subcomponent returns null
         assertThat(serializer.getHl7MaxLength("OBR-16-1-2", emptyTerser)).isNull()
     }


### PR DESCRIPTION
This PR fixes an issue where the new truncation logic inadvertently truncates other fields it should not.

See case #3411 for more details about what caused the bug. In short the `truncateHl7Fields` was treated as a string, when it should have been a list.

Closes #3411 

Test Steps:
1. Run the application in docker
2. Update the settings for a state to truncate `OBX-23-1`
3. Submit a new file for that state
4. View the created HL7 file for the test state
5. Verify that OBX-2 was not affected

## Changes
- Adds a test for a compound type for truncation
- Updates the logic to convert `truncateHl7Fields` to a list
- Updates the settings for VT to include `OBX-23-1` for truncation

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #3411 

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | **30**        | [1h 46m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r2ruul~t~'101)~(d~'r2qefq~t~'f6)~(d~'r2qeq5~t~'pl)~(d~'r2qerc~t~'qs)~(d~'r2rzdk~t~'13e4)~(d~'r2schs~t~'1pa)~(d~'r2pzle~t~'5at)~(d~'r2pzr3~t~'5gi)~(d~'r2tp4t~t~'3k60)~(d~'r2mulc~t~'314)~(d~'r2mum0~t~'31s)~(d~'r2muoq~t~'34i)~(d~'r2mty3~t~'ebb)~(d~'r2of07~t~'9o)~(d~'r2zet7~t~'3jw)~(d~'r3chws~t~'4wy)~(d~'r3v4u1~t~'23wv)~(d~'r3p4z7~t~'cfvc)~(d~'r3uwer~t~'1i)~(d~'r3tcac~t~'16y)~(d~'r3tcwt~t~'df)~(d~'r3tcxq~t~'ec)~(d~'r3sw7k~t~'112)~(d~'r3julm~t~'i7)~(d~'r3k07i~t~'643)~(d~'r2qedb~t~'3ua)~(d~'r3rih1~t~'7tc)~(d~'r3hwfo~t~'1a3q)~(d~'r3hwgo~t~'1a4q)~(d~'r3hwhi~t~'1a5k)~(d~'r3hww8~t~'1aka)~(d~'r3hwzh~t~'1anj)~(d~'r2mu1x~t~'1ip)~(d~'r3wnjd~t~'2al)~(d~'r3x4gx~t~'2o)~(d~'r3wx0e~t~'2bm)~(d~'r3wx1q~t~'2cy)~(d~'r3p6id~t~'8zj8)~(d~'r3p6q7~t~'8zr2)~(d~'r3p6zv~t~'900q)~(d~'r3p78d~t~'9098)~(d~'r3p79m~t~'90ah)~(d~'r3p7bp~t~'90ck)~(d~'r3p9gj~t~'92he)~(d~'r3vagp~t~'c6)~(d~'r3vahy~t~'df)~(d~'r42f3a~t~'4s1)~(d~'r33f07~t~'ffd)~(d~'r42pw7~t~'3t)~(d~'r3ritk~t~'76)~(d~'r3wxq1~t~'1lsp)~(d~'r3wxvt~t~'1lyh)~(d~'r3wxy4~t~'1m0s)~(d~'r3wy5q~t~'1m8e)~(d~'r3wy8p~t~'1mbd)))) | 26             |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 28            | [6h 58m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r2pzyo~t~'15o0)~(d~'r2o37b~t~'27q)~(d~'r2rual~t~'1pbs)~(d~'r2mlha~t~'5ui)~(d~'r2u76d~t~'1ab)~(d~'r316mf~t~'1sao)~(d~'r2zf3l~t~'52cm)~(d~'r2z8ca~t~'4zmi)~(d~'r2zb63~t~'aqke)~(d~'r3d4ef~t~'jc2)~(d~'r3em56~t~'le)~(d~'r3eavf~t~'15m8)~(d~'r3ekss~t~'qv)~(d~'r3el16~t~'7w)~(d~'r3elo4~t~'bd)~(d~'r3emzs~t~'24g)~(d~'r3wlkw~t~'i6)~(d~'r3wk8s~t~'hwik)~(d~'r3wklf~t~'bo)~(d~'r3wkyx~t~'ao)~(d~'r3wm9i~t~'4pkw)~(d~'r3d55g~t~'5zzo)~(d~'r3p73y~t~'adcu)~(d~'r3swhh~t~'9o)~(d~'r3d52y~t~'a8c)~(d~'r3tm6y~t~'o7)~(d~'r3x82v~t~'1id)~(d~'r3d5z9~t~'6e7a)~(d~'r3p7ni~t~'94u3)~(d~'r3wjss~t~'3d1i)~(d~'r3wjvp~t~'1de5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 11             |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 21            | [1d 8h 36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r2puoy~t~'10ea)~(d~'r2tkqx~t~'1kah)~(d~'r2tysp~t~'3ttw)~(d~'r2touj~t~'16j)~(d~'r2n47j~t~'ho)~(d~'r322cl~t~'dp8)~(d~'r3ggw4~t~'4t4)~(d~'r3i7xv~t~'5lj3)~(d~'r2tkxk~t~'302l)~(d~'r3wqxx~t~'12f)~(d~'r3pmko~t~'f8y)~(d~'r3i91h~t~'211c)~(d~'r3hpi7~t~'yiw)~(d~'r3p5c6~t~'alo4)~(d~'r3uvqf~t~'1ykr)~(d~'r424z1~t~'4vv3)~(d~'r3uui4~t~'3ehs)~(d~'r3vp6h~t~'4965)~(d~'r3vp6m~t~'496a)~(d~'r3wpr2~t~'59qq)~(d~'r3ws5p~t~'5c5d)~(d~'r3wsah~t~'5ca5)~(d~'r4268u~t~'4y48)~(d~'r330n0~t~'3se)~(d~'r3p8rx~t~'95yi)~(d~'r42ug0~t~'1to)~(d~'r3p4dv~t~'arae)~(d~'r3wquh~t~'1kcx))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 15             |
| <a href="https://github.com/sean-usds"><img src="https://avatars.githubusercontent.com/u/87096393?u=90127e88c4ff845b6a754d10151b10a5158562ff&v=4" width="20"></a>          | sean-usds          | 21            | [1h 11m](https://app.flowwer.dev/charts/review-time/~(u~(i~'87096393~n~'sean-usds)~p~30~r~(~(d~'r2twyx~t~'3k0q)~(d~'r2u7k7~t~'w6)~(d~'r2ugvm~t~'37v)~(d~'r3ecas~t~'21o5)~(d~'r3gcz2~t~'42fy)~(d~'r3ecg5~t~'21ua)~(d~'r3ebcm~t~'cil5)~(d~'r3ecl0~t~'2200)~(d~'r3jx5m~t~'1ej)~(d~'r3wql0~t~'1h6d)~(d~'r3cppe~t~'lj)~(d~'r3cpsw~t~'p1)~(d~'r3v27u~t~'3c8)~(d~'r3pz9v~t~'850)~(d~'r3pza4~t~'859)~(d~'r3gsti~t~'6hk)~(d~'r3jx46~t~'1bg)~(d~'r3rl89~t~'qo)~(d~'r3rkcf~t~'8e)~(d~'r3rlwp~t~'48)~(d~'r3rlqs~t~'s)~(d~'r3tfxi~t~'iru)~(d~'r3v904~t~'2bug)~(d~'r44eli~t~'h)~(d~'r44f8h~t~'2a)~(d~'r44f0r~t~'9o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 8              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 20            | [1h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r2sf3m~t~'a)~(d~'r2sen7~t~'6p)~(d~'r2seuw~t~'e)~(d~'r2zezt~t~'u)~(d~'r31f6z~t~'4c4)~(d~'r2zjny~t~'3q)~(d~'r2ziqy~t~'u)~(d~'r2zjjk~t~'c5)~(d~'r2mrpn~t~'2p)~(d~'r3hsru~t~'15g7)~(d~'r3i17u~t~'1dw7)~(d~'r3i18e~t~'1dwr)~(d~'r3jmvl~t~'17b5)~(d~'r3phjv~t~'o6nc)~(d~'r3p95o~t~'5cyl)~(d~'r3wqgh~t~'1h1u)~(d~'r3htfd~t~'173f)~(d~'r3i0jd~t~'34w)~(d~'r3jn0b~t~'12bb)~(d~'r3jn5z~t~'12gz)~(d~'r3sw6s~t~'w2c)~(d~'r3t11n~t~'4y)~(d~'r3r4gv~t~'56)~(d~'r43zur~t~'x5j)~(d~'r44g41~t~'22z))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 11             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 17            | [4h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r2q06x~t~'g)~(d~'r2qcc0~t~'1ihh)~(d~'r2rv2m~t~'182)~(d~'r2rv2q~t~'186)~(d~'r2o5zo~t~'2e)~(d~'r3e8nf~t~'19a)~(d~'r314i9~t~'e1s5)~(d~'r3hsnf~t~'3elw)~(d~'r3cahz~t~'55c7)~(d~'r3v4vf~t~'44)~(d~'r2scre~t~'228d)~(d~'r2sdwg~t~'23df)~(d~'r2tw63~t~'1eog)~(d~'r2tw6x~t~'1epa)~(d~'r2tw9t~t~'1es6)~(d~'r2tweg~t~'1ewt)~(d~'r2twfc~t~'1exp)~(d~'r2twj3~t~'1f1g)~(d~'r3g78r~t~'e1c)~(d~'r3r7mz~t~'8p3v)~(d~'r3r7q8~t~'8p74)~(d~'r3wo1p~t~'2sx)~(d~'r3wo37~t~'2uf)~(d~'r3wo3p~t~'2ux)~(d~'r3hsb9~t~'1lc4)~(d~'r3joxu~t~'2wk)~(d~'r3jp02~t~'2ys)~(d~'r337mz~t~'asd)~(d~'r337on~t~'au1)~(d~'r3387t~t~'bd7)~(d~'r33f6c~t~'22v)~(d~'r33f74~t~'23n)~(d~'r33fa8~t~'26r)~(d~'r33fbo~t~'287)~(d~'r3p70t~t~'947e)~(d~'r3p72n~t~'9498)~(d~'r3p73a~t~'949v)~(d~'r42spm~t~'3a)~(d~'r3jotc~t~'173o)~(d~'r44alf~t~'7nc))))                                                                                                                                                                                                                                                                                         | **40**         |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 16            | [4h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r2ou7r~t~'8m)~(d~'r2rvbi~t~'1w6)~(d~'r2mt2k~t~'haa)~(d~'r2s8yz~t~'f8i)~(d~'r2uatn~t~'ei)~(d~'r31dof~t~'4ve)~(d~'r2ow0j~t~'beu)~(d~'r2owa9~t~'bok)~(d~'r2zepb~t~'12x)~(d~'r2zfft~t~'5f79)~(d~'r3ceor~t~'cxsc)~(d~'r31qgm~t~'9bz)~(d~'r2qq41~t~'idj)~(d~'r3cbt3~t~'5fn2)~(d~'r3ve9k~t~'13d)~(d~'r3rib5~t~'9r4)~(d~'r3r8ss~t~'1xpm)~(d~'r3cspw~t~'j2n)~(d~'r3x5ep~t~'14o)~(d~'r3i1c3~t~'3o8m))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 6              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 10            | [17h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r2qel8~t~'ko)~(d~'r2rwr2~t~'fx)~(d~'r2q0xk~t~'6mz)~(d~'r2tm3y~t~'1pu)~(d~'r3c5du~t~'91uk)~(d~'r3e0ib~t~'3hfp)~(d~'r3joxm~t~'2ies)~(d~'r3t172~t~'1m6)~(d~'r3ur8y~t~'1c7p)~(d~'r3ur97~t~'1c7y)~(d~'r3r5ao~t~'1xyy)~(d~'r2tsy0~t~'1bgd)~(d~'r3g87k~t~'7f)~(d~'r3i8g4~t~'20fz)~(d~'r3re9p~t~'235u)~(d~'r3uuwm~t~'3ewa)~(d~'r3uwyw~t~'3gyk)~(d~'r3uxd5~t~'3hct)~(d~'r3wk0l~t~'5409)~(d~'r3jpo5~t~'17yh)~(d~'r3v6oo~t~'74))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 20             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 9             | [2h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r2zq07~t~'o)~(d~'r2zrhe~t~'3m)~(d~'r31hlm~t~'gz)~(d~'r3hyei~t~'1b2v)~(d~'r3pi7c~t~'6ge)~(d~'r3v20b~t~'34p)~(d~'r3s0eo~t~'a8)~(d~'r443iq~t~'10ti)~(d~'r443lh~t~'10w9)~(d~'r44795~t~'14jx)~(d~'r447mv~t~'14xn)~(d~'r3x7aj~t~'6pl)~(d~'r3x7dn~t~'6sp)~(d~'r3x7zy~t~'7f0)~(d~'r3x83c~t~'7ie)~(d~'r3x9sb~t~'97d)~(d~'r449ay~t~'5mm)~(d~'r449br~t~'5nf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 12             |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 9             | [2h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r2qmoh~t~'fk)~(d~'r2oq3n~t~'ch)~(d~'r2opoi~t~'ks)~(d~'r2op0l~t~'fd)~(d~'r2oo1i~t~'6ry)~(d~'r2oojb~t~'fk)~(d~'r2u161~t~'1mo)~(d~'r2zqnb~t~'5kr9)~(d~'r2twb8~t~'1etl)~(d~'r3rdm6~t~'22ib)~(d~'r3rdnl~t~'22jq)~(d~'r3ckty~t~'8u3y)~(d~'r3x8ah~t~'mqt))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 17             |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 5             | [6h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r3jpi1~t~'2iz7)~(d~'r3opz0~t~'y541)~(d~'r3v9k5~t~'353)~(d~'r42p9h~t~'ixa)~(d~'r42mik~t~'3sd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 5             | [1h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r3g187~t~'4sm)~(d~'r3uv0r~t~'130)~(d~'r3r41m~t~'39f)~(d~'r3r474~t~'2i7)~(d~'r3jqri~t~'4q8)~(d~'r3pbdw~t~'s3z))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 1              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 4             | [1h 5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r33c6l~t~'pb)~(d~'r2moeo~t~'jr)~(d~'r3pv34~t~'1fy1)~(d~'r42o2k~t~'5cd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 3              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r3wldl~t~'4t)~(d~'r3wlhs~t~'90))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 1             | [2d 16h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r2zdip~t~'4zuy))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 1             | [2h 42m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r3wsqk~t~'7hs))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/MikeC-A6"><img src="https://avatars.githubusercontent.com/u/77452595?v=4" width="20"></a>                                                      | MikeC-A6           | 1             | [7h 7m](https://app.flowwer.dev/charts/review-time/~(u~(i~'77452595~n~'MikeC-A6)~p~30~r~(~(d~'r3g954~t~'19c4)~(d~'r3hpr9~t~'j8f)~(d~'r3hqu5~t~'kbb)~(d~'r3jpko~t~'7b))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 3              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 1             | [14h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r3ft6z~t~'13ca))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 0              |