### PR TITLE
Adds PID-20 suppression for MA

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -1283,6 +1283,7 @@
         receivingFacilityOID: 2.16.840.1.113883.19.3.2
         truncateHDNamespaceIds: true
         nameFormat: massachusetts
+        suppressHl7Fields: "PID-20"
       transport:
         type: SFTP
         host: sftp

--- a/prime-router/settings/prod/0062-suppress-pid-20-ma.yml
+++ b/prime-router/settings/prod/0062-suppress-pid-20-ma.yml
@@ -1,0 +1,66 @@
+---
+- name: "ma-phd"
+  description: "Massachusetts Public Health Department"
+  jurisdiction: "STATE"
+  stateCode: "MA"
+  countyName: null
+  filters: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "ma-phd"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "MA-MDPH"
+        receivingApplicationOID: "2.16.840.1.113883.19.3.2"
+        receivingFacilityName: "MA-MDPH"
+        receivingFacilityOID: "2.16.840.1.113883.19.3.2"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: "PID-20"
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        truncateHl7Fields: null
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        suppressNonNPI: false
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        valueSetOverrides: {}
+        nameFormat: "MASSACHUSETTS"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, MA, patient_state, MA)"
+      qualityFilter: []
+      routingFilter: []
+      processingModeFilter: []
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 500
+      description: ""
+      transport: !<SFTP>
+        host: "sftp-dph.ehs.mass.gov"
+        port: "22"
+        filePath: "./"
+        credentialName: null
+        type: "SFTP"
+      externalName: null

--- a/prime-router/settings/staging/0062-suppress-pid-20.yml
+++ b/prime-router/settings/staging/0062-suppress-pid-20.yml
@@ -1,0 +1,66 @@
+---
+- name: "ma-phd"
+  description: "Massachusetts Public Health Department"
+  jurisdiction: "STATE"
+  stateCode: "MA"
+  countyName: null
+  filters: null
+  senders: []
+  receivers:
+    - name: "elr"
+      organizationName: "ma-phd"
+      topic: "covid-19"
+      customerStatus: "active"
+      translation: !<HL7>
+        useTestProcessingMode: false
+        useBatchHeaders: true
+        receivingApplicationName: "MA-MDPH"
+        receivingApplicationOID: "2.16.840.1.113883.19.3.2"
+        receivingFacilityName: "MA-MDPH"
+        receivingFacilityOID: "2.16.840.1.113883.19.3.2"
+        messageProfileId: null
+        replaceValue: {}
+        reportingFacilityName: null
+        reportingFacilityId: null
+        reportingFacilityIdType: null
+        suppressQstForAoe: false
+        suppressHl7Fields: "PID-20"
+        suppressAoe: false
+        defaultAoeToUnknown: false
+        useBlankInsteadOfUnknown: null
+        truncateHDNamespaceIds: false
+        truncateHl7Fields: null
+        usePid14ForPatientEmail: false
+        convertTimestampToDateTime: null
+        cliaForOutOfStateTesting: null
+        cliaForSender: {}
+        phoneNumberFormatting: "STANDARD"
+        suppressNonNPI: false
+        processingModeCode: null
+        replaceDiiWithOid: null
+        useOrderingFacilityName: "STANDARD"
+        valueSetOverrides: {}
+        nameFormat: "MASSACHUSETTS"
+        receivingOrganization: null
+        type: "HL7"
+      jurisdictionalFilter:
+        - "orEquals(ordering_facility_state, MA, patient_state, MA)"
+      qualityFilter: []
+      routingFilter: []
+      processingModeFilter: []
+      reverseTheQualityFilter: false
+      deidentify: false
+      timing:
+        operation: "MERGE"
+        numberPerDay: 1440
+        initialTime: "09:15"
+        timeZone: "EASTERN"
+        maxReportCount: 500
+      description: ""
+      transport: !<SFTP>
+        host: "sftp"
+        port: "22"
+        filePath: "./upload"
+        credentialName: DEFAULT-SFTP
+        type: "SFTP"
+      externalName: null


### PR DESCRIPTION
This PR adds PID-20 suppression for MA

Test Steps:
1. Create a test file for MA
2. Run docker
3. Submit your test file to Docker
4. Verify PID-20 is blank

## Changes
- Adds suppression of PID-20 for MA

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- Closes #3287
## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **38**        | [18m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r44rcl~t~'t9)~(d~'r44rlw~t~'8n)~(d~'r44tiz~t~'f0)~(d~'r44u1r~t~'8k)~(d~'r44tpx~t~'6d)~(d~'r44qil~t~'ac)~(d~'r44stp~t~'a8)~(d~'r44t3d~t~'8g)~(d~'r44shr~t~'d9)~(d~'r44rv2~t~'8n)~(d~'r45vb5~t~'zi)~(d~'r44wvz~t~'80d)~(d~'r47uet~t~'43l)~(d~'r4h1t6~t~'1klr)~(d~'r4fatl~t~'200)~(d~'r4j58x~t~'3za7)~(d~'r4j5l6~t~'bd)~(d~'r4j665~t~'a)~(d~'r4j6lr~t~'f8)~(d~'r44s3q~t~'2kvo)~(d~'r4s6j7~t~'6oy7)~(d~'r4s6k0~t~'6t85)~(d~'r4j8bi~t~'vk)~(d~'r4kmh3~t~'68)~(d~'r4u9eh~t~'nt)~(d~'r4u93j~t~'db)~(d~'r4zk8a~t~'jp)~(d~'r4zzqn~t~'1fw)~(d~'r4u7q4~t~'1ld)~(d~'r4u8cr~t~'lz)~(d~'r55616~t~'769h)~(d~'r5562h~t~'76b8)~(d~'r4u8od~t~'at)~(d~'r4fav6~t~'4x2)~(d~'r4u9n0~t~'w8)~(d~'r4fav6~t~'4x2)~(d~'r4u9n0~t~'w8)~(d~'r5hy8t~t~'4wc6)~(d~'r5hxz6~t~'1qv)~(d~'r5i0jc~t~'d9)))) | 2              |
| <a href="https://github.com/sean-usds"><img src="https://avatars.githubusercontent.com/u/87096393?u=90127e88c4ff845b6a754d10151b10a5158562ff&v=4" width="20"></a>          | sean-usds          | 18            | [10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'87096393~n~'sean-usds)~p~30~r~(~(d~'r44f0r~t~'9o)~(d~'r4643i~t~'6l)~(d~'r44ljn~t~'3l)~(d~'r44f8h~t~'2a)~(d~'r44eli~t~'h)~(d~'r464wj~t~'2us)~(d~'r4a163~t~'15ao)~(d~'r4a17d~t~'15by)~(d~'r4wm9v~t~'22)~(d~'r4wm1m~t~'1jxw)~(d~'r44loh~t~'6rw)~(d~'r4wm6g~t~'v)~(d~'r5cz5e~t~'fv)~(d~'r5cryk~t~'ex2q)~(d~'r5d2xw~t~'1a)~(d~'r5cs0o~t~'b)~(d~'r4wm4p~t~'1jyp)~(d~'r5cs2a~t~'eweo)~(d~'r4wm4p~t~'1jyp)~(d~'r5cs0o~t~'b)~(d~'r5cs2a~t~'eweo)~(d~'r5cz5e~t~'fv)~(d~'r5csi4~t~'9s))))                                                                                                                                                                                                                                                                                                                                     | 4              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 15            | [7h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r45t10~t~'1c)~(d~'r47v06~t~'yny)~(d~'r42ug0~t~'1to)~(d~'r4aand~t~'d13)~(d~'r49nqa~t~'8b)~(d~'r480sa~t~'339c)~(d~'r4acx3~t~'28x5)~(d~'r4f4nu~t~'70nw)~(d~'r4aell~t~'4e4q)~(d~'r4w0oe~t~'d6cm)~(d~'r4w0qu~t~'d6f2)~(d~'r57g4n~t~'1uc)~(d~'r4j5a7~t~'3al)~(d~'r4j5f3~t~'3fh)~(d~'r4kkeq~t~'nz6)~(d~'r4w684~t~'53)~(d~'r4vtlt~t~'cfak)~(d~'r4womp~t~'96n)~(d~'r4vzz4~t~'frq)~(d~'r5eki9~t~'1n9f))))                                                                                                                                                                                                                                                                                                                                                                           | 13             |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 15            | [1h 7m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r46dpm~t~'7p)~(d~'r45s3t~t~'3i)~(d~'r42f3a~t~'4s1)~(d~'r45udo~t~'21)~(d~'r42pw7~t~'3t)~(d~'r4h1au~t~'1k3f)~(d~'r4hcmb~t~'f5e9)~(d~'r4hi0o~t~'5de)~(d~'r4s7bb~t~'ej)~(d~'r4s7f2~t~'ia)~(d~'r4kmjr~t~'8w)~(d~'r4kft9~t~'jdp)~(d~'r4tzw0~t~'1vc7)~(d~'r56yxt~t~'1el)~(d~'r4u9a9~t~'21md)~(d~'r5awx0~t~'9bh))))                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 2              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 9             | [53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r443iq~t~'10ti)~(d~'r443lh~t~'10w9)~(d~'r44795~t~'14jx)~(d~'r447mv~t~'14xn)~(d~'r49zsc~t~'d7)~(d~'r49zw8~t~'i)~(d~'r4f9jm~t~'q1)~(d~'r4h7wp~t~'1b)~(d~'r4h8es~t~'27)~(d~'r4hrwj~t~'jjy)~(d~'r4s8c3~t~'1fb)~(d~'r4w8ub~t~'1a4)~(d~'r4wb10~t~'3gt)~(d~'r573b6~t~'aopg)~(d~'r573gh~t~'aour)~(d~'r4w65q~t~'3c)~(d~'r5cyi1~t~'l8)~(d~'r5cyi1~t~'l8)~(d~'r554xk~t~'6y6n)~(d~'r58xtq~t~'1ucj))))                                                                                                                                                                                                                                                                                                                                                                                       | 13             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 7             | [5h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r44alf~t~'7nc)~(d~'r42spm~t~'3a)~(d~'r49lhr~t~'1c9l)~(d~'r4iumn~t~'5j7c)~(d~'r4h55o~t~'bg)~(d~'r4mo95~t~'1hae)~(d~'r58rzs~t~'1hrl)~(d~'r5b4ed~t~'2pp)~(d~'r5b4o2~t~'2ze)~(d~'r5cj3p~t~'19w5)~(d~'r5b1qf~t~'e4w)~(d~'r5b1s4~t~'e6l)~(d~'r5b25c~t~'ejt)~(d~'r5b3n0~t~'g1h))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | **39**         |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 6             | [1d 2h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r489ox~t~'5oz)~(d~'r552gu~t~'o2at)~(d~'r4hhd8~t~'1l8h)~(d~'r4iqeb~t~'2u9k)~(d~'r4j72o~t~'152)~(d~'r554ky~t~'1b7n)~(d~'r554aj~t~'afhx)~(d~'r5569j~t~'ahgx)~(d~'r5569r~t~'ahh5)~(d~'r57dn1~t~'3eu)~(d~'r59bgs~t~'218l)~(d~'r59bip~t~'21ai)~(d~'r5cjuv~t~'f6)~(d~'r5i0kt~t~'4z50))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 11             |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 6             | [1h 16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r42mik~t~'3sd)~(d~'r42p9h~t~'ixa)~(d~'r46d6g~t~'1t3)~(d~'r4sdo6~t~'3hv)~(d~'r4sb59~t~'2g3)~(d~'r4wbp1~t~'5m0)~(d~'r56yw7~t~'1cz))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 5             | [10h 16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r43zur~t~'x5j)~(d~'r44g41~t~'22z)~(d~'r49jr2~t~'nvn)~(d~'r4wbjy~t~'3zr)~(d~'r573lw~t~'ap06)~(d~'r4tzd6~t~'1fv0))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 5              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 5             | [1h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r42o2k~t~'5cd)~(d~'r47w8h~t~'61a)~(d~'r4l4t8~t~'1jq)~(d~'r4j36a~t~'3rd)~(d~'r4jgzc~t~'3z7)~(d~'r5cs23~t~'40e)~(d~'r5csqs~t~'e8))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 4              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 4             | [1h 13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r4j4r4~t~'2ri)~(d~'r4j5ch~t~'3cv)~(d~'r4j5hm~t~'3i0)~(d~'r4j7kg~t~'mz)~(d~'r4k03o~t~'3o4)~(d~'r50081~t~'1xa)~(d~'r53o24~t~'dyu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 3              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 3             | [10h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r462tk~t~'1l6t)~(d~'r467tg~t~'1ic)~(d~'r480hz~t~'1eu5)~(d~'r467n5~t~'6j6)~(d~'r467ux~t~'6qy)~(d~'r480cm~t~'1nnd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 6              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 3             | [18h 57m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r4f7lk~t~'43w)~(d~'r54zlt~t~'aat7)~(d~'r5aofo~t~'1gne))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 21             |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 3             | [1h 12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r4l5jm~t~'60q)~(d~'r4l5h8~t~'5xn)~(d~'r55fqk~t~'rr)~(d~'r55fqk~t~'rr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [4h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r4l8ts~t~'sc)~(d~'r48g2k~t~'23db)~(d~'r57gz5~t~'dhy))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 2             | [3h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r49uo7~t~'948)~(d~'r4uamy~t~'9gs)~(d~'r4vydx~t~'e6j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r4w67m~t~'4l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |