### PR TITLE
Lowercase `data-testid`

### DIFF
--- a/frontend-react/src/pages/getting-started/testing-facilities/CsvSchemaDocumentation.tsx
+++ b/frontend-react/src/pages/getting-started/testing-facilities/CsvSchemaDocumentation.tsx
@@ -31,7 +31,7 @@ export const CsvSchemaDocumentationItem: React.FC<CsvSchemaItemProps> = ({
             <h4
                 id={`doc-${item.colHeader}`}
                 className="font-body-md margin-bottom-2"
-                data-testId="header"
+                data-testid="header"
             >
                 {item.name}
                 {item.required ? (
@@ -49,7 +49,7 @@ export const CsvSchemaDocumentationItem: React.FC<CsvSchemaItemProps> = ({
                     </span>
                 )}
             </h4>
-            <div data-testId="notes" className="margin-bottom-3">
+            <div data-testid="notes" className="margin-bottom-3">
                 {item.notes?.map((note, noteIndex) => (
                     <p
                         key={`${item.colHeader}-note-${noteIndex}`}


### PR DESCRIPTION
This PR resolves a React warning about camelcasing `testId`:

```
Warning: React does not recognize the `data-testId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `data-testid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          at h4
          at div
          at CsvSchemaDocumentationItem (/Users/kevinhaube/Projects/prime-reportstream/frontend-react/src/pages/getting-started/testing-facilities/CsvSchemaDocumentation.tsx:26:5)
```

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?