### PR TITLE
Fix for upload nav item and sender permission check

### DIFF
--- a/frontend-react/src/components/header/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/header/ReportStreamHeader.tsx
@@ -40,7 +40,10 @@ export const ReportStreamHeader = () => {
             );
         }
 
-        if (permissionCheck(PERMISSIONS.SENDER, authState)) {
+        if (
+            permissionCheck(PERMISSIONS.SENDER, authState) ||
+            permissionCheck(PERMISSIONS.PRIME_ADMIN, authState)
+        ) {
             itemsMenu.splice(
                 1,
                 0,

--- a/frontend-react/src/webreceiver-utils.ts
+++ b/frontend-react/src/webreceiver-utils.ts
@@ -31,7 +31,9 @@ const permissionCheck = (permission: string, authState: AuthState) => {
     if (permission === PERMISSIONS.RECEIVER) {
         return reportReceiver(authState);
     }
-    return authState.accessToken?.claims.organization.includes(permission);
+    return authState.accessToken?.claims.organization.find((org: string) => {
+        org.includes(permission)
+    });
 };
 
 // A receiver is anyone with an organization that is not "DHSender", i.e.: "DHaz_phd"

--- a/frontend-react/src/webreceiver-utils.ts
+++ b/frontend-react/src/webreceiver-utils.ts
@@ -31,8 +31,10 @@ const permissionCheck = (permission: string, authState: AuthState) => {
     if (permission === PERMISSIONS.RECEIVER) {
         return reportReceiver(authState);
     }
+
+    /* Right now, we're checking for a "DHSender" substring, not an exact match */
     return authState.accessToken?.claims.organization.find((org: string) => {
-        org.includes(permission)
+        org.includes(permission);
     });
 };
 

--- a/frontend-react/src/webreceiver-utils.ts
+++ b/frontend-react/src/webreceiver-utils.ts
@@ -33,9 +33,9 @@ const permissionCheck = (permission: string, authState: AuthState) => {
     }
 
     /* Right now, we're checking for a "DHSender" substring, not an exact match */
-    return authState.accessToken?.claims.organization.find((org: string) => {
-        org.includes(permission);
-    });
+    return authState.accessToken?.claims.organization.find((org: string) =>
+        org.includes(permission)
+    );
 };
 
 // A receiver is anyone with an organization that is not "DHSender", i.e.: "DHaz_phd"


### PR DESCRIPTION
This PR rolls back the permission check refactor and shows upload nav item to admins and senders.

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **30**        | [29m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r4h1t6~t~'1klr)~(d~'r4fatl~t~'200)~(d~'r5i0jc~t~'d9)~(d~'r5m3yg~t~'3ljr)~(d~'r5nlxx~t~'vlw)~(d~'r5hxz6~t~'1qv)~(d~'r5jurt~t~'19l)~(d~'r4kmh3~t~'68)~(d~'r4u9eh~t~'nt)~(d~'r4u93j~t~'db)~(d~'r4zk8a~t~'jp)~(d~'r4zzqn~t~'1fw)~(d~'r4u7q4~t~'1ld)~(d~'r4u8cr~t~'lz)~(d~'r55616~t~'769h)~(d~'r5562h~t~'76b8)~(d~'r58oe5~t~'8n)~(d~'r4km48~t~'2t)~(d~'r4j58x~t~'3za7)~(d~'r4j5l6~t~'bd)~(d~'r4j665~t~'a)~(d~'r4s6j7~t~'6oy7)~(d~'r4s6k0~t~'6t85)~(d~'r4j8bi~t~'vk)~(d~'r5pds7~t~'12k)~(d~'r4u9n0~t~'w8)~(d~'r4fav6~t~'4x2)~(d~'r4u8od~t~'at)~(d~'r4u9n0~t~'w8)~(d~'r4fav6~t~'4x2)~(d~'r5hy8t~t~'4wc6)~(d~'r5nmg4~t~'5cgu)))) | 2              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 20            | [20h 12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r4h1au~t~'1k3f)~(d~'r5al30~t~'cujo)~(d~'r5al3i~t~'cuk6)~(d~'r5al8e~t~'cup2)~(d~'r5idk5~t~'l0)~(d~'r5ifa8~t~'dr)~(d~'r5awx0~t~'9bh)~(d~'r5ikyp~t~'9l)~(d~'r5il2o~t~'ozb)~(d~'r5lu9b~t~'8sts)~(d~'r5luav~t~'8svc)~(d~'r5lueo~t~'8sz5)~(d~'r4kmjr~t~'8w)~(d~'r4kft9~t~'jdp)~(d~'r4tzw0~t~'1vc7)~(d~'r56yxt~t~'1el)~(d~'r4u9a9~t~'21md)~(d~'r5akvq~t~'bn)~(d~'r58rbg~t~'1wb8)~(d~'r4hi0o~t~'5de)~(d~'r4s7bb~t~'ej)~(d~'r4s7f2~t~'ia)~(d~'r5wo3e~t~'8y92)~(d~'r5wo4m~t~'8yaa)~(d~'r5wo6q~t~'8yce)~(d~'r5wxin~t~'16r)~(d~'r5wnq8~t~'c7d1))))                                                                                    | 8              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 14            | [14h 18m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r5lq7w~t~'8w6y)~(d~'r5igom~t~'5f8t)~(d~'r5jrit~t~'12v5)~(d~'r5o6xg~t~'cuwf)~(d~'r4w0oe~t~'d6cm)~(d~'r4w0qu~t~'d6f2)~(d~'r57g4n~t~'1uc)~(d~'r4j5a7~t~'3al)~(d~'r4j5f3~t~'3fh)~(d~'r4kkeq~t~'nz6)~(d~'r4w684~t~'53)~(d~'r4vzz4~t~'frq)~(d~'r58o52~t~'14ks)~(d~'r5ai4q~t~'1mga)~(d~'r5eki9~t~'1n9f)~(d~'r4km4n~t~'38))))                                                                                                                                                                                                                                                                                                      | 3              |
| <a href="https://github.com/sean-usds"><img src="https://avatars.githubusercontent.com/u/87096393?u=90127e88c4ff845b6a754d10151b10a5158562ff&v=4" width="20"></a>          | sean-usds          | 14            | [**10m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'87096393~n~'sean-usds)~p~30~r~(~(d~'r5ic36~t~'mb)~(d~'r5ic4z~t~'o4)~(d~'r5lwb1~t~'1exp)~(d~'r5oa7x~t~'1t)~(d~'r5oa8j~t~'2f)~(d~'r4wm9v~t~'22)~(d~'r4wm1m~t~'1jxw)~(d~'r4wm6g~t~'v)~(d~'r5cz5e~t~'fv)~(d~'r5d2xw~t~'1a)~(d~'r4wm4p~t~'1jyp)~(d~'r5cs0o~t~'b)~(d~'r5csi4~t~'9s)~(d~'r5cs2a~t~'eweo)~(d~'r5csi4~t~'9s)~(d~'r5cryk~t~'ex2q)~(d~'r5pm6i~t~'55tb))))                                                                                                                                                                                                                                                                                                    | 3              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 12            | [1h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r4f9jm~t~'q1)~(d~'r4h7wp~t~'1b)~(d~'r4h8es~t~'27)~(d~'r4hrwj~t~'jjy)~(d~'r5kihi~t~'2h0)~(d~'r5m0z4~t~'1kym)~(d~'r5i85t~t~'5f7i)~(d~'r5lvf8~t~'3d0j)~(d~'r5lvmd~t~'3d7o)~(d~'r5lvyj~t~'3dju)~(d~'r5i74c~t~'31w)~(d~'r5i7b1~t~'38l)~(d~'r5ib9d~t~'4q)~(d~'r4w8ub~t~'1a4)~(d~'r4wb10~t~'3gt)~(d~'r573b6~t~'aopg)~(d~'r573gh~t~'aour)~(d~'r4w65q~t~'3c)~(d~'r5cyi1~t~'l8)~(d~'r554xk~t~'6y6n)~(d~'r58xtq~t~'1ucj)~(d~'r4s8c3~t~'1fb)~(d~'r5nsa9~t~'4ay)~(d~'r5poww~t~'1g2)~(d~'r5pqr4~t~'1eg))))                                                                                                                                    | 22             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 10            | [5h 14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r5m8hs~t~'ob)~(d~'r5m8hy~t~'oh)~(d~'r5nmxi~t~'103)~(d~'r5iew2~t~'jb)~(d~'r5b1qf~t~'e4w)~(d~'r5b1s4~t~'e6l)~(d~'r5b25c~t~'ejt)~(d~'r5b3n0~t~'g1h)~(d~'r58rzs~t~'1hrl)~(d~'r5b4ed~t~'2pp)~(d~'r5b4o2~t~'2ze)~(d~'r5cj3p~t~'19w5)~(d~'r5jv0z~t~'1ir)~(d~'r5jv6h~t~'85k)~(d~'r5jv9j~t~'88m)~(d~'r5ls88~t~'17xv)~(d~'r5nvd8~t~'1hip)~(d~'r5nvh1~t~'1hmi)~(d~'r5nw93~t~'1iek)~(d~'r5nwd6~t~'1iin)~(d~'r4h55o~t~'bg)~(d~'r4mo95~t~'1hae)~(d~'r5pfqs~t~'17qs)~(d~'r5wvhb~t~'5n5m)~(d~'r5ww0q~t~'5np1))))                                                                                                                            | **68**         |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 7             | [1h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r5i7xa~t~'4qe)~(d~'r5if0f~t~'box)~(d~'r4wbp1~t~'5m0)~(d~'r56yw7~t~'1cz)~(d~'r4y67e~t~'7jj)~(d~'r55atl~t~'6cr)~(d~'r4sdo6~t~'3hv)~(d~'r4sb59~t~'2g3))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 1              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 7             | [1h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r55fqk~t~'rr)~(d~'r5m7ao~t~'si)~(d~'r5ikju~t~'7ol)~(d~'r5k73p~t~'6j)~(d~'r5i8ld~t~'6ia)~(d~'r5iorm~t~'92)~(d~'r4l5jm~t~'60q)~(d~'r4l5h8~t~'5xn)~(d~'r5q0km~t~'36f))))                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 6             | [1h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r5kdkf~t~'402)~(d~'r5ls19~t~'1mj)~(d~'r56ww1~t~'1vt)~(d~'r4l4t8~t~'1jq)~(d~'r4j36a~t~'3rd)~(d~'r4jgzc~t~'3z7)~(d~'r5cs23~t~'40e)~(d~'r5csqs~t~'e8)~(d~'r5pgvb~t~'39d))))                                                                                                                                                                                                                                                                                                                                                                                                                                              | 3              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 5             | [1h 14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r5i5lc~t~'4fa)~(d~'r4j4r4~t~'2ri)~(d~'r4j5ch~t~'3cv)~(d~'r4j5hm~t~'3i0)~(d~'r4j7kg~t~'mz)~(d~'r4k03o~t~'3o4)~(d~'r50081~t~'1xa)~(d~'r53o24~t~'dyu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 3              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 4             | [1d 21h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r57dn1~t~'3eu)~(d~'r59bgs~t~'218l)~(d~'r59bip~t~'21ai)~(d~'r5cjuv~t~'f6)~(d~'r5i0kt~t~'4z50)~(d~'r552gu~t~'o2at)~(d~'r554ky~t~'1b7n)~(d~'r554aj~t~'afhx)~(d~'r5569j~t~'ahgx)~(d~'r5569r~t~'ahh5))))                                                                                                                                                                                                                                                                                                                                                                                                                     | 7              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 4             | [30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r5m6nq~t~'1e)~(d~'r5m0bp~t~'18p)~(d~'r5pgq9~t~'1in)~(d~'r5x1pp~t~'61i))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 2              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 4             | [3h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r5i5qi~t~'1n9)~(d~'r5nzx9~t~'cnw8)~(d~'r4uamy~t~'9gs)~(d~'r4vydx~t~'e6j)~(d~'r5jxj0~t~'x))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 4             | [2h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r5m4pt~t~'2h)~(d~'r57gz5~t~'dhy)~(d~'r4l8ts~t~'sc)~(d~'r5oall~t~'mma))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 3             | [16h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r5lqhv~t~'1ahd)~(d~'r5lqj0~t~'1aii)~(d~'r4wbjy~t~'3zr)~(d~'r573lw~t~'ap06)~(d~'r4tzd6~t~'1fv0))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 5              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 3             | [22h 21m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r54zlt~t~'aat7)~(d~'r5aofo~t~'1gne)~(d~'r5rcmh~t~'1q31))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 21             |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 2             | [10h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r4w67m~t~'4l)~(d~'r5pdtd~t~'1nz1))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 1             | [1d 20h 56m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r5lz7z~t~'3gta))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 0              |
| <a href="https://github.com/victorialb-usds"><img src="https://avatars.githubusercontent.com/u/92449888?u=7b96445c1d1f5bb2dc6b7d26fbe1ad170fbf510d&v=4" width="20"></a>    | victorialb-usds    | 1             | [2d 20h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92449888~n~'victorialb-usds)~p~30~r~(~(d~'r5pr0v~t~'5ano))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1              |