### PR TITLE
add valueOfOrNone function to Options to handle invalid incoming options

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -55,7 +55,21 @@ enum class Options {
     ValidatePayload,
     CheckConnections,
     SkipSend,
-    SendImmediately,
+    SendImmediately;
+
+    companion object {
+        /**
+         * Handles invalid values, which are technically not allowed in an enum. In this case if the [input]
+         *  is not one that is supported, it will be set to None
+         */
+        fun valueOfOrNone(input: String): Options {
+            return try {
+                valueOf(input)
+            } catch (ex: IllegalArgumentException) {
+                None
+            }
+        }
+    }
 }
 
 /**

--- a/prime-router/src/main/kotlin/azure/Event.kt
+++ b/prime-router/src/main/kotlin/azure/Event.kt
@@ -107,7 +107,7 @@ abstract class Event(val eventAction: EventAction, val at: OffsetDateTime?) {
                     //  or a blank string
                     val after = if (parts[6].isNotEmpty()) OffsetDateTime.parse(parts[6]) else null
                     val reportId = UUID.fromString(parts[2])
-                    val options = Options.valueOf(parts[3])
+                    val options = Options.valueOfOrNone(parts[3])
 
                     // convert incoming serialized routeTo string into List<String>
                     val routeTo = if (parts[5].isNotEmpty())

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -165,7 +165,7 @@ class ReportFunction(
         val optionsText = request.queryParameters.getOrDefault(OPTION_PARAMETER, "None")
         val httpStatus: HttpStatus =
             try {
-                val options = Options.valueOf(optionsText)
+                val options = Options.valueOfOrNone(optionsText)
                 val payloadName = extractPayloadName(request)
                 // track the sending organization and client based on the header
                 actionHistory.trackActionSenderInfo(sender.fullName, payloadName)

--- a/prime-router/src/test/kotlin/azure/EventTest.kt
+++ b/prime-router/src/test/kotlin/azure/EventTest.kt
@@ -2,6 +2,7 @@ package gov.cdc.prime.router.azure
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import gov.cdc.prime.router.Options
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.Test
@@ -69,5 +70,23 @@ class EventTest {
         val message = event.toQueueMessage()
         val returnEvent = Event.parseQueueMessage(message)
         assertThat(returnEvent).isEqualTo(event)
+    }
+
+    @Test
+    fun `test valid options param sent`() {
+        val result = Options.valueOfOrNone("CheckConnections")
+        assertThat(result).isEqualTo(Options.CheckConnections)
+    }
+
+    @Test
+    fun `test incorrect capitalization options param sent`() {
+        val result = Options.valueOfOrNone("CHECKCONNECTIONS")
+        assertThat(result).isEqualTo(Options.None)
+    }
+
+    @Test
+    fun `test entirely invalid options param sent`() {
+        val result = Options.valueOfOrNone("NoGood")
+        assertThat(result).isEqualTo(Options.None)
     }
 }


### PR DESCRIPTION
This PR makes it so that when an invalid option (anything we don't support) is passed to the /reports endpoint or is included in an event message for process (which can happen when an invalid option is passed to /reports or when we are updating code), it will simply ignore the invalid option and progress without erroring out.

Test Steps:
1. POST to /reports with an invalid options

## Changes
- add companion object to enum Options with function getValueOrNone
- update all locations Options.valueOf was used to instead use the new function
- add unit tests

## Checklist

### Testing
- [X] Tested locally?
- [x] Added tests?



## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | **16**        | [3h 21m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r8wcvo~t~'1awl)~(d~'r9m53e~t~'8w)~(d~'r9gvny~t~'198)~(d~'r9ixde~t~'afk)~(d~'r9b2d0~t~'g4)~(d~'r9gu7h~t~'hi)~(d~'r9gk4y~t~'7w)~(d~'r9b21v~t~'1db3)~(d~'r9gjpv~t~'is)~(d~'r9kf0r~t~'jb)~(d~'r9kf1p~t~'k9)~(d~'r9vm6f~t~'9aw)~(d~'r99ebu~t~'7v)~(d~'r95i3g~t~'16rr)~(d~'ra6idn~t~'6co)~(d~'r95g1t~t~'cg)~(d~'r95h0u~t~'1bh)~(d~'r9z6rv~t~'1pu2)~(d~'r9z6vv~t~'1py2)~(d~'r9z6w2~t~'1py9)~(d~'r9z6wv~t~'1pz2)~(d~'raa89o~t~'kx7)~(d~'raa8aj~t~'ky2)~(d~'raa8bc~t~'kyv)~(d~'rac71y~t~'1aex))))                                        | 46             |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 15            | [1h](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r95n1v~t~'7kug)~(d~'r95qbj~t~'2ow)~(d~'r95tlx~t~'n8)~(d~'r95w3z~t~'ks)~(d~'r95xi0~t~'he)~(d~'r93hak~t~'3b3s)~(d~'r95mx9~t~'1en5)~(d~'r9hcra~t~'6dmh)~(d~'r97riy~t~'2tj)~(d~'r97ktb~t~'53s)~(d~'r97sdu~t~'jk)~(d~'r9vnwl~t~'1j34)~(d~'r9hdfw~t~'6ul)~(d~'r9kc7j~t~'fk)~(d~'r9kawr~t~'u1)~(d~'r9kbrq~t~'8y)~(d~'r9kbrq~t~'8y)~(d~'r95mzq~t~'7ad)~(d~'r9ka1y~t~'1csu)~(d~'r9kbi0~t~'ju))))                                                                                                                                       | 8              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 13            | [5h 1m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r9m0um~t~'ze)~(d~'r9j4qb~t~'1ryt)~(d~'r9b5n0~t~'m5)~(d~'r9auxq~t~'38ge)~(d~'r9axvc~t~'18x4)~(d~'r9tmdx~t~'ki)~(d~'r9u7xq~t~'349)~(d~'r9zg7u~t~'6ys)~(d~'ra73ie~t~'2i)~(d~'r9kyj2~t~'ak)~(d~'ra6jjd~t~'dpdp)~(d~'ra972u~t~'kxl)~(d~'r9b0ei~t~'1p7u)~(d~'r9z6xv~t~'1q02))))                                                                                                                                                                                                                                                        | 16             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 13            | [1h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r901l2~t~'17hx)~(d~'r9kj14~t~'1j)~(d~'r9im5i~t~'73s)~(d~'r9mf04~t~'hg)~(d~'r9u6zc~t~'25v)~(d~'r96mjp~t~'ofy)~(d~'r97g2i~t~'20o)~(d~'r97qx8~t~'88g)~(d~'r97r2d~t~'8dl)~(d~'r97r5q~t~'d3w)~(d~'r97r8z~t~'8k7)~(d~'r97rf3~t~'8qb)~(d~'r97rsp~t~'ee)~(d~'r99brm~t~'3dnv)~(d~'r99hys~t~'qr)~(d~'r99ist~t~'1ks)~(d~'r9oaln~t~'ea)~(d~'r9topv~t~'5gov)~(d~'r9xl0t~t~'cu)~(d~'ra13ls~t~'1487)~(d~'r9xl0t~t~'cu)~(d~'ra13ls~t~'1487)~(d~'raa9u4~t~'1nov)~(d~'raahal~t~'1gp)~(d~'raaq0n~t~'2j8)~(d~'raabmo~t~'uz))))                          | **49**         |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 11            | [30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r95vp5~t~'1dy)~(d~'r8yy8m~t~'45h)~(d~'r9kd1y~t~'8m)~(d~'r9koic~t~'9l)~(d~'r9kbe1~t~'1a03)~(d~'r9kkve~t~'68)~(d~'r9nxqg~t~'3t8)~(d~'r99joj~t~'561)~(d~'r97nx1~t~'eh)~(d~'r97om7~t~'13n)~(d~'r9bo8f~t~'6x5)~(d~'r9gwwx~t~'8vy)~(d~'r9keso~t~'e4)~(d~'r9xlkk~t~'98q)~(d~'raagdk~t~'jo))))                                                                                                                                                                                                                                                | 5              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 11            | [1h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r8udja~t~'1bc8)~(d~'r9490i~t~'66t3)~(d~'r95q4n~t~'2i0)~(d~'r93ugs~t~'3ad)~(d~'r9baxp~t~'397)~(d~'r9ii0a~t~'566)~(d~'r9vgm1~t~'1fdt)~(d~'r9x7zx~t~'2y2)~(d~'r9x8ly~t~'ek)~(d~'ra6ime~t~'3wj)~(d~'ra70q3~t~'5d7)~(d~'ra8z0p~t~'9tn)~(d~'rachnn~t~'dud))))                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 11            | [2h 29m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r9ky9r~t~'18n)~(d~'r9h54v~t~'13r)~(d~'r9h6gx~t~'cc)~(d~'r9h5p3~t~'b8)~(d~'r97rwo~t~'1t65)~(d~'r97isi~t~'39mh)~(d~'r97zdd~t~'x)~(d~'r99o15~t~'9)~(d~'ra1gz6~t~'cid)~(d~'r9z887~t~'1qu3)~(d~'r9zdpc~t~'1wb8)~(d~'ra1abh~t~'1v25)~(d~'raal21~t~'ft)~(d~'ra8ys5~t~'l6b))))                                                                                                                                                                                                                                                       | 4              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 10            | [6d 5h 16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r9k6c0~t~'eb)~(d~'r97fsz~t~'3hfi)~(d~'r9mh3t~t~'b11n)~(d~'r95iby~t~'88)~(d~'ra70hi~t~'741)~(d~'ra6tov~t~'bimi)~(d~'ra6tpb~t~'bimy)~(d~'ra6v16~t~'bjyt)~(d~'ra6v1t~t~'bjzg)~(d~'ra6v2d~t~'bk00)~(d~'ra6v2l~t~'bk08)~(d~'ra6v45~t~'bk1s)~(d~'ra6yq8~t~'320)~(d~'ra6z5f~t~'d2x)~(d~'ra6z5f~t~'d2x)~(d~'ra6tov~t~'bimi)~(d~'ra6tpb~t~'bimy)~(d~'ra6v16~t~'bjyt)~(d~'ra6v1t~t~'bjzg)~(d~'ra6v2d~t~'bk00)~(d~'ra6v2l~t~'bk08)~(d~'ra6v45~t~'bk1s)~(d~'ra6yq8~t~'320)~(d~'ra8a59~t~'12rc)~(d~'ra70hi~t~'741)~(d~'raan3g~t~'eyl)))) | 12             |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 9             | [1h 54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r93tb2~t~'5am)~(d~'r9ivvt~t~'9yb)~(d~'r9it4j~t~'1n1t)~(d~'r9bb6i~t~'vm)~(d~'r97nq7~t~'80o)~(d~'r93wz3~t~'5t4)~(d~'r9idz6~t~'1iqr)~(d~'r9trbr~t~'93)~(d~'ra19cq~t~'4vx)~(d~'ra8ezi~t~'5t)~(d~'ra8ezi~t~'5t))))                                                                                                                                                                                                                                                                                                                     | 3              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 8             | [2h](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r8y2e7~t~'69u)~(d~'r8y7zm~t~'do)~(d~'r93yvl~t~'90dn)~(d~'r97q57~t~'1fs)~(d~'r97t2j~t~'9o)~(d~'r9tm8t~t~'fe)~(d~'r9o4jb~t~'u4)~(d~'r9tuwj~t~'2bhz)~(d~'r9zc85~t~'5ks)~(d~'ra6ucy~t~'2d79)~(d~'ra8kjj~t~'1fge))))                                                                                                                                                                                                                                                                                                               | 4              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 7             | [48m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r95xi3~t~'36w)~(d~'r8ywb5~t~'280)~(d~'r9khdw~t~'3x)~(d~'r99ho8~t~'g7)~(d~'r95khd~t~'u7z)~(d~'r9oas9~t~'kw)~(d~'ra1ljm~t~'29x))))                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 7             | [54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r8ye9a~t~'a1)~(d~'r8wrgf~t~'8i6)~(d~'r8ycul~t~'2hk)~(d~'r8ww37~t~'c2f)~(d~'r9khhg~t~'7h)~(d~'r9mlwq~t~'856)~(d~'r97ntx~t~'bd)~(d~'r97nu8~t~'bo)~(d~'r9vuo0~t~'1ocl))))                                                                                                                                                                                                                                                                                                                                                           | 2              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 4             | [29m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r8wfs2~t~'2w5)~(d~'r93yow~t~'14c)~(d~'ra8uvl~t~'jb)~(d~'ra8rfj~t~'1k6))))                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r8xwi0~t~'dn)~(d~'r9m0s7~t~'wz)~(d~'r9u29d~t~'23)~(d~'ra72jq~t~'5v5u))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 4             | [2h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r955hu~t~'1ebv)~(d~'r955lz~t~'1eg0)~(d~'r99kbu~t~'5tc)~(d~'r99nlh~t~'92z)~(d~'r9gqlv~t~'4h2)~(d~'r9gqzv~t~'4v2)~(d~'r9grbt~t~'570)~(d~'r9hfbs~t~'t6z)~(d~'ra6ixc~t~'6wd)~(d~'ra6mxd~t~'awe))))                                                                                                                                                                                                                                                                                                                                         | 10             |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 3             | [**13m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r8y2iv~t~'25)~(d~'r9ma4z~t~'m5)~(d~'r95cd5~t~'1f5n))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 4              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 3             | [1h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r97iw8~t~'36p)~(d~'r97q3a~t~'adr)~(d~'r93ikc~t~'2tht)~(d~'r9w84b~t~'55)~(d~'r9w8pz~t~'qt))))                                                                                                                                                                                                                                                                                                                                                                                                                                           | 3              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 3             | [3d 8h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r9zu0t~t~'blzt)~(d~'r9zu4m~t~'6688)~(d~'r9ztx6~t~'68e2)~(d~'r9ztxm~t~'68ei))))                                                                                                                                                                                                                                                                                                                                                                                                                                              | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 3             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r95y16~t~'187)~(d~'r948zz~t~'xz)~(d~'raan3s~t~'3vsm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 3             | [15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r9awir~t~'16mc)~(d~'r9o3y3~t~'8w)~(d~'r9x9ps~t~'pm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 3             | [1h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r93vx0~t~'4r1)~(d~'r9mi7y~t~'23qi)~(d~'ra8ujp~t~'7f))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 1             | [1h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'r8wg4n~t~'38q))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/meckila"><img src="https://avatars.githubusercontent.com/u/68879427?u=f820e48d2924ecd35b62030423c5a6377fc4e1f4&v=4" width="20"></a>            | meckila            | 1             | [3h 35m](https://app.flowwer.dev/charts/review-time/~(u~(i~'68879427~n~'meckila)~p~30~r~(~(d~'r93xqs~t~'9yd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 2              |