### PR TITLE
groupToOrg now replaces all underscores, not only first

### DIFF
--- a/frontend-react/src/utils/OrganizationUtils.test.ts
+++ b/frontend-react/src/utils/OrganizationUtils.test.ts
@@ -27,12 +27,14 @@ test("groupToOrg", () => {
     const mdPhd = groupToOrg("DHmd_phd");
     const simpleReport = groupToOrg("simple_report");
     const malformedGroupName = groupToOrg("DHSender_test_org");
+    const multipleUnderscoresName = groupToOrg("DHxx_yyy_phd");
 
     expect(admins).toBe("PrimeAdmins");
     expect(ignoreWaters).toBe("ignore.ignore-waters");
     expect(mdPhd).toBe("md-phd");
     expect(simpleReport).toBe("simple_report");
     expect(malformedGroupName).toBe("test_org");
+    expect(multipleUnderscoresName).toBe("xx-yyy-phd");
 });
 
 test("getOktaGroups", () => {

--- a/frontend-react/src/utils/OrganizationUtils.ts
+++ b/frontend-react/src/utils/OrganizationUtils.ts
@@ -49,7 +49,7 @@ const groupToOrg = (group: string | undefined): string => {
             return group ? group.replace(senderPrefix, "") : "";
         case "receiver":
             // DHmd_phd -> md-phd
-            return group ? group.replace("DH", "").replace("_", "-") : "";
+            return group ? group.replace("DH", "").replace(/_/g, "-") : "";
         case "non-standard":
             // simple_report -> simple_report
             return group ? group : "";


### PR DESCRIPTION
This PR replaces the search value for `.replace()` so it replaces all underscores, not only the first instance of one.

Test Steps:
1. Log into RS locally as an receiver with multiple underscores (i.e. DHca_scc_phd) and ensure Application > sessionStorage > global_stored_org is `xx-yyy-zzz` format

## Checklist

### Testing
- [X] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [X] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [X] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #5509 

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
