### PR TITLE
Add a Makefile for prime-router development commands

### DIFF
--- a/prime-router/Makefile
+++ b/prime-router/Makefile
@@ -1,0 +1,77 @@
+OS_NAME := $(shell uname -m)
+
+.PHONY: help
+help: ## Show this help.
+	@egrep '^[a-zA-Z_\.%-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: docker-build
+docker-build: ## Spin up the docker containers needed to build the application
+docker-build:
+	docker-compose -f docker-compose.build.yml up -d; \
+	sleep 1
+
+build: ## Build the prime-router application
+build: src/**/* docker-build
+	./gradlew package
+
+.vault/env:
+	mkdir .vault/env
+
+.vault/env/.env.local: .vault/env
+	touch .vault/env/.env.local
+
+build/ftps: build
+	mkdir build/ftps
+
+.PHONY: docker
+docker: ## Bring up docker containers needed for running the prime router
+docker: $(OS_NAME).docker
+
+.PHONY: arm64.docker
+arm64.docker: build .vault/env/.env.local build/ftps
+	docker-compose -f docker-compose.yml up -d vault; \
+  	while [ ! -s .vault/env/.env.local ]; do sleep 1; done; \
+	docker-compose -f docker-compose.build.yml -f docker-compose.yml up -d azurite sftp ftps
+
+.PHONY: x86_64.docker
+x86_64.docker: build .vault/env/.env.local build/ftps
+	docker-compose -f docker-compose.yml up -d vault; \
+  	while [ ! -s .vault/env/.env.local ]; do sleep 1; done; \
+	docker-compose -f docker-compose.build.yml -f docker-compose.yml up -d prime_dev azurite sftp ftps settings
+
+.PHONY: run
+run: ## Run the prime router application
+run: $(OS_NAME).run
+
+.PHONY: arm64.run
+arm64.run: docker setPermissions
+	make reloadState & ./gradlew run;
+
+/PHONY: setPermissions
+setPermissions: ## Set permissions needed for smoke tests to run successfully
+setPermissions: 
+	export $$(xargs < .vault/env/.env.local); \
+	./prime create-credential --type=UserPass --persist=DEFAULT-SFTP --user foo --pass pass; \
+	docker exec -it prime-router_sftp_1 chmod 777 /home/foo/upload; 
+
+.PHONY: reloadState
+reloadState: ## Load the tables and settings into a running prime router
+reloadState:
+	./gradlew reloadTables; \
+	./gradlew reloadSettings;
+
+.PHONY: x86_64.run
+x86_64.run: docker setPermissions
+
+.PHONY: restart
+restart: ## When running completely in docker; restart the prime router application and docker container
+restart: docker
+	docker-compose restart prime_dev
+
+.PHONY: clean
+clean: ## Stop containers and remove all artifacts
+clean:
+	docker-compose -f docker-compose.build.yml -f docker-compose.yml down
+	sudo rm -rf build
+	sudo rm -rf .vault/env
+	docker volume prune


### PR DESCRIPTION
Allows easy detection of the chip architecture and execution of standard local development commands

This PR adds a Makefile for common local environment creation and cleanup commands.

Test Steps:
1. run `make` to see the help information
2. run `make clean` this should remove all local artifacts
2. run `make run` this should spin up the local environment (still takes a bit)
3. run `./gradlew testSmoke` and see if it works

## Changes
- Create a Makefile for prime-router

## Checklist

### Testing
- [x] Tested locally?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue