### PR TITLE
Prevent logback from getting pulled in

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -569,6 +569,14 @@ repositories {
     }
 }
 
+// Prevent logback from being used by slf4j, no matter who declares it. Otherwise slf4j can pickup logback instead of
+// log4j from the classpath and our configuration gets ignored.
+configurations {
+    implementation {
+        exclude(group = "ch.qos.logback")
+    }
+}
+
 dependencies {
     jooqGenerator("org.postgresql:postgresql:42.3.1")
 


### PR DESCRIPTION
This PR prevents any logback library from coming in. If it does slf4j may pick it up before log4j and our logging configuration gets ignored.

Test Steps:
1. Deploy the app
2. Check logging amounts, hopefully it's much less.

## Changes
- Exclude logback libraries from being brought in by gradle, no matter who declares the dependency

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [-] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [-] Added tests?

### Process
- [x] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [-] Updated the release notes?
- [-] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **45**        | [13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r44rcl~t~'t9)~(d~'r44rlw~t~'8n)~(d~'r44tiz~t~'f0)~(d~'r44u1r~t~'8k)~(d~'r44tpx~t~'6d)~(d~'r44q7o~t~'4gg)~(d~'r44qil~t~'ac)~(d~'r44stp~t~'a8)~(d~'r44t3d~t~'8g)~(d~'r44shr~t~'d9)~(d~'r44rv2~t~'8n)~(d~'r45vb5~t~'zi)~(d~'r44wvz~t~'80d)~(d~'r44lqa~t~'be)~(d~'r44jks~t~'fl)~(d~'r44ld4~t~'b9)~(d~'r47uet~t~'43l)~(d~'r3wlkw~t~'i6)~(d~'r3wkyx~t~'ao)~(d~'r3wm9i~t~'4pkw)~(d~'r3tm6y~t~'o7)~(d~'r3x82v~t~'1id)~(d~'r4h1t6~t~'1klr)~(d~'r4fatl~t~'200)~(d~'r4j58x~t~'3za7)~(d~'r4j5l6~t~'bd)~(d~'r4j665~t~'a)~(d~'r4j6lr~t~'f8)~(d~'r44s3q~t~'2kvo)~(d~'r4s6j7~t~'6oy7)~(d~'r4s6k0~t~'6t85)~(d~'r4j8bi~t~'vk)~(d~'r4kmh3~t~'68)~(d~'r4u7q4~t~'1ld)~(d~'r4u8cr~t~'lz)~(d~'r4u9eh~t~'nt)~(d~'r4u93j~t~'db)~(d~'r4u8od~t~'at)~(d~'r4fav6~t~'4x2)~(d~'r4zk8a~t~'jp)~(d~'r4zzqn~t~'1fw)~(d~'r55616~t~'769h)~(d~'r5562h~t~'76b8)~(d~'r4km48~t~'2t)~(d~'r4u9n0~t~'w8)))) | 0              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 22            | [51m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r46dpm~t~'7p)~(d~'r3wxq1~t~'1lsp)~(d~'r3wxvt~t~'1lyh)~(d~'r3wxy4~t~'1m0s)~(d~'r3wy5q~t~'1m8e)~(d~'r3wy8p~t~'1mbd)~(d~'r4685g~t~'1sv3)~(d~'r45s3t~t~'3i)~(d~'r42f3a~t~'4s1)~(d~'r45udo~t~'21)~(d~'r42pw7~t~'3t)~(d~'r3v4u1~t~'23wv)~(d~'r3uwer~t~'1i)~(d~'r3tcac~t~'16y)~(d~'r3tcwt~t~'df)~(d~'r3tcxq~t~'ec)~(d~'r3sw7k~t~'112)~(d~'r3rih1~t~'7tc)~(d~'r3wnjd~t~'2al)~(d~'r3x4gx~t~'2o)~(d~'r3wx0e~t~'2bm)~(d~'r3wx1q~t~'2cy)~(d~'r4h1au~t~'1k3f)~(d~'r4hcmb~t~'f5e9)~(d~'r4hi0o~t~'5de)~(d~'r4s7bb~t~'ej)~(d~'r4s7f2~t~'ia)~(d~'r4kmjr~t~'8w)~(d~'r4kft9~t~'jdp)~(d~'r4tzw0~t~'1vc7)~(d~'r56yxt~t~'1el)~(d~'r4u9a9~t~'21md))))                                                                                                                                                                                                                                       | 10             |
| <a href="https://github.com/sean-usds"><img src="https://avatars.githubusercontent.com/u/87096393?u=90127e88c4ff845b6a754d10151b10a5158562ff&v=4" width="20"></a>          | sean-usds          | 20            | [1h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'87096393~n~'sean-usds)~p~30~r~(~(d~'r44f0r~t~'9o)~(d~'r4643i~t~'6l)~(d~'r44ljn~t~'3l)~(d~'r44f8h~t~'2a)~(d~'r44eli~t~'h)~(d~'r3wql0~t~'1h6d)~(d~'r3v27u~t~'3c8)~(d~'r3pz9v~t~'850)~(d~'r3pza4~t~'859)~(d~'r3rl89~t~'qo)~(d~'r3rkcf~t~'8e)~(d~'r3rlwp~t~'48)~(d~'r3rlqs~t~'s)~(d~'r3tfxi~t~'iru)~(d~'r3v904~t~'2bug)~(d~'r464wj~t~'2us)~(d~'r4a163~t~'15ao)~(d~'r4a17d~t~'15by)~(d~'r44loh~t~'6rw)~(d~'r4wm6g~t~'v)~(d~'r4wm9v~t~'22)~(d~'r4wm4p~t~'1jyp)~(d~'r4wm1m~t~'1jxw))))                                                                                                                                                                                                                                                                                                                                                                                                                            | 6              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 19            | [1d 1h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r3uui4~t~'3ehs)~(d~'r3vp6h~t~'4965)~(d~'r3vp6m~t~'496a)~(d~'r3wpr2~t~'59qq)~(d~'r3ws5p~t~'5c5d)~(d~'r3wsah~t~'5ca5)~(d~'r4268u~t~'4y48)~(d~'r466pz~t~'1nlb)~(d~'r45t10~t~'1c)~(d~'r47v06~t~'yny)~(d~'r42ug0~t~'1to)~(d~'r3wqxx~t~'12f)~(d~'r3uvqf~t~'1ykr)~(d~'r4aand~t~'d13)~(d~'r49nqa~t~'8b)~(d~'r480sa~t~'339c)~(d~'r4acx3~t~'28x5)~(d~'r4f4nu~t~'70nw)~(d~'r4aell~t~'4e4q)~(d~'r4j5a7~t~'3al)~(d~'r4j5f3~t~'3fh)~(d~'r424z1~t~'4vv3)~(d~'r4kkeq~t~'nz6)~(d~'r4vzz4~t~'frq)~(d~'r4w684~t~'53)~(d~'r4vtlt~t~'cfak)~(d~'r4womp~t~'96n)~(d~'r4km4n~t~'38)~(d~'r4w0oe~t~'d6cm)~(d~'r4w0qu~t~'d6f2)~(d~'r57g4n~t~'1uc))))                                                                                                                                                                                                                                        | **22**         |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 11            | [2h 14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r443iq~t~'10ti)~(d~'r443lh~t~'10w9)~(d~'r44795~t~'14jx)~(d~'r447mv~t~'14xn)~(d~'r3x7aj~t~'6pl)~(d~'r3x7dn~t~'6sp)~(d~'r3x7zy~t~'7f0)~(d~'r3x83c~t~'7ie)~(d~'r3x9sb~t~'97d)~(d~'r449ay~t~'5mm)~(d~'r449br~t~'5nf)~(d~'r3v20b~t~'34p)~(d~'r3s0eo~t~'a8)~(d~'r49zsc~t~'d7)~(d~'r49zw8~t~'i)~(d~'r4f9jm~t~'q1)~(d~'r4h7wp~t~'1b)~(d~'r4h8es~t~'27)~(d~'r4hrwj~t~'jjy)~(d~'r4s8c3~t~'1fb)~(d~'r4w65q~t~'3c)~(d~'r4w8ub~t~'1a4)~(d~'r4wb10~t~'3gt)~(d~'r573b6~t~'aopg)~(d~'r573gh~t~'aour)~(d~'r554xk~t~'6y6n))))                                                                                                                                                                                                                                                                                                                                                            | 18             |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 9             | [10h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r43zur~t~'x5j)~(d~'r44g41~t~'22z)~(d~'r3wqgh~t~'1h1u)~(d~'r3sw6s~t~'w2c)~(d~'r3t11n~t~'4y)~(d~'r3r4gv~t~'56)~(d~'r49jr2~t~'nvn)~(d~'r4tzd6~t~'1fv0)~(d~'r4wbjy~t~'3zr)~(d~'r573lw~t~'ap06))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 6              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 8             | [1d 12h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r3uuwm~t~'3ewa)~(d~'r3uwyw~t~'3gyk)~(d~'r3uxd5~t~'3hct)~(d~'r3wk0l~t~'5409)~(d~'r3t172~t~'1m6)~(d~'r3ur8y~t~'1c7p)~(d~'r3ur97~t~'1c7y)~(d~'r489ox~t~'5oz)~(d~'r4hhd8~t~'1l8h)~(d~'r4iqeb~t~'2u9k)~(d~'r4j72o~t~'152)~(d~'r554ky~t~'1b7n)~(d~'r554aj~t~'afhx)~(d~'r5569j~t~'ahgx)~(d~'r5569r~t~'ahh5)~(d~'r552gu~t~'o2at)~(d~'r57dn1~t~'3eu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 15             |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 8             | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r42mik~t~'3sd)~(d~'r3v9k5~t~'353)~(d~'r42p9h~t~'ixa)~(d~'r46d6g~t~'1t3)~(d~'r4sdo6~t~'3hv)~(d~'r4sb59~t~'2g3)~(d~'r4wbp1~t~'5m0)~(d~'r4y67e~t~'7jj)~(d~'r55atl~t~'6cr)~(d~'r56yw7~t~'1cz))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 6             | [1h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r44alf~t~'7nc)~(d~'r42spm~t~'3a)~(d~'r3wo1p~t~'2sx)~(d~'r3wo37~t~'2uf)~(d~'r3wo3p~t~'2ux)~(d~'r49lhr~t~'1c9l)~(d~'r4iumn~t~'5j7c)~(d~'r4h55o~t~'bg)~(d~'r4mo95~t~'1hae))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 17             |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 6             | [1h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r3uv0r~t~'130)~(d~'r3r41m~t~'39f)~(d~'r3r474~t~'2i7)~(d~'r4l5jm~t~'60q)~(d~'r4l5h8~t~'5xn)~(d~'r55fqk~t~'rr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 5             | [3h 21m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r3ve9k~t~'13d)~(d~'r3x5ep~t~'14o)~(d~'r49uo7~t~'948)~(d~'r46wwk~t~'9wa6)~(d~'r4uamy~t~'9gs)~(d~'r4vydx~t~'e6j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 1              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 5             | [1h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r42o2k~t~'5cd)~(d~'r47w8h~t~'61a)~(d~'r4l4t8~t~'1jq)~(d~'r4j36a~t~'3rd)~(d~'r4jgzc~t~'3z7)~(d~'r56ww1~t~'1vt))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 3              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 4             | [1h 13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r4j4r4~t~'2ri)~(d~'r4j5ch~t~'3cv)~(d~'r4j5hm~t~'3i0)~(d~'r4j7kg~t~'mz)~(d~'r4k03o~t~'3o4)~(d~'r50081~t~'1xa)~(d~'r53o24~t~'dyu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 3              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 3             | [10h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r462tk~t~'1l6t)~(d~'r467tg~t~'1ic)~(d~'r480hz~t~'1eu5)~(d~'r467n5~t~'6j6)~(d~'r467ux~t~'6qy)~(d~'r480cm~t~'1nnd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 6              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 3             | [2h 42m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r3wsqk~t~'7hs)~(d~'r4f7lk~t~'43w)~(d~'r54zlt~t~'aat7))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 2              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [4h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r4l8ts~t~'sc)~(d~'r48g2k~t~'23db)~(d~'r57gz5~t~'dhy))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r3wldl~t~'4t)~(d~'r3wlhs~t~'90))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 2              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r4w67m~t~'4l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |