### PR TITLE
Fix okta group name parsing

### DIFF
--- a/frontend-react/src/contexts/SessionStorageTools.ts
+++ b/frontend-react/src/contexts/SessionStorageTools.ts
@@ -2,7 +2,7 @@
  * right, but by no means is it a context. Feel free to move
  * it if you can think of a better spot. */
 import { PERMISSIONS } from "../resources/PermissionsResource";
-import { groupToOrg } from "../webreceiver-utils";
+import { groupToOrg } from "../utils/OrganizationUtils";
 import { SessionStore } from "../hooks/UseSessionStorage";
 
 export enum GLOBAL_STORAGE_KEYS {

--- a/frontend-react/src/utils/OrganizationUtils.test.ts
+++ b/frontend-react/src/utils/OrganizationUtils.test.ts
@@ -1,0 +1,15 @@
+import { groupToOrg } from "./OrganizationUtils";
+
+test("groupToOrg", () => {
+    const admins = groupToOrg("DHPrimeAdmins");
+    const ignoreWaters = groupToOrg("DHSender_ignore.ignore-waters");
+    const mdPhd = groupToOrg("DHmd_phd");
+    const simpleReport = groupToOrg("simple_report");
+    const malformedGroupName = groupToOrg("DHSender_test_org");
+
+    expect(admins).toBe("PrimeAdmins");
+    expect(ignoreWaters).toBe("ignore.ignore-waters");
+    expect(mdPhd).toBe("md-phd");
+    expect(simpleReport).toBe("simple_report");
+    expect(malformedGroupName).toBe("test_org");
+});

--- a/frontend-react/src/utils/OrganizationUtils.ts
+++ b/frontend-react/src/utils/OrganizationUtils.ts
@@ -2,7 +2,7 @@ import { useResource } from "rest-hooks";
 
 import { getStoredOrg } from "../contexts/SessionStorageTools";
 import OrganizationResource from "../resources/OrganizationResource";
-import { groupToOrg } from "../webreceiver-utils";
+import { PERMISSIONS } from "../resources/PermissionsResource";
 
 export const getStates = () => {
     return [
@@ -66,6 +66,27 @@ export const getStates = () => {
         "Wisconsin",
         "Wyoming",
     ].sort();
+};
+
+export const groupToOrg = (group: string | undefined): string => {
+    const senderPrefix = `${PERMISSIONS.SENDER}_`;
+    const isStandardGroup = group?.startsWith("DH");
+    const isSenderGroup = group?.startsWith(senderPrefix);
+    /* If isStandardGroup, either sender/receiver, else non-standard */
+    const groupType = isStandardGroup
+        ? isSenderGroup
+            ? "sender"
+            : "receiver"
+        : "non-standard";
+
+    switch (groupType) {
+        case "sender":
+            return group ? group.replace(senderPrefix, "") : "";
+        case "receiver":
+            return group ? group.replace("DH", "").replace("_", "-") : "";
+        case "non-standard":
+            return group ? group : "";
+    }
 };
 
 export function useOrgName(): string {

--- a/frontend-react/src/utils/OrganizationUtils.ts
+++ b/frontend-react/src/utils/OrganizationUtils.ts
@@ -72,7 +72,10 @@ export const groupToOrg = (group: string | undefined): string => {
     const senderPrefix = `${PERMISSIONS.SENDER}_`;
     const isStandardGroup = group?.startsWith("DH");
     const isSenderGroup = group?.startsWith(senderPrefix);
-    /* If isStandardGroup, either sender/receiver, else non-standard */
+    /* Quick definitions:
+     * Sender - has an OktaGroup name beginning with DHSender_
+     * Receiver - has an OktaGroup name beginning with DHxx_ where xx is any state code
+     * Non-standard - has no associated OktaGroup and is already the org value in the db table */
     const groupType = isStandardGroup
         ? isSenderGroup
             ? "sender"
@@ -81,10 +84,14 @@ export const groupToOrg = (group: string | undefined): string => {
 
     switch (groupType) {
         case "sender":
+            // DHSender_test_sender -> test_sender
+            // DHSender_another-test-sender -> another-test-sender
             return group ? group.replace(senderPrefix, "") : "";
         case "receiver":
+            // DHmd_phd -> md-phd
             return group ? group.replace("DH", "").replace("_", "-") : "";
         case "non-standard":
+            // simple_report -> simple_report
             return group ? group : "";
     }
 };

--- a/frontend-react/src/webreceiver-utils.ts
+++ b/frontend-react/src/webreceiver-utils.ts
@@ -2,6 +2,7 @@ import { AccessToken, AuthState, UserClaims } from "@okta/okta-auth-js";
 
 import { PERMISSIONS } from "./resources/PermissionsResource";
 import { getStoredOrg } from "./contexts/SessionStorageTools";
+import { groupToOrg } from "./utils/OrganizationUtils";
 
 declare type RSUserClaims = UserClaims<{ organization: string[] }>;
 
@@ -11,22 +12,6 @@ export const getOrganizationFromAccessToken = (
     const newclaim: RSUserClaims =
         (accessToken?.claims as RSUserClaims) || undefined;
     return newclaim?.organization || [];
-};
-
-const groupToOrg = (group: String | undefined): string => {
-    // in order to replace all instances of the underscore we needed to use a
-    // global regex instead of a string. a string pattern only replaces the first
-    // instance
-    const startsWithSender = `${PERMISSIONS.SENDER}_`;
-    const isSender = group?.startsWith(startsWithSender);
-    const re = /_/g;
-    return group
-        ? group.toUpperCase().startsWith("DH")
-            ? isSender
-                ? group.replace(startsWithSender, "")
-                : group.slice(2).replace(re, "-")
-            : group.replace(re, "-")
-        : "";
 };
 
 const getOrganization = (authState: AuthState | undefined | null) => {
@@ -82,10 +67,4 @@ const senderClient = (authState: AuthState | undefined | null) => {
     return "";
 };
 
-export {
-    groupToOrg,
-    getOrganization,
-    permissionCheck,
-    reportReceiver,
-    senderClient,
-};
+export { getOrganization, permissionCheck, reportReceiver, senderClient };


### PR DESCRIPTION
This PR refactors `groupToOrg` to handle non-standard names (i.e. names that don't follow our okta group naming convention)

Test Steps:
1. Pull branch
2. Observe the `OrganizationUtils.test.ts` file for example input/output
3. Run tests
4. Alter tests to check some stress cases that might need to be considered.

## Changes
- Refactor: `groupToOrg()`
- Added: `OrganizationUtils.test.ts`

## Checklist

### Testing
- [X] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [X] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [X] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **33**        | [1h 54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r7t8iu~t~'10xu)~(d~'r7trsx~t~'3mi)~(d~'r7vu7z~t~'6ox)~(d~'r7tgos~t~'1mh)~(d~'r851ga~t~'5u)~(d~'r82l0j~t~'aj9)~(d~'r82wm3~t~'23z5)~(d~'r7rkat~t~'17zq)~(d~'r7vuas~t~'23)~(d~'r7rk82~t~'14lw)~(d~'r7rke9~t~'1cyr)~(d~'r7rk5m~t~'g1)~(d~'r86rtt~t~'2ou)~(d~'r8nh45~t~'5ht)~(d~'r8yg9r~t~'g7n5)~(d~'r8l2yp~t~'2rh)~(d~'r82xbj~t~'24ob)~(d~'r8foaf~t~'3g)~(d~'r8hfp7~t~'2of)~(d~'r8hfw8~t~'6nm)~(d~'r8fogk~t~'29)~(d~'r8yg6e~t~'v9zq)~(d~'r95n1v~t~'7kug)~(d~'r95qbj~t~'2ow)~(d~'r95tlx~t~'n8)~(d~'r95w3z~t~'ks)~(d~'r95xi0~t~'he)~(d~'r7vu74~t~'51q)~(d~'r93hak~t~'3b3s)~(d~'r8yg7p~t~'to7e)~(d~'r95o90~t~'1p5t)~(d~'r97sdu~t~'jk)~(d~'r95mzq~t~'7ad)~(d~'r95mx9~t~'1en5)~(d~'r97riy~t~'2tj)~(d~'r97ktb~t~'53s)))) | 12             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 20            | [15h 31m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r86krr~t~'9z5)~(d~'r82kk3~t~'a2t)~(d~'r810wn~t~'58xu)~(d~'r86arq~t~'4nw)~(d~'r8hfho~t~'18ax)~(d~'r8shfd~t~'173b)~(d~'r8shg4~t~'1742)~(d~'r8shko~t~'178m)~(d~'r8wbwj~t~'1iet)~(d~'r8wcvo~t~'1awl)~(d~'r8spql~t~'44)~(d~'r8sg1r~t~'1de7)~(d~'r8sps0~t~'1n4g)~(d~'r8sptb~t~'fd)~(d~'r8l4ux~t~'1l0w)~(d~'r8lezb~t~'3jt)~(d~'r8hfrz~t~'8p)~(d~'r8hg7g~t~'1rw9)~(d~'r8ftzo~t~'4tw)~(d~'r86ad6~t~'1fde)~(d~'r8jabx~t~'1r)~(d~'r82koo~t~'18p8)~(d~'r86bj6~t~'3q13)~(d~'r95i3g~t~'16rr)~(d~'r97krj~t~'3loc)~(d~'r8qxgg~t~'837)~(d~'r8sg3m~t~'1d20)~(d~'r99ebu~t~'7v)~(d~'r95g1t~t~'cg)~(d~'r95h0u~t~'1bh))))                                                                                                                 | 29             |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 18            | [17h 30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r7q2q3~t~'35b)~(d~'r7tfcz~t~'416)~(d~'r86doc~t~'1bq)~(d~'r7v69p~t~'1h1x)~(d~'r7v9xd~t~'182)~(d~'r7v9y7~t~'18w)~(d~'r7v6wj~t~'1bv4)~(d~'r7vafl~t~'1fe6)~(d~'r7vcl4~t~'16y)~(d~'r86b47~t~'1fvo)~(d~'r86cbb~t~'1h2s)~(d~'r8wb58~t~'cgya)~(d~'r8kzrv~t~'1agr)~(d~'r8l5ex~t~'1g3t)~(d~'r8l6cx~t~'1h1t)~(d~'r8y2iv~t~'25)~(d~'r8sfxy~t~'1bjt)~(d~'r8shps~t~'1dbn)~(d~'r8si1i~t~'1dnd)~(d~'r8srxc~t~'sd)~(d~'r8qo6p~t~'6vux)~(d~'r8l00d~t~'1g6c)~(d~'r8qnz2~t~'4zsf)~(d~'r8hfq4~t~'h2)~(d~'r8dlzt~t~'6nxo)~(d~'r8e64p~t~'2mh)~(d~'r8hg25~t~'q2)~(d~'r8yjdk~t~'22y)~(d~'r8qoju~t~'531n)~(d~'r8qolu~t~'533n)~(d~'r97iz1~t~'4ha)~(d~'r95cd5~t~'1f5n))))                                                                       | 29             |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 16            | [3h 35m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r7rx2c~t~'f1o)~(d~'r7tf4o~t~'3sv)~(d~'r7rwtb~t~'aic)~(d~'r86kuo~t~'a22)~(d~'r82qoa~t~'1prf)~(d~'r82w52~t~'353)~(d~'r7z318~t~'321r)~(d~'r80zp4~t~'74v)~(d~'r80zrk~t~'77f)~(d~'r8ncmk~t~'108)~(d~'r8ncol~t~'129)~(d~'r8jtis~t~'47o)~(d~'r8jtk6~t~'492)~(d~'r8ju7e~t~'4wa)~(d~'r8e0wt~t~'9mu)~(d~'r8e13g~t~'6f)~(d~'r8e26t~t~'fs)~(d~'r8e14q~t~'9um)~(d~'r8e0s4~t~'93tu)~(d~'r8192e~t~'gly)~(d~'r81cbd~t~'jux)~(d~'r82qr6~t~'1yaq)~(d~'r93pbe~t~'5nyl)~(d~'r93pbz~t~'5nz6)~(d~'r93pg2~t~'5o39)~(d~'r93pjl~t~'5o6s)~(d~'r95iby~t~'88)~(d~'r8lna0~t~'1rt)~(d~'r8y9fi~t~'1fk0)~(d~'r97fsz~t~'3hfi))))                                                                                                                     | 13             |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 14            | [2h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r7q2zb~t~'57u)~(d~'r7tnwd~t~'8eo)~(d~'r7s620~t~'dg2)~(d~'r7tx7b~t~'6sm)~(d~'r86kjk~t~'efq)~(d~'r7tgzs~t~'2tp)~(d~'r8skx3~t~'32x)~(d~'r8e46d~t~'8pm)~(d~'r95xi3~t~'36w)~(d~'r8e7bg~t~'1vm)~(d~'r88fpu~t~'ix)~(d~'r7xcej~t~'v57)~(d~'r8ywb5~t~'280)~(d~'r95khd~t~'u7z))))                                                                                                                                                                                                                                                                                                                                                                                                                                               | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 13            | [1h 20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r7tced~t~'3vd)~(d~'r7vw9t~t~'1y8)~(d~'r854kz~t~'3aj)~(d~'r854xt~t~'3nd)~(d~'r854yg~t~'3o0)~(d~'r85514~t~'3qo)~(d~'r8556w~t~'3wg)~(d~'r8560y~t~'a8)~(d~'r86mkn~t~'4wy)~(d~'r86rje~t~'amf)~(d~'r7rpog~t~'1ddd)~(d~'r7rpqg~t~'1dfd)~(d~'r8uxcy~t~'j3t)~(d~'r8uzd4~t~'l3z)~(d~'r839rp~t~'3l1)~(d~'r95y16~t~'187)~(d~'r88mbb~t~'2tj)~(d~'r88q3d~t~'5u)~(d~'r8hmnt~t~'7bq)~(d~'r948zz~t~'xz))))                                                                                                                                                                                                                                                                                                                              | 8              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 13            | [4h 29m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r82kv2~t~'ads)~(d~'r82kxp~t~'1k0u)~(d~'r80rpq~t~'4xh1)~(d~'r88hjp~t~'156)~(d~'r8se4l~t~'1bh1)~(d~'r8htmt~t~'ekz)~(d~'r8t1iu~t~'adv)~(d~'r8lpyp~t~'ej7)~(d~'r8r04j~t~'1j)~(d~'r8qk66~t~'4vzj)~(d~'r8fpbf~t~'1de)~(d~'r86yh5~t~'k39)~(d~'r8hqad~t~'109)~(d~'r8qv8k~t~'84))))                                                                                                                                                                                                                                                                                                                                                                                                                                           | 2              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 13            | [1h 1m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r7pzxh~t~'260)~(d~'r7pzz6~t~'27p)~(d~'r7tquw~t~'bd7)~(d~'r84q27~t~'xf)~(d~'r84r0n~t~'1vv)~(d~'r84t4m~t~'3zu)~(d~'r84thl~t~'4ct)~(d~'r7w1h5~t~'ho)~(d~'r7ttc5~t~'2z4)~(d~'r7txr4~t~'2pp)~(d~'r7ty7m~t~'367)~(d~'r88cg2~t~'6x)~(d~'r88dkz~t~'z7)~(d~'r8sn1l~t~'1wf)~(d~'r8g3pi~t~'2w)~(d~'r8g3ps~t~'36)~(d~'r8g58l~t~'6v)~(d~'r85nw7~t~'fez)~(d~'r86ufu~t~'dq)~(d~'r901l2~t~'17hx)~(d~'r8y9fv~t~'4en)~(d~'r96mjp~t~'ofy)~(d~'r97g2i~t~'20o)~(d~'r97qx8~t~'88g)~(d~'r97r2d~t~'8dl)~(d~'r97r5q~t~'d3w)~(d~'r97r8z~t~'8k7)~(d~'r97rf3~t~'8qb)~(d~'r97rsp~t~'ee)~(d~'r99brm~t~'3dnv))))                                                                                                                                         | **58**         |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 12            | [50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r86qq2~t~'2c5)~(d~'r86rge~t~'32h)~(d~'r86s5f~t~'1a)~(d~'r86s6m~t~'2h)~(d~'r86snb~t~'h3)~(d~'r84v2o~t~'be)~(d~'r8w59c~t~'9)~(d~'r8qnbt~t~'4c1d)~(d~'r8k9ky~t~'pqx)~(d~'r8fro6~t~'28o)~(d~'r86bjt~t~'132l)~(d~'r86cxb~t~'14g3)~(d~'r86hro~t~'19ag)~(d~'r8frpw~t~'290)~(d~'r95vp5~t~'1dy)~(d~'r88gis~t~'1ign)~(d~'r7w1vd~t~'cpz)~(d~'r8yy8m~t~'45h)~(d~'r97nx1~t~'eh)~(d~'r97om7~t~'13n))))                                                                                                                                                                                                                                                                                                                                   | 9              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 11            | [2h 16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r7tc2g~t~'3jg)~(d~'r7vrzr~t~'1ztt)~(d~'r7tck5~t~'1a1p)~(d~'r810r3~t~'591)~(d~'r7vsb9~t~'2b7i)~(d~'r80vrx~t~'4z7n)~(d~'r8ugq9~t~'2f1f)~(d~'r8y2e7~t~'69u)~(d~'r8y7zm~t~'do)~(d~'r8dtai~t~'4y0v)~(d~'r93yvl~t~'90dn)~(d~'r8r437~t~'1fp)~(d~'r8su9g~t~'690)~(d~'r97q57~t~'1fs)~(d~'r97t2j~t~'9o))))                                                                                                                                                                                                                                                                                                                                                                                                               | 7              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 10            | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r7vueg~t~'10)~(d~'r82x6m~t~'19j)~(d~'r7rza1~t~'6b)~(d~'r8udja~t~'1bc8)~(d~'r8g8q9~t~'26fr)~(d~'r8li4o~t~'re)~(d~'r8r3t6~t~'13x)~(d~'r8houx~t~'za)~(d~'r9490i~t~'66t3)~(d~'r95q4n~t~'2i0)~(d~'r93ugs~t~'3ad))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 3              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 10            | [3h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r86mg1~t~'5rgg)~(d~'r86oyd~t~'b86)~(d~'r8ye9a~t~'a1)~(d~'r8wrgf~t~'8i6)~(d~'r8ycul~t~'2hk)~(d~'r8ww37~t~'c2f)~(d~'r8jug4~t~'am3)~(d~'r8eakp~t~'54v)~(d~'r88rp9~t~'1tn4)~(d~'r80wgo~t~'4f7c)~(d~'r97ntx~t~'bd)~(d~'r97nu8~t~'bo))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 2              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 8             | [1h 32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r8jtb9~t~'405)~(d~'r8ju5r~t~'rm)~(d~'r8hfmn~t~'dl)~(d~'r8hh3b~t~'4gw)~(d~'r84v2s~t~'30)~(d~'r93tb2~t~'5am)~(d~'r93wz3~t~'5t4)~(d~'r97nq7~t~'80o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 2              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 8             | [37m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r8311x~t~'2vq)~(d~'r81f1p~t~'1s)~(d~'r7r4gx~t~'our)~(d~'r8uhru~t~'2g30)~(d~'r8r9tm~t~'4ht)~(d~'r8xwi0~t~'dn)~(d~'r8hfwj~t~'kg)~(d~'r84rmx~t~'hu))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 1              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 6             | [1h 46m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r7tstc~t~'dbn)~(d~'r7tx10~t~'6mb)~(d~'r7txem~t~'63)~(d~'r7v9mv~t~'2ak)~(d~'r8fr6x~t~'1f2)~(d~'r93ikc~t~'2tht)~(d~'r97iw8~t~'36p)~(d~'r97q3a~t~'adr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 5              |
| <a href="https://github.com/meckila"><img src="https://avatars.githubusercontent.com/u/68879427?u=f820e48d2924ecd35b62030423c5a6377fc4e1f4&v=4" width="20"></a>            | meckila            | 5             | [4h 12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'68879427~n~'meckila)~p~30~r~(~(d~'r7q3cx~t~'5lg)~(d~'r7s9hf~t~'gvh)~(d~'r7txba~t~'2r)~(d~'r7txg7~t~'7o)~(d~'r8rdzy~t~'bn7)~(d~'r8s0ua~t~'yhj)~(d~'r8t8l1~t~'nfv)~(d~'r8t8l8~t~'ng2)~(d~'r93xqs~t~'9yd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 14             |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 4             | [1d 8h 20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r7vrd6~t~'303)~(d~'r8qom5~t~'4wnr)~(d~'r8r5bg~t~'9cu2)~(d~'r8l5s3~t~'9q))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 4             | [1d 8h 54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r97q4o~t~'3gya)~(d~'r97rwo~t~'1t65)~(d~'r97isi~t~'39mh)~(d~'r97zdd~t~'x))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 3             | [**24m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r84kbp~t~'q1)~(d~'r8wfs2~t~'2w5)~(d~'r93yow~t~'14c))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 3             | [22h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r888gz~t~'1x56)~(d~'r88e8q~t~'1r43)~(d~'r93vx0~t~'4r1))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 2             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'r8wg4n~t~'38q)~(d~'r8e5rg~t~'c4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 1             | [18h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r8shpj~t~'1f1z))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 1             | [18h 8m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r955hu~t~'1ebv)~(d~'r955lz~t~'1eg0))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 2              |