### PR TITLE
4995 - Generate a exposure notification message with a UUID for deduplication

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -3271,7 +3271,11 @@
         type: GAEN
       transport:
         type: GAEN
-        apiUrl: ""
+        uuidFormat: WA_NOTIFY
+        uuidIV: 1  # actual value provided by WA NOTIFY
+        apiUrl: "" # for no sending
+        # apiUrl: "https://adminapi.encv-test.org/api/issue" # for test
+        # apiUrl: "https://adminapi.encv.org/api/issue" # for prod
 
 - name: wv-phd
   description: West Virginia Public Health Department

--- a/prime-router/src/main/kotlin/TransportType.kt
+++ b/prime-router/src/main/kotlin/TransportType.kt
@@ -87,14 +87,31 @@ data class FTPSTransportType
         "host=$host, port=$port, username=$username, protocol=$protocol, binaryTransfer=$binaryTransfer"
 }
 
+/**
+ * The GAEN UUID Format instructs how the UUID field of the GAEN payload is built
+ */
+enum class GAENUUIDFormat {
+    PHONE_DATE, // Default if IV specified hmac_md5(phone+date, iv).toHex()
+    REPORT_ID, // Default if IV is not specified, use report stream's report id
+    WA_NOTIFY, // Use the format that WA_NOTIFY uses, must specify IV
+}
+
+/**
+ * The Google/Apple Exposure Notification transport sends a report to the Exposure Notification service
+ */
 data class GAENTransportType
 @JsonCreator constructor(
     /**
      * [apiUrl] is API URL to post to. Typically, something like https://adminapi.encv.org/api/issue.
+     * [uuidFormat] is format that is used for generating the UUID of the message.
+     * The UUID enables the GAEN system deduplicate notifications.
+     * [uuidIV] is the HMAC initialization vector (aka key) in hex
      */
     val apiUrl: String,
+    val uuidFormat: GAENUUIDFormat? = null,
+    val uuidIV: String? = null,
 ) : TransportType("GAEN") {
-    override fun toString(): String = "url=$apiUrl"
+    override fun toString(): String = "url=$apiUrl, uuidFormat=$uuidFormat, uuidIV=$uuidIV"
 }
 
 data class NullTransportType

--- a/prime-router/src/main/kotlin/transport/GAENTransport.kt
+++ b/prime-router/src/main/kotlin/transport/GAENTransport.kt
@@ -8,8 +8,10 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.Headers
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.result.Result
+import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.microsoft.azure.functions.ExecutionContext
 import gov.cdc.prime.router.GAENTransportType
+import gov.cdc.prime.router.GAENUUIDFormat
 import gov.cdc.prime.router.Receiver
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.ReportId
@@ -20,6 +22,8 @@ import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.credentials.CredentialHelper
 import gov.cdc.prime.router.credentials.CredentialRequestReason
 import gov.cdc.prime.router.credentials.UserApiKeyCredential
+import org.apache.commons.codec.digest.HmacAlgorithms
+import org.apache.commons.codec.digest.HmacUtils
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.logging.log4j.kotlin.Logging
 import java.io.ByteArrayInputStream
@@ -178,7 +182,12 @@ class GAENTransport : ITransport, Logging {
      * The structure is defined in
      * https://github.com/google/exposure-notifications-verification-server/blob/main/docs/api.md#apiissue
      */
-    internal class Notification(table: List<Map<String, String>>, reportId: ReportId /* = java.util.UUID */) {
+    internal class Notification(
+        table: List<Map<String, String>>,
+        reportId: ReportId, /* = java.util.UUID */
+        uuidFormat: GAENUUIDFormat?,
+        uuidIV: String?
+    ) {
         val symptomDate: String
         val testDate: String
         val testType: String = "confirmed"
@@ -194,7 +203,7 @@ class GAENTransport : ITransport, Logging {
             symptomDate = table[0][ "illness_onset_date"] ?: testDate
             phone = table[0]["patient_phone_number"] ?: ""
             padding = RandomStringUtils.randomAlphanumeric(16)
-            uuid = "$reportId"
+            uuid = formatUUID(uuidFormat, reportId, phone, testDate, uuidIV)
         }
     }
 
@@ -213,7 +222,9 @@ class GAENTransport : ITransport, Logging {
         val table = csvReader().readAllWithHeader(reportStream)
 
         // Send the notification
-        val notification = Notification(table, params.reportId)
+        val notification = Notification(
+            table, params.reportId, params.gaenTransportInfo.uuidFormat, params.gaenTransportInfo.uuidIV
+        )
         val payload = mapper.writeValueAsString(notification)
         val (_, response, result) = Fuel
             .post(params.gaenTransportInfo.apiUrl)
@@ -262,6 +273,38 @@ class GAENTransport : ITransport, Logging {
     companion object {
         const val API_KEY = "x-api-key"
         const val GAEN_TIMEOUT = 1000
+
+        /**
+         * Format the UUID of the GAEN message. The UUID is used for notification deduplication
+         *
+         * [uuidFormat] is the format to follow. If non specified, use [GAENUUIDFormat.REPORT_ID]
+         * [reportId] is how to the report stream id
+         * [phone] is the phone number sent to the GAEN server
+         * [testDate] is the test date sent to the GAEN server
+         * [uuidIV] is initialization vector for the HMAC (aka key)
+         */
+        fun formatUUID(
+            uuidFormat: GAENUUIDFormat?,
+            reportId: ReportId,
+            phone: String,
+            testDate: String,
+            uuidIV: String?
+        ): String {
+            if (uuidFormat == null || uuidIV == null) return "$reportId"
+            val hmacGenerator = HmacUtils(HmacAlgorithms.HMAC_MD5, uuidIV)
+            return when (uuidFormat) {
+                GAENUUIDFormat.PHONE_DATE -> {
+                    hmacGenerator.hmacHex("$phone$testDate")
+                }
+                GAENUUIDFormat.REPORT_ID -> {
+                    "$reportId"
+                }
+                GAENUUIDFormat.WA_NOTIFY -> {
+                    val phoneNumber = PhoneNumberUtil.getInstance().parse(phone, "US")
+                    hmacGenerator.hmacHex("${phoneNumber.nationalNumber}$testDate")
+                }
+            }
+        }
 
         private val mapper = ObjectMapper().registerModule(
             KotlinModule.Builder()

--- a/prime-router/src/main/kotlin/transport/GAENTransport.kt
+++ b/prime-router/src/main/kotlin/transport/GAENTransport.kt
@@ -300,6 +300,7 @@ class GAENTransport : ITransport, Logging {
                     "$reportId"
                 }
                 GAENUUIDFormat.WA_NOTIFY -> {
+                    // WA Notify doesn't want the country code in the UUID calculation
                     val phoneNumber = PhoneNumberUtil.getInstance().parse(phone, "US")
                     hmacGenerator.hmacHex("${phoneNumber.nationalNumber}$testDate")
                 }

--- a/prime-router/src/test/kotlin/transport/GAENTransportTests.kt
+++ b/prime-router/src/test/kotlin/transport/GAENTransportTests.kt
@@ -1,0 +1,58 @@
+package gov.cdc.prime.router.transport
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import gov.cdc.prime.router.GAENUUIDFormat
+import java.util.UUID
+import kotlin.test.Test
+
+class GAENTransportTests {
+
+    @Test
+    fun `test formatUUID`() {
+        val reportId = UUID.randomUUID()
+        // Test example sent by WA
+        assertThat(
+            GAENTransport.formatUUID(
+                GAENUUIDFormat.WA_NOTIFY,
+                reportId = reportId,
+                phone = "15555555555",
+                testDate = "2022-03-31",
+                uuidIV = "1"
+            )
+        ).isEqualTo("26e0844004867d563359edcc2f4f8d62")
+
+        // Using default
+        assertThat(
+            GAENTransport.formatUUID(
+                GAENUUIDFormat.PHONE_DATE,
+                reportId = reportId,
+                phone = "15555555555",
+                testDate = "2022-03-31",
+                uuidIV = "1"
+            )
+        ).isEqualTo("86454c037eeed17a8a542371fdc1683e")
+
+        // Using report-id
+        assertThat(
+            GAENTransport.formatUUID(
+                GAENUUIDFormat.REPORT_ID,
+                reportId = reportId,
+                phone = "15555555555",
+                testDate = "2022-03-31",
+                uuidIV = "1"
+            )
+        ).isEqualTo(reportId.toString())
+
+        // No key test case
+        assertThat(
+            GAENTransport.formatUUID(
+                GAENUUIDFormat.PHONE_DATE,
+                reportId = reportId,
+                phone = "15555555555",
+                testDate = "2022-03-31",
+                uuidIV = null
+            )
+        ).isEqualTo(reportId.toString())
+    }
+}


### PR DESCRIPTION
This PR adds more options to generate UUID of an exposure notification message. This PR allows the UUID of the message to be either `PHONE_DATE`, `WA_NOTIFY`, or `REPORT_ID` formatted. The `PHONE_DATE` is the recommended way to generate UUIDs. `WA_NOTIFY` is a WA variant of the formatting. `REPORT_ID` is the previous implementation. 

The UUID of a message is used to deduplicate notification. WA Notify requested this feature because they were sending manual notifications in addition to the  

Test Steps:
This feature is hard to test locally, since it requires coordination with the WA Notify team. In coordination with the WA Notify team this was how the feature was tested. 

1. In the Keybase, there are instructions on how to setup WA test messages
2. Send a test message to the test cluster
3. Confirm by email with the WA Notify engineer that the message was sent correctly

## Changes
- Added options to the GAEN transport
- Expanded the setting GAEN transports

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #4495

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
