### PR TITLE
Two-column state layout

### DIFF
--- a/frontend-react/src/pages/how-it-works/SystemsAndSettings.tsx
+++ b/frontend-react/src/pages/how-it-works/SystemsAndSettings.tsx
@@ -135,9 +135,10 @@ export const SystemsAndSettings = () => {
 
                 <p>
                     ReportStream uses a Secure File Transfer Protocol (SFTP)
-                    standard ELR connection. Public health departments using the
-                    ReportStream ELR can request data be sent in real time, or
-                    batched according to your needs.
+                    standard Electronic Laboratory Reporting (ELR) connection.
+                    Public health departments using the ReportStream ELR can
+                    request data be sent in real time, or batched according to
+                    your needs.
                 </p>
 
                 <p>

--- a/frontend-react/src/pages/how-it-works/WhereWereLive.tsx
+++ b/frontend-react/src/pages/how-it-works/WhereWereLive.tsx
@@ -46,7 +46,7 @@ export const WhereWereLive = () => {
                 ReportStream has established connections to send and report
                 public health data for each of the states and territories listed
                 here.
-                <ul>
+                <ul className={"rs-livestate-two-column"}>
                     {live.data
                         .sort((a, b) => a.state.localeCompare(b.state))
                         .map((data) => (

--- a/frontend-react/src/styles/_reportstream.scss
+++ b/frontend-react/src/styles/_reportstream.scss
@@ -239,6 +239,20 @@ h3 img[src*="svg"] {
     font-weight: 900;
 }
 
+.rs-livestate-two-column {
+    list-style: unset;
+    overflow: hidden;
+    column-count: 2;
+    column-gap: 1.25em;
+}
+
+.rs-livestate-two-column>* {
+    list-style: unset;
+    display: inline-block;
+    width: 80%;
+    padding-bottom: 0.5em;
+}
+
 /* tweak toaster notifications - other variables can be found by search node_modules for `--toastify-toast-width`  */
 :root {
     --toastify-toast-width: 600px;


### PR DESCRIPTION
- Make the long list of states more condensed. This is part of the #4004 but it's taking a while to get Iowa onboarded, so I'm breaking it out.
- Added definition of ELR by using the full term the first time it's mentioned. "Electronic Laboratory Reporting (ELR) connection"

Desktop
<img width="439" alt="image" src="https://user-images.githubusercontent.com/74203452/156243394-f9213e80-5c5b-4842-be9e-c0d382fec81c.png">

Mobile
<img width="385" alt="image" src="https://user-images.githubusercontent.com/74203452/156243559-785ada0c-a922-4ba3-9749-d8cd63b1ab23.png">
