### PR TITLE
Fixed issue in history test and similar issue in UI

### DIFF
--- a/frontend-react/src/resources/AuthResource.ts
+++ b/frontend-react/src/resources/AuthResource.ts
@@ -20,6 +20,7 @@ export default class AuthResource extends Resource {
                 ...init.headers,
                 Authorization: `Bearer ${accessToken}`,
                 Organization: organization || "",
+                "authentication-type": "okta",
             },
         };
     };

--- a/prime-router/src/main/kotlin/TranslatorConfiguration.kt
+++ b/prime-router/src/main/kotlin/TranslatorConfiguration.kt
@@ -153,7 +153,6 @@ data class Hl7Configuration
     @get:JsonIgnore
     override val format: Report.Format get() = if (useBatchHeaders) Report.Format.HL7_BATCH else Report.Format.HL7
 
-
     @get:JsonIgnore
     override val defaults: Map<String, String> get() {
         val receivingApplication = when {

--- a/prime-router/src/main/kotlin/cli/tests/HistoryApiTest.kt
+++ b/prime-router/src/main/kotlin/cli/tests/HistoryApiTest.kt
@@ -183,7 +183,7 @@ class HistoryApiTest : CoolTest() {
             HistoryApiTestCase(
                 "simple history API happy path test",
                 "${environment.url}/api/waters/org/$historyTestOrgName/submissions",
-                emptyMap(),
+                mapOf("authentication-type" to "okta"),
                 listOf("pagesize" to options.submits),
                 bearer,
                 HttpStatus.OK,
@@ -194,7 +194,7 @@ class HistoryApiTest : CoolTest() {
             HistoryApiTestCase(
                 "no such organization",
                 "${environment.url}/api/waters/org/gobblegobble/submissions",
-                emptyMap(),
+                mapOf("authentication-type" to "okta"),
                 listOf("pagesize" to options.submits),
                 bearer,
                 HttpStatus.UNAUTHORIZED,
@@ -208,7 +208,7 @@ class HistoryApiTest : CoolTest() {
                 HistoryApiTestCase(
                     "bad bearer token - TESTED ON STAGING, NOT TESTED ON LOCAL",
                     "${environment.url}/api/waters/org/$historyTestOrgName/submissions",
-                    emptyMap(),
+                    mapOf("authentication-type" to "okta"),
                     listOf("pagesize" to options.submits),
                     bearer + "x",
                     HttpStatus.UNAUTHORIZED,


### PR DESCRIPTION
This PR fixes the issue found in #5371 .   On staging, the history test was attempting to use an Okta token to connect using the Server2Server auth.  The solution is to add a header that tells the system its using Okta auth.

In addition, several frontend-react API calls to the back end were missing the authentication-type: okta header too.  So, I added it there.


### Backend Pipeline Test Steps:

Since this change is only in the test, you can actually run the test against staging.  After doing a build with this branch, do:
```
./prime login --env staging
./prime test --run history --sequential --env staging --key <SECRETKEY>

```
### Frontend test steps

Confirm that the both the Submissions and the Submissions details pages work locally.

## Changes
- added the authentication-type header in the cli test, and in the frontend code.

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [N] Are there licensing issues with any new dependencies introduced?
- [Y] Includes a summary of what a code reviewer should test/verify?
- [N/A] Updated the release notes?
- [N/A] Database changes are submitted as a separate PR?
- [N/A] DevOps team has been notified if PR requires ops support?

## Fixes
- #5371 

## To Be Done
- n/a

