### PR TITLE
changing availibility alert to use correct naming convention

### DIFF
--- a/operations/app/terraform/modules/application_insights/alert_availability.tf
+++ b/operations/app/terraform/modules/application_insights/alert_availability.tf
@@ -6,7 +6,7 @@
 
 resource "azurerm_monitor_metric_alert" "availability_alert" {
   count               = local.alerting_enabled
-  name                = "Degraded Availability"
+  name                = "${var.resource_prefix}-availability_alert"
   description         = "Degraded Availability"
   resource_group_name = var.resource_group
   scopes              = [azurerm_application_insights.app_insights.id]

--- a/operations/app/terraform/modules/application_insights/main.tf
+++ b/operations/app/terraform/modules/application_insights/main.tf
@@ -34,6 +34,6 @@ resource "azurerm_monitor_action_group" "action_group" {
 
 // Prevent TF changes where Microsoft.Insights is forced lowercase
 locals {
-  action_group_id = try(replace(azurerm_monitor_action_group.action_group[0].id,"Microsoft.Insights","microsoft.insights"), "")
-  app_insights_id = replace(azurerm_application_insights.app_insights.id,"Microsoft.Insights","microsoft.insights")
+  action_group_id = try(replace(azurerm_monitor_action_group.action_group[0].id, "Microsoft.Insights", "microsoft.insights"), "")
+  app_insights_id = replace(azurerm_application_insights.app_insights.id, "Microsoft.Insights", "microsoft.insights")
 }


### PR DESCRIPTION
Tiny change - updates the name of one of the alerts & changes the format in one of the TF files to match the output from `terraform format`

#4595 

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **60**        | [1h 18m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r75kue~t~'3g7a)~(d~'r75l74~t~'3gk0)~(d~'r73hlv~t~'2c)~(d~'r6zrt0~t~'1get)~(d~'r73gcq~t~'1pfh)~(d~'r73g59~t~'3xm)~(d~'r7eow1~t~'179)~(d~'r7avmr~t~'32b)~(d~'r7d5yg~t~'wo)~(d~'r7augf~t~'3wh)~(d~'r7ayzn~t~'36)~(d~'r7ax8t~t~'az)~(d~'r6zrpl~t~'4qu)~(d~'r6zrqt~t~'1b6w)~(d~'r7gfjf~t~'1i7f)~(d~'r7gkdc~t~'1km)~(d~'r7gkkx~t~'1n8x)~(d~'r7gklk~t~'1su)~(d~'r7exg7~t~'1ca)~(d~'r7gkoh~t~'2pr)~(d~'r7f0jk~t~'ge)~(d~'r7gugi~t~'5fh)~(d~'r7ij1v~t~'8m3)~(d~'r7pvw5~t~'8me)~(d~'r7kjey~t~'kf05)~(d~'r7ixv9~t~'4129)~(d~'r7iy5n~t~'h6ky)~(d~'r7j502~t~'dl)~(d~'r7j5s6~t~'eh)~(d~'r7ixn7~t~'ao6)~(d~'r7ix8d~t~'2ip)~(d~'r7j4kk~t~'v5)~(d~'r7j81e~t~'4v)~(d~'r7iz0o~t~'97)~(d~'r7j7bl~t~'db)~(d~'r7j43v~t~'ez)~(d~'r7j7q8~t~'12)~(d~'r7j9ud~t~'47)~(d~'r7j93e~t~'2a)~(d~'r7j6x9~t~'j)~(d~'r7kh87~t~'269)~(d~'r7k3ul~t~'i)~(d~'r7kfak~t~'2nx)~(d~'r7ii8y~t~'7c4)~(d~'r7t8iu~t~'10xu)~(d~'r7trsx~t~'3mi)~(d~'r7vu7z~t~'6ox)~(d~'r7tgos~t~'1mh)~(d~'r7axu9~t~'78n8)~(d~'r7vuee~t~'czah)~(d~'r851ga~t~'5u)~(d~'r73g5z~t~'1rvz)~(d~'r82l0j~t~'aj9)~(d~'r82wm3~t~'23z5)~(d~'r7psct~t~'7i7o)~(d~'r810pm~t~'5mv4)~(d~'r7ggj1~t~'1aw4)~(d~'r814x6~t~'1fy)~(d~'r7rkat~t~'17zq)~(d~'r7vuas~t~'23)~(d~'r7rk82~t~'14lw)~(d~'r7rke9~t~'1cyr)~(d~'r7rk5m~t~'g1)~(d~'r86rtt~t~'2ou)~(d~'r7pv77~t~'77lz)~(d~'r7vu74~t~'51q)~(d~'r82xbj~t~'24ob)~(d~'r8fogk~t~'29)~(d~'r8foaf~t~'3g)))) | 27             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 23            | [7h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r73l2z~t~'1gfv)~(d~'r73mwz~t~'2k)~(d~'r7ejkt~t~'nz)~(d~'r7av0y~t~'2gi)~(d~'r7ejxt~t~'1ew1)~(d~'r7cucb~t~'1pir)~(d~'r7asyw~t~'wux)~(d~'r73rq1~t~'dj)~(d~'r6zzir~t~'1zwa)~(d~'r71ode~t~'1vs)~(d~'r7gnjg~t~'1zzm)~(d~'r7pn9i~t~'1qax)~(d~'r7ik32~t~'o3)~(d~'r7io0t~t~'c1)~(d~'r7ikbi~t~'cxaf)~(d~'r75dtc~t~'1c18)~(d~'r86krr~t~'9z5)~(d~'r86ad6~t~'1fde)~(d~'r82kk3~t~'a2t)~(d~'r810wn~t~'58xu)~(d~'r7po11~t~'7dvw)~(d~'r7tpv5~t~'1pgz)~(d~'r813my~t~'5q)~(d~'r86arq~t~'4nw)~(d~'r7pngs~t~'6zvk)~(d~'r8dolv~t~'3ms)~(d~'r8doly~t~'3mv)~(d~'r8ftzo~t~'4tw))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | **51**         |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 23            | [3h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r720zk~t~'16h)~(d~'r75tz5~t~'hn6)~(d~'r7ep8o~t~'76)~(d~'r7d2e4~t~'co)~(d~'r7bdr8~t~'8xo)~(d~'r6zpol~t~'1bkm)~(d~'r70881~t~'hz)~(d~'r708hv~t~'44)~(d~'r7gxzs~t~'l)~(d~'r7eoyf~t~'1el)~(d~'r7rx2c~t~'f1o)~(d~'r7tf4o~t~'3sv)~(d~'r75ttc~t~'avh)~(d~'r75twm~t~'ayr)~(d~'r7ep3q~t~'16e4)~(d~'r7ep6f~t~'16gt)~(d~'r7ep71~t~'16hf)~(d~'r7euc3~t~'1bmh)~(d~'r7euh4~t~'1bri)~(d~'r7rwtb~t~'aic)~(d~'r86fkz~t~'8u)~(d~'r86kuo~t~'a22)~(d~'r82qoa~t~'1prf)~(d~'r82w52~t~'353)~(d~'r7z318~t~'321r)~(d~'r80zp4~t~'74v)~(d~'r80zrk~t~'77f)~(d~'r7rzr6~t~'q4gq)~(d~'r8e0wt~t~'9mu)~(d~'r8e13g~t~'6f)~(d~'r8e26t~t~'fs)~(d~'r8e14q~t~'9um)~(d~'r8e0s4~t~'93tu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 8              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 20            | [11h 32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r759bu~t~'1t3d)~(d~'r75cwd~t~'3899)~(d~'r75mz3~t~'lt)~(d~'r71xmb~t~'6eq)~(d~'r7cnzl~t~'1h6d)~(d~'r7coh7~t~'1hnz)~(d~'r7as1v~t~'vxw)~(d~'r7asa8~t~'w69)~(d~'r6zsn8~t~'1pwr)~(d~'r7f4rn~t~'7fn)~(d~'r7f5ep~t~'172)~(d~'r7gi6p~t~'mq)~(d~'r7czsi~t~'4zx)~(d~'r7i9je~t~'1jyb)~(d~'r759nv~t~'17vr)~(d~'r82kv2~t~'ads)~(d~'r82kxp~t~'1k0u)~(d~'r7ttqp~t~'1tcj)~(d~'r7iabk~t~'34on)~(d~'r82juw~t~'bz)~(d~'r80rpq~t~'4xh1)~(d~'r88hjp~t~'156)~(d~'r86yh5~t~'k39)~(d~'r8fpbf~t~'1de))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 18             |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 18            | [3h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r741bn~t~'gej)~(d~'r75s3n~t~'1o5)~(d~'r7d0hl~t~'cx)~(d~'r73puw~t~'1rv6)~(d~'r73qay~t~'1sb8)~(d~'r7b4qr~t~'540)~(d~'r7eubf~t~'11c)~(d~'r7q2zb~t~'57u)~(d~'r7tnwd~t~'8eo)~(d~'r7idms~t~'3e4i)~(d~'r7s620~t~'dg2)~(d~'r7tx7b~t~'6sm)~(d~'r86kjk~t~'efq)~(d~'r7pshp~t~'78sx)~(d~'r7tgzs~t~'2tp)~(d~'r8e7bg~t~'1vm)~(d~'r88fpu~t~'ix)~(d~'r7xcej~t~'v57)~(d~'r8e46d~t~'8pm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 7              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 16            | [1h 21m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r74233~t~'n1)~(d~'r7a3qm~t~'4db4)~(d~'r6yplo~t~'8wy)~(d~'r73ri7~t~'1tih)~(d~'r73yc6~t~'uh)~(d~'r7016q~t~'h)~(d~'r7glx3~t~'40a)~(d~'r7pzxh~t~'260)~(d~'r7pzz6~t~'27p)~(d~'r7tquw~t~'bd7)~(d~'r7exfw~t~'gn)~(d~'r7glca~t~'1lu0)~(d~'r7glm1~t~'1m3r)~(d~'r7glns~t~'1m5i)~(d~'r7ici4~t~'3czu)~(d~'r7icli~t~'3d38)~(d~'r7icth~t~'3db7)~(d~'r82zy3~t~'1v10)~(d~'r84q27~t~'xf)~(d~'r84r0n~t~'1vv)~(d~'r84t4m~t~'3zu)~(d~'r84thl~t~'4ct)~(d~'r7w1h5~t~'ho)~(d~'r7ttc5~t~'2z4)~(d~'r7txr4~t~'2pp)~(d~'r7ty7m~t~'367)~(d~'r7iino~t~'7l2)~(d~'r88cg2~t~'6x)~(d~'r88dkz~t~'z7)~(d~'r7pzwc~t~'3i0)~(d~'r85nw7~t~'fez)~(d~'r86ufu~t~'dq))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 45             |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 12            | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r7ema3~t~'3d9)~(d~'r7czsz~t~'va)~(d~'r7tced~t~'3vd)~(d~'r7vw9t~t~'1y8)~(d~'r854kz~t~'3aj)~(d~'r854xt~t~'3nd)~(d~'r854yg~t~'3o0)~(d~'r85514~t~'3qo)~(d~'r8556w~t~'3wg)~(d~'r8560y~t~'a8)~(d~'r86mkn~t~'4wy)~(d~'r86rje~t~'amf)~(d~'r73ym1~t~'2ac1)~(d~'r73ywx~t~'2amx)~(d~'r7401v~t~'15)~(d~'r7rpog~t~'1ddd)~(d~'r7rpqg~t~'1dfd)~(d~'r88mbb~t~'2tj)~(d~'r88q3d~t~'5u)~(d~'r839rp~t~'3l1))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 9              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 11            | [8h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r6zq2t~t~'1ncc)~(d~'r6zul9~t~'ao)~(d~'r7f1hq~t~'45q)~(d~'r7f2yw~t~'5mw)~(d~'r7f1qd~t~'35p)~(d~'r7q2q3~t~'35b)~(d~'r7tfcz~t~'416)~(d~'r86doc~t~'1bq)~(d~'r7gaky~t~'14y1)~(d~'r7t83r~t~'16f5)~(d~'r7v5wh~t~'1crv)~(d~'r7v69p~t~'1h1x)~(d~'r7v9xd~t~'182)~(d~'r7v9y7~t~'18w)~(d~'r7v6wj~t~'1bv4)~(d~'r7vafl~t~'1fe6)~(d~'r7vcl4~t~'16y)~(d~'r86b47~t~'1fvo)~(d~'r86cbb~t~'1h2s)~(d~'r7v79u~t~'cjom)~(d~'r8dlzt~t~'6nxo)~(d~'r8e64p~t~'2mh))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 25             |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 11            | [50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r7b3kc~t~'3xl)~(d~'r7012m~t~'p3)~(d~'r6y0xk~t~'y5)~(d~'r6y0yf~t~'z0)~(d~'r7ei86~t~'1bhy)~(d~'r75mw6~t~'3yb)~(d~'r86qq2~t~'2c5)~(d~'r86rge~t~'32h)~(d~'r86s5f~t~'1a)~(d~'r86s6m~t~'2h)~(d~'r86snb~t~'h3)~(d~'r84v2o~t~'be)~(d~'r88gis~t~'1ign)~(d~'r7w1vd~t~'cpz)~(d~'r86bjt~t~'132l)~(d~'r86cxb~t~'14g3)~(d~'r86hro~t~'19ag)~(d~'r8frpw~t~'290)~(d~'r8fro6~t~'28o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 7              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 11            | [1h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r7ejcv~t~'g1)~(d~'r75bis~t~'421)~(d~'r75byk~t~'4ht)~(d~'r7ayrj~t~'v8)~(d~'r71g93~t~'qjb)~(d~'r7f0w4~t~'sy)~(d~'r7fbck~t~'b9)~(d~'r7grbj~t~'2ai)~(d~'r7iez3~t~'1t0m)~(d~'r7ir48~t~'2zh)~(d~'r7ir6a~t~'31j)~(d~'r8311x~t~'2vq)~(d~'r81f1p~t~'1s)~(d~'r7r4gx~t~'our)~(d~'r84rmx~t~'hu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 4              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 8             | [3h 11m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r71riz~t~'19c)~(d~'r7goc7~t~'6fe)~(d~'r7gy13~t~'1w)~(d~'r86mg1~t~'5rgg)~(d~'r86oyd~t~'b86)~(d~'r8eakp~t~'54v)~(d~'r88rp9~t~'1tn4)~(d~'r80wgo~t~'4f7c))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 7             | [21h 13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r7ejgq~t~'1520)~(d~'r7tc2g~t~'3jg)~(d~'r7vrzr~t~'1ztt)~(d~'r7tck5~t~'1a1p)~(d~'r810r3~t~'591)~(d~'r7vsb9~t~'2b7i)~(d~'r80vrx~t~'4z7n)~(d~'r8dtai~t~'4y0v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 2              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 5             | [1h 36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r7tstc~t~'dbn)~(d~'r7icnt~t~'3d5j)~(d~'r7tx10~t~'6mb)~(d~'r7txem~t~'63)~(d~'r7v9mv~t~'2ak)~(d~'r8fr6x~t~'1f2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 4              |
| <a href="https://github.com/meckila"><img src="https://avatars.githubusercontent.com/u/68879427?u=f820e48d2924ecd35b62030423c5a6377fc4e1f4&v=4" width="20"></a>            | meckila            | 5             | [2h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'68879427~n~'meckila)~p~30~r~(~(d~'r74o0k~t~'qiv)~(d~'r7q3cx~t~'5lg)~(d~'r7iq7s~t~'8zt)~(d~'r7s9hf~t~'gvh)~(d~'r7txba~t~'2r)~(d~'r7txg7~t~'7o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 9              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 5             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r7ep3v~t~'2d)~(d~'r7gsis~t~'1v2e)~(d~'r7vueg~t~'10)~(d~'r82x6m~t~'19j)~(d~'r7rza1~t~'6b))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 5             | [47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r71o8q~t~'22z)~(d~'r73i7c~t~'lb)~(d~'r7ejbv~t~'f1)~(d~'r7gra1~t~'290)~(d~'r7jvt1~t~'rm9)~(d~'r7vrd6~t~'303))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 4             | [22h 56m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r7iw4u~t~'a8a)~(d~'r831xn~t~'1okt)~(d~'r84v2s~t~'30)~(d~'r7s0qn~t~'1uu0)~(d~'r8519c~t~'mdo4)~(d~'r88lid~t~'pxx5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 2              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 4             | [16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r7clni~t~'rm)~(d~'r7087q~t~'ho)~(d~'r7q3s7~t~'3nf)~(d~'r84kbp~t~'q1))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 3             | [22h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r6y6om~t~'pw)~(d~'r888gz~t~'1x56)~(d~'r88e8q~t~'1r43))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 2             | [8h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'r756s2~t~'18wv)~(d~'r8e5rg~t~'c4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 2             | [2h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r7244n~t~'cx2)~(d~'r7gvby~t~'2d1))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 2             | [18h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r7cl2e~t~'6i)~(d~'r7iosa~t~'2wp5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 1              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 1             | [17h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r7eu3w~t~'1bea))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 1              |