### PR TITLE
Added a backstop time to batch queries, to prevent it processing very old data

### DIFF
--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -594,6 +594,7 @@ class WorkflowEngine(
     fun handleBatchEvent(
         messageEvent: BatchEvent,
         maxCount: Int,
+        backstopTime: OffsetDateTime?,
         updateBlock: (headers: List<Header>, txn: Configuration?) -> Unit,
     ) {
         db.transact { txn ->
@@ -602,6 +603,7 @@ class WorkflowEngine(
                 messageEvent.at,
                 messageEvent.receiverName,
                 maxCount,
+                backstopTime,
                 txn
             )
             val ids = tasks.map { it.reportId }


### PR DESCRIPTION
Current Exceptions in Staging are caused by new Batch being over-eager -- reaching back to try to run reports from August.   For sanity, we had a "backstopTime" oldest-time-to-look-for built into the BatchDecider, but it was missing from the BatchFunction query itself.   I added it there.

Note that the actual exception thrown in Staging was a date parse formatting exception -- caused by attempting to process very old data with the current schema.     A bizarre case of our old "WIP" bug.  This further emphasizes @mauricereeves 's point that we need schema versioning.    Regardless of that, we shouldn't be regularly running data from last August.  ;) 

It can be very hard to tell which original data has caused merged data to fail.   The particular error in Staging occurred after the batch was already merged, and was writing the output file.  So the info on which report created the offending row is long gone at that point.  I previously added some logging to help with that.

Our batch retry design is based on the hypothesis that unrecoverable batch failures are rare, so all failed batched get retried until the backstopTime.   An unrecoverable batch failure can be fairly bad, because batch just keeps retrying and retrying, as new incoming data gets piled on top of old.    Hence the 26 hour max backstop - give ourselves a day of attempts, then give it up as poison.  I added lots of logging about the timing, because that's a useful clue to help narrow which data is causing the error.


This PR adds a backstopTime to batch function workflow queries.

Test Steps:
1. Run smoke tests.
2.  Mark an old record in TASK as needing work (by setting its next_action_at value non-null) and confirm it does NOT get picked up.

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?
