### PR TITLE
Fix random unit test failure

### DIFF
--- a/prime-router/src/test/kotlin/unittest/UnitTestUtils.kt
+++ b/prime-router/src/test/kotlin/unittest/UnitTestUtils.kt
@@ -12,14 +12,14 @@ object UnitTestUtils {
 
     /**
      * A new instance of a simple schema for testing. Note a new schema instance is created each time this
-     * simpleSchema variable is referenced, so unit tests do not interfere with each other.
+     * [simpleSchema] variable is referenced, so unit tests do not interfere with each other.
      */
     val simpleSchema get() =
         Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
 
     /**
      * A new instance of a simple metadata instance that does not use the real configuration. Note a new
-     * Metadata instance is created each time this simpleMetadata variable is referenced, so unit tests do not
+     * Metadata instance is created each time this [simpleMetadata] variable is referenced, so unit tests do not
      * interfere with each other.
      */
     val simpleMetadata get() = Metadata(simpleSchema)

--- a/prime-router/src/test/kotlin/unittest/UnitTestUtils.kt
+++ b/prime-router/src/test/kotlin/unittest/UnitTestUtils.kt
@@ -11,16 +11,18 @@ import gov.cdc.prime.router.Schema
 object UnitTestUtils {
 
     /**
-     * A simple schema for testing.
+     * A new instance of a simple schema for testing. Note a new schema instance is created each time this
+     * simpleSchema variable is referenced, so unit tests do not interfere with each other.
      */
-    val simpleSchema = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
+    val simpleSchema get() =
+        Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
 
     /**
-     * A simple metadata instance that does not use the real configuration.
+     * A new instance of a simple metadata instance that does not use the real configuration. Note a new
+     * Metadata instance is created each time this simpleMetadata variable is referenced, so unit tests do not
+     * interfere with each other.
      */
-    val simpleMetadata by lazy {
-        Metadata(simpleSchema)
-    }
+    val simpleMetadata get() = Metadata(simpleSchema)
 
     /** returns a "mocked" hl7Config class */
     fun createConfig(


### PR DESCRIPTION
This PR fixes a random unit test failure we are getting in Github Actions.  This one is very hard to duplicate locally and we only found one person that could duplicate it.  The problem is that multiple unit tests were using the same instance of metadata and schema and some of them were changing those objects.  If those tests run in the same JVM and in the right order then you get a failure.

Test Steps:
1. Verify the build in Github Actions is successful.

## Changes
- schema and metadata variables create a new instance of the objects every time it is called

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- None

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
