### PR TITLE
Fix in waters endpoint to just send the org name, not full client name, to OktaAuth

### DIFF
--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -115,7 +115,7 @@ class ReportFunction(
         val authenticationStrategy = AuthenticationStrategy.authStrategy(
             request.headers["authentication-type"],
             PrincipalLevel.USER,
-            workflowEngine
+            workflowEngine.db
         )
 
         try {
@@ -123,7 +123,7 @@ class ReportFunction(
 
             if (authenticationStrategy is OktaAuthentication) {
                 // The report is coming from a sender that is using Okta, so set "oktaSender" to true
-                return authenticationStrategy.checkAccess(request, senderName, true, actionHistory) {
+                return authenticationStrategy.checkAccess(request, sender.organizationName, true, actionHistory) {
                     return@checkAccess processRequest(request, sender)
                 }
             }

--- a/prime-router/src/main/kotlin/tokens/AuthenticationStrategy.kt
+++ b/prime-router/src/main/kotlin/tokens/AuthenticationStrategy.kt
@@ -1,25 +1,24 @@
 package gov.cdc.prime.router.tokens
 
-import gov.cdc.prime.router.azure.WorkflowEngine
+import gov.cdc.prime.router.azure.DatabaseAccess
 import org.apache.logging.log4j.kotlin.Logging
 
 class AuthenticationStrategy() : Logging {
-    companion object Types {
+    companion object {
 
         // Returns an OktaAuthentication strategy if the authenticationType is "okta"
         fun authStrategy(
             authenticationType: String?,
             principalLevel: PrincipalLevel,
-            workflowEngine: WorkflowEngine
+            db: DatabaseAccess,
         ): Any {
-
             // Clients using Okta will send "authentication-type": "okta" in the request header
             if (authenticationType == "okta") {
                 return OktaAuthentication(principalLevel)
             }
 
             // default is TokenAuthentication
-            return TokenAuthentication(DatabaseJtiCache(workflowEngine.db))
+            return TokenAuthentication(DatabaseJtiCache(db))
         }
     }
 }

--- a/prime-router/src/test/kotlin/azure/ReportFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/ReportFunctionTests.kt
@@ -12,9 +12,14 @@ import gov.cdc.prime.router.Schema
 import gov.cdc.prime.router.Sender
 import gov.cdc.prime.router.SettingsProvider
 import gov.cdc.prime.router.azure.db.enums.TaskAction
+import gov.cdc.prime.router.tokens.AuthenticatedClaims
+import gov.cdc.prime.router.tokens.AuthenticationStrategy
+import gov.cdc.prime.router.tokens.OktaAuthentication
+import gov.cdc.prime.router.tokens.PrincipalLevel
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkClass
+import io.mockk.mockkObject
 import io.mockk.spyk
 import io.mockk.verify
 import org.jooq.tools.jdbc.MockConnection
@@ -55,6 +60,83 @@ class ReportFunctionTests {
     @BeforeEach
     fun reset() {
         clearAllMocks()
+    }
+
+    /**
+     * Do all the zany setup work needed to run the 'waters' endpoint as a test.
+     * Written specifically for the 'client header' tests below, to start.  But could probably
+     * be generalized for all 'waters' endpoint tests in the future.
+     */
+    private fun setupForDotNotationTests(): Pair<ReportFunction, MockHttpRequestMessage> {
+        every { timing1.isValid() } returns true
+        every { timing1.numberPerDay } returns 1
+        every { timing1.maxReportCount } returns 1
+        every { timing1.whenEmpty } returns Receiver.WhenEmpty()
+
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
+        val metadata = Metadata(schema = one)
+        val settings = FileSettings().loadOrganizations(oneOrganization)
+        val sender = Sender("default", "simple_report", Sender.Format.CSV, "test", schemaName = "one")
+        val req = MockHttpRequestMessage("test")
+        val engine = makeEngine(metadata, settings)
+        val actionHistory = spyk(ActionHistory(TaskAction.receive))
+        val reportFunc = spyk(ReportFunction(engine, actionHistory))
+        val resp = HttpUtilities.okResponse(req, "fakeOkay")
+        every { engine.db } returns accessSpy
+        val oktaAuth = spyk(OktaAuthentication(PrincipalLevel.USER))
+        mockkObject(AuthenticationStrategy.Companion)
+        every { AuthenticationStrategy.authStrategy(any(), any(), any()) } returns oktaAuth
+        val jwt = mapOf("organization" to listOf("DHSender_simple_report"), "sub" to "c@rlos.com")
+        val claims = AuthenticatedClaims(jwt)
+        every { oktaAuth.authenticate(any()) } returns claims
+        every { reportFunc.processRequest(any(), any()) } returns resp
+        every { engine.settings.findSender(any()) } returns sender // This test only works with org = simple_report
+        return Pair(reportFunc, req)
+    }
+
+    /**
+     * Test that header of the form client:simple_report.default works with the auth code.
+     */
+    @Test
+    fun `test the waters function with dot-notation client header - basic happy path`() {
+        val (reportFunc, req) = setupForDotNotationTests()
+        // This is the most common way our customers use the client string
+        req.httpHeaders += mapOf(
+            "client" to "simple_report",
+            "authentication-type" to "okta",
+            "content-length" to "4"
+        )
+        // Invoke the waters function run
+        reportFunc.report(req)
+        // processFunction should be called
+        verify(exactly = 1) { reportFunc.processRequest(any(), any()) }
+    }
+
+    @Test
+    fun `test the waters function with dot-notation client header - full dotted name`() {
+        val (reportFunc, req) = setupForDotNotationTests()
+        // Now try it with a full client name
+        req.httpHeaders += mapOf(
+            "client" to "simple_report.default",
+            "authentication-type" to "okta",
+            "content-length" to "4"
+        )
+        reportFunc.report(req)
+        verify(exactly = 1) { reportFunc.processRequest(any(), any()) }
+    }
+
+    @Test
+    fun `test the waters function with dot-notation client header - dotted but not default`() {
+        val (reportFunc, req) = setupForDotNotationTests()
+        // Now try it with a full client name but not with "default"
+        // The point of these tests is that the call to the auth code only contains the org prefix 'simple_report'
+        req.httpHeaders += mapOf(
+            "client" to "simple_report.foobar",
+            "authentication-type" to "okta",
+            "content-length" to "4"
+        )
+        reportFunc.report(req)
+        verify(exactly = 1) { reportFunc.processRequest(any(), any()) }
     }
 
     // Hits processRequest, tracks 'receive' action in actionHistory


### PR DESCRIPTION
This PR fixes a bug where the authentication code was being passed the fully dotted sender name (eg simple_report.myspecialsender) instead of just simple_report.

We had no tests for this, so tests were added as well.

Test Steps:
1. Run unit tests.

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process

**None apply**

- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #4655 - partial.


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Median time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | **25**        | [2h 20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r86krr~t~'9z5)~(d~'r86arq~t~'4nw)~(d~'r8hfho~t~'18ax)~(d~'r8shfd~t~'173b)~(d~'r8shg4~t~'1742)~(d~'r8shko~t~'178m)~(d~'r8wbwj~t~'1iet)~(d~'r8wcvo~t~'1awl)~(d~'r8spql~t~'44)~(d~'r8sg1r~t~'1de7)~(d~'r8sps0~t~'1n4g)~(d~'r8sptb~t~'fd)~(d~'r8l4ux~t~'1l0w)~(d~'r8lezb~t~'3jt)~(d~'r8hfrz~t~'8p)~(d~'r8hg7g~t~'1rw9)~(d~'r8ftzo~t~'4tw)~(d~'r86ad6~t~'1fde)~(d~'r8jabx~t~'1r)~(d~'r99ebu~t~'7v)~(d~'r95i3g~t~'16rr)~(d~'r8qxgg~t~'837)~(d~'r8sg3m~t~'1d20)~(d~'r9b2d0~t~'g4)~(d~'r9gu7h~t~'hi)~(d~'r9gk4y~t~'7w)~(d~'r9b21v~t~'1db3)~(d~'r9gjpv~t~'is)~(d~'r9gvny~t~'198)~(d~'r9ixde~t~'afk)~(d~'r95g1t~t~'cg)~(d~'r95h0u~t~'1bh)~(d~'r9m53e~t~'8w)~(d~'r9kf0r~t~'jb)~(d~'r9kf1p~t~'k9)~(d~'r97krj~t~'3loc)))) | **64**         |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **25**        | [1h](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r851ga~t~'5u)~(d~'r86rtt~t~'2ou)~(d~'r8nh45~t~'5ht)~(d~'r8yg9r~t~'g7n5)~(d~'r8l2yp~t~'2rh)~(d~'r8foaf~t~'3g)~(d~'r8hfp7~t~'2of)~(d~'r8hfw8~t~'6nm)~(d~'r8fogk~t~'29)~(d~'r95n1v~t~'7kug)~(d~'r95qbj~t~'2ow)~(d~'r95tlx~t~'n8)~(d~'r95w3z~t~'ks)~(d~'r95xi0~t~'he)~(d~'r93hak~t~'3b3s)~(d~'r97riy~t~'2tj)~(d~'r97ktb~t~'53s)~(d~'r97sdu~t~'jk)~(d~'r9hdfw~t~'6ul)~(d~'r95mx9~t~'1en5)~(d~'r9hcra~t~'6dmh)~(d~'r9kbrq~t~'8y)~(d~'r9kawr~t~'u1)~(d~'r9ka1y~t~'1csu)~(d~'r8yg7p~t~'to7e)~(d~'r9kc7j~t~'fk)~(d~'r95mzq~t~'7ad)~(d~'r9kbi0~t~'ju)~(d~'r95o90~t~'1p5t))))                                                                                                                                         | 12             |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 17            | [4h 29m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r88hjp~t~'156)~(d~'r8se4l~t~'1bh1)~(d~'r8htmt~t~'ekz)~(d~'r8t1iu~t~'adv)~(d~'r8lpyp~t~'ej7)~(d~'r8r04j~t~'1j)~(d~'r8qk66~t~'4vzj)~(d~'r8fpbf~t~'1de)~(d~'r86yh5~t~'k39)~(d~'r8hqad~t~'109)~(d~'r9b5n0~t~'m5)~(d~'r9auxq~t~'38ge)~(d~'r9axvc~t~'18x4)~(d~'r9j4qb~t~'1ryt)~(d~'r9kyj2~t~'ak)~(d~'r9m0um~t~'ze)~(d~'r9b0ei~t~'1p7u)~(d~'r8qv8k~t~'84))))                                                                                                                                                                                                                                                                                                                                                        | 9              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 16            | [50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r86qq2~t~'2c5)~(d~'r86rge~t~'32h)~(d~'r86s5f~t~'1a)~(d~'r86s6m~t~'2h)~(d~'r86snb~t~'h3)~(d~'r84v2o~t~'be)~(d~'r8qnbt~t~'4c1d)~(d~'r8k9ky~t~'pqx)~(d~'r8fro6~t~'28o)~(d~'r86bjt~t~'132l)~(d~'r86cxb~t~'14g3)~(d~'r86hro~t~'19ag)~(d~'r8frpw~t~'290)~(d~'r95vp5~t~'1dy)~(d~'r88gis~t~'1ign)~(d~'r8yy8m~t~'45h)~(d~'r99joj~t~'561)~(d~'r97nx1~t~'eh)~(d~'r97om7~t~'13n)~(d~'r9kd1y~t~'8m)~(d~'r9koic~t~'9l)~(d~'r9kbe1~t~'1a03)~(d~'r9kkve~t~'68)~(d~'r9bo8f~t~'6x5)~(d~'r9gwwx~t~'8vy)~(d~'r9keso~t~'e4)~(d~'r9nxqg~t~'3t8))))                                                                                                                                                                                       | 12             |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 14            | [18h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r86b47~t~'1fvo)~(d~'r86cbb~t~'1h2s)~(d~'r8wb58~t~'cgya)~(d~'r8kzrv~t~'1agr)~(d~'r8l5ex~t~'1g3t)~(d~'r8l6cx~t~'1h1t)~(d~'r8y2iv~t~'25)~(d~'r8sfxy~t~'1bjt)~(d~'r8shps~t~'1dbn)~(d~'r8si1i~t~'1dnd)~(d~'r8srxc~t~'sd)~(d~'r8qo6p~t~'6vux)~(d~'r8l00d~t~'1g6c)~(d~'r8qnz2~t~'4zsf)~(d~'r8hfq4~t~'h2)~(d~'r8dlzt~t~'6nxo)~(d~'r8e64p~t~'2mh)~(d~'r97iz1~t~'4ha)~(d~'r95cd5~t~'1f5n)~(d~'r8qoju~t~'531n)~(d~'r8qolu~t~'533n)~(d~'r9ma4z~t~'m5))))                                                                                                                                                                                                                                                                | 21             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 13            | [42m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r84q27~t~'xf)~(d~'r84r0n~t~'1vv)~(d~'r84t4m~t~'3zu)~(d~'r84thl~t~'4ct)~(d~'r88cg2~t~'6x)~(d~'r88dkz~t~'z7)~(d~'r8sn1l~t~'1wf)~(d~'r8g3pi~t~'2w)~(d~'r8g3ps~t~'36)~(d~'r8g58l~t~'6v)~(d~'r85nw7~t~'fez)~(d~'r86ufu~t~'dq)~(d~'r901l2~t~'17hx)~(d~'r96mjp~t~'ofy)~(d~'r97g2i~t~'20o)~(d~'r97qx8~t~'88g)~(d~'r97r2d~t~'8dl)~(d~'r97r5q~t~'d3w)~(d~'r97r8z~t~'8k7)~(d~'r97rf3~t~'8qb)~(d~'r97rsp~t~'ee)~(d~'r99brm~t~'3dnv)~(d~'r99hys~t~'qr)~(d~'r99ist~t~'1ks)~(d~'r9kj14~t~'1j)~(d~'r9im5i~t~'73s)~(d~'r8y9fv~t~'4en)~(d~'r9mf04~t~'hg))))                                                                                                                                                                           | 49             |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 12            | [1h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r8jtb9~t~'405)~(d~'r8ju5r~t~'rm)~(d~'r8hfmn~t~'dl)~(d~'r8hh3b~t~'4gw)~(d~'r84v2s~t~'30)~(d~'r93tb2~t~'5am)~(d~'r9bb6i~t~'vm)~(d~'r97nq7~t~'80o)~(d~'r93wz3~t~'5t4)~(d~'r9it4j~t~'1n1t)~(d~'r9ivvt~t~'9yb)~(d~'r9idz6~t~'1iqr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 3              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 11            | [1h 32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r86kuo~t~'a22)~(d~'r8ncmk~t~'108)~(d~'r8ncol~t~'129)~(d~'r8jtis~t~'47o)~(d~'r8jtk6~t~'492)~(d~'r8ju7e~t~'4wa)~(d~'r8e0wt~t~'9mu)~(d~'r8e13g~t~'6f)~(d~'r8e26t~t~'fs)~(d~'r8e14q~t~'9um)~(d~'r8e0s4~t~'93tu)~(d~'r95iby~t~'88)~(d~'r97fsz~t~'3hfi)~(d~'r9k6c0~t~'eb)~(d~'r9mh3t~t~'b11n)~(d~'r8lna0~t~'1rt)~(d~'r8y9fi~t~'1fk0))))                                                                                                                                                                                                                                                                                                                                                                           | 5              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 10            | [57m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r86kjk~t~'efq)~(d~'r8skx3~t~'32x)~(d~'r8e46d~t~'8pm)~(d~'r95xi3~t~'36w)~(d~'r8e7bg~t~'1vm)~(d~'r88fpu~t~'ix)~(d~'r8ywb5~t~'280)~(d~'r99ho8~t~'g7)~(d~'r95khd~t~'u7z)~(d~'r9khdw~t~'3x))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 10            | [2h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r86oyd~t~'b86)~(d~'r8ye9a~t~'a1)~(d~'r8wrgf~t~'8i6)~(d~'r8ycul~t~'2hk)~(d~'r8ww37~t~'c2f)~(d~'r8jug4~t~'am3)~(d~'r8eakp~t~'54v)~(d~'r88rp9~t~'1tn4)~(d~'r97ntx~t~'bd)~(d~'r97nu8~t~'bo)~(d~'r9khhg~t~'7h)~(d~'r9mlwq~t~'856))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 9             | [1h 11m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r8udja~t~'1bc8)~(d~'r8g8q9~t~'26fr)~(d~'r8li4o~t~'re)~(d~'r8r3t6~t~'13x)~(d~'r8houx~t~'za)~(d~'r9490i~t~'66t3)~(d~'r95q4n~t~'2i0)~(d~'r93ugs~t~'3ad)~(d~'r9baxp~t~'397)~(d~'r9ii0a~t~'566))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 3              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 8             | [**16m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r99o15~t~'9)~(d~'r9h54v~t~'13r)~(d~'r9h6gx~t~'cc)~(d~'r9h5p3~t~'b8)~(d~'r97rwo~t~'1t65)~(d~'r97isi~t~'39mh)~(d~'r97zdd~t~'x)~(d~'r9ky9r~t~'18n))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 0              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 7             | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r854kz~t~'3aj)~(d~'r854xt~t~'3nd)~(d~'r854yg~t~'3o0)~(d~'r85514~t~'3qo)~(d~'r8556w~t~'3wg)~(d~'r8560y~t~'a8)~(d~'r86rje~t~'amf)~(d~'r8uxcy~t~'j3t)~(d~'r8uzd4~t~'l3z)~(d~'r95y16~t~'187)~(d~'r88mbb~t~'2tj)~(d~'r88q3d~t~'5u)~(d~'r948zz~t~'xz))))                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 5              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 6             | [2h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r8ugq9~t~'2f1f)~(d~'r8y2e7~t~'69u)~(d~'r8y7zm~t~'do)~(d~'r93yvl~t~'90dn)~(d~'r8r437~t~'1fp)~(d~'r8su9g~t~'690)~(d~'r97q57~t~'1fs)~(d~'r97t2j~t~'9o)~(d~'r8dtai~t~'4y0v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 5              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 5             | [20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r8uhru~t~'2g30)~(d~'r8r9tm~t~'4ht)~(d~'r8xwi0~t~'dn)~(d~'r84rmx~t~'hu)~(d~'r9m0s7~t~'wz))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 1              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 5             | [15h 21m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r8qom5~t~'4wnr)~(d~'r8r5bg~t~'9cu2)~(d~'r8l5s3~t~'9q)~(d~'r9awir~t~'16mc)~(d~'r9o3y3~t~'8w))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 4             | [1d 1h](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r88e8q~t~'1r43)~(d~'r93vx0~t~'4r1)~(d~'r9mi7y~t~'23qi)~(d~'r9nxmy~t~'3f7o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 1              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 3             | [2h 27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r8fr6x~t~'1f2)~(d~'r97iw8~t~'36p)~(d~'r97q3a~t~'adr)~(d~'r93ikc~t~'2tht))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 3              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 3             | [2h 41m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r955hu~t~'1ebv)~(d~'r955lz~t~'1eg0)~(d~'r99kbu~t~'5tc)~(d~'r99nlh~t~'92z)~(d~'r9gqlv~t~'4h2)~(d~'r9gqzv~t~'4v2)~(d~'r9grbt~t~'570)~(d~'r9hfbs~t~'t6z))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 8              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 2             | [43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r8wfs2~t~'2w5)~(d~'r93yow~t~'14c))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 2             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'r8wg4n~t~'38q)~(d~'r8e5rg~t~'c4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/meckila"><img src="https://avatars.githubusercontent.com/u/68879427?u=f820e48d2924ecd35b62030423c5a6377fc4e1f4&v=4" width="20"></a>            | meckila            | 2             | [8h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'68879427~n~'meckila)~p~30~r~(~(d~'r8rdzy~t~'bn7)~(d~'r8s0ua~t~'yhj)~(d~'r8t8l1~t~'nfv)~(d~'r8t8l8~t~'ng2)~(d~'r93xqs~t~'9yd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 9              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 1             | [18h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r8shpj~t~'1f1z))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |