### PR TITLE
container registry TF settings

### DIFF
--- a/operations/app/terraform/modules/container_registry/main.tf
+++ b/operations/app/terraform/modules/container_registry/main.tf
@@ -1,9 +1,10 @@
 resource "azurerm_container_registry" "container_registry" {
-  name                = "${var.resource_prefix}containerregistry"
-  resource_group_name = var.resource_group
-  location            = var.location
-  sku                 = "Premium"
-  admin_enabled       = true
+  name                          = "${var.resource_prefix}containerregistry"
+  resource_group_name           = var.resource_group
+  location                      = var.location
+  sku                           = "Premium"
+  admin_enabled                 = false
+  public_network_access_enabled = false
 
   # network_rule_set {
   #   default_action = "Allow"


### PR DESCRIPTION
SonarCloud terraform recommendations:
  admin_enabled                 = false
  public_network_access_enabled = false

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry

MS documentation:
https://docs.microsoft.com/en-us/azure/container-registry/container-registry-access-selected-networks
https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli

Documentation indicates that there are cases where these may be breaking changes.



This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | **17**        | [2h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r8sg1r~t~'1de7)~(d~'r8sps0~t~'1n4g)~(d~'r8sptb~t~'fd)~(d~'r8spql~t~'44)~(d~'r8wcvo~t~'1awl)~(d~'r95i3g~t~'16rr)~(d~'r9kf0r~t~'jb)~(d~'r9kf1p~t~'k9)~(d~'r9m53e~t~'8w)~(d~'r9ixde~t~'afk)~(d~'r9gu7h~t~'hi)~(d~'r9gvny~t~'198)~(d~'r9b21v~t~'1db3)~(d~'r9gjpv~t~'is)~(d~'r9gk4y~t~'7w)~(d~'r9b2d0~t~'g4)~(d~'r99ebu~t~'7v)~(d~'r9vm6f~t~'9aw)~(d~'ra6idn~t~'6co)~(d~'r9z6rv~t~'1pu2)~(d~'r9z6vv~t~'1py2)~(d~'r9z6w2~t~'1py9)~(d~'r9z6wv~t~'1pz2)~(d~'raa89o~t~'kx7)~(d~'raa8aj~t~'ky2)~(d~'raa8bc~t~'kyv)~(d~'r95g1t~t~'cg)~(d~'r95h0u~t~'1bh)))) | **51**         |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 15            | [1h 1m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r93hak~t~'3b3s)~(d~'r95w3z~t~'ks)~(d~'r95xi0~t~'he)~(d~'r9hdfw~t~'6ul)~(d~'r97sdu~t~'jk)~(d~'r95n1v~t~'7kug)~(d~'r95qbj~t~'2ow)~(d~'r95tlx~t~'n8)~(d~'r97riy~t~'2tj)~(d~'r95mx9~t~'1en5)~(d~'r9hcra~t~'6dmh)~(d~'r97ktb~t~'53s)~(d~'r9vnwl~t~'1j34)~(d~'r9kc7j~t~'fk)~(d~'r9kawr~t~'u1)~(d~'r9kbrq~t~'8y)~(d~'r9kbi0~t~'ju)~(d~'r9ka1y~t~'1csu)~(d~'r95mzq~t~'7ad))))                                                                                                                                                                       | 8              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 14            | [2h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r901l2~t~'17hx)~(d~'r9mf04~t~'hg)~(d~'r8y9fv~t~'4en)~(d~'r9oaln~t~'ea)~(d~'r9kj14~t~'1j)~(d~'r9im5i~t~'73s)~(d~'r96mjp~t~'ofy)~(d~'r97g2i~t~'20o)~(d~'r97qx8~t~'88g)~(d~'r97r2d~t~'8dl)~(d~'r97r5q~t~'d3w)~(d~'r97r8z~t~'8k7)~(d~'r97rf3~t~'8qb)~(d~'r97rsp~t~'ee)~(d~'r99brm~t~'3dnv)~(d~'r99hys~t~'qr)~(d~'r99ist~t~'1ks)~(d~'r9u6zc~t~'25v)~(d~'r9xl0t~t~'cu)~(d~'ra13ls~t~'1487)~(d~'r9topv~t~'5gov)~(d~'raa9u4~t~'1nov)~(d~'raahal~t~'1gp)~(d~'raabmo~t~'uz))))                                                                                  | 42             |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 14            | [5d 7h 58m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r95iby~t~'88)~(d~'r9mh3t~t~'b11n)~(d~'r9k6c0~t~'eb)~(d~'r97fsz~t~'3hfi)~(d~'ra70hi~t~'741)~(d~'ra6tov~t~'bimi)~(d~'ra6tpb~t~'bimy)~(d~'ra6v16~t~'bjyt)~(d~'ra6v1t~t~'bjzg)~(d~'ra6v2d~t~'bk00)~(d~'ra6v2l~t~'bk08)~(d~'ra6v45~t~'bk1s)~(d~'ra6yq8~t~'320)~(d~'ra6z5f~t~'d2x)~(d~'ra6ycp~t~'32z)~(d~'ra6y7s~t~'30e)~(d~'ra6vp7~t~'ji)~(d~'ra6z7u~t~'9vha)~(d~'ra6zdc~t~'9vms)~(d~'ra6zfr~t~'9vp7)~(d~'ra6zm0~t~'9vvg)~(d~'ra6yrj~t~'8u)~(d~'ra8a59~t~'12rc))))                                                                                | 9              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 13            | [11h 51m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r8se4l~t~'1bh1)~(d~'r9tmdx~t~'ki)~(d~'r9m0um~t~'ze)~(d~'r9j4qb~t~'1ryt)~(d~'r9axvc~t~'18x4)~(d~'r9b5n0~t~'m5)~(d~'r9auxq~t~'38ge)~(d~'r9u7xq~t~'349)~(d~'r9kyj2~t~'ak)~(d~'r9kyj2~t~'ak)~(d~'ra6jjd~t~'dpdp)~(d~'ra972u~t~'kxl)~(d~'r9z6xv~t~'1q02)~(d~'r9b0ei~t~'1p7u))))                                                                                                                                                                                                                                                                      | 9              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 11            | [30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r8yy8m~t~'45h)~(d~'r95vp5~t~'1dy)~(d~'r9nxqg~t~'3t8)~(d~'r97nx1~t~'eh)~(d~'r97om7~t~'13n)~(d~'r99joj~t~'561)~(d~'r9kd1y~t~'8m)~(d~'r9kbe1~t~'1a03)~(d~'r9kkve~t~'68)~(d~'r9koic~t~'9l)~(d~'r9bo8f~t~'6x5)~(d~'r9gwwx~t~'8vy)~(d~'r9keso~t~'e4)~(d~'r9xlkk~t~'98q)~(d~'raagdk~t~'jo))))                                                                                                                                                                                                                                                                 | 5              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 11            | [2h 29m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r9ky9r~t~'18n)~(d~'r97zdd~t~'x)~(d~'r97rwo~t~'1t65)~(d~'r97isi~t~'39mh)~(d~'r9h6gx~t~'cc)~(d~'r9h5p3~t~'b8)~(d~'r9h54v~t~'13r)~(d~'r99o15~t~'9)~(d~'ra1gz6~t~'cid)~(d~'ra8ys5~t~'l6b)~(d~'r9z887~t~'1qu3)~(d~'r9zdpc~t~'1wb8)~(d~'ra1abh~t~'1v25)~(d~'raal21~t~'ft))))                                                                                                                                                                                                                                                                        | 4              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 10            | [1h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r8udja~t~'1bc8)~(d~'r93ugs~t~'3ad)~(d~'r9490i~t~'66t3)~(d~'r95q4n~t~'2i0)~(d~'r9ii0a~t~'566)~(d~'r9baxp~t~'397)~(d~'r9vgm1~t~'1fdt)~(d~'r9x7zx~t~'2y2)~(d~'r9x8ly~t~'ek)~(d~'ra6ime~t~'3wj)~(d~'ra70q3~t~'5d7)~(d~'ra8z0p~t~'9tn))))                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 9             | [2h](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r93tb2~t~'5am)~(d~'r9idz6~t~'1iqr)~(d~'r9trbr~t~'93)~(d~'r9ivvt~t~'9yb)~(d~'r93wz3~t~'5t4)~(d~'r9it4j~t~'1n1t)~(d~'r97nq7~t~'80o)~(d~'r9bb6i~t~'vm)~(d~'ra8ezi~t~'5t)~(d~'ra19cq~t~'4vx))))                                                                                                                                                                                                                                                                                                                                                            | 3              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 9             | [2h 8m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r8ugq9~t~'2f1f)~(d~'r8y2e7~t~'69u)~(d~'r8y7zm~t~'do)~(d~'r93yvl~t~'90dn)~(d~'r9tm8t~t~'fe)~(d~'r9o4jb~t~'u4)~(d~'r9tuwj~t~'2bhz)~(d~'r97q57~t~'1fs)~(d~'r97t2j~t~'9o)~(d~'r9zc85~t~'5ks)~(d~'ra6ucy~t~'2d79)~(d~'ra8kjj~t~'1fge))))                                                                                                                                                                                                                                                                                                         | 4              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 8             | [49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r8skx3~t~'32x)~(d~'r8ywb5~t~'280)~(d~'r95khd~t~'u7z)~(d~'r95xi3~t~'36w)~(d~'r9oas9~t~'kw)~(d~'r9khdw~t~'3x)~(d~'r99ho8~t~'g7)~(d~'ra1ljm~t~'29x))))                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 7             | [54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r8ww37~t~'c2f)~(d~'r8wrgf~t~'8i6)~(d~'r8ycul~t~'2hk)~(d~'r8ye9a~t~'a1)~(d~'r9mlwq~t~'856)~(d~'r97ntx~t~'bd)~(d~'r97nu8~t~'bo)~(d~'r9khhg~t~'7h)~(d~'r9vuo0~t~'1ocl))))                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 5             | [24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r93yow~t~'14c)~(d~'r8wfs2~t~'2w5)~(d~'r9x3th~t~'2x)~(d~'ra8uvl~t~'jb)~(d~'ra8rfj~t~'1k6))))                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 5             | [20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r8uhru~t~'2g30)~(d~'r8xwi0~t~'dn)~(d~'r9u29d~t~'23)~(d~'r9m0s7~t~'wz)~(d~'ra72jq~t~'5v5u))))                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 5             | [5h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r9mi7y~t~'23qi)~(d~'r93vx0~t~'4r1)~(d~'r9nxmy~t~'3f7o)~(d~'r9xk35~t~'gcl)~(d~'ra8ujp~t~'7f))))                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 4             | [55m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r8y2iv~t~'25)~(d~'r97iz1~t~'4ha)~(d~'r9ma4z~t~'m5)~(d~'r95cd5~t~'1f5n))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 7              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 4             | [2h 27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r93ikc~t~'2tht)~(d~'r97iw8~t~'36p)~(d~'r97q3a~t~'adr)~(d~'r9w84b~t~'55)~(d~'r9w8pz~t~'qt)~(d~'ra6y5a~t~'ckd))))                                                                                                                                                                                                                                                                                                                                                                                                                                        | 3              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 4             | [2h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r9gqlv~t~'4h2)~(d~'r9gqzv~t~'4v2)~(d~'r9grbt~t~'570)~(d~'r9hfbs~t~'t6z)~(d~'r955hu~t~'1ebv)~(d~'r955lz~t~'1eg0)~(d~'r99kbu~t~'5tc)~(d~'r99nlh~t~'92z)~(d~'ra6ixc~t~'6wd)~(d~'ra6mxd~t~'awe))))                                                                                                                                                                                                                                                                                                                                                          | 10             |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 3             | [3d 8h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r9zu4m~t~'6688)~(d~'r9zu0t~t~'blzt)~(d~'r9ztx6~t~'68e2)~(d~'r9ztxm~t~'68ei))))                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 2              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 3             | [**15m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r9o3y3~t~'8w)~(d~'r9awir~t~'16mc)~(d~'r9x9ps~t~'pm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 0              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 2             | [23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r948zz~t~'xz)~(d~'r95y16~t~'187))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 2             | [9h 12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r8shpj~t~'1f1z)~(d~'r9x3to~t~'34))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 1             | [1h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'r8wg4n~t~'38q))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/meckila"><img src="https://avatars.githubusercontent.com/u/68879427?u=f820e48d2924ecd35b62030423c5a6377fc4e1f4&v=4" width="20"></a>            | meckila            | 1             | [3h 35m](https://app.flowwer.dev/charts/review-time/~(u~(i~'68879427~n~'meckila)~p~30~r~(~(d~'r93xqs~t~'9yd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 2              |