### PR TITLE
reproduce test failures from kevin's session branch

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -54,7 +54,7 @@
         "e2e": "cypress run",
         "e2e:open": "cypress open",
         "test": "react-scripts test",
-        "test:ci": "yarn test --clearCache && CI=true yarn --verbose test --coverage --verbose",
+        "test:ci": "CI=true yarn --verbose test --coverage --runInBand=false",
         "eject": "react-scripts eject",
         "lint": "npm-run-all -p lint:eslint",
         "lint:write": "npm-run-all -p lint:eslint:write",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -54,7 +54,7 @@
         "e2e": "cypress run",
         "e2e:open": "cypress open",
         "test": "react-scripts test",
-        "test:ci": "CI=true yarn --verbose test --coverage --runInBand=false",
+        "test:ci": "CI=true yarn --verbose test --coverage --runInBand=true",
         "eject": "react-scripts eject",
         "lint": "npm-run-all -p lint:eslint",
         "lint:write": "npm-run-all -p lint:eslint:write",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -54,7 +54,7 @@
         "e2e": "cypress run",
         "e2e:open": "cypress open",
         "test": "react-scripts test",
-        "test:ci": "CI=true yarn --verbose test --coverage --runInBand=true",
+        "test:ci": "CI=true yarn --verbose test --coverage --runInBand=true ./src/hooks/UseGroups.test.ts",
         "eject": "react-scripts eject",
         "lint": "npm-run-all -p lint:eslint",
         "lint:write": "npm-run-all -p lint:eslint:write",

--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -4,7 +4,7 @@ import { OktaAuth, toRelativeUrl } from "@okta/okta-auth-js";
 import { LoginCallback, SecureRoute, Security } from "@okta/okta-react";
 import { isIE } from "react-device-detect";
 import { useIdleTimer } from "react-idle-timer";
-import React, { Suspense, useContext } from "react";
+import React, { Suspense } from "react";
 import { NetworkErrorBoundary } from "rest-hooks";
 import { ToastContainer } from "react-toastify";
 
@@ -36,7 +36,7 @@ import SubmissionDetails from "./pages/submissions/SubmissionDetails";
 import { NewSetting } from "./components/Admin/NewSetting";
 import { FeatureFlagUIComponent } from "./pages/misc/FeatureFlags";
 import SenderModeBanner from "./components/SenderModeBanner";
-import { SessionStorageContext } from "./contexts/SessionStorageContext";
+import SessionProvider from "./contexts/SessionStorageContext";
 import { AdminOrgNew } from "./pages/admin/AdminOrgNew";
 import { DAPHeader } from "./components/header/DAPHeader";
 import ValueSetsIndex from "./pages/admin/value-set-editor/ValueSetsIndex";
@@ -51,7 +51,6 @@ const App = () => {
         }'`
     );
     const history = useHistory();
-    const context = useContext(SessionStorageContext);
     const customAuthHandler = (): void => {
         history.push("/login");
     };
@@ -90,127 +89,129 @@ const App = () => {
             onAuthRequired={customAuthHandler}
             restoreOriginalUri={restoreOriginalUri}
         >
-            <Suspense fallback={<Spinner size={"fullpage"} />}>
-                <NetworkErrorBoundary
-                    fallbackComponent={() => <ErrorPage type="page" />}
-                >
-                    <DAPHeader env={process.env.REACT_APP_ENV?.toString()} />
-                    <GovBanner aria-label="Official government website" />
-                    {context.values.org && context.values.senderName ? (
+            <SessionProvider>
+                <Suspense fallback={<Spinner size={"fullpage"} />}>
+                    <NetworkErrorBoundary
+                        fallbackComponent={() => <ErrorPage type="page" />}
+                    >
+                        <DAPHeader
+                            env={process.env.REACT_APP_ENV?.toString()}
+                        />
+                        <GovBanner aria-label="Official government website" />
                         <SenderModeBanner />
-                    ) : null}
-                    <ReportStreamHeader />
-                    {/* Changed from main to div to fix weird padding issue at the top
-                            caused by USWDS styling | 01/22 merged styles from .content into main, don't see padding issues anymore? */}
-                    <main id="main-content">
-                        <Switch>
-                            <Route path="/" exact={true} component={Home} />
-                            <Route
-                                path="/how-it-works"
-                                component={HowItWorks}
-                            />
-                            <Route
-                                path="/terms-of-service"
-                                component={TermsOfService}
-                            />
-                            <Route path="/login" render={() => <Login />} />
-                            <Route
-                                path="/login/callback"
-                                component={LoginCallback}
-                            />
-                            <Route
-                                path="/sign-tos"
-                                component={TermsOfServiceForm}
-                            />
-                            <Route
-                                path="/getting-started/public-health-departments"
-                                component={
-                                    GettingStartedPublicHealthDepartments
-                                }
-                            />
-                            <Route
-                                path="/getting-started/testing-facilities"
-                                component={GettingStartedTestingFacilities}
-                            />
-                            <AuthorizedRoute
-                                path="/daily-data"
-                                authorize={PERMISSIONS.RECEIVER}
-                                component={Daily}
-                            />
-                            <AuthorizedRoute
-                                path="/upload"
-                                authorize={PERMISSIONS.SENDER}
-                                component={Upload}
-                            />
-                            {/* TODO: AuthorizedRoute needs to take many potential auth groups.
-                             *  We should fix this when we refactor our permissions layer.
-                             */}
-                            <AuthorizedRoute
-                                path="/submissions/:actionId"
-                                authorize={PERMISSIONS.SENDER}
-                                component={SubmissionDetails}
-                            />
-                            <AuthorizedRoute
-                                path="/submissions"
-                                authorize={PERMISSIONS.SENDER}
-                                component={Submissions}
-                            />
-                            <AuthorizedRoute
-                                path="/admin/settings"
-                                authorize={PERMISSIONS.PRIME_ADMIN}
-                                component={AdminMain}
-                            />
-                            <AuthorizedRoute
-                                path="/admin/new/org"
-                                authorize={PERMISSIONS.PRIME_ADMIN}
-                                component={AdminOrgNew}
-                            />
-                            <AuthorizedRoute
-                                path="/admin/orgsettings/org/:orgname"
-                                authorize={PERMISSIONS.PRIME_ADMIN}
-                                component={AdminOrgEdit}
-                            />
-                            <AuthorizedRoute
-                                path="/admin/orgreceiversettings/org/:orgname/receiver/:receivername/action/:action"
-                                authorize={PERMISSIONS.PRIME_ADMIN}
-                                component={EditReceiverSettings}
-                            />
-                            <AuthorizedRoute
-                                path="/admin/orgsendersettings/org/:orgname/sender/:sendername/action/:action"
-                                authorize={PERMISSIONS.PRIME_ADMIN}
-                                component={EditSenderSettings}
-                            />
-                            <AuthorizedRoute
-                                path="/admin/orgnewsetting/org/:orgname/settingtype/:settingtype"
-                                authorize={PERMISSIONS.PRIME_ADMIN}
-                                component={NewSetting}
-                            />
-                            <SecureRoute
-                                path="/report-details"
-                                component={Details}
-                            />
-                            <SecureRoute
-                                path="/features"
-                                component={FeatureFlagUIComponent}
-                            />
-                            <SecureRoute
-                                path={"/admin/value-sets"}
-                                component={ValueSetsIndex}
-                            />
-                            {/* Handles any undefined route */}
-                            <Route
-                                render={() => (
-                                    <ErrorPage code={CODES.NOT_FOUND_404} />
-                                )}
-                            />
-                        </Switch>
-                    </main>
-                    <ToastContainer limit={4} />
-                    <footer className="usa-identifier footer">
-                        <ReportStreamFooter />
-                    </footer>
-                </NetworkErrorBoundary>
-            </Suspense>
+                        <ReportStreamHeader />
+                        {/* Changed from main to div to fix weird padding issue at the top
+                                caused by USWDS styling | 01/22 merged styles from .content into main, don't see padding issues anymore? */}
+                        <main id="main-content">
+                            <Switch>
+                                <Route path="/" exact={true} component={Home} />
+                                <Route
+                                    path="/how-it-works"
+                                    component={HowItWorks}
+                                />
+                                <Route
+                                    path="/terms-of-service"
+                                    component={TermsOfService}
+                                />
+                                <Route path="/login" render={() => <Login />} />
+                                <Route
+                                    path="/login/callback"
+                                    component={LoginCallback}
+                                />
+                                <Route
+                                    path="/sign-tos"
+                                    component={TermsOfServiceForm}
+                                />
+                                <Route
+                                    path="/getting-started/public-health-departments"
+                                    component={
+                                        GettingStartedPublicHealthDepartments
+                                    }
+                                />
+                                <Route
+                                    path="/getting-started/testing-facilities"
+                                    component={GettingStartedTestingFacilities}
+                                />
+                                <AuthorizedRoute
+                                    path="/daily-data"
+                                    authorize={PERMISSIONS.RECEIVER}
+                                    component={Daily}
+                                />
+                                <AuthorizedRoute
+                                    path="/upload"
+                                    authorize={PERMISSIONS.SENDER}
+                                    component={Upload}
+                                />
+                                {/* TODO: AuthorizedRoute needs to take many potential auth groups.
+                                 *  We should fix this when we refactor our permissions layer.
+                                 */}
+                                <AuthorizedRoute
+                                    path="/submissions/:actionId"
+                                    authorize={PERMISSIONS.SENDER}
+                                    component={SubmissionDetails}
+                                />
+                                <AuthorizedRoute
+                                    path="/submissions"
+                                    authorize={PERMISSIONS.SENDER}
+                                    component={Submissions}
+                                />
+                                <AuthorizedRoute
+                                    path="/admin/settings"
+                                    authorize={PERMISSIONS.PRIME_ADMIN}
+                                    component={AdminMain}
+                                />
+                                <AuthorizedRoute
+                                    path="/admin/new/org"
+                                    authorize={PERMISSIONS.PRIME_ADMIN}
+                                    component={AdminOrgNew}
+                                />
+                                <AuthorizedRoute
+                                    path="/admin/orgsettings/org/:orgname"
+                                    authorize={PERMISSIONS.PRIME_ADMIN}
+                                    component={AdminOrgEdit}
+                                />
+                                <AuthorizedRoute
+                                    path="/admin/orgreceiversettings/org/:orgname/receiver/:receivername/action/:action"
+                                    authorize={PERMISSIONS.PRIME_ADMIN}
+                                    component={EditReceiverSettings}
+                                />
+                                <AuthorizedRoute
+                                    path="/admin/orgsendersettings/org/:orgname/sender/:sendername/action/:action"
+                                    authorize={PERMISSIONS.PRIME_ADMIN}
+                                    component={EditSenderSettings}
+                                />
+                                <AuthorizedRoute
+                                    path="/admin/orgnewsetting/org/:orgname/settingtype/:settingtype"
+                                    authorize={PERMISSIONS.PRIME_ADMIN}
+                                    component={NewSetting}
+                                />
+                                <SecureRoute
+                                    path="/report-details"
+                                    component={Details}
+                                />
+                                <SecureRoute
+                                    path="/features"
+                                    component={FeatureFlagUIComponent}
+                                />
+                                <SecureRoute
+                                    path={"/admin/value-sets"}
+                                    component={ValueSetsIndex}
+                                />
+                                {/* Handles any undefined route */}
+                                <Route
+                                    render={() => (
+                                        <ErrorPage code={CODES.NOT_FOUND_404} />
+                                    )}
+                                />
+                            </Switch>
+                        </main>
+                        <ToastContainer limit={4} />
+                        <footer className="usa-identifier footer">
+                            <ReportStreamFooter />
+                        </footer>
+                    </NetworkErrorBoundary>
+                </Suspense>
+            </SessionProvider>
         </Security>
     );
 };

--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -36,7 +36,7 @@ import SubmissionDetails from "./pages/submissions/SubmissionDetails";
 import { NewSetting } from "./components/Admin/NewSetting";
 import { FeatureFlagUIComponent } from "./pages/misc/FeatureFlags";
 import SenderModeBanner from "./components/SenderModeBanner";
-import SessionProvider from "./contexts/SessionStorageContext";
+// import SessionProvider from "./contexts/SessionStorageContext";
 import { AdminOrgNew } from "./pages/admin/AdminOrgNew";
 import { DAPHeader } from "./components/header/DAPHeader";
 import ValueSetsIndex from "./pages/admin/value-set-editor/ValueSetsIndex";
@@ -89,129 +89,125 @@ const App = () => {
             onAuthRequired={customAuthHandler}
             restoreOriginalUri={restoreOriginalUri}
         >
-            <SessionProvider>
-                <Suspense fallback={<Spinner size={"fullpage"} />}>
-                    <NetworkErrorBoundary
-                        fallbackComponent={() => <ErrorPage type="page" />}
-                    >
-                        <DAPHeader
-                            env={process.env.REACT_APP_ENV?.toString()}
-                        />
-                        <GovBanner aria-label="Official government website" />
-                        <SenderModeBanner />
-                        <ReportStreamHeader />
-                        {/* Changed from main to div to fix weird padding issue at the top
+            <Suspense fallback={<Spinner size={"fullpage"} />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={() => <ErrorPage type="page" />}
+                >
+                    <DAPHeader env={process.env.REACT_APP_ENV?.toString()} />
+                    <GovBanner aria-label="Official government website" />
+                    <SenderModeBanner />
+                    <ReportStreamHeader />
+                    {/* Changed from main to div to fix weird padding issue at the top
                                 caused by USWDS styling | 01/22 merged styles from .content into main, don't see padding issues anymore? */}
-                        <main id="main-content">
-                            <Switch>
-                                <Route path="/" exact={true} component={Home} />
-                                <Route
-                                    path="/how-it-works"
-                                    component={HowItWorks}
-                                />
-                                <Route
-                                    path="/terms-of-service"
-                                    component={TermsOfService}
-                                />
-                                <Route path="/login" render={() => <Login />} />
-                                <Route
-                                    path="/login/callback"
-                                    component={LoginCallback}
-                                />
-                                <Route
-                                    path="/sign-tos"
-                                    component={TermsOfServiceForm}
-                                />
-                                <Route
-                                    path="/getting-started/public-health-departments"
-                                    component={
-                                        GettingStartedPublicHealthDepartments
-                                    }
-                                />
-                                <Route
-                                    path="/getting-started/testing-facilities"
-                                    component={GettingStartedTestingFacilities}
-                                />
-                                <AuthorizedRoute
-                                    path="/daily-data"
-                                    authorize={PERMISSIONS.RECEIVER}
-                                    component={Daily}
-                                />
-                                <AuthorizedRoute
-                                    path="/upload"
-                                    authorize={PERMISSIONS.SENDER}
-                                    component={Upload}
-                                />
-                                {/* TODO: AuthorizedRoute needs to take many potential auth groups.
-                                 *  We should fix this when we refactor our permissions layer.
-                                 */}
-                                <AuthorizedRoute
-                                    path="/submissions/:actionId"
-                                    authorize={PERMISSIONS.SENDER}
-                                    component={SubmissionDetails}
-                                />
-                                <AuthorizedRoute
-                                    path="/submissions"
-                                    authorize={PERMISSIONS.SENDER}
-                                    component={Submissions}
-                                />
-                                <AuthorizedRoute
-                                    path="/admin/settings"
-                                    authorize={PERMISSIONS.PRIME_ADMIN}
-                                    component={AdminMain}
-                                />
-                                <AuthorizedRoute
-                                    path="/admin/new/org"
-                                    authorize={PERMISSIONS.PRIME_ADMIN}
-                                    component={AdminOrgNew}
-                                />
-                                <AuthorizedRoute
-                                    path="/admin/orgsettings/org/:orgname"
-                                    authorize={PERMISSIONS.PRIME_ADMIN}
-                                    component={AdminOrgEdit}
-                                />
-                                <AuthorizedRoute
-                                    path="/admin/orgreceiversettings/org/:orgname/receiver/:receivername/action/:action"
-                                    authorize={PERMISSIONS.PRIME_ADMIN}
-                                    component={EditReceiverSettings}
-                                />
-                                <AuthorizedRoute
-                                    path="/admin/orgsendersettings/org/:orgname/sender/:sendername/action/:action"
-                                    authorize={PERMISSIONS.PRIME_ADMIN}
-                                    component={EditSenderSettings}
-                                />
-                                <AuthorizedRoute
-                                    path="/admin/orgnewsetting/org/:orgname/settingtype/:settingtype"
-                                    authorize={PERMISSIONS.PRIME_ADMIN}
-                                    component={NewSetting}
-                                />
-                                <SecureRoute
-                                    path="/report-details"
-                                    component={Details}
-                                />
-                                <SecureRoute
-                                    path="/features"
-                                    component={FeatureFlagUIComponent}
-                                />
-                                <SecureRoute
-                                    path={"/admin/value-sets"}
-                                    component={ValueSetsIndex}
-                                />
-                                {/* Handles any undefined route */}
-                                <Route
-                                    render={() => (
-                                        <ErrorPage code={CODES.NOT_FOUND_404} />
-                                    )}
-                                />
-                            </Switch>
-                        </main>
-                        <ToastContainer limit={4} />
-                        <footer className="usa-identifier footer">
-                            <ReportStreamFooter />
-                        </footer>
-                    </NetworkErrorBoundary>
-                </Suspense>
-            </SessionProvider>
+                    <main id="main-content">
+                        <Switch>
+                            <Route path="/" exact={true} component={Home} />
+                            <Route
+                                path="/how-it-works"
+                                component={HowItWorks}
+                            />
+                            <Route
+                                path="/terms-of-service"
+                                component={TermsOfService}
+                            />
+                            <Route path="/login" render={() => <Login />} />
+                            <Route
+                                path="/login/callback"
+                                component={LoginCallback}
+                            />
+                            <Route
+                                path="/sign-tos"
+                                component={TermsOfServiceForm}
+                            />
+                            <Route
+                                path="/getting-started/public-health-departments"
+                                component={
+                                    GettingStartedPublicHealthDepartments
+                                }
+                            />
+                            <Route
+                                path="/getting-started/testing-facilities"
+                                component={GettingStartedTestingFacilities}
+                            />
+                            <AuthorizedRoute
+                                path="/daily-data"
+                                authorize={PERMISSIONS.RECEIVER}
+                                component={Daily}
+                            />
+                            <AuthorizedRoute
+                                path="/upload"
+                                authorize={PERMISSIONS.SENDER}
+                                component={Upload}
+                            />
+                            {/* TODO: AuthorizedRoute needs to take many potential auth groups.
+                             *  We should fix this when we refactor our permissions layer.
+                             */}
+                            <AuthorizedRoute
+                                path="/submissions/:actionId"
+                                authorize={PERMISSIONS.SENDER}
+                                component={SubmissionDetails}
+                            />
+                            <AuthorizedRoute
+                                path="/submissions"
+                                authorize={PERMISSIONS.SENDER}
+                                component={Submissions}
+                            />
+                            <AuthorizedRoute
+                                path="/admin/settings"
+                                authorize={PERMISSIONS.PRIME_ADMIN}
+                                component={AdminMain}
+                            />
+                            <AuthorizedRoute
+                                path="/admin/new/org"
+                                authorize={PERMISSIONS.PRIME_ADMIN}
+                                component={AdminOrgNew}
+                            />
+                            <AuthorizedRoute
+                                path="/admin/orgsettings/org/:orgname"
+                                authorize={PERMISSIONS.PRIME_ADMIN}
+                                component={AdminOrgEdit}
+                            />
+                            <AuthorizedRoute
+                                path="/admin/orgreceiversettings/org/:orgname/receiver/:receivername/action/:action"
+                                authorize={PERMISSIONS.PRIME_ADMIN}
+                                component={EditReceiverSettings}
+                            />
+                            <AuthorizedRoute
+                                path="/admin/orgsendersettings/org/:orgname/sender/:sendername/action/:action"
+                                authorize={PERMISSIONS.PRIME_ADMIN}
+                                component={EditSenderSettings}
+                            />
+                            <AuthorizedRoute
+                                path="/admin/orgnewsetting/org/:orgname/settingtype/:settingtype"
+                                authorize={PERMISSIONS.PRIME_ADMIN}
+                                component={NewSetting}
+                            />
+                            <SecureRoute
+                                path="/report-details"
+                                component={Details}
+                            />
+                            <SecureRoute
+                                path="/features"
+                                component={FeatureFlagUIComponent}
+                            />
+                            <SecureRoute
+                                path={"/admin/value-sets"}
+                                component={ValueSetsIndex}
+                            />
+                            {/* Handles any undefined route */}
+                            <Route
+                                render={() => (
+                                    <ErrorPage code={CODES.NOT_FOUND_404} />
+                                )}
+                            />
+                        </Switch>
+                    </main>
+                    <ToastContainer limit={4} />
+                    <footer className="usa-identifier footer">
+                        <ReportStreamFooter />
+                    </footer>
+                </NetworkErrorBoundary>
+            </Suspense>
         </Security>
     );
 };

--- a/frontend-react/src/components/SenderModeBanner.tsx
+++ b/frontend-react/src/components/SenderModeBanner.tsx
@@ -3,15 +3,18 @@ import { IconWarning } from "@trussworks/react-uswds";
 import { NavLink } from "react-router-dom";
 
 import useSenderMode from "../hooks/UseSenderMode";
-import { SessionStorageContext } from "../contexts/SessionStorageContext";
+import { SessionContext } from "../contexts/SessionStorageContext";
 
 const isNotActive = (val: string): boolean => {
     return val === "testing" || val === "inactive";
 };
 
 const SenderModeBanner = (): ReactElement | null => {
-    const session = useContext(SessionStorageContext);
-    const status = useSenderMode(session.values.org, session.values.senderName);
+    const session = useContext(SessionContext);
+    const status = useSenderMode(
+        session.store.values.org,
+        session.store.values.senderName
+    );
     const path = "/getting-started/testing-facilities/overview";
 
     if (isNotActive(status)) {

--- a/frontend-react/src/contexts/SessionStorageContext.test.tsx
+++ b/frontend-react/src/contexts/SessionStorageContext.test.tsx
@@ -5,15 +5,15 @@ import { orgServer } from "../__mocks__/OrganizationMockServer";
 import { renderWithSession } from "../utils/CustomRenderUtils";
 
 import { setStoredOrg, setStoredSenderName } from "./SessionStorageTools";
-import { SessionStorageContext } from "./SessionStorageContext";
+import { SessionContext } from "./SessionStorageContext";
 
 const TestComponent = () => {
-    const { values } = useContext(SessionStorageContext);
+    const { store } = useContext(SessionContext);
 
     return (
         <>
-            <div>{values.org}</div>
-            <div>{values.senderName}</div>
+            <div>{store.values.org}</div>
+            <div>{store.values.senderName}</div>
         </>
     );
 };

--- a/frontend-react/src/contexts/SessionStorageContext.tsx
+++ b/frontend-react/src/contexts/SessionStorageContext.tsx
@@ -1,26 +1,36 @@
-import { createContext, FC } from "react";
+import { createContext, FC, useContext } from "react";
 
 import useSessionStorage, {
     SessionController,
-    SessionStore,
 } from "../hooks/UseSessionStorage";
+import { MembershipController, useGroups } from "../hooks/UseGroups";
 
-export const SessionStorageContext = createContext<SessionController>({
-    values: {},
-    updateSessionStorage: (store: Partial<SessionStore>) => {
-        // Never gets called, just used store to please the linter
-        console.log(`${store}`);
-    },
+interface ISessionContext {
+    memberships: MembershipController;
+    store: SessionController;
+}
+
+export const SessionContext = createContext<ISessionContext>({
+    memberships: {} as MembershipController,
+    store: {} as SessionController,
 });
 
 const SessionProvider: FC = ({ children }) => {
-    const payload = useSessionStorage();
+    const store = useSessionStorage();
+    const memberships = useGroups();
 
     return (
-        <SessionStorageContext.Provider value={payload}>
+        <SessionContext.Provider
+            value={{
+                memberships: memberships,
+                store: store,
+            }}
+        >
             {children}
-        </SessionStorageContext.Provider>
+        </SessionContext.Provider>
     );
 };
+
+export const useSessionContext = () => useContext(SessionContext);
 
 export default SessionProvider;

--- a/frontend-react/src/contexts/SessionStorageContext.tsx
+++ b/frontend-react/src/contexts/SessionStorageContext.tsx
@@ -1,9 +1,9 @@
-import { createContext, FC, useContext } from "react";
+import { createContext, FC, useContext, useReducer } from "react";
 
 import useSessionStorage, {
     SessionController,
 } from "../hooks/UseSessionStorage";
-import { MembershipController, useGroups } from "../hooks/UseGroups";
+import { MembershipController /* useGroups */ } from "../hooks/UseGroups";
 
 interface ISessionContext {
     memberships: MembershipController;
@@ -17,12 +17,16 @@ export const SessionContext = createContext<ISessionContext>({
 
 const SessionProvider: FC = ({ children }) => {
     const store = useSessionStorage();
-    const memberships = useGroups();
+    // const memberships = useGroups();
+    const [fakeMemberState, fakeMemberDispatch] = useReducer(() => ({}), {});
 
     return (
         <SessionContext.Provider
             value={{
-                memberships: memberships,
+                memberships: {
+                    state: fakeMemberState,
+                    dispatch: fakeMemberDispatch,
+                },
                 store: store,
             }}
         >

--- a/frontend-react/src/contexts/SessionStorageContext.tsx
+++ b/frontend-react/src/contexts/SessionStorageContext.tsx
@@ -1,9 +1,9 @@
-import { createContext, FC, useContext, useReducer } from "react";
+import { createContext, FC, useContext /* useReducer */ } from "react";
 
 import useSessionStorage, {
     SessionController,
 } from "../hooks/UseSessionStorage";
-import { MembershipController /* useGroups */ } from "../hooks/UseGroups";
+import { MembershipController, useGroups } from "../hooks/UseGroups";
 
 interface ISessionContext {
     memberships: MembershipController;
@@ -17,16 +17,17 @@ export const SessionContext = createContext<ISessionContext>({
 
 const SessionProvider: FC = ({ children }) => {
     const store = useSessionStorage();
-    // const memberships = useGroups();
-    const [fakeMemberState, fakeMemberDispatch] = useReducer(() => ({}), {});
+    const memberships = useGroups();
+    // const [fakeMemberState, fakeMemberDispatch] = useReducer(() => ({}), {});
 
     return (
         <SessionContext.Provider
             value={{
-                memberships: {
-                    state: fakeMemberState,
-                    dispatch: fakeMemberDispatch,
-                },
+                // memberships: {
+                //     state: fakeMemberState,
+                //     dispatch: fakeMemberDispatch,
+                // },
+                memberships,
                 store: store,
             }}
         >

--- a/frontend-react/src/hooks/UseGroups.test.ts
+++ b/frontend-react/src/hooks/UseGroups.test.ts
@@ -1,182 +1,185 @@
-import { act, renderHook } from "@testing-library/react-hooks";
-import * as OktaReact from "@okta/okta-react";
-import { IOktaContext } from "@okta/okta-react/bundles/types/OktaContext";
-import { AccessToken } from "@okta/okta-auth-js";
+// import { act, renderHook } from "@testing-library/react-hooks";
+// import * as OktaReact from "@okta/okta-react";
+// import { IOktaContext } from "@okta/okta-react/bundles/types/OktaContext";
+// import { AccessToken } from "@okta/okta-auth-js";
 
-import {
-    MembershipActionType,
-    membershipsFromToken,
-    MemberType,
-    useGroups,
-} from "./UseGroups";
+// import {
+//     MembershipActionType,
+//     membershipsFromToken,
+//     MemberType,
+//     useGroups,
+// } from "./UseGroups";
 
-const mockAuth = jest.spyOn(OktaReact, "useOktaAuth");
+// const mockAuth = jest.spyOn(OktaReact, "useOktaAuth");
 
 describe("useGroups", () => {
     test("renders with default values", () => {
-        mockAuth.mockReturnValue({} as IOktaContext);
-        const { result } = renderHook(() => useGroups());
-        expect(result.current.state.memberships).toBeUndefined();
-        expect(result.current.state.active).toBeUndefined();
+        // mockAuth.mockReturnValue({} as IOktaContext);
+        // const { result } = renderHook(() => useGroups());
+        // expect(result.current.state.memberships).toBeUndefined();
+        // expect(result.current.state.active).toBeUndefined();
+        expect(true).toBe(true);
     });
 
-    test("accounts for non-standard groups", () => {
-        mockAuth.mockReturnValue({
-            authState: {
-                accessToken: {
-                    claims: {
-                        //@ts-ignore
-                        organization: ["NotYourStandardGroup"],
-                    },
-                },
-            },
-        });
-        const { result } = renderHook(() => useGroups());
-        expect(result.current.state.active?.memberType).toEqual("non-standard");
-    });
+    //     test("accounts for non-standard groups", () => {
+    //         mockAuth.mockReturnValue({
+    //             authState: {
+    //                 accessToken: {
+    //                     claims: {
+    //                         //@ts-ignore
+    //                         organization: ["NotYourStandardGroup"],
+    //                     },
+    //                 },
+    //             },
+    //         });
+    //         const { result } = renderHook(() => useGroups());
+    //         expect(result.current.state.active?.memberType).toEqual("non-standard");
+    //     });
 
-    test("can be set with AccessToken", () => {
-        mockAuth.mockReturnValue({
-            authState: {
-                accessToken: {
-                    claims: {
-                        //@ts-ignore
-                        organization: [
-                            "DHPrimeAdmins",
-                            "DHSender_ignore",
-                            "DHmd_phd",
-                        ],
-                    },
-                },
-            },
-        });
-        const { result } = renderHook(() => useGroups());
-        expect(result.current.state.active).toEqual({
-            parsedName: "PrimeAdmins",
-            memberType: MemberType.PRIME_ADMIN,
-        });
-        expect(result.current.state.memberships).toEqual(
-            new Map([
-                [
-                    "DHPrimeAdmins",
-                    {
-                        parsedName: "PrimeAdmins",
-                        memberType: MemberType.PRIME_ADMIN,
-                    },
-                ],
-                [
-                    "DHSender_ignore",
-                    {
-                        parsedName: "ignore",
-                        memberType: MemberType.SENDER,
-                    },
-                ],
-                [
-                    "DHmd_phd",
-                    {
-                        parsedName: "md-phd",
-                        memberType: MemberType.RECEIVER,
-                    },
-                ],
-            ])
-        );
-    });
+    //     test("can be set with AccessToken", () => {
+    //         mockAuth.mockReturnValue({
+    //             authState: {
+    //                 accessToken: {
+    //                     claims: {
+    //                         //@ts-ignore
+    //                         organization: [
+    //                             "DHPrimeAdmins",
+    //                             "DHSender_ignore",
+    //                             "DHmd_phd",
+    //                         ],
+    //                     },
+    //                 },
+    //             },
+    //         });
+    //         const { result } = renderHook(() => useGroups());
+    //         expect(result.current.state.active).toEqual({
+    //             parsedName: "PrimeAdmins",
+    //             memberType: MemberType.PRIME_ADMIN,
+    //         });
+    //         expect(result.current.state.memberships).toEqual(
+    //             new Map([
+    //                 [
+    //                     "DHPrimeAdmins",
+    //                     {
+    //                         parsedName: "PrimeAdmins",
+    //                         memberType: MemberType.PRIME_ADMIN,
+    //                     },
+    //                 ],
+    //                 [
+    //                     "DHSender_ignore",
+    //                     {
+    //                         parsedName: "ignore",
+    //                         memberType: MemberType.SENDER,
+    //                     },
+    //                 ],
+    //                 [
+    //                     "DHmd_phd",
+    //                     {
+    //                         parsedName: "md-phd",
+    //                         memberType: MemberType.RECEIVER,
+    //                     },
+    //                 ],
+    //             ])
+    //         );
+    //     });
 
-    test("can swap active membership", () => {
-        mockAuth.mockReturnValue({
-            authState: {
-                accessToken: {
-                    claims: {
-                        //@ts-ignore
-                        organization: [
-                            "DHPrimeAdmins",
-                            "DHSender_ignore",
-                            "DHmd_phd",
-                        ],
-                    },
-                },
-            },
-        });
-        const { result } = renderHook(() => useGroups());
-        expect(result.current.state.active).toEqual({
-            parsedName: "PrimeAdmins",
-            memberType: MemberType.PRIME_ADMIN,
-        });
-        act(() =>
-            result.current.dispatch({
-                type: MembershipActionType.SWITCH,
-                payload: "DHmd_phd",
-            })
-        );
-        expect(result.current.state.active).toEqual({
-            parsedName: "md-phd",
-            memberType: MemberType.RECEIVER,
-        });
-    });
+    //     test("can swap active membership", () => {
+    //         mockAuth.mockReturnValue({
+    //             authState: {
+    //                 accessToken: {
+    //                     claims: {
+    //                         //@ts-ignore
+    //                         organization: [
+    //                             "DHPrimeAdmins",
+    //                             "DHSender_ignore",
+    //                             "DHmd_phd",
+    //                         ],
+    //                     },
+    //                 },
+    //             },
+    //         });
+    //         const { result } = renderHook(() => useGroups());
+    //         expect(result.current.state.active).toEqual({
+    //             parsedName: "PrimeAdmins",
+    //             memberType: MemberType.PRIME_ADMIN,
+    //         });
+    //         act(() =>
+    //             result.current.dispatch({
+    //                 type: MembershipActionType.SWITCH,
+    //                 payload: "DHmd_phd",
+    //             })
+    //         );
+    //         expect(result.current.state.active).toEqual({
+    //             parsedName: "md-phd",
+    //             memberType: MemberType.RECEIVER,
+    //         });
+    //     });
 
-    test("can override as admin", () => {
-        mockAuth.mockReturnValue({
-            authState: {
-                accessToken: {
-                    claims: {
-                        //@ts-ignore
-                        organization: ["DHPrimeAdmins"],
-                    },
-                },
-            },
-        });
-        const { result } = renderHook(() => useGroups());
-        expect(result.current.state.active).toEqual({
-            parsedName: "PrimeAdmins",
-            memberType: MemberType.PRIME_ADMIN,
-        });
-        act(() =>
-            result.current.dispatch({
-                type: MembershipActionType.ADMIN_OVERRIDE,
-                payload: {
-                    parsedName: "sender-org",
-                    memberType: MemberType.SENDER,
-                },
-            })
-        );
-        expect(result.current.state.active).toEqual({
-            parsedName: "sender-org",
-            memberType: MemberType.SENDER,
-        });
-    });
+    //     test("can override as admin", () => {
+    //         mockAuth.mockReturnValue({
+    //             authState: {
+    //                 accessToken: {
+    //                     claims: {
+    //                         //@ts-ignore
+    //                         organization: ["DHPrimeAdmins"],
+    //                     },
+    //                 },
+    //             },
+    //         });
+    //         const { result } = renderHook(() => useGroups());
+    //         expect(result.current.state.active).toEqual({
+    //             parsedName: "PrimeAdmins",
+    //             memberType: MemberType.PRIME_ADMIN,
+    //         });
+    //         act(() =>
+    //             result.current.dispatch({
+    //                 type: MembershipActionType.ADMIN_OVERRIDE,
+    //                 payload: {
+    //                     parsedName: "sender-org",
+    //                     memberType: MemberType.SENDER,
+    //                 },
+    //             })
+    //         );
+    //         expect(result.current.state.active).toEqual({
+    //             parsedName: "sender-org",
+    //             memberType: MemberType.SENDER,
+    //         });
+    //     });
 });
 
-describe("membershipsFromToken extra coverage", () => {
-    test("can handle undefined token", () => {
-        const state = membershipsFromToken({} as AccessToken);
-        expect(state).toEqual({
-            active: undefined,
-            memberships: undefined,
-        });
-    });
-});
+// describe("membershipsFromToken extra coverage", () => {
+//     test("can handle undefined token", () => {
+//         const state = membershipsFromToken({} as AccessToken);
+//         expect(state).toEqual({
+//             active: undefined,
+//             memberships: undefined,
+//         });
+//     });
+// });
 
-describe("membershipReducer extra coverage", () => {
-    test("can handle bad request", () => {
-        mockAuth.mockReturnValue({
-            authState: {
-                accessToken: {
-                    claims: {
-                        //@ts-ignore
-                        organization: ["DHPrimeAdmins"],
-                    },
-                },
-            },
-        });
-        const { result } = renderHook(() => useGroups());
+// describe("membershipReducer extra coverage", () => {
+//     test("can handle bad request", () => {
+//         mockAuth.mockReturnValue({
+//             authState: {
+//                 accessToken: {
+//                     claims: {
+//                         //@ts-ignore
+//                         organization: ["DHPrimeAdmins"],
+//                     },
+//                 },
+//             },
+//         });
+//         const { result } = renderHook(() => useGroups());
 
-        // bad switch
-        act(() =>
-            result.current.dispatch({
-                type: MembershipActionType.SWITCH,
-                payload: "org-does-not-exist",
-            })
-        );
-        expect(result.current.state.active?.parsedName).toEqual("PrimeAdmins");
-    });
-});
+//         // bad switch
+//         act(() =>
+//             result.current.dispatch({
+//                 type: MembershipActionType.SWITCH,
+//                 payload: "org-does-not-exist",
+//             })
+//         );
+//         expect(result.current.state.active?.parsedName).toEqual("PrimeAdmins");
+//     });
+// });
+
+export {};

--- a/frontend-react/src/hooks/UseGroups.test.ts
+++ b/frontend-react/src/hooks/UseGroups.test.ts
@@ -1,185 +1,182 @@
-// import { act, renderHook } from "@testing-library/react-hooks";
-// import * as OktaReact from "@okta/okta-react";
-// import { IOktaContext } from "@okta/okta-react/bundles/types/OktaContext";
-// import { AccessToken } from "@okta/okta-auth-js";
+import { act, renderHook } from "@testing-library/react-hooks";
+import * as OktaReact from "@okta/okta-react";
+import { IOktaContext } from "@okta/okta-react/bundles/types/OktaContext";
+import { AccessToken } from "@okta/okta-auth-js";
 
-// import {
-//     MembershipActionType,
-//     membershipsFromToken,
-//     MemberType,
-//     useGroups,
-// } from "./UseGroups";
+import {
+    MembershipActionType,
+    membershipsFromToken,
+    MemberType,
+    useGroups,
+} from "./UseGroups";
 
-// const mockAuth = jest.spyOn(OktaReact, "useOktaAuth");
+const mockAuth = jest.spyOn(OktaReact, "useOktaAuth");
 
 describe("useGroups", () => {
     test("renders with default values", () => {
-        // mockAuth.mockReturnValue({} as IOktaContext);
-        // const { result } = renderHook(() => useGroups());
-        // expect(result.current.state.memberships).toBeUndefined();
-        // expect(result.current.state.active).toBeUndefined();
-        expect(true).toBe(true);
+        mockAuth.mockReturnValue({} as IOktaContext);
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.memberships).toBeUndefined();
+        expect(result.current.state.active).toBeUndefined();
     });
 
-    //     test("accounts for non-standard groups", () => {
-    //         mockAuth.mockReturnValue({
-    //             authState: {
-    //                 accessToken: {
-    //                     claims: {
-    //                         //@ts-ignore
-    //                         organization: ["NotYourStandardGroup"],
-    //                     },
-    //                 },
-    //             },
-    //         });
-    //         const { result } = renderHook(() => useGroups());
-    //         expect(result.current.state.active?.memberType).toEqual("non-standard");
-    //     });
+    test("accounts for non-standard groups", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: ["NotYourStandardGroup"],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active?.memberType).toEqual("non-standard");
+    });
 
-    //     test("can be set with AccessToken", () => {
-    //         mockAuth.mockReturnValue({
-    //             authState: {
-    //                 accessToken: {
-    //                     claims: {
-    //                         //@ts-ignore
-    //                         organization: [
-    //                             "DHPrimeAdmins",
-    //                             "DHSender_ignore",
-    //                             "DHmd_phd",
-    //                         ],
-    //                     },
-    //                 },
-    //             },
-    //         });
-    //         const { result } = renderHook(() => useGroups());
-    //         expect(result.current.state.active).toEqual({
-    //             parsedName: "PrimeAdmins",
-    //             memberType: MemberType.PRIME_ADMIN,
-    //         });
-    //         expect(result.current.state.memberships).toEqual(
-    //             new Map([
-    //                 [
-    //                     "DHPrimeAdmins",
-    //                     {
-    //                         parsedName: "PrimeAdmins",
-    //                         memberType: MemberType.PRIME_ADMIN,
-    //                     },
-    //                 ],
-    //                 [
-    //                     "DHSender_ignore",
-    //                     {
-    //                         parsedName: "ignore",
-    //                         memberType: MemberType.SENDER,
-    //                     },
-    //                 ],
-    //                 [
-    //                     "DHmd_phd",
-    //                     {
-    //                         parsedName: "md-phd",
-    //                         memberType: MemberType.RECEIVER,
-    //                     },
-    //                 ],
-    //             ])
-    //         );
-    //     });
+    test("can be set with AccessToken", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: [
+                            "DHPrimeAdmins",
+                            "DHSender_ignore",
+                            "DHmd_phd",
+                        ],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active).toEqual({
+            parsedName: "PrimeAdmins",
+            memberType: MemberType.PRIME_ADMIN,
+        });
+        expect(result.current.state.memberships).toEqual(
+            new Map([
+                [
+                    "DHPrimeAdmins",
+                    {
+                        parsedName: "PrimeAdmins",
+                        memberType: MemberType.PRIME_ADMIN,
+                    },
+                ],
+                [
+                    "DHSender_ignore",
+                    {
+                        parsedName: "ignore",
+                        memberType: MemberType.SENDER,
+                    },
+                ],
+                [
+                    "DHmd_phd",
+                    {
+                        parsedName: "md-phd",
+                        memberType: MemberType.RECEIVER,
+                    },
+                ],
+            ])
+        );
+    });
 
-    //     test("can swap active membership", () => {
-    //         mockAuth.mockReturnValue({
-    //             authState: {
-    //                 accessToken: {
-    //                     claims: {
-    //                         //@ts-ignore
-    //                         organization: [
-    //                             "DHPrimeAdmins",
-    //                             "DHSender_ignore",
-    //                             "DHmd_phd",
-    //                         ],
-    //                     },
-    //                 },
-    //             },
-    //         });
-    //         const { result } = renderHook(() => useGroups());
-    //         expect(result.current.state.active).toEqual({
-    //             parsedName: "PrimeAdmins",
-    //             memberType: MemberType.PRIME_ADMIN,
-    //         });
-    //         act(() =>
-    //             result.current.dispatch({
-    //                 type: MembershipActionType.SWITCH,
-    //                 payload: "DHmd_phd",
-    //             })
-    //         );
-    //         expect(result.current.state.active).toEqual({
-    //             parsedName: "md-phd",
-    //             memberType: MemberType.RECEIVER,
-    //         });
-    //     });
+    test("can swap active membership", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: [
+                            "DHPrimeAdmins",
+                            "DHSender_ignore",
+                            "DHmd_phd",
+                        ],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active).toEqual({
+            parsedName: "PrimeAdmins",
+            memberType: MemberType.PRIME_ADMIN,
+        });
+        act(() =>
+            result.current.dispatch({
+                type: MembershipActionType.SWITCH,
+                payload: "DHmd_phd",
+            })
+        );
+        expect(result.current.state.active).toEqual({
+            parsedName: "md-phd",
+            memberType: MemberType.RECEIVER,
+        });
+    });
 
-    //     test("can override as admin", () => {
-    //         mockAuth.mockReturnValue({
-    //             authState: {
-    //                 accessToken: {
-    //                     claims: {
-    //                         //@ts-ignore
-    //                         organization: ["DHPrimeAdmins"],
-    //                     },
-    //                 },
-    //             },
-    //         });
-    //         const { result } = renderHook(() => useGroups());
-    //         expect(result.current.state.active).toEqual({
-    //             parsedName: "PrimeAdmins",
-    //             memberType: MemberType.PRIME_ADMIN,
-    //         });
-    //         act(() =>
-    //             result.current.dispatch({
-    //                 type: MembershipActionType.ADMIN_OVERRIDE,
-    //                 payload: {
-    //                     parsedName: "sender-org",
-    //                     memberType: MemberType.SENDER,
-    //                 },
-    //             })
-    //         );
-    //         expect(result.current.state.active).toEqual({
-    //             parsedName: "sender-org",
-    //             memberType: MemberType.SENDER,
-    //         });
-    //     });
+    test("can override as admin", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: ["DHPrimeAdmins"],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active).toEqual({
+            parsedName: "PrimeAdmins",
+            memberType: MemberType.PRIME_ADMIN,
+        });
+        act(() =>
+            result.current.dispatch({
+                type: MembershipActionType.ADMIN_OVERRIDE,
+                payload: {
+                    parsedName: "sender-org",
+                    memberType: MemberType.SENDER,
+                },
+            })
+        );
+        expect(result.current.state.active).toEqual({
+            parsedName: "sender-org",
+            memberType: MemberType.SENDER,
+        });
+    });
 });
 
-// describe("membershipsFromToken extra coverage", () => {
-//     test("can handle undefined token", () => {
-//         const state = membershipsFromToken({} as AccessToken);
-//         expect(state).toEqual({
-//             active: undefined,
-//             memberships: undefined,
-//         });
-//     });
-// });
+describe("membershipsFromToken extra coverage", () => {
+    test("can handle undefined token", () => {
+        const state = membershipsFromToken({} as AccessToken);
+        expect(state).toEqual({
+            active: undefined,
+            memberships: undefined,
+        });
+    });
+});
 
-// describe("membershipReducer extra coverage", () => {
-//     test("can handle bad request", () => {
-//         mockAuth.mockReturnValue({
-//             authState: {
-//                 accessToken: {
-//                     claims: {
-//                         //@ts-ignore
-//                         organization: ["DHPrimeAdmins"],
-//                     },
-//                 },
-//             },
-//         });
-//         const { result } = renderHook(() => useGroups());
+describe("membershipReducer extra coverage", () => {
+    test("can handle bad request", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: ["DHPrimeAdmins"],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
 
-//         // bad switch
-//         act(() =>
-//             result.current.dispatch({
-//                 type: MembershipActionType.SWITCH,
-//                 payload: "org-does-not-exist",
-//             })
-//         );
-//         expect(result.current.state.active?.parsedName).toEqual("PrimeAdmins");
-//     });
-// });
-
-export {};
+        // bad switch
+        act(() =>
+            result.current.dispatch({
+                type: MembershipActionType.SWITCH,
+                payload: "org-does-not-exist",
+            })
+        );
+        expect(result.current.state.active?.parsedName).toEqual("PrimeAdmins");
+    });
+});

--- a/frontend-react/src/hooks/UseGroups.test.ts
+++ b/frontend-react/src/hooks/UseGroups.test.ts
@@ -1,0 +1,182 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import * as OktaReact from "@okta/okta-react";
+import { IOktaContext } from "@okta/okta-react/bundles/types/OktaContext";
+import { AccessToken } from "@okta/okta-auth-js";
+
+import {
+    MembershipActionType,
+    membershipsFromToken,
+    MemberType,
+    useGroups,
+} from "./UseGroups";
+
+const mockAuth = jest.spyOn(OktaReact, "useOktaAuth");
+
+describe("useGroups", () => {
+    test("renders with default values", () => {
+        mockAuth.mockReturnValue({} as IOktaContext);
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.memberships).toBeUndefined();
+        expect(result.current.state.active).toBeUndefined();
+    });
+
+    test("accounts for non-standard groups", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: ["NotYourStandardGroup"],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active?.memberType).toEqual("non-standard");
+    });
+
+    test("can be set with AccessToken", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: [
+                            "DHPrimeAdmins",
+                            "DHSender_ignore",
+                            "DHmd_phd",
+                        ],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active).toEqual({
+            parsedName: "PrimeAdmins",
+            memberType: MemberType.PRIME_ADMIN,
+        });
+        expect(result.current.state.memberships).toEqual(
+            new Map([
+                [
+                    "DHPrimeAdmins",
+                    {
+                        parsedName: "PrimeAdmins",
+                        memberType: MemberType.PRIME_ADMIN,
+                    },
+                ],
+                [
+                    "DHSender_ignore",
+                    {
+                        parsedName: "ignore",
+                        memberType: MemberType.SENDER,
+                    },
+                ],
+                [
+                    "DHmd_phd",
+                    {
+                        parsedName: "md-phd",
+                        memberType: MemberType.RECEIVER,
+                    },
+                ],
+            ])
+        );
+    });
+
+    test("can swap active membership", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: [
+                            "DHPrimeAdmins",
+                            "DHSender_ignore",
+                            "DHmd_phd",
+                        ],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active).toEqual({
+            parsedName: "PrimeAdmins",
+            memberType: MemberType.PRIME_ADMIN,
+        });
+        act(() =>
+            result.current.dispatch({
+                type: MembershipActionType.SWITCH,
+                payload: "DHmd_phd",
+            })
+        );
+        expect(result.current.state.active).toEqual({
+            parsedName: "md-phd",
+            memberType: MemberType.RECEIVER,
+        });
+    });
+
+    test("can override as admin", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: ["DHPrimeAdmins"],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+        expect(result.current.state.active).toEqual({
+            parsedName: "PrimeAdmins",
+            memberType: MemberType.PRIME_ADMIN,
+        });
+        act(() =>
+            result.current.dispatch({
+                type: MembershipActionType.ADMIN_OVERRIDE,
+                payload: {
+                    parsedName: "sender-org",
+                    memberType: MemberType.SENDER,
+                },
+            })
+        );
+        expect(result.current.state.active).toEqual({
+            parsedName: "sender-org",
+            memberType: MemberType.SENDER,
+        });
+    });
+});
+
+describe("membershipsFromToken extra coverage", () => {
+    test("can handle undefined token", () => {
+        const state = membershipsFromToken({} as AccessToken);
+        expect(state).toEqual({
+            active: undefined,
+            memberships: undefined,
+        });
+    });
+});
+
+describe("membershipReducer extra coverage", () => {
+    test("can handle bad request", () => {
+        mockAuth.mockReturnValue({
+            authState: {
+                accessToken: {
+                    claims: {
+                        //@ts-ignore
+                        organization: ["DHPrimeAdmins"],
+                    },
+                },
+            },
+        });
+        const { result } = renderHook(() => useGroups());
+
+        // bad switch
+        act(() =>
+            result.current.dispatch({
+                type: MembershipActionType.SWITCH,
+                payload: "org-does-not-exist",
+            })
+        );
+        expect(result.current.state.active?.parsedName).toEqual("PrimeAdmins");
+    });
+});

--- a/frontend-react/src/hooks/UseGroups.ts
+++ b/frontend-react/src/hooks/UseGroups.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer } from "react";
 import { AccessToken } from "@okta/okta-auth-js";
-import { useOktaAuth } from "@okta/okta-react";
+// import { useOktaAuth } from "@okta/okta-react";
 
 import { getOktaGroups, groupToOrg } from "../utils/OrganizationUtils";
 
@@ -132,17 +132,19 @@ export const membershipReducer = (
 };
 
 export const useGroups = (): MembershipController => {
-    const { authState } = useOktaAuth();
+    // const { authState } = useOktaAuth();
     const [state, dispatch] = useReducer(membershipReducer, defaultState);
 
     useEffect(() => {
-        if (authState?.accessToken) {
-            dispatch({
-                type: MembershipActionType.UPDATE,
-                payload: authState.accessToken,
-            });
-        }
-    }, [authState]);
+        // if (authState?.accessToken) {
+        dispatch({
+            type: MembershipActionType.UPDATE,
+            // payload: authState.accessToken,
+            payload: "",
+        });
+        // }
+    }, []);
+    // }, [authState]);
 
     return { state, dispatch };
 };

--- a/frontend-react/src/hooks/UseGroups.ts
+++ b/frontend-react/src/hooks/UseGroups.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer } from "react";
 import { AccessToken } from "@okta/okta-auth-js";
-// import { useOktaAuth } from "@okta/okta-react";
+import { useOktaAuth } from "@okta/okta-react";
 
 import { getOktaGroups, groupToOrg } from "../utils/OrganizationUtils";
 
@@ -132,19 +132,19 @@ export const membershipReducer = (
 };
 
 export const useGroups = (): MembershipController => {
-    // const { authState } = useOktaAuth();
+    const { authState } = useOktaAuth();
     const [state, dispatch] = useReducer(membershipReducer, defaultState);
 
     useEffect(() => {
-        // if (authState?.accessToken) {
-        dispatch({
-            type: MembershipActionType.UPDATE,
-            // payload: authState.accessToken,
-            payload: "",
-        });
-        // }
-    }, []);
-    // }, [authState]);
+        if (authState?.accessToken) {
+            dispatch({
+                type: MembershipActionType.UPDATE,
+                payload: authState.accessToken,
+                // payload: "",
+            });
+        }
+        // }, []);
+    }, [authState]);
 
     return { state, dispatch };
 };

--- a/frontend-react/src/hooks/UseGroups.ts
+++ b/frontend-react/src/hooks/UseGroups.ts
@@ -1,0 +1,148 @@
+import React, { useEffect, useReducer } from "react";
+import { AccessToken } from "@okta/okta-auth-js";
+import { useOktaAuth } from "@okta/okta-react";
+
+import { getOktaGroups, groupToOrg } from "../utils/OrganizationUtils";
+
+export enum MemberType {
+    SENDER = "sender",
+    RECEIVER = "receiver",
+    PRIME_ADMIN = "prime-admin",
+    NON_STAND = "non-standard",
+}
+
+export enum MembershipActionType {
+    SWITCH = "switch",
+    UPDATE = "update",
+    ADMIN_OVERRIDE = "override",
+}
+
+interface MembershipSettings {
+    // The org header value
+    parsedName: string;
+    // The type of membership
+    memberType: MemberType;
+}
+
+export interface MembershipState {
+    active?: MembershipSettings;
+    // Key is the OKTA group name, settings has parsedName
+    memberships?: Map<string, MembershipSettings>;
+}
+
+export interface MembershipController {
+    state: MembershipState;
+    dispatch: React.Dispatch<MembershipAction>;
+}
+
+interface MembershipAction {
+    type: MembershipActionType;
+    // Only need to pass name of an org to swap to
+    payload: string | AccessToken | Partial<MembershipSettings>;
+}
+
+export const getTypeOfGroup = (org: string) => {
+    const isStandardType = org.startsWith("DH");
+    const isSenderType = org.startsWith("DHSender_");
+    const isAdminType = org === "DHPrimeAdmins";
+    if (isStandardType) {
+        if (isAdminType) {
+            return MemberType.PRIME_ADMIN;
+        }
+        if (isSenderType) {
+            return MemberType.SENDER;
+        }
+        return MemberType.RECEIVER;
+    } else {
+        return MemberType.NON_STAND;
+    }
+};
+
+export const getSettingsFromOrganization = (
+    org: string
+): MembershipSettings => {
+    return {
+        parsedName: groupToOrg(org),
+        memberType: getTypeOfGroup(org),
+    };
+};
+
+export const makeMembershipMapFromToken = (
+    token: AccessToken
+): Map<string, MembershipSettings> => {
+    // Extracts claims from token
+    const organizationClaim = getOktaGroups(token);
+    const settings: Map<string, MembershipSettings> = new Map();
+    // Creates map from claims
+    organizationClaim.forEach((org: string) => {
+        settings.set(org, getSettingsFromOrganization(org));
+    });
+    return settings;
+};
+
+const defaultState: MembershipState = {
+    active: undefined,
+    memberships: undefined,
+};
+export const membershipsFromToken = (token: AccessToken): MembershipState => {
+    // One big undefined check to see if we have what we need for the next line
+    if (!token?.claims) {
+        return defaultState;
+    }
+    const claimData: Map<string, MembershipSettings> =
+        makeMembershipMapFromToken(token);
+    // Catch anyone with no claim data
+    if (!claimData.size) {
+        return defaultState;
+    }
+    // Get defaults
+    const [first] = claimData.keys();
+    const active = claimData.get(first);
+    return {
+        active: active,
+        memberships: claimData,
+    };
+};
+
+export const membershipReducer = (
+    state: MembershipState,
+    action: MembershipAction
+) => {
+    const { type, payload } = action;
+    switch (type) {
+        case MembershipActionType.SWITCH:
+            return {
+                ...state,
+                active:
+                    state.memberships?.get(payload as string) || state.active,
+            };
+        case MembershipActionType.UPDATE:
+            return membershipsFromToken(payload as AccessToken);
+        case MembershipActionType.ADMIN_OVERRIDE:
+            return {
+                ...state,
+                active: {
+                    ...state.active,
+                    ...(payload as MembershipSettings),
+                },
+            };
+        default:
+            return state;
+    }
+};
+
+export const useGroups = (): MembershipController => {
+    const { authState } = useOktaAuth();
+    const [state, dispatch] = useReducer(membershipReducer, defaultState);
+
+    useEffect(() => {
+        if (authState?.accessToken) {
+            dispatch({
+                type: MembershipActionType.UPDATE,
+                payload: authState.accessToken,
+            });
+        }
+    }, [authState]);
+
+    return { state, dispatch };
+};

--- a/frontend-react/src/pages/Login.tsx
+++ b/frontend-react/src/pages/Login.tsx
@@ -8,17 +8,17 @@ import OktaSignInWidget from "../components/OktaSignInWidget";
 import { getOktaGroups, parseOrgs } from "../utils/OrganizationUtils";
 import { setStoredOktaToken } from "../contexts/SessionStorageTools";
 import { oktaSignInConfig } from "../oktaConfig";
-import { SessionStorageContext } from "../contexts/SessionStorageContext";
+import { SessionContext } from "../contexts/SessionStorageContext";
 
 export const Login = () => {
     const { oktaAuth, authState } = useOktaAuth();
-    const { updateSessionStorage } = useContext(SessionStorageContext);
+    const { store } = useContext(SessionContext);
 
     const onSuccess = (tokens: Tokens | undefined) => {
         const parsedOrgs = parseOrgs(getOktaGroups(tokens?.accessToken));
         const newOrg = parsedOrgs[0]?.org || "";
         const newSender = parsedOrgs[0]?.senderName || undefined;
-        updateSessionStorage({
+        store.updateSessionStorage({
             // Sets admins to `ignore` org
             org: newOrg === "PrimeAdmins" ? "ignore" : newOrg,
             senderName: newSender,


### PR DESCRIPTION
This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **24**        | [36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rb9v97~t~'2fu)~(d~'rbh8wb~t~'sy)~(d~'rbhbdb~t~'70)~(d~'rbryjn~t~'1hry)~(d~'rbrykf~t~'1hsq)~(d~'rbrylr~t~'1hu2)~(d~'rbryn3~t~'5pnk)~(d~'rbryno~t~'5po5)~(d~'rbse3c~t~'54)~(d~'rbubyv~t~'3bo)~(d~'rc1r6v~t~'r2)~(d~'rbse2z~t~'4v)~(d~'rbse3p~t~'5d)~(d~'rbo8yc~t~'11r)~(d~'rc4uds~t~'i)~(d~'rc501s~t~'1ny)~(d~'rc4uau~t~'1mc)~(d~'rc4ucl~t~'h)~(d~'rcek78~t~'4vo)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1)~(d~'rcicp0~t~'v9)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcjsm1~t~'3ux)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q))))                                        | 3              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 13            | [9h 46m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rbd2pf~t~'1qox)~(d~'rbd2qw~t~'1qqe)~(d~'rbd2sv~t~'1qsd)~(d~'rbd8g2~t~'1wfk)~(d~'rbd28d~t~'3ps)~(d~'rbd874~t~'1lbb)~(d~'rbdbbd~t~'1ofk)~(d~'rbdbc0~t~'1h3)~(d~'rbd8a1~t~'1hfz)~(d~'rbd8aj~t~'1hgh)~(d~'rbqbw3~t~'2c)~(d~'rbq6k1~t~'1ynv)~(d~'rbq9cw~t~'jv)~(d~'rbq9fl~t~'mk)~(d~'rbgx2h~t~'1bhu)~(d~'rbh436~t~'1iij)~(d~'rbhuv7~t~'29ak)~(d~'rbmq43~t~'14i)~(d~'rbmq4a~t~'14p)~(d~'rcc92y~t~'fi)~(d~'rcg6bm~t~'7t)~(d~'rcet3i~t~'6qs)~(d~'rc6wfc~t~'2j)~(d~'rcifmu~t~'vn))))                                                                                       | 19             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 13            | [14h 16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rbbg9e~t~'1cuv)~(d~'rc1ekb~t~'u)~(d~'rc1asl~t~'1t)~(d~'rbs3qd~t~'1cb7)~(d~'rbsbos~t~'t)~(d~'rboezr~t~'7)~(d~'rbzk1a~t~'630)~(d~'rc1fvp~t~'1vu6)~(d~'rc31gq~t~'1dl8)~(d~'rc4u0n~t~'3655)~(d~'rc4u12~t~'19z1)~(d~'rc5jdl~t~'1v8)~(d~'rc6qbz~t~'13iz)~(d~'rc6qdg~t~'13kg)~(d~'rc6qdv~t~'13kv)~(d~'rc6qe9~t~'13l9)~(d~'rc6qej~t~'13lj)~(d~'rc6qgg~t~'13ng)~(d~'rbzcqr~t~'1jl)~(d~'rci1nv~t~'1b)~(d~'rcr0os~t~'1p63)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rcr4z1~t~'13m)))) | **41**         |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 7             | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rbbc3j~t~'31)~(d~'rbbek4~t~'2jm)~(d~'rbdfl0~t~'23ki)~(d~'rbdfo5~t~'ct0)~(d~'rbdfi8~t~'1smf)~(d~'rbqff9~t~'6g)~(d~'rc36ga~t~'3n8)~(d~'rc36n7~t~'1kn5)~(d~'rbfoeo~t~'2u1)~(d~'rbh75z~t~'1llc)~(d~'rbmga9~t~'6upm)~(d~'rc73tt~t~'31)~(d~'rcfzf6~t~'27))))                                                                                                                                                                                                                                                                                                             | 18             |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 6             | [1h 1m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rbd6vp~t~'8d4)~(d~'rb9kvb~t~'1wc)~(d~'rbz79u~t~'52c2)~(d~'rbzc3r~t~'ia)~(d~'rbzcy9~t~'h1)~(d~'rc2z4i~t~'3i)~(d~'rc4srj~t~'1gyh)~(d~'rccjyn~t~'3s2))))                                                                                                                                                                                                                                                                                                                                                                                                                 | 1              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 6             | [56m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rbqkv9~t~'2ll)~(d~'rbqlix~t~'399)~(d~'rc6ulc~t~'10f)~(d~'rccotv~t~'df)~(d~'rc746w~t~'ckd)~(d~'rc6tgh~t~'ds)~(d~'rbzlqr~t~'amv))))                                                                                                                                                                                                                                                                                                                                                                                                                              | 3              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 5             | [1h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'rb9vu0~t~'30n)~(d~'rbbmge~t~'cmt)~(d~'rbbmic~t~'cor)~(d~'rbbmmo~t~'ct3)~(d~'rbbnbd~t~'dhs)~(d~'rbbnx9~t~'e3o)~(d~'rb9j73~t~'84)~(d~'rb9j7t~t~'8u)~(d~'rb9mxc~t~'3yd)~(d~'rb9hrk~t~'1o)~(d~'rb9hrv~t~'1z)~(d~'rb9gs1~t~'71))))                                                                                                                                                                                                                                                                                                                                 | 7              |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 5             | [30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rbf7d7~t~'sa)~(d~'rbzbjk~t~'9r)~(d~'rc55bf~t~'1eh)~(d~'rceg1r~t~'1y3)~(d~'rcctsn~t~'6l5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 4             | [2h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rbg05i~t~'ekv)~(d~'rbg05v~t~'el8)~(d~'rc73t6~t~'2e)~(d~'rck4y1~t~'57)~(d~'rcrdi5~t~'72h))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 2              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 3             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rbto84~t~'17bn)~(d~'rc73td~t~'2l)~(d~'rc5ble~t~'1hj))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 3             | [13h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rc58jg~t~'5ex1)~(d~'rchp2w~t~'117k)~(d~'rccu86~t~'ng))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 3             | [2h 30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rc4y4f~t~'54i0)~(d~'rc50yb~t~'6xn)~(d~'rcjvov~t~'6xr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rbez2c~t~'35xo)~(d~'rcctyo~t~'52w)~(d~'rcr50d~t~'14y))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rbqh6q~t~'1xx)~(d~'rbn1hp~t~'jwn)~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 2              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 2             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rbd338~t~'17j)~(d~'rbd351~t~'19c)~(d~'rbd423~t~'26e)~(d~'rb9u6e~t~'ep))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rcic8f~t~'54))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 2              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [10h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rbcykq~t~'tt4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 1             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'rbd32j~t~'16u)~(d~'rbd3mk~t~'1qv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 2              |