### PR TITLE
DRAFT ONLY Bump hapi-fhir-base from 5.7.1 to 6.0.1 in /prime-router

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -690,7 +690,7 @@ dependencies {
         exclude(group = "org.yaml", module = "snakeyaml")
     }
     implementation("io.github.linuxforhealth:hl7v2-fhir-converter:1.0.18")
-    implementation("ca.uhn.hapi.fhir:hapi-fhir-base:5.7.1")
+    implementation("ca.uhn.hapi.fhir:hapi-fhir-base:6.0.1")
     implementation("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:5.7.1")
     implementation("ca.uhn.hapi:hapi-base:2.3")
     implementation("ca.uhn.hapi:hapi-structures-v251:2.3")

--- a/prime-router/src/test/kotlin/azure/LookupTableFunctionsTests.kt
+++ b/prime-router/src/test/kotlin/azure/LookupTableFunctionsTests.kt
@@ -11,6 +11,8 @@ import com.microsoft.azure.functions.HttpStatus
 import gov.cdc.prime.router.azure.db.tables.pojos.LookupTableRow
 import gov.cdc.prime.router.azure.db.tables.pojos.LookupTableVersion
 import gov.cdc.prime.router.common.JacksonMapperUtilities
+import gov.cdc.prime.router.tokens.AuthenticatedClaims
+import gov.cdc.prime.router.tokens.OktaAuthentication
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -37,10 +39,19 @@ class LookupTableFunctionsTests {
      */
     private val mapper = JacksonMapperUtilities.defaultMapper
 
+    /**
+     * Okta authenticator
+     */
+    private val mockOktaAuthenticator = mockk<OktaAuthentication>()
+
     @BeforeAll
     fun initDependencies() {
         every { mockRequest.headers } returns mapOf(HttpHeaders.AUTHORIZATION.lowercase() to "Bearer dummy")
         every { mockRequest.uri } returns URI.create("http://localhost:7071/api/lookuptables")
+        val mockAuthenticatedClaims = mockk<AuthenticatedClaims>()
+        every { mockOktaAuthenticator.checkAccess(any(), any(), any(), any(), captureLambda()) } answers {
+            lambda<(AuthenticatedClaims) -> HttpResponseMessage>().captured.invoke(mockAuthenticatedClaims)
+        }
     }
 
     /**
@@ -77,7 +88,8 @@ class LookupTableFunctionsTests {
         every { mockRequest.queryParameters } returns emptyMap()
         var mockResponseBuilder = createResponseBuilder()
         every { mockRequest.createResponseBuilder(HttpStatus.OK) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableList(mockRequest)
+        val function = LookupTableFunctions(lookupTableAccess, mockOktaAuthenticator)
+        function.getLookupTableList(mockRequest)
         verify(exactly = 1) {
             mockResponseBuilder.body(
                 withArg {
@@ -95,7 +107,7 @@ class LookupTableFunctionsTests {
         every { mockRequest.queryParameters } returns mapOf(LookupTableFunctions.showInactiveParamName to "true")
         mockResponseBuilder = createResponseBuilder()
         every { mockRequest.createResponseBuilder(HttpStatus.OK) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableList(mockRequest)
+        function.getLookupTableList(mockRequest)
         verify(exactly = 1) {
             mockResponseBuilder.body(
                 withArg {
@@ -111,7 +123,7 @@ class LookupTableFunctionsTests {
         every { lookupTableAccess.fetchTableList(any()) }.throws(DataAccessException("error"))
         mockResponseBuilder = createResponseBuilder()
         every { mockRequest.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableList(mockRequest)
+        function.getLookupTableList(mockRequest)
         verifyError(mockResponseBuilder)
     }
 
@@ -126,7 +138,8 @@ class LookupTableFunctionsTests {
         val lookupTableAccess = mockk<DatabaseLookupTableAccess>()
         every { lookupTableAccess.doesTableExist(eq(tableName), eq(tableVersionNum)) } returns false
         every { mockRequest.createResponseBuilder(HttpStatus.NOT_FOUND) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableData(mockRequest, tableName, tableVersionNum)
+        val function = LookupTableFunctions(lookupTableAccess, mockOktaAuthenticator)
+        function.getLookupTableData(mockRequest, tableName, tableVersionNum)
         verifyError(mockResponseBuilder)
 
         // Get a table
@@ -140,7 +153,7 @@ class LookupTableFunctionsTests {
         every { lookupTableAccess.doesTableExist(eq(tableName), eq(tableVersionNum)) } returns true
         every { lookupTableAccess.fetchTable(eq(tableName), eq(tableVersionNum)) } returns tableData
         every { mockRequest.createResponseBuilder(HttpStatus.OK) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableData(mockRequest, tableName, tableVersionNum)
+        function.getLookupTableData(mockRequest, tableName, tableVersionNum)
         verify(exactly = 1) {
             mockResponseBuilder.body(
                 withArg {
@@ -158,7 +171,7 @@ class LookupTableFunctionsTests {
         mockResponseBuilder = createResponseBuilder()
         every { lookupTableAccess.doesTableExist(any(), any()) }.throws(DataAccessException("error"))
         every { mockRequest.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableData(mockRequest, tableName, tableVersionNum)
+        function.getLookupTableData(mockRequest, tableName, tableVersionNum)
         verifyError(mockResponseBuilder)
     }
 
@@ -173,7 +186,8 @@ class LookupTableFunctionsTests {
         val lookupTableAccess = mockk<DatabaseLookupTableAccess>()
         every { lookupTableAccess.fetchVersionInfo(eq(tableName), eq(tableVersionNum)) } returns null
         every { mockRequest.createResponseBuilder(HttpStatus.NOT_FOUND) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableInfo(mockRequest, tableName, tableVersionNum)
+        val function = LookupTableFunctions(lookupTableAccess, mockOktaAuthenticator)
+        function.getLookupTableInfo(mockRequest, tableName, tableVersionNum)
         verifyError(mockResponseBuilder)
 
         // Get a table info
@@ -186,7 +200,7 @@ class LookupTableFunctionsTests {
         mockResponseBuilder = createResponseBuilder()
         every { lookupTableAccess.fetchVersionInfo(eq(tableName), eq(tableVersionNum)) } returns tableInfo
         every { mockRequest.createResponseBuilder(HttpStatus.OK) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableInfo(mockRequest, tableName, tableVersionNum)
+        function.getLookupTableInfo(mockRequest, tableName, tableVersionNum)
         verify(exactly = 1) {
             mockResponseBuilder.body(
                 withArg {
@@ -202,7 +216,7 @@ class LookupTableFunctionsTests {
         mockResponseBuilder = createResponseBuilder()
         every { lookupTableAccess.doesTableExist(any(), any()) }.throws(DataAccessException("error"))
         every { mockRequest.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableData(mockRequest, tableName, tableVersionNum)
+        function.getLookupTableData(mockRequest, tableName, tableVersionNum)
         verifyError(mockResponseBuilder)
     }
 
@@ -216,7 +230,8 @@ class LookupTableFunctionsTests {
         tableData[1].data = JSONB.jsonb("""{"a": "12", "b": "22"}""")
 
         val lookupTableAccess = mockk<DatabaseLookupTableAccess>()
-        val data = LookupTableFunctions(lookupTableAccess).convertTableDataToJsonString(tableData)
+        val data = LookupTableFunctions(lookupTableAccess, mockOktaAuthenticator)
+            .convertTableDataToJsonString(tableData)
         assertThat(data).isNotEmpty()
         val rows = mapper.readValue<List<Map<String, String>>>(data)
         assertTrue(rows.size == 2)
@@ -238,20 +253,21 @@ class LookupTableFunctionsTests {
         every { mockRequest.body } returns ""
         every { mockRequest.queryParameters } returns emptyMap()
         every { lookupTableAccess.fetchLatestVersion(tableName) } returns latestVersion
-        LookupTableFunctions(lookupTableAccess).createLookupTable(mockRequest, tableName)
+        val function = LookupTableFunctions(lookupTableAccess, mockOktaAuthenticator)
+        function.createLookupTable(mockRequest, tableName)
         verifyError(mockResponseBuilder)
 
         // Payload is not consistent
         mockResponseBuilder = createResponseBuilder()
         every { mockRequest.createResponseBuilder(HttpStatus.BAD_REQUEST) } returns mockResponseBuilder
         every { mockRequest.body } returns """[{"a": "11", "b": "21"},{"a": "12"}]"""
-        LookupTableFunctions(lookupTableAccess).createLookupTable(mockRequest, tableName)
+        function.createLookupTable(mockRequest, tableName)
         verifyError(mockResponseBuilder)
 
         mockResponseBuilder = createResponseBuilder()
         every { mockRequest.createResponseBuilder(HttpStatus.BAD_REQUEST) } returns mockResponseBuilder
         every { mockRequest.body } returns """[{"a": "11", "b": "21"},{"a": "12", "b": "22", "c": "32"}]"""
-        LookupTableFunctions(lookupTableAccess).createLookupTable(mockRequest, tableName)
+        function.createLookupTable(mockRequest, tableName)
         verifyError(mockResponseBuilder)
 
         // Create a new version of an existing table
@@ -274,7 +290,7 @@ class LookupTableFunctionsTests {
             )
         } returns Unit
         every { lookupTableAccess.fetchVersionInfo(eq(tableName), eq(latestVersion + 1)) } returns versionInfo
-        LookupTableFunctions(lookupTableAccess).createLookupTable(mockRequest, tableName)
+        function.createLookupTable(mockRequest, tableName)
         verify(exactly = 1) {
             lookupTableAccess.createTable(
                 any(), any(),
@@ -302,7 +318,7 @@ class LookupTableFunctionsTests {
         every { lookupTableAccess.fetchLatestVersion(tableName) } returns null
         every { lookupTableAccess.createTable(eq(tableName), eq(1), any(), any(), force) } returns Unit
         every { lookupTableAccess.fetchVersionInfo(eq(tableName), eq(1)) } returns versionInfo
-        LookupTableFunctions(lookupTableAccess).createLookupTable(mockRequest, tableName)
+        function.createLookupTable(mockRequest, tableName)
         verify(exactly = 1) {
             mockResponseBuilder.body(
                 withArg {
@@ -319,7 +335,7 @@ class LookupTableFunctionsTests {
         mockResponseBuilder = createResponseBuilder()
         every { lookupTableAccess.fetchLatestVersion(tableName) }.throws(DataAccessException("error"))
         every { mockRequest.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).createLookupTable(mockRequest, tableName)
+        function.createLookupTable(mockRequest, tableName)
         verifyError(mockResponseBuilder)
     }
 
@@ -334,7 +350,8 @@ class LookupTableFunctionsTests {
         val lookupTableAccess = mockk<DatabaseLookupTableAccess>()
         every { lookupTableAccess.doesTableExist(eq(tableName), eq(tableVersionNum)) } returns false
         every { mockRequest.createResponseBuilder(HttpStatus.NOT_FOUND) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).activateLookupTable(mockRequest, tableName, tableVersionNum)
+        val function = LookupTableFunctions(lookupTableAccess, mockOktaAuthenticator)
+        function.activateLookupTable(mockRequest, tableName, tableVersionNum)
         verifyError(mockResponseBuilder)
 
         // Activate a table
@@ -349,7 +366,7 @@ class LookupTableFunctionsTests {
         every { lookupTableAccess.activateTable(eq(tableName), eq(tableVersionNum)) } returns true
         every { lookupTableAccess.fetchVersionInfo(eq(tableName), eq(tableVersionNum)) } returns versionInfo
         every { mockRequest.createResponseBuilder(HttpStatus.OK) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).activateLookupTable(mockRequest, tableName, tableVersionNum)
+        function.activateLookupTable(mockRequest, tableName, tableVersionNum)
         verify(exactly = 1) {
             mockResponseBuilder.body(
                 withArg {
@@ -365,7 +382,7 @@ class LookupTableFunctionsTests {
         mockResponseBuilder = createResponseBuilder()
         every { lookupTableAccess.doesTableExist(any(), any()) }.throws(DataAccessException("error"))
         every { mockRequest.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR) } returns mockResponseBuilder
-        LookupTableFunctions(lookupTableAccess).getLookupTableData(mockRequest, tableName, tableVersionNum)
+        function.getLookupTableData(mockRequest, tableName, tableVersionNum)
         verifyError(mockResponseBuilder)
     }
 


### PR DESCRIPTION
Bumps hapi-fhir-base from 5.7.1 to 6.0.1.

---
updated-dependencies:
- dependency-name: ca.uhn.hapi.fhir:hapi-fhir-base
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **27**        | [35m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rbhbdb~t~'70)~(d~'rbh8wb~t~'sy)~(d~'rbo8yc~t~'11r)~(d~'rbse3p~t~'5d)~(d~'rbse2z~t~'4v)~(d~'rbse3c~t~'54)~(d~'rbubyv~t~'3bo)~(d~'rc4uau~t~'1mc)~(d~'rc4uds~t~'i)~(d~'rbryjn~t~'1hry)~(d~'rbrykf~t~'1hsq)~(d~'rbrylr~t~'1hu2)~(d~'rbryn3~t~'5pnk)~(d~'rbryno~t~'5po5)~(d~'rc1r6v~t~'r2)~(d~'rc4ucl~t~'h)~(d~'rc501s~t~'1ny)~(d~'rcjsm1~t~'3ux)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcrma8~t~'1q)~(d~'rcrcml~t~'786y)~(d~'rcek78~t~'4vo)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1)~(d~'rcicp0~t~'v9)~(d~'rcuq8n~t~'63)~(d~'rcuqf6~t~'51)~(d~'rcuqhq~t~'idxj)~(d~'rcuphg~t~'1l0a))))  | 3              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 13            | [1h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rbd8a1~t~'1hfz)~(d~'rbd8aj~t~'1hgh)~(d~'rbd28d~t~'3ps)~(d~'rbd874~t~'1lbb)~(d~'rbdbbd~t~'1ofk)~(d~'rbdbc0~t~'1h3)~(d~'rbgx2h~t~'1bhu)~(d~'rbh436~t~'1iij)~(d~'rbhuv7~t~'29ak)~(d~'rbmq43~t~'14i)~(d~'rbmq4a~t~'14p)~(d~'rbqbw3~t~'2c)~(d~'rbq6k1~t~'1ynv)~(d~'rbq9cw~t~'jv)~(d~'rbq9fl~t~'mk)~(d~'rc6wfc~t~'2j)~(d~'rcg6bm~t~'7t)~(d~'rcet3i~t~'6qs)~(d~'rcc92y~t~'fi)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh))))                                                                                                            | 17             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 13            | [14h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rboezr~t~'7)~(d~'rbsbos~t~'t)~(d~'rbs3qd~t~'1cb7)~(d~'rc1asl~t~'1t)~(d~'rc1ekb~t~'u)~(d~'rbzk1a~t~'630)~(d~'rc1fvp~t~'1vu6)~(d~'rc31gq~t~'1dl8)~(d~'rc4u0n~t~'3655)~(d~'rc4u12~t~'19z1)~(d~'rc5jdl~t~'1v8)~(d~'rc6qbz~t~'13iz)~(d~'rc6qdg~t~'13kg)~(d~'rc6qdv~t~'13kv)~(d~'rc6qe9~t~'13l9)~(d~'rc6qej~t~'13lj)~(d~'rc6qgg~t~'13ng)~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rbzcqr~t~'1jl)~(d~'rci1nv~t~'1b)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rbgvkj~t~'1d1l)))) | **56**         |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 8             | [1h 3m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rbqkv9~t~'2ll)~(d~'rbqlix~t~'399)~(d~'rc6ulc~t~'10f)~(d~'rccotv~t~'df)~(d~'rc746w~t~'ckd)~(d~'rc6tgh~t~'ds)~(d~'rbzlqr~t~'amv)~(d~'rcrqor~t~'lig)~(d~'rc3fwk~t~'1sp7)~(d~'rc75l3~t~'lu)~(d~'rctavi~t~'mhud)~(d~'rctb6v~t~'ir))))                                                                                                                                                                                                                                                                                                                                                | 16             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 6             | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rbdfi8~t~'1smf)~(d~'rbfoeo~t~'2u1)~(d~'rbh75z~t~'1llc)~(d~'rbmga9~t~'6upm)~(d~'rbqff9~t~'6g)~(d~'rc36ga~t~'3n8)~(d~'rc36n7~t~'1kn5)~(d~'rc73tt~t~'31)~(d~'rcfzf6~t~'27))))                                                                                                                                                                                                                                                                                                                                                                                                            | 12             |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 5             | [1h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rbd6vp~t~'8d4)~(d~'rbz79u~t~'52c2)~(d~'rbzc3r~t~'ia)~(d~'rbzcy9~t~'h1)~(d~'rc2z4i~t~'3i)~(d~'rc4srj~t~'1gyh)~(d~'rccjyn~t~'3s2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 1              |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 5             | [30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rbf7d7~t~'sa)~(d~'rbzbjk~t~'9r)~(d~'rc55bf~t~'1eh)~(d~'rceg1r~t~'1y3)~(d~'rcctsn~t~'6l5))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 4             | [2h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rbg05i~t~'ekv)~(d~'rbg05v~t~'el8)~(d~'rc73t6~t~'2e)~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 2              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 3             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rbto84~t~'17bn)~(d~'rc5ble~t~'1hj)~(d~'rc73td~t~'2l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 3             | [13h 24m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rc58jg~t~'5ex1)~(d~'rccu86~t~'ng)~(d~'rchp2w~t~'117k))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 3             | [2h 30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rc4y4f~t~'54i0)~(d~'rc50yb~t~'6xn)~(d~'rcjvov~t~'6xr))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 0              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rcctyo~t~'52w)~(d~'rcuqdp~t~'11jz))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rbn1hp~t~'jwn)~(d~'rbqh6q~t~'1xx)~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 2              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 1             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rbd338~t~'17j)~(d~'rbd351~t~'19c)~(d~'rbd423~t~'26e))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rcic8f~t~'54))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [10h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rbcykq~t~'tt4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 0              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 1             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'rbd32j~t~'16u)~(d~'rbd3mk~t~'1qv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 2              |