### PR TITLE
Oo/mo/international phone number changes

### DIFF
--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -1,6 +1,8 @@
 package gov.cdc.prime.router
 
+import com.google.i18n.phonenumbers.NumberParseException
 import com.google.i18n.phonenumbers.PhoneNumberUtil
+import com.google.i18n.phonenumbers.Phonenumber
 import gov.cdc.prime.router.Element.Cardinality.ONE
 import gov.cdc.prime.router.Element.Cardinality.ZERO_OR_ONE
 import gov.cdc.prime.router.common.Environment
@@ -9,7 +11,6 @@ import gov.cdc.prime.router.metadata.LIVDLookupMapper
 import gov.cdc.prime.router.metadata.LookupMapper
 import gov.cdc.prime.router.metadata.LookupTable
 import gov.cdc.prime.router.metadata.Mapper
-import java.lang.Exception
 import java.text.DecimalFormat
 import java.time.DateTimeException
 import java.time.Instant
@@ -595,17 +596,7 @@ data class Element(
                 }
             }
             Type.TELEPHONE -> {
-                return try {
-                    // parse can fail if the phone number is not correct, which feels like bad behavior
-                    // this then causes a report level failure, not an element level failure
-                    val number = phoneNumberUtil.parse(cleanedValue, "US")
-                    if (!number.hasNationalNumber() || number.nationalNumber > 999999999999L)
-                        InvalidPhoneMessage(cleanedValue, fieldMapping)
-                    else
-                        null
-                } catch (ex: Exception) {
-                    InvalidPhoneMessage(cleanedValue, fieldMapping)
-                }
+                return checkPhoneNumber(cleanedValue, fieldMapping)
             }
             Type.POSTAL_CODE -> {
                 // Let in all formats defined by http://www.dhl.com.tw/content/dam/downloads/tw/express/forms/postcode_formats.pdf
@@ -1094,6 +1085,45 @@ data class Element(
         const val zipFiveToken = "\$zipFive"
         const val zipFivePlusFourToken = "\$zipFivePlusFour"
         const val usZipFormat = """^(\d{5})[- ]?(\d{4})?$"""
+        // a regex to check for the presence of only valid phone number characters. this will fail if
+        // someone passes through character values, like a name, or some other text info. this is not
+        // attempting to check and see if the number is properly formatted, just a short circuit to
+        // fail out on REALLY bad data
+        private val maybeAPhoneNumber = Regex("""[\d\(\)\+x\- ]+""")
+        // possible regions a phone number could be from. This is a wider list than we will we probably
+        // pull from, at least initially, because there are many more places in North America that use
+        // the +1 country code for international phone numbers, and therefore, our system could break if
+        // someone presents a number from the Caribbean and we're set up to allow it
+        val phoneRegions = listOf(
+            "US",
+            "MX",
+            "CA",
+            "AU", // Australia
+            "AG", // Antigua
+            "AI", // Anguilla
+            "AS", // American Samoa
+            "BB", // Barbados
+            "BM", // Bermuda
+            "BS", // Bahamas
+            "DM", // Dominica
+            "DO", // Dominican Republic
+            "GD", // Grenada
+            "GU", // Guam
+            "JM", // Jamaica
+            "KN", // St. Kitts and Nevis
+            "KY", // Cayman Islands
+            "LC", // St. Lucia
+            "MP", // Northern Mariana Islands
+            "MS", // Montserrat
+            "PR", // Puerto Rico
+            "SX", // Sint Maarten
+            "TC", // Turks and Caicos
+            "TT", // Trinidad and Tobago
+            "VC", // Saint Vincent and the Grenadines
+            "VG", // British Virgin Islands
+            "VI", // Virgin Islands
+            "UM", // US Minor Outlying Islands
+        )
 
         fun csvFields(name: String, format: String? = null): List<CsvField> {
             return listOf(CsvField(name, format))
@@ -1249,6 +1279,47 @@ data class Element(
                 // the regex didn't match, so return the original value we passed in
                 else -> value
             }
+        }
+
+        /**
+         * Given [cleanedValue] this method checks to see if it is possibly a phone number in a safe
+         * way without blowing up all the processing of rows in a report. If the phone number is probably
+         * valid it returns null, as the `checkForErrors` method would expect, otherwise it returns an
+         * InvalidPhoneMessage
+         */
+        fun checkPhoneNumber(cleanedValue: String, fieldMapping: String): InvalidPhoneMessage? {
+            // use a quick regex to see if the normalized value contains something other than our
+            // expected values, and also use the `isPossibleNumber` method our phone number util gives us
+            if (
+                maybeAPhoneNumber.matchEntire(cleanedValue) != null &&
+                phoneNumberUtil.isPossibleNumber(cleanedValue, "US")
+            ) {
+                // attempt to parse the number. if it is parseable then we can return null and move
+                // on with our work, otherwise, return an InvalidPhoneMessage
+                val phoneNumber = tryParsePhoneNumber(cleanedValue)
+                if (phoneNumber != null)
+                    return null
+            }
+            // all attempts have failed. bad number
+            return InvalidPhoneMessage(cleanedValue, fieldMapping)
+        }
+
+        /**
+         * Given a nullable [cleanedValue] this method tries to parse a phone number in
+         * a safe way according to our four most common phone regions: US, Mexico, Canada, and Australia.
+         * If the number really can't be parsed at all (and the phoneNumberUtil is very lenient) then
+         * it is almost certainly not a phone number, so return null
+         */
+        fun tryParsePhoneNumber(cleanedValue: String?): Phonenumber.PhoneNumber? {
+            for (region in phoneRegions) {
+                try {
+                    return phoneNumberUtil.parse(cleanedValue, region)
+                } catch (_: NumberParseException) {
+                    continue
+                }
+            }
+
+            return null
         }
     }
 }

--- a/prime-router/src/main/kotlin/Element.kt
+++ b/prime-router/src/main/kotlin/Element.kt
@@ -599,7 +599,7 @@ data class Element(
                     // parse can fail if the phone number is not correct, which feels like bad behavior
                     // this then causes a report level failure, not an element level failure
                     val number = phoneNumberUtil.parse(cleanedValue, "US")
-                    if (!number.hasNationalNumber() || number.nationalNumber > 9999999999L)
+                    if (!number.hasNationalNumber() || number.nationalNumber > 999999999999L)
                         InvalidPhoneMessage(cleanedValue, fieldMapping)
                     else
                         null
@@ -749,7 +749,7 @@ data class Element(
             }
             Type.TELEPHONE -> {
                 val number = phoneNumberUtil.parse(cleanedFormattedValue, "US")
-                if (!number.hasNationalNumber() || number.nationalNumber > 9999999999L)
+                if (!number.hasNationalNumber() || number.nationalNumber > 999999999999L)
                     error("Invalid phone number '$cleanedFormattedValue' for $fieldMapping")
                 val nationalNumber = DecimalFormat("0000000000").format(number.nationalNumber)
                 "${nationalNumber}$phoneDelimiter${number.countryCode}$phoneDelimiter${number.extension}"

--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -1309,7 +1309,7 @@ class Hl7Serializer(
             // possibilities
             val regionCode = phoneNumberUtil.getRegionCodeForNumber(phone) ?: when (phone.countryCode) {
                 1 -> "US" // and CA and others in North America, but the phone number's invalid, so we're guessing now
-                52 -> "MX"
+                52 -> "MX" // Mexico
                 61 -> "AU" // Australia
                 else -> null
             }

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -463,7 +463,8 @@ internal class ElementTests {
             "+61 491 578 888", // AU cell number
             "613-688-5335", // CA
             "+1613-688-5335", // CA
-            "+52 55 5080 2000" // MX
+            "+52 55 5080 2000", // MX
+            "(230)7136595", // US, but invalid area code, but pass it through anyway
         ).forEach {
             Element.checkPhoneNumber(it, it).run {
                 assertThat(this).isNull()
@@ -476,7 +477,6 @@ internal class ElementTests {
             "           ",
             "99999999999999999999999999999999999999999999999999999999999999",
             "9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9",
-            "(230)7136595", // US, but invalid area code
         ).forEach {
             Element.checkPhoneNumber(it, "test field").run {
                 assertThat(this).isNotNull()

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -401,14 +401,14 @@ internal class ElementTests {
     }
 
     @Test
-    fun `testToNormalizedIntenationalPhone`() {
+    fun `test To Normalized International Phone`() {
         val one = Element(
             "a",
             type = Element.Type.TELEPHONE,
             csvFields = Element.csvFields("phone")
         )
 
-        val arrayOfPhoneNumbersAndResults = arrayOf(
+        val arrayOfPhoneNumbersAndResults = listOf(
             // Pair("+1-316-667-9400", "3166679400:1:"),   // US
             // Pair("(230)7136595", "2307136595:1:"),  // US
             Pair("+61 2 6214 5600", "0262145600:61:"), // AU
@@ -418,9 +418,68 @@ internal class ElementTests {
         )
 
         // Verify phone numbers
-        arrayOfPhoneNumbersAndResults.forEach { phRslt ->
-            one.toNormalized(phRslt.first).run {
-                assertThat(this).isEqualTo(phRslt.second)
+        arrayOfPhoneNumbersAndResults.forEach { phoneNumberAndResult ->
+            one.toNormalized(phoneNumberAndResult.first).run {
+                assertThat(this).isEqualTo(phoneNumberAndResult.second)
+            }
+        }
+    }
+
+    @Test
+    fun `test try parse Phone Number`() {
+        listOf(
+            "+1-316-667-9400", // US
+            "(230)7136595", // US
+            "+61 2 6214 5600", // AU
+            "613-688-5335", // CA
+            "+1613-688-5335", // CA
+            "+52 55 5080 2000" // MX
+        ).forEach {
+            Element.tryParsePhoneNumber(it).run {
+                assertThat(this).isNotNull()
+            }
+        }
+
+        listOf(
+            "",
+            "abcdefghijk",
+            "           ",
+            "99999999999999999999999999999999999999999999999999999999999999",
+            "9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9",
+            null
+        ).forEach {
+            Element.tryParsePhoneNumber(it).run {
+                assertThat(this).isNull()
+            }
+        }
+    }
+
+    @Test
+    fun `test checkPhoneNumber method`() {
+        listOf(
+            "+1-316-667-9400", // US
+            "(717)531-0123", // US alternate formatting
+            "+61 2 9667 9111", // AU
+            "+61 491 578 888", // AU cell number
+            "613-688-5335", // CA
+            "+1613-688-5335", // CA
+            "+52 55 5080 2000" // MX
+        ).forEach {
+            Element.checkPhoneNumber(it, it).run {
+                assertThat(this).isNull()
+            }
+        }
+
+        listOf(
+            "",
+            "abcdefghijk",
+            "           ",
+            "99999999999999999999999999999999999999999999999999999999999999",
+            "9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9",
+            "(230)7136595", // US, but invalid area code
+        ).forEach {
+            Element.checkPhoneNumber(it, "test field").run {
+                assertThat(this).isNotNull()
             }
         }
     }

--- a/prime-router/src/test/kotlin/ElementTests.kt
+++ b/prime-router/src/test/kotlin/ElementTests.kt
@@ -398,9 +398,30 @@ internal class ElementTests {
         one.toNormalized("+1(555)-968-5052 x5555").run {
             assertThat(this).isEqualTo("5559685052:1:5555")
         }
-        // MX phone number
-        one.toNormalized("+52-65-8888-8888").run {
-            assertThat(this).isEqualTo("6588888888:52:")
+    }
+
+    @Test
+    fun `testToNormalizedIntenationalPhone`() {
+        val one = Element(
+            "a",
+            type = Element.Type.TELEPHONE,
+            csvFields = Element.csvFields("phone")
+        )
+
+        val arrayOfPhoneNumbersAndResults = arrayOf(
+            // Pair("+1-316-667-9400", "3166679400:1:"),   // US
+            // Pair("(230)7136595", "2307136595:1:"),  // US
+            Pair("+61 2 6214 5600", "0262145600:61:"), // AU
+            // Pair("613-688-5335", "6136885335:1:"),     // CA
+            // Pair("+1613-688-5335", "6136885335:1:"),     // CA
+            // Pair("+52 55 5080 2000", "5550802000:52:")   // MX
+        )
+
+        // Verify phone numbers
+        arrayOfPhoneNumbersAndResults.forEach { phRslt ->
+            one.toNormalized(phRslt.first).run {
+                assertThat(this).isEqualTo(phRslt.second)
+            }
         }
     }
 

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -453,6 +453,61 @@ NTE|1|L|This is a final comment|RE"""
             hl7Field = "ORC-23",
             type = Element.Type.TELEPHONE
         )
+
+        // Invalid telephone
+        serializer.setTelephoneComponent(
+            mockTerser,
+            "5555555555:1:3333",
+            facilityPathSpec,
+            facilityElement,
+            Hl7Configuration.PhoneNumberFormatting.STANDARD
+        )
+
+        verify {
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-1", "(555)555-5555X3333")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-2", "WPN")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-3", "PH")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-5", "1")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-6", "555")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-7", "5555555")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-8", "3333")
+        }
+
+        // Valid telephone
+        serializer.setTelephoneComponent(
+            mockTerser,
+            "8002324636:1:3333",
+            facilityPathSpec,
+            facilityElement,
+            Hl7Configuration.PhoneNumberFormatting.STANDARD
+        )
+
+        verify {
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-1", "(800)232-4636X3333")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-2", "WPN")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-3", "PH")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-5", "1")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-6", "800")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-7", "2324636")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-8", "3333")
+        }
+    }
+
+    @Test
+    fun `testSetTelephoneComponentsValidatePhoneNumbers`() {
+        val settings = FileSettings("./settings")
+        val serializer = Hl7Serializer(UnitTestUtils.simpleMetadata, settings)
+        val mockTerser = mockk<Terser>()
+        every { mockTerser.set(any(), any()) } returns Unit
+
+        val facilityPathSpec = serializer.formPathSpec("ORC-23")
+        val facilityElement = Element(
+            "ordering_facility_phone_number",
+            hl7Field = "ORC-23",
+            type = Element.Type.TELEPHONE
+        )
+
+        // Valid (MX) telephone
         serializer.setTelephoneComponent(
             mockTerser,
             "5555555555:1:3333",


### PR DESCRIPTION
This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Fixes
- #issue - List GitHub issues this PR fixes

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | **18**        | [5h 3m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'r9k6c0~t~'eb)~(d~'ra70hi~t~'741)~(d~'ra6ycp~t~'32z)~(d~'ra6y7s~t~'30e)~(d~'ra6vp7~t~'ji)~(d~'ra6yrj~t~'8u)~(d~'ra8a59~t~'12rc)~(d~'rajkq1~t~'1eb)~(d~'rajjwe~t~'ki)~(d~'randoy~t~'1m6o)~(d~'ra6tov~t~'bimi)~(d~'ra6tpb~t~'bimy)~(d~'ra6v16~t~'bjyt)~(d~'ra6v1t~t~'bjzg)~(d~'ra6v2d~t~'bk00)~(d~'ra6v2l~t~'bk08)~(d~'ra6v45~t~'bk1s)~(d~'ra6yq8~t~'320)~(d~'ra6z5f~t~'d2x)~(d~'raan3g~t~'eyl)~(d~'rawsnr~t~'9rs)~(d~'ra6z7u~t~'9vha)~(d~'ra6zdc~t~'9vms)~(d~'ra6zfr~t~'9vp7)~(d~'ra6zm0~t~'9vvg)~(d~'rap3h5~t~'5ld)~(d~'rap3oa~t~'5si)~(d~'rap3u2~t~'5ya)~(d~'rap3v1~t~'5z9)~(d~'rapcmi~t~'1h6v)))) | 12             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 16            | [1h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'r9kj14~t~'1j)~(d~'r9im5i~t~'73s)~(d~'r9mf04~t~'hg)~(d~'r9u6zc~t~'25v)~(d~'r9oaln~t~'ea)~(d~'r9xl0t~t~'cu)~(d~'ra13ls~t~'1487)~(d~'raabmo~t~'uz)~(d~'raahal~t~'1gp)~(d~'raaq0n~t~'2j8)~(d~'raa9u4~t~'1nov)~(d~'r9topv~t~'5gov)~(d~'ranx74~t~'41e)~(d~'ranl2b~t~'71w)~(d~'rann29~t~'912)~(d~'ranqr9~t~'cq2)~(d~'ranqs0~t~'cqt)~(d~'ranqvj~t~'cuc)~(d~'ranr16~t~'czz)~(d~'rawjxk~t~'137)~(d~'rannrm~t~'lk)~(d~'rayc0z~t~'3l7))))                                                                                                                                                                          | **32**         |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 15            | [5h 39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'r9m53e~t~'8w)~(d~'r9gvny~t~'198)~(d~'r9ixde~t~'afk)~(d~'r9gu7h~t~'hi)~(d~'r9kf0r~t~'jb)~(d~'r9kf1p~t~'k9)~(d~'r9vm6f~t~'9aw)~(d~'ra6idn~t~'6co)~(d~'rajssu~t~'d)~(d~'ral8jy~t~'12ox)~(d~'racj9t~t~'ga)~(d~'r9z6rv~t~'1pu2)~(d~'r9z6vv~t~'1py2)~(d~'r9z6w2~t~'1py9)~(d~'r9z6wv~t~'1pz2)~(d~'raa89o~t~'kx7)~(d~'raa8aj~t~'ky2)~(d~'raa8bc~t~'kyv)~(d~'rac71y~t~'1aex)~(d~'ray6q8~t~'6d)~(d~'raye00~t~'1bkb)~(d~'rayefc~t~'1bzn)~(d~'raymt1~t~'6my)~(d~'rale5z~t~'717x))))                                                                                                                            | 16             |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 9             | [10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'r9kd1y~t~'8m)~(d~'r9koic~t~'9l)~(d~'r9kbe1~t~'1a03)~(d~'r9kkve~t~'68)~(d~'r9nxqg~t~'3t8)~(d~'r9xlkk~t~'98q)~(d~'raagdk~t~'jo)~(d~'randwm~t~'12l)~(d~'ray6yk~t~'ep)~(d~'ray8p5~t~'9d))))                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 9             | [1h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'r9m0um~t~'ze)~(d~'r9tmdx~t~'ki)~(d~'r9u7xq~t~'349)~(d~'ralx6h~t~'97k)~(d~'ra6jjd~t~'dpdp)~(d~'r9zg7u~t~'6ys)~(d~'ra73ie~t~'2i)~(d~'r9z6xv~t~'1q02)~(d~'ra972u~t~'kxl)~(d~'r9kyj2~t~'ak))))                                                                                                                                                                                                                                                                                                                                                                                                         | 12             |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 9             | [17h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'r9vnwl~t~'1j34)~(d~'r9hdfw~t~'6ul)~(d~'r9kawr~t~'u1)~(d~'r9kbrq~t~'8y)~(d~'r9ka1y~t~'1csu)~(d~'ran8ri~t~'3f7w)~(d~'ran8wv~t~'ee7y)~(d~'ran92b~t~'1pym)~(d~'r9kbi0~t~'ju))))                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 8             | [1h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'r9ii0a~t~'566)~(d~'r9vgm1~t~'1fdt)~(d~'r9x7zx~t~'2y2)~(d~'r9x8ly~t~'ek)~(d~'ra6ime~t~'3wj)~(d~'ralj3v~t~'40g)~(d~'ra70q3~t~'5d7)~(d~'ra8z0p~t~'9tn)~(d~'rachnn~t~'dud))))                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 8             | [18h 7m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'r9tm8t~t~'fe)~(d~'r9tuwj~t~'2bhz)~(d~'rajwl0~t~'7epq)~(d~'ralqg4~t~'2h7)~(d~'rae77k~t~'1ecg)~(d~'r9zc85~t~'5ks)~(d~'ra6ucy~t~'2d79)~(d~'ra8kjj~t~'1fge)~(d~'ray8m1~t~'1a))))                                                                                                                                                                                                                                                                                                                                                                                                                 | 2              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 7             | [11h 39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'r9ivvt~t~'9yb)~(d~'r9it4j~t~'1n1t)~(d~'r9idz6~t~'1iqr)~(d~'r9trbr~t~'93)~(d~'ra8ezi~t~'5t)~(d~'ra19cq~t~'4vx)~(d~'rawfff~t~'ciot)~(d~'rap5sl~t~'b4tj))))                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 7             | [59m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'r9khhg~t~'7h)~(d~'r9mlwq~t~'856)~(d~'r9vuo0~t~'1ocl)~(d~'ralg8a~t~'1bht)~(d~'racj5j~t~'xv)~(d~'rap54k~t~'8y)~(d~'rapdam~t~'2qr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 5             | [5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'ra8uvl~t~'jb)~(d~'ra8rfj~t~'1k6)~(d~'r9x3th~t~'2x)~(d~'raylpp~t~'7u)~(d~'raycjl~t~'2m))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 5             | [13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'r9khdw~t~'3x)~(d~'r9oas9~t~'kw)~(d~'racj7w~t~'108)~(d~'ra1ljm~t~'29x)~(d~'rantih~t~'cr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 5             | [4h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'r9ky9r~t~'18n)~(d~'ralngx~t~'25z)~(d~'ralvem~t~'a3o)~(d~'ra8ys5~t~'l6b)~(d~'ra1gz6~t~'cid)~(d~'rapdcr~t~'cbq))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 4              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 5             | [3h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'r9mi7y~t~'23qi)~(d~'r9nxmy~t~'3f7o)~(d~'ra8ujp~t~'7f)~(d~'r9xk35~t~'gcl)~(d~'raea21~t~'2po)~(d~'rawizc~t~'17k))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 3              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [11m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'r9m0s7~t~'wz)~(d~'r9u29d~t~'23)~(d~'rarbmz~t~'15)~(d~'ra72jq~t~'5v5u))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 4             | [12m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'ralb8g~t~'7u)~(d~'raltse~t~'13h)~(d~'rapjor~t~'vs)~(d~'r9x3to~t~'34))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 4             | [1h 45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'r9gqlv~t~'4h2)~(d~'r9gqzv~t~'4v2)~(d~'r9grbt~t~'570)~(d~'r9hfbs~t~'t6z)~(d~'ra6ixc~t~'6wd)~(d~'ra6mxd~t~'awe)~(d~'racmrq~t~'21d)~(d~'raecmt~t~'wn)~(d~'raecr6~t~'110))))                                                                                                                                                                                                                                                                                                                                                                                                                                  | 7              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 3             | [3d 8h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'r9zu0t~t~'blzt)~(d~'r9zu4m~t~'6688)~(d~'r9ztx6~t~'68e2)~(d~'r9ztxm~t~'68ei))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 2              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 2             | [16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'r9w84b~t~'55)~(d~'r9w8pz~t~'qt)~(d~'ra6y5a~t~'ckd))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 1              |
| <a href="https://github.com/whytheplatypus"><img src="https://avatars.githubusercontent.com/u/410846?v=4" width="20"></a>                                                  | whytheplatypus     | 1             | [13m](https://app.flowwer.dev/charts/review-time/~(u~(i~'410846~n~'whytheplatypus)~p~30~r~(~(d~'r9ma4z~t~'m5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 2              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 1             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'ralb7c~t~'6q))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 0              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 1             | [2d 2h 20m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'raan3s~t~'3vsm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/rhood23699"><img src="https://avatars.githubusercontent.com/u/86322826?v=4" width="20"></a>                                                    | rhood23699         | 1             | [15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86322826~n~'rhood23699)~p~30~r~(~(d~'r9x9ps~t~'pm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |