### PR TITLE
Fixes issue with MSH-7 for VT and OH

### DIFF
--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -142,7 +142,7 @@ elements:
     hhsGuidanceField:
 
   - name: file_created_date
-    type: DATE
+    type: DATETIME
     natFlatFileField: File_created_date
     hhsGuidanceField:
     hl7Field: MSH-7

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -796,7 +796,7 @@
         truncateHDNamespaceIds: true
         usePid14ForPatientEmail: true
         suppressNonNPI: true
-        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3
+        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3, MSH-19-1, MSH-19-2, MSH-19-3
         replaceValue:
           MSH-3-1: CDC PRIME - Atlanta,
         convertPositiveDateTimeOffsetToNegative: true
@@ -831,7 +831,7 @@
         truncateHDNamespaceIds: true
         usePid14ForPatientEmail: true
         suppressNonNPI: true
-        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3
+        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3, MSH-19-1, MSH-19-2, MSH-19-3
         replaceValue:
           MSH-3-1: CDC PRIME - Atlanta,
       timing:
@@ -868,7 +868,7 @@
         truncateHDNamespaceIds: true
         usePid14ForPatientEmail: true
         suppressNonNPI: true
-        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3
+        suppressHl7Fields: OBX-18-1, OBX-18-2, OBX-18-3, OBX-18-4, OBX-15-3, MSH-19-1, MSH-19-2, MSH-19-3
         replaceValue:
           MSH-3-1: CDC PRIME - Atlanta,
       timing:
@@ -968,7 +968,7 @@
         reportingFacilityName: CDC PRIME
         reportingFacilityId: 36DSMP9999
         nameFormat: ohio
-        suppressHl7Fields: OBX-23-11
+        suppressHl7Fields: OBX-23-11, MSH-19-1, MSH-19-2, MSH-19-3
         # turn off UNK and ASKU for this field
         useBlankInsteadOfUnknown: patient_race
       timing:


### PR DESCRIPTION
This PR fixes an issue for both VT and OH where the value in MSH-7 is a date and not a timestamp. The `file_created_date` field in the HL7 file was listed as a date but should be a timestamp according to the HL7 specification. This also blanks out MSH-19 for both states. The settings are already updated in production via the web app, but this PR unifies the local settings to match.

Test Steps:
1. Create a new fake file for posting to yourself: `./prime data --input-fake 10 --input-schema primedatainput/pdi-covid-19 --output-format CSV --output build/5565-test-file.csv --target-states VT,OH`
2. Send the file to your instance of report stream: `curl -X POST -H 'client: simple_report' -H 'Content-Type: text/csv' --data-binary @"build/5565-test-file.csv" 'http://localhost:7071/api/reports'`
3. Navigate to your SFTP folder and review the two files created there
4. Confirm that the files created have a timestamp for the MSH-7 field

- Updates the schema to change the MSH-7 field to a date time type
- Updated OH and VT also blank out the MSH-19 field

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

