### PR TITLE
fix unit tests failing during remote build

### DIFF
--- a/prime-router/docs/getting-started/getting-started.md
+++ b/prime-router/docs/getting-started/getting-started.md
@@ -517,3 +517,18 @@ Run the following command to change the permissions for the folder:
 ```bash
 docker exec -it prime-router_sftp_1 chmod 777 /home/foo/upload
 ```
+## Unit test failing in GitHub actions, but succeeding locally
+1. A potential cause for this issue is a schema has not been loaded for a fresh remote build, while it was previously loaded for the local build. Resolve this issue by adding the missing schema to the unit test.
+    * This error was found by debugging [`parseCovidReport`](../../src/main/kotlin/azure/WorkflowEngine.kt#L868):
+        ```bash
+        Internal Error: invalid schema name 'one'
+        ```
+    * Changes made to resolve:
+        ```java
+        val metadata = UnitTestUtils.simpleMetadata
+        ```
+        to
+        ```java
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
+        val metadata = Metadata(schema = one)
+        ```

--- a/prime-router/src/test/kotlin/azure/ReportFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/ReportFunctionTests.kt
@@ -537,17 +537,12 @@ class ReportFunctionTests {
     }
 
     /** processFunction tests **/
-
-    // TODO: These two test *should* be present, but while they succeed locally for everyone they do not run
-    //  in gitHub actions, and no one can figure out why as of 5/12/2022. These will need to be put back in
-    //  for full test coverage at some point, but no one is currently using duplicate detection so there is
-    //  no harm in commenting it out.
     // test duplicate override = false
-    @Ignore
     @Test
     fun `test processFunction duplicate override true to false`() {
         // setup
-        val metadata = UnitTestUtils.simpleMetadata
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
+        val metadata = Metadata(schema = one)
         val settings = FileSettings().loadOrganizations(oneOrganization)
 
         val engine = makeEngine(metadata, settings)
@@ -590,11 +585,11 @@ class ReportFunctionTests {
     }
 
     // test processFunction when an error is added to ActionLogs
-    @Ignore
     @Test
     fun `test processFunction when ActionLogs has an error`() {
         // setup
-        val metadata = UnitTestUtils.simpleMetadata
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
+        val metadata = Metadata(schema = one)
         val settings = FileSettings().loadOrganizations(oneOrganization)
 
         val engine = makeEngine(metadata, settings)


### PR DESCRIPTION
This PR fixes an issue with 2 unit tests where a schema that has not been loaded for a remote build caused it to fail. Testing locally succeeded, as the schema was previously loaded for the local build. Resolved this issue by adding the missing schema to the unit test.

Test Steps:
1. Run `./gradlew package -Pshowtests` in a GitHub action and confirm `test processFunction duplicate override true to false` passes.

## Changes
- Add schema to 2 unit tests
- Update documentation

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Linked Issues
- Fixes #5484


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **18**        | [19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'ralb8g~t~'7u)~(d~'raltse~t~'13h)~(d~'rapjor~t~'vs)~(d~'rb0mxs~t~'74)~(d~'rb071w~t~'2u)~(d~'rb2c0j~t~'ai)~(d~'rb9v97~t~'2fu)~(d~'rbh8wb~t~'sy)~(d~'rbhbdb~t~'70)~(d~'rbo1k5~t~'13rb)~(d~'rbo8yc~t~'11r)~(d~'rbse2b~t~'4b)~(d~'rbse2z~t~'4v)~(d~'rbse3p~t~'5d)~(d~'rbse3c~t~'54)~(d~'rbryjn~t~'1hry)~(d~'rbrykf~t~'1hsq)~(d~'rbrylr~t~'1hu2)~(d~'rbryn3~t~'5pnk)~(d~'rbryno~t~'5po5)~(d~'rbubyv~t~'3bo))))                                                                                                                                                            | 3              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | **18**        | [1h 25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'rajkq1~t~'1eb)~(d~'rajjwe~t~'ki)~(d~'rb29v0~t~'6b)~(d~'rb2bup~t~'4o)~(d~'rb2bz2~t~'91)~(d~'raya68~t~'12ho)~(d~'rb9vu0~t~'30n)~(d~'rbbmge~t~'cmt)~(d~'rbbmic~t~'cor)~(d~'rbbmmo~t~'ct3)~(d~'rbbnbd~t~'dhs)~(d~'rbbnx9~t~'e3o)~(d~'rb4980~t~'b8)~(d~'rb3pty~t~'16uq)~(d~'rb2blm~t~'4z)~(d~'razzi8~t~'1qmd)~(d~'rb9j73~t~'84)~(d~'rb9j7t~t~'8u)~(d~'rb9mxc~t~'3yd)~(d~'rb9hrk~t~'1o)~(d~'rb9hrv~t~'1z)~(d~'rb9gs1~t~'71)~(d~'rapcmi~t~'1h6v)~(d~'rawsnr~t~'9rs)~(d~'rb40tn~t~'3wy)~(d~'rap3h5~t~'5ld)~(d~'rap3oa~t~'5si)~(d~'rap3u2~t~'5ya)~(d~'rap3v1~t~'5z9)))) | 12             |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 11            | [18h 10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'randwm~t~'12l)~(d~'ray8p5~t~'9d)~(d~'rbd2pf~t~'1qox)~(d~'rbd2qw~t~'1qqe)~(d~'rbd2sv~t~'1qsd)~(d~'rbd8g2~t~'1wfk)~(d~'rbd28d~t~'3ps)~(d~'rbd874~t~'1lbb)~(d~'rbdbbd~t~'1ofk)~(d~'rbdbc0~t~'1h3)~(d~'rbd8a1~t~'1hfz)~(d~'rbd8aj~t~'1hgh)~(d~'ray6yk~t~'ep)~(d~'rbgx2h~t~'1bhu)~(d~'rbh436~t~'1iij)~(d~'rbhuv7~t~'29ak)~(d~'rbmq43~t~'14i)~(d~'rbmq4a~t~'14p)~(d~'rbqbw3~t~'2c)~(d~'rbq6k1~t~'1ynv)~(d~'rbq9cw~t~'jv)~(d~'rbq9fl~t~'mk))))                                                                                                                           | 13             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 10            | [2h 23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'ral8jy~t~'12ox)~(d~'rb27db~t~'71z)~(d~'raye00~t~'1bkb)~(d~'rayefc~t~'1bzn)~(d~'raymt1~t~'6my)~(d~'rb3t95~t~'fa)~(d~'rb9lx3~t~'za)~(d~'rb2bj0~t~'2d)~(d~'rbbg9e~t~'1cuv)~(d~'ray6q8~t~'6d)~(d~'rboezr~t~'7)~(d~'rbs3qd~t~'1cb7)~(d~'rbsbos~t~'t))))                                                                                                                                                                                                                                                                                                              | **39**         |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 10            | [10h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'ran8ri~t~'3f7w)~(d~'rb05mj~t~'k9)~(d~'rb0hb2~t~'cmjw)~(d~'rb2d4q~t~'e5)~(d~'rb2den~t~'8a)~(d~'rbez2c~t~'35xo)~(d~'rb0d4x~t~'gj)~(d~'rb3slg~t~'1i5l)~(d~'rbbjiu~t~'1k8)~(d~'rb2dsv~t~'bt)~(d~'rb21so~t~'23oa)~(d~'rbez62~t~'ag9r))))                                                                                                                                                                                                                                                                                                                       | 6              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 10            | [3h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'ranx74~t~'41e)~(d~'ranl2b~t~'71w)~(d~'rann29~t~'912)~(d~'ranqr9~t~'cq2)~(d~'ranqs0~t~'cqt)~(d~'ranqvj~t~'cuc)~(d~'ranr16~t~'czz)~(d~'rawjxk~t~'137)~(d~'rayc0z~t~'3l7)~(d~'rbbc3j~t~'31)~(d~'rbbek4~t~'2jm)~(d~'rbdfl0~t~'23ki)~(d~'rbdfo5~t~'ct0)~(d~'rbdfi8~t~'1smf)~(d~'rbfoeo~t~'2u1)~(d~'rbh75z~t~'1llc)~(d~'rbmga9~t~'6upm)~(d~'rbqff9~t~'6g)~(d~'rannrm~t~'lk))))                                                                                                                                                                                            | 31             |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 6             | [51m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'ralg8a~t~'1bht)~(d~'rap54k~t~'8y)~(d~'rapdam~t~'2qr)~(d~'rb0n6l~t~'re)~(d~'rbn1hp~t~'jwn)~(d~'rbqh6q~t~'1xx))))                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 1              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 6             | [45m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rawizc~t~'17k)~(d~'rbcykq~t~'tt4)~(d~'rb48yg~t~'1o)~(d~'rb42un~t~'1p4)~(d~'rb4392~t~'23j)~(d~'rb43gk~t~'2b1)~(d~'rb44el~t~'392)~(d~'rb46fa~t~'59r)~(d~'rb9lrj~t~'p3)~(d~'rb9a2d~t~'55i7)~(d~'rb3shh~t~'bp))))                                                                                                                                                                                                                                                                                                                                                             | 6              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 5             | [41m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rb20a1~t~'4w)~(d~'rb0mhn~t~'1j0)~(d~'rbd6vp~t~'8d4)~(d~'rb9kvb~t~'1wc)~(d~'rbz79u~t~'52c2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 5             | [4h 55m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rarbmz~t~'15)~(d~'raqxnk~t~'5hd4)~(d~'rb0gcz~t~'a3)~(d~'rb0hgs~t~'cmpm)~(d~'rbbj5r~t~'175)~(d~'rbpmv0~t~'q41))))                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 1              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 4             | [54m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'ralqg4~t~'2h7)~(d~'rbf7d7~t~'sa)~(d~'ray8m1~t~'1a)~(d~'rb9m6q~t~'53af)~(d~'rbqazy~t~'1e8z))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 4             | [2h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'ralngx~t~'25z)~(d~'ralvem~t~'a3o)~(d~'rapdcr~t~'cbq)~(d~'rb17b8~t~'i2n)~(d~'rbqkv9~t~'2ll)~(d~'rbqlix~t~'399))))                                                                                                                                                                                                                                                                                                                                                                                                                                             | 6              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 3             | [26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rb42oo~t~'vz)~(d~'rbd338~t~'17j)~(d~'rbd351~t~'19c)~(d~'rbd423~t~'26e)~(d~'rb9u6e~t~'ep))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 3             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'raylpp~t~'7u)~(d~'rb075p~t~'6n)~(d~'rb07gk~t~'3b)~(d~'raycjl~t~'2m))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 3             | [3h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'ralx6h~t~'97k)~(d~'rb3siu~t~'d2)~(d~'rb68d5~t~'3oaq))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 4              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 3             | [1h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'ralj3v~t~'40g)~(d~'rb2k1h~t~'2o)~(d~'rboswg~t~'2yp))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 2             | [4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'ralb7c~t~'6q)~(d~'rb0754~t~'62))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 2             | [5h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rantih~t~'cr)~(d~'rbg05i~t~'ekv)~(d~'rbg05v~t~'el8))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 1              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 2             | [15h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rb0hl6~t~'cmu0)~(d~'rbq4h9~t~'17qa)~(d~'rbq4os~t~'17xt)~(d~'rbq4q1~t~'17z2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 2              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 2             | [38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'rb170i~t~'1768)~(d~'rbd32j~t~'16u)~(d~'rbd3mk~t~'1qv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 3              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 1             | [15h 36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rbto84~t~'17bn))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |