### PR TITLE
Experience/4325: guard against simultaneous setting edits

### DIFF
--- a/frontend-react/src/components/Admin/CompareJsonModal.tsx
+++ b/frontend-react/src/components/Admin/CompareJsonModal.tsx
@@ -53,6 +53,7 @@ export interface ConfirmSaveSettingModalRef extends ModalRef {
     setWarning: (warning: string) => void;
     showModal: () => void;
     hideModal: () => void;
+    disableSave: () => void;
 }
 
 interface CompareSettingsModalProps {
@@ -70,6 +71,7 @@ export const ConfirmSaveSettingModal = forwardRef(
         const modalRef = useRef<ModalRef>(null);
         const diffEditorRef = useRef<EditableCompareRef>(null);
         const [errorText, setErrorText] = useState("");
+        const [saveDisabled, setSaveDisabled] = useState(false);
         const scopedConfirm = () => {
             onConfirm();
         };
@@ -94,6 +96,9 @@ export const ConfirmSaveSettingModal = forwardRef(
                 },
                 hideModal: () => {
                     modalRef?.current?.toggleModal(undefined, false);
+                },
+                disableSave: () => {
+                    setSaveDisabled(true);
                 },
                 // route these down to modal ref
                 modalId: modalRef?.current?.modalId || "",
@@ -145,6 +150,7 @@ export const ConfirmSaveSettingModal = forwardRef(
                             <ModalConfirmSaveButton
                                 uniquid={uniquid}
                                 handleClose={scopedConfirm}
+                                disabled={saveDisabled}
                             >
                                 Save
                             </ModalConfirmSaveButton>

--- a/frontend-react/src/components/Admin/CompareJsonModal.tsx
+++ b/frontend-react/src/components/Admin/CompareJsonModal.tsx
@@ -7,7 +7,13 @@ import {
     ModalRef,
     ModalToggleButton,
 } from "@trussworks/react-uswds";
-import React, { forwardRef, Ref, useImperativeHandle, useRef } from "react";
+import React, {
+    forwardRef,
+    Ref,
+    useImperativeHandle,
+    useRef,
+    useState,
+} from "react";
 import { ButtonProps } from "@trussworks/react-uswds/lib/components/Button/Button";
 
 import { EditableCompare, EditableCompareRef } from "../EditableCompare";
@@ -43,6 +49,8 @@ ModalConfirmSaveButton.displayName = "ModalConfirmSaveButton";
 // interface on Component that is callable
 export interface ConfirmSaveSettingModalRef extends ModalRef {
     getEditedText: () => string;
+    getOriginalText: () => string;
+    setWarning: (warning: string) => void;
     showModal: () => void;
     hideModal: () => void;
 }
@@ -61,7 +69,7 @@ export const ConfirmSaveSettingModal = forwardRef(
     ) => {
         const modalRef = useRef<ModalRef>(null);
         const diffEditorRef = useRef<EditableCompareRef>(null);
-
+        const [errorText, setErrorText] = useState("");
         const scopedConfirm = () => {
             onConfirm();
         };
@@ -73,9 +81,15 @@ export const ConfirmSaveSettingModal = forwardRef(
                 getEditedText: (): string => {
                     return diffEditorRef?.current?.getEditedText() || newjson;
                 },
+                getOriginalText: (): string => {
+                    return diffEditorRef?.current?.getOriginalText() || newjson;
+                },
+                setWarning(warning) {
+                    setErrorText(warning);
+                },
                 showModal: () => {
                     // need to refresh data passed into object
-                    diffEditorRef?.current?.refeshEditedText(newjson);
+                    diffEditorRef?.current?.refreshEditedText(newjson);
                     modalRef?.current?.toggleModal(undefined, true);
                 },
                 hideModal: () => {
@@ -105,6 +119,12 @@ export const ConfirmSaveSettingModal = forwardRef(
                     <div className="usa-prose">
                         <p id={`${uniquid}-description`}>
                             You are about to change this setting: {uniquid}
+                        </p>
+                        <p
+                            id={`${uniquid}-error`}
+                            className="usa-error-message"
+                        >
+                            {errorText}
                         </p>
                         <EditableCompare
                             ref={diffEditorRef}

--- a/frontend-react/src/components/Admin/EditReceiverSettings.tsx
+++ b/frontend-react/src/components/Admin/EditReceiverSettings.tsx
@@ -12,7 +12,11 @@ import {
 } from "../../contexts/SessionStorageTools";
 import { jsonSortReplacer } from "../../utils/JsonSortReplacer";
 import Spinner from "../Spinner";
-import { getErrorDetailFromResponse } from "../../utils/misc";
+import {
+    getErrorDetailFromResponse,
+    getVersionWarning,
+    VersionWarningType,
+} from "../../utils/misc";
 
 import {
     ConfirmSaveSettingModal,
@@ -52,11 +56,6 @@ export function EditReceiverSettings({ match }: RouteComponentProps<Props>) {
             useState("");
         const { invalidate } = useController();
 
-        const newerVersionPopupMessage = `WARNING!!! A newer version of this setting now exists in the database'`;
-        const newerVersionModalMessage = `WARNING!!! A change has been made to the setting you're trying to update by 
-                    '${orgReceiverSettings?.meta?.createdBy}'. Please coordinate with that user and return to update the setting 
-                    again, if needed`;
-
         async function getLatestReceiverResponse() {
             const accessToken = getStoredOktaToken();
             const organization = getStoredOrg();
@@ -90,9 +89,12 @@ export function EditReceiverSettings({ match }: RouteComponentProps<Props>) {
                     latestResponse?.meta?.version !==
                     orgReceiverSettings?.meta?.version
                 ) {
-                    showError(newerVersionPopupMessage);
+                    showError(getVersionWarning(VersionWarningType.POPUP));
                     confirmModalRef?.current?.setWarning(
-                        newerVersionModalMessage
+                        getVersionWarning(
+                            VersionWarningType.FULL,
+                            orgReceiverSettings
+                        )
                     );
                 }
 
@@ -131,9 +133,12 @@ export function EditReceiverSettings({ match }: RouteComponentProps<Props>) {
                     setOrgReceiverSettingsOldJson(
                         JSON.stringify(latestResponse, jsonSortReplacer, 2)
                     );
-                    showError(newerVersionPopupMessage);
+                    showError(getVersionWarning(VersionWarningType.POPUP));
                     confirmModalRef?.current?.setWarning(
-                        newerVersionModalMessage
+                        getVersionWarning(
+                            VersionWarningType.FULL,
+                            orgReceiverSettings
+                        )
                     );
                     return false;
                 }

--- a/frontend-react/src/components/Admin/EditReceiverSettings.tsx
+++ b/frontend-react/src/components/Admin/EditReceiverSettings.tsx
@@ -93,9 +93,10 @@ export function EditReceiverSettings({ match }: RouteComponentProps<Props>) {
                     confirmModalRef?.current?.setWarning(
                         getVersionWarning(
                             VersionWarningType.FULL,
-                            orgReceiverSettings
+                            latestResponse
                         )
                     );
+                    confirmModalRef?.current?.disableSave();
                 }
 
                 confirmModalRef?.current?.showModal();
@@ -137,9 +138,10 @@ export function EditReceiverSettings({ match }: RouteComponentProps<Props>) {
                     confirmModalRef?.current?.setWarning(
                         getVersionWarning(
                             VersionWarningType.FULL,
-                            orgReceiverSettings
+                            latestResponse
                         )
                     );
+                    confirmModalRef?.current?.disableSave();
                     return false;
                 }
 

--- a/frontend-react/src/components/Admin/EditSenderSettings.tsx
+++ b/frontend-react/src/components/Admin/EditSenderSettings.tsx
@@ -85,9 +85,10 @@ export function EditSenderSettings({ match }: RouteComponentProps<Props>) {
                     confirmModalRef?.current?.setWarning(
                         getVersionWarning(
                             VersionWarningType.FULL,
-                            orgSenderSettings
+                            latestResponse
                         )
                     );
+                    confirmModalRef?.current?.disableSave();
                 }
 
                 confirmModalRef?.current?.showModal();
@@ -128,9 +129,10 @@ export function EditSenderSettings({ match }: RouteComponentProps<Props>) {
                     confirmModalRef?.current?.setWarning(
                         getVersionWarning(
                             VersionWarningType.FULL,
-                            orgSenderSettings
+                            latestResponse
                         )
                     );
+                    confirmModalRef?.current?.disableSave();
                     return false;
                 }
 

--- a/frontend-react/src/components/Admin/EditSenderSettings.tsx
+++ b/frontend-react/src/components/Admin/EditSenderSettings.tsx
@@ -12,7 +12,11 @@ import {
 } from "../../contexts/SessionStorageTools";
 import { jsonSortReplacer } from "../../utils/JsonSortReplacer";
 import Spinner from "../Spinner";
-import { getErrorDetailFromResponse } from "../../utils/misc";
+import {
+    getErrorDetailFromResponse,
+    getVersionWarning,
+    VersionWarningType,
+} from "../../utils/misc";
 
 import { TextAreaComponent, TextInputComponent } from "./AdminFormEdit";
 import {
@@ -43,11 +47,6 @@ export function EditSenderSettings({ match }: RouteComponentProps<Props>) {
         const { fetch: fetchController } = useController();
         const { invalidate } = useController();
         const [loading, setLoading] = useState(false);
-
-        const newerVersionPopupMessage = `WARNING!!! A newer version of this setting now exists in the database'`;
-        const newerVersionModalMessage = `WARNING!!! A change has been made to the setting you're trying to update by 
-                    '${orgSenderSettings?.meta?.createdBy}'. Please coordinate with that user and return to update the setting 
-                    again, if needed`;
 
         async function getLatestSenderResponse() {
             const accessToken = getStoredOktaToken();
@@ -82,9 +81,12 @@ export function EditSenderSettings({ match }: RouteComponentProps<Props>) {
                     latestResponse?.meta?.version !==
                     orgSenderSettings?.meta?.version
                 ) {
-                    showError(newerVersionPopupMessage);
+                    showError(getVersionWarning(VersionWarningType.POPUP));
                     confirmModalRef?.current?.setWarning(
-                        newerVersionModalMessage
+                        getVersionWarning(
+                            VersionWarningType.FULL,
+                            orgSenderSettings
+                        )
                     );
                 }
 
@@ -122,9 +124,12 @@ export function EditSenderSettings({ match }: RouteComponentProps<Props>) {
                     setOrgSenderSettingsOldJson(
                         JSON.stringify(latestResponse, jsonSortReplacer, 2)
                     );
-                    showError(newerVersionPopupMessage);
+                    showError(getVersionWarning(VersionWarningType.POPUP));
                     confirmModalRef?.current?.setWarning(
-                        newerVersionModalMessage
+                        getVersionWarning(
+                            VersionWarningType.FULL,
+                            orgSenderSettings
+                        )
                     );
                     return false;
                 }

--- a/frontend-react/src/components/EditableCompare.tsx
+++ b/frontend-react/src/components/EditableCompare.tsx
@@ -16,7 +16,8 @@ import { checkTextAreaJson, splitOn } from "../utils/misc";
 // interface on Component that is callable
 export type EditableCompareRef = {
     getEditedText: () => string;
-    refeshEditedText: (updatedjson: string) => void;
+    getOriginalText: () => string;
+    refreshEditedText: (updatedjson: string) => void;
 };
 
 interface EditableCompareProps {
@@ -62,8 +63,11 @@ export const EditableCompare = forwardRef(
                 getEditedText() {
                     return textAreaContent;
                 },
+                getOriginalText() {
+                    return props.original;
+                },
                 // when showing/hiding json, force am update of the content
-                refeshEditedText(updatedjson) {
+                refreshEditedText(updatedjson) {
                     setTextAreaContent(updatedjson);
                     onChangeHandler(updatedjson);
                 },

--- a/frontend-react/src/hooks/UseOrgName.ts
+++ b/frontend-react/src/hooks/UseOrgName.ts
@@ -6,7 +6,7 @@ import { groupToOrg } from "../utils/OrganizationUtils";
 
 function useOrgName(): string {
     const org = useResource(OrganizationResource.detail(), {
-        name: groupToOrg(getStoredOrg()),
+        orgname: groupToOrg(getStoredOrg()),
     });
 
     return org?.description || "";

--- a/frontend-react/src/pages/admin/AdminOrgEdit.tsx
+++ b/frontend-react/src/pages/admin/AdminOrgEdit.tsx
@@ -28,7 +28,11 @@ import {
     ConfirmSaveSettingModalRef,
 } from "../../components/Admin/CompareJsonModal";
 import { DisplayMeta } from "../../components/Admin/DisplayMeta";
-import { getErrorDetailFromResponse } from "../../utils/misc";
+import {
+    getErrorDetailFromResponse,
+    getVersionWarning,
+    VersionWarningType,
+} from "../../utils/misc";
 
 type AdminOrgEditProps = {
     orgname: string;
@@ -48,11 +52,6 @@ export function AdminOrgEdit({
     const [orgSettingsNewJson, setOrgSettingsNewJson] = useState("");
     const { fetch: fetchController } = useController();
     const [loading, setLoading] = useState(false);
-
-    const newerVersionPopupMessage = `WARNING!!! A newer version of this setting now exists in the database'`;
-    const newerVersionModalMessage = `WARNING!!! A change has been made to the setting you're trying to update by 
-                    '${orgSettings?.meta?.createdBy}'. Please coordinate with that user and return to update the setting 
-                    again, if needed`;
 
     async function getLatestOrgResponse() {
         const accessToken = getStoredOktaToken();
@@ -84,8 +83,10 @@ export function AdminOrgEdit({
             );
 
             if (latestResponse?.meta?.version !== orgSettings?.meta?.version) {
-                showError(newerVersionPopupMessage);
-                confirmModalRef?.current?.setWarning(newerVersionModalMessage);
+                showError(getVersionWarning(VersionWarningType.POPUP));
+                confirmModalRef?.current?.setWarning(
+                    getVersionWarning(VersionWarningType.FULL, orgSettings)
+                );
             }
 
             confirmModalRef?.current?.showModal();
@@ -107,8 +108,8 @@ export function AdminOrgEdit({
                 setOrgSettingsOldJson(
                     JSON.stringify(latestResponse, jsonSortReplacer, 2)
                 );
-                showError(newerVersionPopupMessage);
-                confirmModalRef?.current?.setWarning(newerVersionModalMessage);
+                showError(getVersionWarning(VersionWarningType.POPUP));
+                getVersionWarning(VersionWarningType.FULL, orgSettings);
                 return false;
             }
 

--- a/frontend-react/src/pages/admin/AdminOrgEdit.tsx
+++ b/frontend-react/src/pages/admin/AdminOrgEdit.tsx
@@ -85,8 +85,9 @@ export function AdminOrgEdit({
             if (latestResponse?.meta?.version !== orgSettings?.meta?.version) {
                 showError(getVersionWarning(VersionWarningType.POPUP));
                 confirmModalRef?.current?.setWarning(
-                    getVersionWarning(VersionWarningType.FULL, orgSettings)
+                    getVersionWarning(VersionWarningType.FULL, latestResponse)
                 );
+                confirmModalRef?.current?.disableSave();
             }
 
             confirmModalRef?.current?.showModal();
@@ -109,7 +110,10 @@ export function AdminOrgEdit({
                     JSON.stringify(latestResponse, jsonSortReplacer, 2)
                 );
                 showError(getVersionWarning(VersionWarningType.POPUP));
-                getVersionWarning(VersionWarningType.FULL, orgSettings);
+                confirmModalRef?.current?.setWarning(
+                    getVersionWarning(VersionWarningType.FULL, latestResponse)
+                );
+                confirmModalRef?.current?.disableSave();
                 return false;
             }
 

--- a/frontend-react/src/styles/_reportstream.scss
+++ b/frontend-react/src/styles/_reportstream.scss
@@ -286,7 +286,7 @@ h3 img[src*="svg"] {
 
 .rs-compare-modal {
     max-width: calc(var(--rs-compare-modal-width));
-    height: var(--rs-compare-modal-height);
+    height: var(--rs-compare-modal-height + 12em);
     .usa-modal__main {
         width:100%;
         max-width:90em;

--- a/frontend-react/src/utils/misc.test.ts
+++ b/frontend-react/src/utils/misc.test.ts
@@ -1,4 +1,11 @@
-import { splitOn, getErrorDetailFromResponse } from "./misc";
+import OrgSettingsBaseResource from "../resources/OrgSettingsBaseResource";
+
+import {
+    getErrorDetailFromResponse,
+    getVersionWarning,
+    splitOn,
+    VersionWarningType,
+} from "./misc";
 import { mockEvent } from "./TestUtils";
 
 test("splitOn test", () => {
@@ -27,4 +34,23 @@ const mockErrorEvent = mockEvent({
 test("getErrorDetailFromResponse test", async () => {
     const error = await getErrorDetailFromResponse(mockErrorEvent);
     expect(error).toBe("fail fail fail");
+});
+
+const objResource: OrgSettingsBaseResource = {
+    name: "test setting",
+    url: "http://localhost",
+    pk: () => "10101",
+    meta: {
+        version: 5,
+        createdBy: "test@example.com",
+        createdAt: "1/1/2000 00:00",
+    },
+};
+
+test("getVersionWarning test", async () => {
+    const fullWarning = getVersionWarning(VersionWarningType.FULL, objResource);
+    expect(fullWarning).toContain(objResource.meta?.createdBy);
+
+    const popupWarning = getVersionWarning(VersionWarningType.POPUP);
+    expect(popupWarning).toContain("WARNING!");
 });

--- a/frontend-react/src/utils/misc.ts
+++ b/frontend-react/src/utils/misc.ts
@@ -66,3 +66,29 @@ export async function getErrorDetailFromResponse(e: any) {
         ? errorResponse.error
         : e.toString();
 }
+
+export enum VersionWarningType {
+    POPUP = "popup",
+    FULL = "full",
+}
+
+/**
+ * returns a customized message in the case of trying to edit the wrong version of a setting
+ * @param warningType either POPUP (for the toast notification) or FULL (for the red text on the compare modal itself)
+ * @param settings the resource object from which to use information helpful to the user
+ */
+export function getVersionWarning(
+    warningType: VersionWarningType,
+    settings: any = null
+): string {
+    switch (warningType) {
+        case VersionWarningType.POPUP:
+            return `WARNING! A newer version of this setting now exists in the database'`;
+        case VersionWarningType.FULL:
+            return `WARNING! A change has been made to the setting you're trying to update by 
+                    '${settings?.meta?.createdBy}'. Please coordinate with that user and return to update the setting 
+                    again, if needed`;
+    }
+
+    return "";
+}


### PR DESCRIPTION
This PR prevents the user from saving changes to any setting if the setting they're trying to edit has been modified by another user at the same time.

Test Steps (happy path 1):
1. Login to ReportStream as an admin and choose Admin->Organization Settings (or click on the top right org picker)
2. Click Edit on a particular org (i.e. abbott)
3. Launch a Chrome tab in Incognito mode
4. Login to ReportStream as an admin and choose Admin->Organization Settings (or click on the top right org picker)
5. Click Edit on the org you chose for step 2
6. Make a change, click on "Preview save...", then click Save on the resulting compare dialog
7. In your _original_ browser tab (without refreshing anything), make a change and click "Preview save..."
8. The modal will popup with a big scary warning all in red, the notification (toast) popup will also display (then dismiss), and finally the Save button will be disabled
9. Repeat the steps above for the Edit Sender workflow and the Edit Receiver workflow to observe the same behavior

Test Steps (happy path 2):
1. Login to ReportStream as an admin and choose Admin->Organization Settings (or click on the top right org picker)
2. Click Edit on a particular org (i.e. abbott)
3. Make a change, click on "Preview save...", then _go no further_ (i.e. do NOT hit Save yet)
4. Launch a Chrome tab in Incognito mode
5. Login to ReportStream as an admin and choose Admin->Organization Settings (or click on the top right org picker)
6. Click Edit on the org you chose for step 2
7. Make a change, click on "Preview save...", then click Save on the resulting compare dialog
8. In your _original_ browser tab (without refreshing anything), click on "Save" in the compare modal that should still be up
9. The modal will update with a big scary warning all in red, the notification (toast) popup will also display (then dismiss), and finally the Save button will become disabled
10. Repeat the steps above for the Edit Sender workflow and the Edit Receiver workflow to observe the same behavior

Example of popup and warning text:
![image](https://user-images.githubusercontent.com/92405130/164114332-574b6a6d-913f-4de2-a0f8-b242b41a9c62.png)

## Changes
- Created a little helper method getVersionWarning() in misc.ts  (to try 'n' keep it D.R.Y) + unit tests.
- Added version checks upon displaying the compare modal (CompareJsonModal) as well as upon hitting Save on the compare modal. Originating pages: AdminOrgEdit.tsx, EditSenderSettings.tsx and EditReceiverSettings.tsx

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #4325 

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | **16**        | [7h 32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r9m53e~t~'8w)~(d~'r9gvny~t~'198)~(d~'r9ixde~t~'afk)~(d~'r9b2d0~t~'g4)~(d~'r9gu7h~t~'hi)~(d~'r9gk4y~t~'7w)~(d~'r9kf0r~t~'jb)~(d~'r9kf1p~t~'k9)~(d~'r9vm6f~t~'9aw)~(d~'r99ebu~t~'7v)~(d~'r95i3g~t~'16rr)~(d~'ra6idn~t~'6co)~(d~'racj9t~t~'ga)~(d~'r9z6rv~t~'1pu2)~(d~'r9z6vv~t~'1py2)~(d~'r9z6w2~t~'1py9)~(d~'r9z6wv~t~'1pz2)~(d~'raa89o~t~'kx7)~(d~'raa8aj~t~'ky2)~(d~'raa8bc~t~'kyv)~(d~'r9z6rv~t~'1pu2)~(d~'r9z6vv~t~'1py2)~(d~'r9z6w2~t~'1py9)~(d~'r9z6wv~t~'1pz2)~(d~'raa89o~t~'kx7)~(d~'raa8aj~t~'ky2)~(d~'raa8bc~t~'kyv)~(d~'rajssu~t~'d)~(d~'ral8jy~t~'12ox)~(d~'rale5z~t~'717x)))) | 16             |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 12            | [1h 1m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r95w3z~t~'ks)~(d~'r95xi0~t~'he)~(d~'r95mx9~t~'1en5)~(d~'r9hcra~t~'6dmh)~(d~'r97riy~t~'2tj)~(d~'r97ktb~t~'53s)~(d~'r97sdu~t~'jk)~(d~'r9vnwl~t~'1j34)~(d~'r9hdfw~t~'6ul)~(d~'r9kc7j~t~'fk)~(d~'r9kawr~t~'u1)~(d~'r9kbrq~t~'8y)~(d~'r9ka1y~t~'1csu)~(d~'r9ka1y~t~'1csu)~(d~'r9kbi0~t~'ju))))                                                                                                                                                                                                                                                                                            | 6              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 12            | [5d 8h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r9k6c0~t~'eb)~(d~'r97fsz~t~'3hfi)~(d~'r9mh3t~t~'b11n)~(d~'r95iby~t~'88)~(d~'ra70hi~t~'741)~(d~'ra6tov~t~'bimi)~(d~'ra6tpb~t~'bimy)~(d~'ra6v16~t~'bjyt)~(d~'ra6v1t~t~'bjzg)~(d~'ra6v2d~t~'bk00)~(d~'ra6v2l~t~'bk08)~(d~'ra6v45~t~'bk1s)~(d~'ra6yq8~t~'320)~(d~'ra6z5f~t~'d2x)~(d~'ra6z7u~t~'9vha)~(d~'ra6zdc~t~'9vms)~(d~'ra6zfr~t~'9vp7)~(d~'ra6zm0~t~'9vvg)~(d~'raan3g~t~'eyl)~(d~'ra6z7u~t~'9vha)~(d~'ra6zdc~t~'9vms)~(d~'ra6zfr~t~'9vp7)~(d~'ra6zm0~t~'9vvg)~(d~'raan3g~t~'eyl)~(d~'rajjwe~t~'ki)~(d~'rajkq1~t~'1eb))))                                                             | 12             |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 11            | [3h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r9m0um~t~'ze)~(d~'r9j4qb~t~'1ryt)~(d~'r9b5n0~t~'m5)~(d~'r9auxq~t~'38ge)~(d~'r9axvc~t~'18x4)~(d~'r9tmdx~t~'ki)~(d~'r9u7xq~t~'349)~(d~'ra6jjd~t~'dpdp)~(d~'r9zg7u~t~'6ys)~(d~'ra73ie~t~'2i)~(d~'r9z6xv~t~'1q02)~(d~'r9z6xv~t~'1q02)~(d~'ralx6h~t~'97k))))                                                                                                                                                                                                                                                                                                                                   | 13             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 11            | [51m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r9kj14~t~'1j)~(d~'r9im5i~t~'73s)~(d~'r9mf04~t~'hg)~(d~'r9u6zc~t~'25v)~(d~'r96mjp~t~'ofy)~(d~'r97g2i~t~'20o)~(d~'r97qx8~t~'88g)~(d~'r97r2d~t~'8dl)~(d~'r97r5q~t~'d3w)~(d~'r97r8z~t~'8k7)~(d~'r97rf3~t~'8qb)~(d~'r97rsp~t~'ee)~(d~'r99brm~t~'3dnv)~(d~'r99hys~t~'qr)~(d~'r99ist~t~'1ks)~(d~'r9oaln~t~'ea)~(d~'r9topv~t~'5gov)~(d~'r9xl0t~t~'cu)~(d~'ra13ls~t~'1487)~(d~'raahal~t~'1gp)~(d~'raaq0n~t~'2j8)~(d~'raahal~t~'1gp)~(d~'raaq0n~t~'2j8)~(d~'raabmo~t~'uz))))                                                                                                                               | **47**         |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 10            | [1h 39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r93ugs~t~'3ad)~(d~'r9baxp~t~'397)~(d~'r9ii0a~t~'566)~(d~'r9vgm1~t~'1fdt)~(d~'r9x7zx~t~'2y2)~(d~'r9x8ly~t~'ek)~(d~'ra6ime~t~'3wj)~(d~'ra70q3~t~'5d7)~(d~'ra8z0p~t~'9tn)~(d~'rachnn~t~'dud)~(d~'rachnn~t~'dud)~(d~'ralj3v~t~'40g))))                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 10            | [2h 12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r9ky9r~t~'18n)~(d~'r9h54v~t~'13r)~(d~'r9h6gx~t~'cc)~(d~'r9h5p3~t~'b8)~(d~'r97rwo~t~'1t65)~(d~'r97isi~t~'39mh)~(d~'r99o15~t~'9)~(d~'ra1gz6~t~'cid)~(d~'ra8ys5~t~'l6b)~(d~'ra8ys5~t~'l6b)~(d~'ralngx~t~'25z)~(d~'ralvem~t~'a3o))))                                                                                                                                                                                                                                                                                                                                                       | 3              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 9             | [18m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r95vp5~t~'1dy)~(d~'r9kd1y~t~'8m)~(d~'r9koic~t~'9l)~(d~'r9kbe1~t~'1a03)~(d~'r9kkve~t~'68)~(d~'r9nxqg~t~'3t8)~(d~'r97nx1~t~'eh)~(d~'r97om7~t~'13n)~(d~'r9bo8f~t~'6x5)~(d~'r9gwwx~t~'8vy)~(d~'r9keso~t~'e4)~(d~'r9xlkk~t~'98q)~(d~'raagdk~t~'jo)~(d~'raagdk~t~'jo))))                                                                                                                                                                                                                                                                                                                              | 5              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 9             | [10h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r97q57~t~'1fs)~(d~'r97t2j~t~'9o)~(d~'r9tm8t~t~'fe)~(d~'r9o4jb~t~'u4)~(d~'r9tuwj~t~'2bhz)~(d~'r9zc85~t~'5ks)~(d~'ra6ucy~t~'2d79)~(d~'ra8kjj~t~'1fge)~(d~'rae77k~t~'1ecg)~(d~'rae77k~t~'1ecg)~(d~'rajwl0~t~'7epq)~(d~'ralqg4~t~'2h7))))                                                                                                                                                                                                                                                                                                                                               | 4              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 8             | [2h 5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r9ivvt~t~'9yb)~(d~'r9it4j~t~'1n1t)~(d~'r9bb6i~t~'vm)~(d~'r97nq7~t~'80o)~(d~'r93wz3~t~'5t4)~(d~'r9idz6~t~'1iqr)~(d~'r9trbr~t~'93)~(d~'ra19cq~t~'4vx)~(d~'ra8ezi~t~'5t))))                                                                                                                                                                                                                                                                                                                                                                                                                     | 3              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 7             | [22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r95xi3~t~'36w)~(d~'r9khdw~t~'3x)~(d~'r99ho8~t~'g7)~(d~'r95khd~t~'u7z)~(d~'r9oas9~t~'kw)~(d~'racj7w~t~'108)~(d~'ra1ljm~t~'29x)~(d~'racj7w~t~'108)~(d~'ra1ljm~t~'29x))))                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 6             | [20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r9khhg~t~'7h)~(d~'r9mlwq~t~'856)~(d~'r97ntx~t~'bd)~(d~'r97nu8~t~'bo)~(d~'r9vuo0~t~'1ocl)~(d~'racj5j~t~'xv)~(d~'racj5j~t~'xv)~(d~'ralg8a~t~'1bht))))                                                                                                                                                                                                                                                                                                                                                                                                                                        | 1              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 5             | [1h 41m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r955hu~t~'1ebv)~(d~'r955lz~t~'1eg0)~(d~'r9gqlv~t~'4h2)~(d~'r9gqzv~t~'4v2)~(d~'r9grbt~t~'570)~(d~'r9hfbs~t~'t6z)~(d~'ra6ixc~t~'6wd)~(d~'ra6mxd~t~'awe)~(d~'racmrq~t~'21d)~(d~'raecmt~t~'wn)~(d~'raecr6~t~'110)~(d~'raecmt~t~'wn)~(d~'raecr6~t~'110)~(d~'racmrq~t~'21d))))                                                                                                                                                                                                                                                                                                                         | 10             |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 4             | [12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'r93yow~t~'14c)~(d~'ra8uvl~t~'jb)~(d~'ra8rfj~t~'1k6)~(d~'r9x3th~t~'2x)~(d~'r9x3th~t~'2x))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 4             | [1h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r93vx0~t~'4r1)~(d~'r9mi7y~t~'23qi)~(d~'ra8ujp~t~'7f)~(d~'r9xk35~t~'gcl)~(d~'raea21~t~'2po)~(d~'r9xk35~t~'gcl)~(d~'raea21~t~'2po))))                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 5              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 3             | [1h 9m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r97iw8~t~'36p)~(d~'r97q3a~t~'adr)~(d~'r9w84b~t~'55)~(d~'r9w8pz~t~'qt)~(d~'ra6y5a~t~'ckd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 3              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 3             | [20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r9m0s7~t~'wz)~(d~'r9u29d~t~'23)~(d~'ra72jq~t~'5v5u))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 3             | [3d 8h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r9zu0t~t~'blzt)~(d~'r9zu4m~t~'6688)~(d~'r9ztx6~t~'68e2)~(d~'r9ztxm~t~'68ei))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 3             | [1d 1h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'r95y16~t~'187)~(d~'r948zz~t~'xz)~(d~'raan3s~t~'3vsm)~(d~'raan3s~t~'3vsm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 3             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'r9x3to~t~'34)~(d~'r9x3to~t~'34)~(d~'ralb8g~t~'7u)~(d~'raltse~t~'13h))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 3             | [15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r9awir~t~'16mc)~(d~'r9o3y3~t~'8w)~(d~'r9x9ps~t~'pm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 1             | [13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r9ma4z~t~'m5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 2              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 1             | [4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'ralb7c~t~'6q))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |