### PR TITLE
Bugfix: Show topnav even if there's a network error or server is down.

### DIFF
--- a/frontend-react/src/components/header/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/header/ReportStreamHeader.tsx
@@ -7,6 +7,7 @@ import {
     NavMenuButton,
 } from "@trussworks/react-uswds";
 import { NavLink } from "react-router-dom";
+import { NetworkErrorBoundary } from "rest-hooks";
 
 import { permissionCheck } from "../../webreceiver-utils";
 import { PERMISSIONS } from "../../resources/PermissionsResource";
@@ -16,7 +17,6 @@ import { SignInOrUser } from "./SignInOrUser";
 import { HowItWorksDropdown } from "./HowItWorksDropdown";
 import { AdminDropdownNav } from "./AdminDropdownNav";
 import { GettingStartedDropdown } from "./GettingStartedDropdown";
-import { NetworkErrorBoundary } from "rest-hooks";
 
 export const ReportStreamHeader = () => {
     const { authState } = useOktaAuth();

--- a/frontend-react/src/components/header/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/header/ReportStreamHeader.tsx
@@ -16,6 +16,7 @@ import { SignInOrUser } from "./SignInOrUser";
 import { HowItWorksDropdown } from "./HowItWorksDropdown";
 import { AdminDropdownNav } from "./AdminDropdownNav";
 import { GettingStartedDropdown } from "./GettingStartedDropdown";
+import { NetworkErrorBoundary } from "rest-hooks";
 
 export const ReportStreamHeader = () => {
     const { authState } = useOktaAuth();
@@ -104,7 +105,15 @@ export const ReportStreamHeader = () => {
                     {authState?.accessToken?.claims?.organization.includes(
                         PERMISSIONS.PRIME_ADMIN
                     ) ? (
-                        <OrganizationDropdown />
+                        <NetworkErrorBoundary
+                            fallbackComponent={() => (
+                                <select>
+                                    <option>Network error</option>
+                                </select>
+                            )}
+                        >
+                            <OrganizationDropdown />
+                        </NetworkErrorBoundary>
                     ) : null}
                     <SignInOrUser />
                 </PrimaryNav>


### PR DESCRIPTION
To test:

1. Point your client to your localdev API server.
2. Shut down your localdev API server so it generates network errors
3. Log in and let the navbar render.
Result: you should still see the top navbar and "network error" where the Organization dropdown would normally be.

Fixes #4209

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **26**        | [14h 55m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r5i0jc~t~'d9)~(d~'r5jurt~t~'19l)~(d~'r5pds7~t~'12k)~(d~'r5nmg4~t~'5cgu)~(d~'r6bjra~t~'1kkq)~(d~'r62a4v~t~'zxg)~(d~'r68026~t~'3pc9)~(d~'r6bjqe~t~'16iu)~(d~'r6bk48~t~'8g)~(d~'r6bkdq~t~'7s)~(d~'r6bkly~t~'9x)~(d~'r6bjo2~t~'15fl)~(d~'r6c1hp~t~'ae)~(d~'r6dec9~t~'17ov)~(d~'r5yn3y~t~'1tyq)~(d~'r5yp3j~t~'99vx)~(d~'r5yop9~t~'1d1o)~(d~'r5ynan~t~'20dl)~(d~'r60l83~t~'18hg)~(d~'r67z1h~t~'7)~(d~'r5yu2x~t~'1whn)~(d~'r60kw1~t~'1bpm)~(d~'r60rbh~t~'da)~(d~'r684pw~t~'i)~(d~'r5yn0w~t~'1rcp)~(d~'r67yoj~t~'4vz3)~(d~'r60l73~t~'2c2)~(d~'r682b4~t~'h)~(d~'r682xy~t~'aw)~(d~'r6bjqx~t~'1b6d)~(d~'r6bldq~t~'12h))))                                                                                                                                                                                                                              | 9              |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 24            | [1h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r5m8hs~t~'ob)~(d~'r5m8hy~t~'oh)~(d~'r5nmxi~t~'103)~(d~'r5iew2~t~'jb)~(d~'r5jv0z~t~'1ir)~(d~'r5jv6h~t~'85k)~(d~'r5jv9j~t~'88m)~(d~'r5ls88~t~'17xv)~(d~'r5nvd8~t~'1hip)~(d~'r5nvh1~t~'1hmi)~(d~'r5nw93~t~'1iek)~(d~'r5nwd6~t~'1iin)~(d~'r60ydi~t~'cg)~(d~'r60ydu~t~'cs)~(d~'r67wdj~t~'3lnm)~(d~'r6bmn4~t~'3wj)~(d~'r6bmq3~t~'3zi)~(d~'r6bn8c~t~'4hr)~(d~'r6bnap~t~'4k4)~(d~'r69xot~t~'6ns)~(d~'r69t4b~t~'4b)~(d~'r6kvkj~t~'13qu)~(d~'r6lezi~t~'1m)~(d~'r6lf3v~t~'5z)~(d~'r6n0dd~t~'1j8)~(d~'r6n0di~t~'1jd)~(d~'r6fssg~t~'9p)~(d~'r6drh4~t~'1zv8)~(d~'r6kvpx~t~'7mx)~(d~'r5z012~t~'7s)~(d~'r5yoqk~t~'21ti)~(d~'r5pfqs~t~'17qs)~(d~'r5wvhb~t~'5n5m)~(d~'r5ww0q~t~'5np1)~(d~'r5x6n8~t~'91y)~(d~'r6qg86~t~'6e)~(d~'r6qhin~t~'1gv)~(d~'r6r1bu~t~'i2)~(d~'r6n5pj~t~'28c)~(d~'r6sua4~t~'3mik)~(d~'r6saea~t~'18sr)~(d~'r6saxz~t~'507)~(d~'r6sb1a~t~'eq07)))) | **64**         |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 19            | [7h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r5idk5~t~'l0)~(d~'r5ifa8~t~'dr)~(d~'r5ikyp~t~'9l)~(d~'r5il2o~t~'ozb)~(d~'r5wnss~t~'8rb7)~(d~'r5wo3e~t~'8y92)~(d~'r5wo4m~t~'8yaa)~(d~'r5wo6q~t~'8yce)~(d~'r5wxin~t~'16r)~(d~'r69wtd~t~'3td)~(d~'r6lf7a~t~'e8t)~(d~'r6p4xs~t~'1wp)~(d~'r6bs6m~t~'kq)~(d~'r60fh9~t~'1fnz)~(d~'r60cux~t~'axnb)~(d~'r60cw0~t~'axoe)~(d~'r60mwv~t~'4e)~(d~'r60txe~t~'4jj)~(d~'r5wnq8~t~'c7d1)~(d~'r5yzk3~t~'3my)~(d~'r6p61i~t~'bcq6)~(d~'r6p6al~t~'dhg0))))                                                                                                                                                                                                                                                                                                                                                                                                              | 3              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 15            | [1h 6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r5kihi~t~'2h0)~(d~'r5m0z4~t~'1kym)~(d~'r5i74c~t~'31w)~(d~'r5i7b1~t~'38l)~(d~'r5ib9d~t~'4q)~(d~'r5nsa9~t~'4ay)~(d~'r5poww~t~'1g2)~(d~'r5pqr4~t~'1eg)~(d~'r5x4de~t~'12x)~(d~'r5pri0~t~'3wd7)~(d~'r610jw~t~'123)~(d~'r6l3o4~t~'25z)~(d~'r6fugu~t~'3gg)~(d~'r6l17r~t~'94)~(d~'r5yx53~t~'2z)~(d~'r5ysqs~t~'1zlk)~(d~'r5z1i7~t~'3x5)~(d~'r612b0~t~'f3)~(d~'r6mxme~t~'13aa)~(d~'r6pi1x~t~'3q0)~(d~'r6pi6t~t~'3uw))))                                                                                                                                                                                                                                                                                                                                                                                                                                           | 14             |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 13            | [1h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r5ikju~t~'7ol)~(d~'r5k73p~t~'6j)~(d~'r5i8ld~t~'6ia)~(d~'r5iorm~t~'92)~(d~'r5q0km~t~'36f)~(d~'r69x8n~t~'4sk)~(d~'r6kzoa~t~'vp)~(d~'r6kzqe~t~'1fa)~(d~'r6nan3~t~'5av)~(d~'r6fyt9~t~'2jm)~(d~'r6fnmw~t~'1kf5)~(d~'r6fvqz~t~'3po)~(d~'r6qq9p~t~'bfm)~(d~'r6p8hl~t~'2fd)~(d~'r6sqa5~t~'2ui))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 12            | [1h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r5kdkf~t~'402)~(d~'r5ls19~t~'1mj)~(d~'r5wuiw~t~'n1)~(d~'r5pgvb~t~'39d)~(d~'r6ab9n~t~'c33)~(d~'r6brw6~t~'1ar)~(d~'r6fewv~t~'1b2)~(d~'r6fdj9~t~'y5)~(d~'r6e5ts~t~'2rd)~(d~'r6btti~t~'1sn)~(d~'r6c0m4~t~'8l9)~(d~'r67zwf~t~'4x6z)~(d~'r5kdyd~t~'73m)~(d~'r62gt0~t~'1urw)~(d~'r5x9sg~t~'df67)~(d~'r62go4~t~'6g8)~(d~'r62ifd~t~'5v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 9             | [6h 14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r5lqhv~t~'1ahd)~(d~'r5lqj0~t~'1aii)~(d~'r62hs2~t~'1ia9)~(d~'r6fru0~t~'tm)~(d~'r6kv3i~t~'4xj2)~(d~'r6fsbl~t~'ak)~(d~'r6duug~t~'57)~(d~'r612bd~t~'fg)~(d~'r6qwjc~t~'4r0)~(d~'r6let4~t~'hbr)~(d~'r6fmur~t~'35o1))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 1              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 8             | [3h 8m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r5jrit~t~'12v5)~(d~'r628oy~t~'yhj)~(d~'r6a3l2~t~'ck1)~(d~'r6k3cb~t~'bim)~(d~'r6c63l~t~'2ol)~(d~'r60m2h~t~'nv)~(d~'r62ect~t~'10k)~(d~'r6qil3~t~'5vi))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 2              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 6             | [1h](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r6lapo~t~'5rqp)~(d~'r6dz8l~t~'lz)~(d~'r6lars~t~'50h)~(d~'r6qd9c~t~'1d9o)~(d~'r6qh3u~t~'ef)~(d~'r6qh8k~t~'j5)~(d~'r6qjlc~t~'2vx)~(d~'r6qm4h~t~'5f2)~(d~'r6qo1h~t~'uj)~(d~'r6n644~t~'2mx)~(d~'r6p5h7~t~'2c3)~(d~'r6p74t~t~'3zp))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 8              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 6             | [1h 25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r5m6nq~t~'1e)~(d~'r5m0bp~t~'18p)~(d~'r6myli~t~'1jxz)~(d~'r5pgq9~t~'1in)~(d~'r5x1pp~t~'61i)~(d~'r682hf~t~'3xx)~(d~'r6s809~t~'16eq))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 3              |
| <a href="https://github.com/sean-usds"><img src="https://avatars.githubusercontent.com/u/87096393?u=90127e88c4ff845b6a754d10151b10a5158562ff&v=4" width="20"></a>          | sean-usds          | 6             | [**16m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'87096393~n~'sean-usds)~p~30~r~(~(d~'r5ic36~t~'mb)~(d~'r5ic4z~t~'o4)~(d~'r5lwb1~t~'1exp)~(d~'r5oa7x~t~'1t)~(d~'r5oa8j~t~'2f)~(d~'r5x42o~t~'s7)~(d~'r5pm6i~t~'55tb)~(d~'r60yt6~t~'9o4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 2              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 5             | [4h 28m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r5oall~t~'mma)~(d~'r6l3o8~t~'263)~(d~'r6duue~t~'55)~(d~'r612ap~t~'es)~(d~'r6myu5~t~'1r92)~(d~'r6oqj4~t~'16h3))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [19h 13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r6dn5p~t~'ws)~(d~'r5rcmh~t~'1q31)~(d~'r6273k~t~'1o8j)~(d~'r6qaij~t~'1aiv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 1              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 3             | [1h 42m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r5i7xa~t~'4qe)~(d~'r5if0f~t~'box)~(d~'r62j5e~t~'ef))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 1              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 3             | [1h 57m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r6biq1~t~'2xn2)~(d~'r69xv2~t~'5ez)~(d~'r5xbox~t~'1c))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 2             | [2h 21m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r5i5qi~t~'1n9)~(d~'r6k385~t~'beg))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 2             | [10h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r5pdtd~t~'1nz1)~(d~'r6n2va~t~'j4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 2             | [1h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r5i5lc~t~'4fa)~(d~'r6jude~t~'2jp))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 1             | [1d 23h 57m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r5pkaz~t~'3p66))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/victorialb-usds"><img src="https://avatars.githubusercontent.com/u/92449888?u=7b96445c1d1f5bb2dc6b7d26fbe1ad170fbf510d&v=4" width="20"></a>    | victorialb-usds    | 1             | [2d 20h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92449888~n~'victorialb-usds)~p~30~r~(~(d~'r5pr0v~t~'5ano))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 1              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 1             | [2h 54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r6dxgl~t~'821))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |