### PR TITLE
Updating Install-OpenJDK getting started doc

### DIFF
--- a/prime-router/docs/getting-started/install-openjdk.md
+++ b/prime-router/docs/getting-started/install-openjdk.md
@@ -15,6 +15,37 @@ VERSION=11
 brew install openjdk@${VERSION?}
 ```
 
+If after running `./cleanslate.sh` you see the following error
+```bash
+./cleanslate.sh
+# ...
+INFO: Bringing up the minimum build dependencies
+The operation couldn’t be completed. Unable to locate a Java Runtime.
+Please visit http://www.java.com for information on installing Java.
+```
+
+You need to follow the rest of the brew install instructions:
+```bash
+brew info openjdk
+# Example output from running the above command, please run yourself
+# just in case brew updates the install instructions
+==> Caveats
+For the system Java wrappers to find this JDK, symlink it with
+  sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+
+openjdk is keg-only, which means it was not symlinked into /usr/local,
+because macOS provides similar software and installing this software in
+parallel can cause all kinds of trouble.
+
+If you need to have openjdk first in your PATH, run:
+  echo 'export PATH="/usr/local/opt/openjdk/bin:$PATH"' >> ~/.zshrc
+
+For compilers to find openjdk you may need to set:
+  export CPPFLAGS="-I/usr/local/opt/openjdk/include"
+```
+
+I had to follow all three commands to get `./cleanslate.sh` to run cleanly.
+
 ## Linux
 
 ### Debian-based


### PR DESCRIPTION
This commit adds documentation covering an issue I ran into while setting up ./cleanslate.sh
It updates the Install-OpenJdk page with the mac commands to run after brew installing openjdk
so that the system knows where the jdk has been installed.


Test Steps:
1.  Run markdown preview in VSCode and confirm that the changes are formatted appropriately

## Changes
- Adds a new section to the OpenJDK getting started document that walks through additional steps on a mac required after using homebrew to install.

## Checklist

### Testing
- [X] Tested locally
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - No
- Does this PR include changes in authentication and/or authorization of existing endpoints? No
- Does this change introduce new dependencies that need vetting? No
- Does this change require changes to our infrastructure? No
- Does logging contain sensitive data? No
- Does this PR include or remove any sensitive information itself? No

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
