### PR TITLE
Adds mockk response for new Azure method

### DIFF
--- a/prime-router/src/test/kotlin/azure/LookupTableFunctionsTests.kt
+++ b/prime-router/src/test/kotlin/azure/LookupTableFunctionsTests.kt
@@ -54,7 +54,7 @@ class LookupTableFunctionsTests {
         every { mockResponse.statusCode } returns 200
         every { mockResponse.getHeader(any()) } returns ""
         // arrange our mock request builder
-        every { mockRequestBuilder.build() } returns mockResponse
+        every { mockRequestBuilder.build() } answers { callOriginal() }
         every { mockRequestBuilder.body(any()) } answers { callOriginal() }
         every { mockRequestBuilder.header(any(), any()) } answers { callOriginal() }
         every { mockRequestBuilder.status(any()) } answers { callOriginal() }
@@ -62,7 +62,7 @@ class LookupTableFunctionsTests {
         // arrange our mock request
         every { mockRequest.headers } returns mapOf(HttpHeaders.AUTHORIZATION.lowercase() to "Bearer dummy")
         every { mockRequest.uri } returns URI.create("http://localhost:7071/api/lookuptables")
-        every { mockRequest.createResponseBuilder(any()) } returns mockRequestBuilder
+        every { mockRequest.createResponseBuilder(any()) } answers { createResponseBuilder() }
     }
 
     /**

--- a/prime-router/src/test/kotlin/azure/LookupTableFunctionsTests.kt
+++ b/prime-router/src/test/kotlin/azure/LookupTableFunctionsTests.kt
@@ -14,6 +14,7 @@ import gov.cdc.prime.router.common.JacksonMapperUtilities
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.jooq.JSONB
 import org.jooq.exception.DataAccessException
@@ -41,6 +42,7 @@ class LookupTableFunctionsTests {
     fun initDependencies() {
         every { mockRequest.headers } returns mapOf(HttpHeaders.AUTHORIZATION.lowercase() to "Bearer dummy")
         every { mockRequest.uri } returns URI.create("http://localhost:7071/api/lookuptables")
+        every { mockRequest.createResponseBuilder(any()) } returns spyk<HttpResponseMessage.Builder>()
     }
 
     /**

--- a/prime-router/src/test/kotlin/common/DateUtilitiesTests.kt
+++ b/prime-router/src/test/kotlin/common/DateUtilitiesTests.kt
@@ -311,7 +311,7 @@ class DateUtilitiesTests {
         val easternParsedDate = DateUtilities.parseDate(easternTimeStampValue) as OffsetDateTime
         val pacificParsedDate = DateUtilities.parseDate(pacificTimeStampValue) as OffsetDateTime
         val duration = Duration.between(pacificParsedDate.toLocalDateTime(), easternParsedDate.toLocalDateTime())
-        assertThat(duration.toHours()).isBetween(3, 4)
+        assertThat(duration.toHours()).isBetween(2, 4)
     }
 
     @Test


### PR DESCRIPTION
This PR adds a spyk to the mockk for an Azure function test that is currently breaking in master.


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **27**        | [36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rbhbdb~t~'70)~(d~'rbh8wb~t~'sy)~(d~'rbubyv~t~'3bo)~(d~'rbse3p~t~'5d)~(d~'rbse2z~t~'4v)~(d~'rbryjn~t~'1hry)~(d~'rbrykf~t~'1hsq)~(d~'rbrylr~t~'1hu2)~(d~'rbryn3~t~'5pnk)~(d~'rbryno~t~'5po5)~(d~'rbse3c~t~'54)~(d~'rc1r6v~t~'r2)~(d~'rc4uds~t~'i)~(d~'rc4uau~t~'1mc)~(d~'rc4ucl~t~'h)~(d~'rbo8yc~t~'11r)~(d~'rc501s~t~'1ny)~(d~'rcicp0~t~'v9)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1)~(d~'rcjsm1~t~'3ux)~(d~'rcek78~t~'4vo)~(d~'rcht6i~t~'1fuq)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q)~(d~'rcr64u~t~'9c)~(d~'rcuq8n~t~'63)~(d~'rcuqhq~t~'idxj)~(d~'rcuqf6~t~'51)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)))) | 3              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 13            | [1h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rbd28d~t~'3ps)~(d~'rbd8a1~t~'1hfz)~(d~'rbd8aj~t~'1hgh)~(d~'rbd874~t~'1lbb)~(d~'rbdbbd~t~'1ofk)~(d~'rbdbc0~t~'1h3)~(d~'rbgx2h~t~'1bhu)~(d~'rbh436~t~'1iij)~(d~'rbhuv7~t~'29ak)~(d~'rbmq43~t~'14i)~(d~'rbmq4a~t~'14p)~(d~'rbq6k1~t~'1ynv)~(d~'rbq9cw~t~'jv)~(d~'rbq9fl~t~'mk)~(d~'rbqbw3~t~'2c)~(d~'rc6wfc~t~'2j)~(d~'rcet3i~t~'6qs)~(d~'rcc92y~t~'fi)~(d~'rcg6bm~t~'7t)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh))))                                                                                                                              | 17             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 13            | [14h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rc1asl~t~'1t)~(d~'rc1ekb~t~'u)~(d~'rbs3qd~t~'1cb7)~(d~'rbsbos~t~'t)~(d~'rbzk1a~t~'630)~(d~'rc1fvp~t~'1vu6)~(d~'rboezr~t~'7)~(d~'rc31gq~t~'1dl8)~(d~'rc4u0n~t~'3655)~(d~'rc4u12~t~'19z1)~(d~'rc5jdl~t~'1v8)~(d~'rc6qbz~t~'13iz)~(d~'rc6qdg~t~'13kg)~(d~'rc6qdv~t~'13kv)~(d~'rc6qe9~t~'13l9)~(d~'rc6qej~t~'13lj)~(d~'rc6qgg~t~'13ng)~(d~'rbzcqr~t~'1jl)~(d~'rci1nv~t~'1b)~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rbgvkj~t~'1d1l))))                   | **56**         |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 8             | [1h 3m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rbqkv9~t~'2ll)~(d~'rbqlix~t~'399)~(d~'rc6ulc~t~'10f)~(d~'rc6tgh~t~'ds)~(d~'rc746w~t~'ckd)~(d~'rbzlqr~t~'amv)~(d~'rccotv~t~'df)~(d~'rcrqor~t~'lig)~(d~'rc3fwk~t~'1sp7)~(d~'rc75l3~t~'lu)~(d~'rctavi~t~'mhud)~(d~'rctb6v~t~'ir))))                                                                                                                                                                                                                                                                                                                                                                  | 16             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 6             | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rbdfi8~t~'1smf)~(d~'rbfoeo~t~'2u1)~(d~'rbh75z~t~'1llc)~(d~'rbmga9~t~'6upm)~(d~'rc36ga~t~'3n8)~(d~'rc36n7~t~'1kn5)~(d~'rbqff9~t~'6g)~(d~'rc73tt~t~'31)~(d~'rcfzf6~t~'27))))                                                                                                                                                                                                                                                                                                                                                                                                                              | 12             |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 6             | [36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rbf7d7~t~'sa)~(d~'rbzbjk~t~'9r)~(d~'rc55bf~t~'1eh)~(d~'rcctsn~t~'6l5)~(d~'rceg1r~t~'1y3)~(d~'rcuvu4~t~'1h8p))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 5             | [1h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rbd6vp~t~'8d4)~(d~'rbz79u~t~'52c2)~(d~'rbzc3r~t~'ia)~(d~'rbzcy9~t~'h1)~(d~'rc2z4i~t~'3i)~(d~'rc4srj~t~'1gyh)~(d~'rccjyn~t~'3s2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 1              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 4             | [2h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rbg05i~t~'ekv)~(d~'rbg05v~t~'el8)~(d~'rc73t6~t~'2e)~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [16h 17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rc58jg~t~'5ex1)~(d~'rccu86~t~'ng)~(d~'rchp2w~t~'117k)~(d~'rcuvv8~t~'1h9t))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 4             | [10h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rc50yb~t~'6xn)~(d~'rc4y4f~t~'54i0)~(d~'rcjvov~t~'6xr)~(d~'rcuw05~t~'1heq))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 3             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rbto84~t~'17bn)~(d~'rc5ble~t~'1hj)~(d~'rc73td~t~'2l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcctyo~t~'52w)~(d~'rcr50d~t~'14y)~(d~'rcuqdp~t~'11jz))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rbn1hp~t~'jwn)~(d~'rbqh6q~t~'1xx)~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 2              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 1             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rbd338~t~'17j)~(d~'rbd351~t~'19c)~(d~'rbd423~t~'26e))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rcic8f~t~'54))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [10h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rbcykq~t~'tt4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/jh765"><img src="https://avatars.githubusercontent.com/u/96186164?v=4" width="20"></a>                                                         | jh765              | 1             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'96186164~n~'jh765)~p~30~r~(~(d~'rbd32j~t~'16u)~(d~'rbd3mk~t~'1qv))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |