### PR TITLE
add blob level diag and permit lifecycle management access

### DIFF
--- a/operations/app/terraform/modules/log_analytics_workspace/data.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/data.tf
@@ -33,6 +33,9 @@ locals {
     "storage_account" = {
       resource_id = var.storage_account_id
     },
+    "storage_account_blob" = {
+      resource_id = "${var.storage_account_id}/blobServices/default"
+    },
     "storage_public" = {
       resource_id = var.storage_public_id
     },

--- a/operations/app/terraform/modules/storage/main.tf
+++ b/operations/app/terraform/modules/storage/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_storage_account" "storage_account" {
 
   network_rules {
     default_action = "Deny"
-    bypass         = ["None"]
+    bypass         = ["AzureServices"]
 
     # ip_rules = sensitive(concat(
     #   split(",", data.azurerm_key_vault_secret.cyberark_ip_ingress.value),


### PR DESCRIPTION
This PR adds azure diagnostic settings for blob-level actions (read/write/delete) and enables storage account access to Azure services, which is required to [support lifecycle management](https://docs.microsoft.com/en-us/answers/questions/107954/lifecycle-mangement-isn39t-doing-anything.html?childToView=154361#answer-154361)

Test Steps:
1. Validate blobs are deleted according to the desired lifecycle by checking the logs:
   * `StorageBlobLogs` 

## Changes
- Add blob-level diagnostics
- Enabled Azure service access to storage account

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Linked Issues
- Fixes #5566 


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **22**        | [23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rb0mxs~t~'74)~(d~'rb071w~t~'2u)~(d~'rb2c0j~t~'ai)~(d~'rb9v97~t~'2fu)~(d~'rbh8wb~t~'sy)~(d~'rbhbdb~t~'70)~(d~'rbryjn~t~'1hry)~(d~'rbrykf~t~'1hsq)~(d~'rbrylr~t~'1hu2)~(d~'rbryn3~t~'5pnk)~(d~'rbryno~t~'5po5)~(d~'rbse3c~t~'54)~(d~'rbubyv~t~'3bo)~(d~'rc1r6v~t~'r2)~(d~'rbse2b~t~'4b)~(d~'rbse2z~t~'4v)~(d~'rbse3p~t~'5d)~(d~'rbo1k5~t~'13rb)~(d~'rbo8yc~t~'11r)~(d~'rc4uds~t~'i)~(d~'rc501s~t~'1ny)~(d~'rc4uau~t~'1mc)~(d~'rc4ucl~t~'h)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1))))                                                                           | 3              |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 15            | [14h 14m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rb27db~t~'71z)~(d~'raye00~t~'1bkb)~(d~'rayefc~t~'1bzn)~(d~'raymt1~t~'6my)~(d~'rb2bj0~t~'2d)~(d~'rbbg9e~t~'1cuv)~(d~'ray6q8~t~'6d)~(d~'rbzbj5~t~'vcvk)~(d~'rbzdr1~t~'26r)~(d~'rc1ekb~t~'u)~(d~'rc1asl~t~'1t)~(d~'rbs3qd~t~'1cb7)~(d~'rbsbos~t~'t)~(d~'rboezr~t~'7)~(d~'rbzk1a~t~'630)~(d~'rc1fvp~t~'1vu6)~(d~'rc31gq~t~'1dl8)~(d~'rc4u0n~t~'3655)~(d~'rc4u12~t~'19z1)~(d~'rc5jdl~t~'1v8)~(d~'rc6qbz~t~'13iz)~(d~'rc6qdg~t~'13kg)~(d~'rc6qdv~t~'13kv)~(d~'rc6qe9~t~'13l9)~(d~'rc6qej~t~'13lj)~(d~'rc6qgg~t~'13ng)~(d~'rbzcqr~t~'1jl)~(d~'rce3ax~t~'4oi)))) | **51**         |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 12            | [17h 6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'ray8p5~t~'9d)~(d~'rbd2pf~t~'1qox)~(d~'rbd2qw~t~'1qqe)~(d~'rbd2sv~t~'1qsd)~(d~'rbd8g2~t~'1wfk)~(d~'rbd28d~t~'3ps)~(d~'rbd874~t~'1lbb)~(d~'rbdbbd~t~'1ofk)~(d~'rbdbc0~t~'1h3)~(d~'rbd8a1~t~'1hfz)~(d~'rbd8aj~t~'1hgh)~(d~'ray6yk~t~'ep)~(d~'rbqbw3~t~'2c)~(d~'rbq6k1~t~'1ynv)~(d~'rbq9cw~t~'jv)~(d~'rbq9fl~t~'mk)~(d~'rbgx2h~t~'1bhu)~(d~'rbh436~t~'1iij)~(d~'rbhuv7~t~'29ak)~(d~'rbmq43~t~'14i)~(d~'rbmq4a~t~'14p)~(d~'rc6wfc~t~'2j)~(d~'rcc92y~t~'fi))))                                                                                                     | 13             |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 12            | [1h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'rb2bup~t~'4o)~(d~'rb2bz2~t~'91)~(d~'rb9vu0~t~'30n)~(d~'rbbmge~t~'cmt)~(d~'rbbmic~t~'cor)~(d~'rbbmmo~t~'ct3)~(d~'rbbnbd~t~'dhs)~(d~'rbbnx9~t~'e3o)~(d~'rb4980~t~'b8)~(d~'rb3pty~t~'16uq)~(d~'rb2blm~t~'4z)~(d~'razzi8~t~'1qmd)~(d~'rb9j73~t~'84)~(d~'rb9j7t~t~'8u)~(d~'rb9mxc~t~'3yd)~(d~'rb9hrk~t~'1o)~(d~'rb9hrv~t~'1z)~(d~'rb9gs1~t~'71)~(d~'rawsnr~t~'9rs)~(d~'rb40tn~t~'3wy))))                                                                                                                                                                      | 8              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 8             | [37m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rb20a1~t~'4w)~(d~'rb0mhn~t~'1j0)~(d~'rbd6vp~t~'8d4)~(d~'rb9kvb~t~'1wc)~(d~'rbz79u~t~'52c2)~(d~'rbzc3r~t~'ia)~(d~'rbzcy9~t~'h1)~(d~'rc2z4i~t~'3i)~(d~'rc4srj~t~'1gyh)~(d~'rccjyn~t~'3s2))))                                                                                                                                                                                                                                                                                                                                                                         | 1              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 8             | [10h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rb2d4q~t~'e5)~(d~'rb2den~t~'8a)~(d~'rbez2c~t~'35xo)~(d~'rb0d4x~t~'gj)~(d~'rb3slg~t~'1i5l)~(d~'rbbjiu~t~'1k8)~(d~'rb21so~t~'23oa)~(d~'rbez62~t~'ag9r)~(d~'rcctyo~t~'52w)~(d~'rce0vj~t~'cdw4))))                                                                                                                                                                                                                                                                                                                                                     | 4              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 8             | [1h 18m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rawjxk~t~'137)~(d~'rayc0z~t~'3l7)~(d~'rbbc3j~t~'31)~(d~'rbbek4~t~'2jm)~(d~'rbdfl0~t~'23ki)~(d~'rbdfo5~t~'ct0)~(d~'rbdfi8~t~'1smf)~(d~'rbqff9~t~'6g)~(d~'rc36ga~t~'3n8)~(d~'rc36n7~t~'1kn5)~(d~'rbfoeo~t~'2u1)~(d~'rbh75z~t~'1llc)~(d~'rbmga9~t~'6upm)~(d~'rc73tt~t~'31))))                                                                                                                                                                                                                                                                                    | 20             |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 8             | [56m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rb17b8~t~'i2n)~(d~'rbqkv9~t~'2ll)~(d~'rbqlix~t~'399)~(d~'rc5img~t~'rg)~(d~'rc6ulc~t~'10f)~(d~'rc746w~t~'ckd)~(d~'rc6tgh~t~'ds)~(d~'rbzlqr~t~'amv)~(d~'rccotv~t~'df))))                                                                                                                                                                                                                                                                                                                                                                                    | 3              |
| <a href="https://github.com/brick-green-agile6"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a> | brick-green-agile6 | 6             | [30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green-agile6)~p~30~r~(~(d~'rbf7d7~t~'sa)~(d~'ray8m1~t~'1a)~(d~'rbzbjk~t~'9r)~(d~'rc55bf~t~'1eh)~(d~'rb9m6q~t~'53af)~(d~'rbqazy~t~'1e8z)~(d~'rcctsn~t~'6l5))))                                                                                                                                                                                                                                                                                                                                                                                                                     | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 5             | [48m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rbcykq~t~'tt4)~(d~'rb48yg~t~'1o)~(d~'rb42un~t~'1p4)~(d~'rb4392~t~'23j)~(d~'rb43gk~t~'2b1)~(d~'rb44el~t~'392)~(d~'rb46fa~t~'59r)~(d~'rb9lrj~t~'p3)~(d~'rb9a2d~t~'55i7)~(d~'rb3shh~t~'bp))))                                                                                                                                                                                                                                                                                                                                                                          | 6              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [4h 55m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rbbj5r~t~'175)~(d~'rc58jg~t~'5ex1)~(d~'rbpmv0~t~'q41)~(d~'rccu86~t~'ng))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 2              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 4             | [1h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rb0n6l~t~'re)~(d~'rbqh6q~t~'1xx)~(d~'rbn1hp~t~'jwn)~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 3             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rbd338~t~'17j)~(d~'rbd351~t~'19c)~(d~'rbd423~t~'26e)~(d~'rb9u6e~t~'ep)~(d~'rccrjv~t~'g68))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 3             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rbto84~t~'17bn)~(d~'rc73td~t~'2l)~(d~'rc5ble~t~'1hj))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 1              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 3             | [15h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rc4y4f~t~'54i0)~(d~'rc50yb~t~'6xn)~(d~'rbq4h9~t~'17qa)~(d~'rbq4os~t~'17xt)~(d~'rbq4q1~t~'17z2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 2             | [4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'raylpp~t~'7u)~(d~'rb075p~t~'6n)~(d~'rb07gk~t~'3b))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 2             | [5h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rbg05i~t~'ekv)~(d~'rbg05v~t~'el8)~(d~'rc73t6~t~'2e))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 2             | [23h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rb68d5~t~'3oaq)~(d~'rb3siu~t~'d2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 2             | [33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'rb2k1h~t~'2o)~(d~'rboswg~t~'2yp))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/acoushawk"><img src="https://avatars.githubusercontent.com/u/9059393?u=a28896651bbe093372aa593ebc66296fa638250c&v=4" width="20"></a>           | acoushawk          | 1             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'9059393~n~'acoushawk)~p~30~r~(~(d~'rb0754~t~'62))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 2              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 1             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'rbd32j~t~'16u)~(d~'rbd3mk~t~'1qv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 2              |