### PR TITLE
Fixed the Hl7Serializer.setTelephoneComponent Error out On Blank Value

### DIFF
--- a/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
+++ b/prime-router/src/main/kotlin/serializers/Hl7Serializer.kt
@@ -1304,6 +1304,7 @@ class Hl7Serializer(
         element: Element,
         phoneNumberFormatting: Hl7Configuration.PhoneNumberFormatting
     ) {
+        if (value.isEmpty()) return
         val parts = value.split(Element.phoneDelimiter)
         val areaCode = parts[0].substring(0, 3)
         val local = parts[0].substring(3)

--- a/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
+++ b/prime-router/src/test/kotlin/serializers/Hl7SerializerTests.kt
@@ -429,6 +429,22 @@ NTE|1|L|This is a final comment|RE"""
             type = Element.Type.TELEPHONE
         )
 
+        // InValid empty or blank telephone
+        serializer.setTelephoneComponent(
+            mockTerser,
+            "",
+            facilityPathSpec,
+            facilityElement,
+            Hl7Configuration.PhoneNumberFormatting.STANDARD
+        )
+
+        // Verify following methods never been called
+        verify(exactly = 0) {
+            mockTerser.set(any(), any())
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-2", "WPN")
+            mockTerser.set("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-23-3", "PH")
+        }
+
         // Invalid telephone
         serializer.setTelephoneComponent(
             mockTerser,


### PR DESCRIPTION
This PR Fixed the Hl7Serializer.setTelephoneComponent Error out On Blank Value

Test Steps:
1. ./gradlew clean package
2. ./gradlew test --tests "gov.cdc.prime.router.serializers.Hl7SerializerTests.test setTelephoneComponents for facility"
3. Verify the test SUCCESS

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue
- https://app.zenhub.com/workspaces/onboarding--operations-6166edbd409257001e09f1b2/issues/cdcgov/prime-reportstream/4877
- 

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **27**        | [36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rbh8wb~t~'sy)~(d~'rbhbdb~t~'70)~(d~'rbryjn~t~'1hry)~(d~'rbrykf~t~'1hsq)~(d~'rbrylr~t~'1hu2)~(d~'rbryn3~t~'5pnk)~(d~'rbryno~t~'5po5)~(d~'rbse3c~t~'54)~(d~'rbubyv~t~'3bo)~(d~'rc1r6v~t~'r2)~(d~'rbse2z~t~'4v)~(d~'rbse3p~t~'5d)~(d~'rbo8yc~t~'11r)~(d~'rc4uds~t~'i)~(d~'rc501s~t~'1ny)~(d~'rc4uau~t~'1mc)~(d~'rc4ucl~t~'h)~(d~'rcicp0~t~'v9)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcek78~t~'4vo)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1)~(d~'rcjsm1~t~'3ux)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q)~(d~'rcuqf6~t~'51)~(d~'rcuq8n~t~'63)~(d~'rcuqhq~t~'idxj)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)))) | 3              |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 13            | [14h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rc1ekb~t~'u)~(d~'rc1asl~t~'1t)~(d~'rbs3qd~t~'1cb7)~(d~'rbsbos~t~'t)~(d~'rboezr~t~'7)~(d~'rbzk1a~t~'630)~(d~'rc1fvp~t~'1vu6)~(d~'rci1nv~t~'1b)~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rc31gq~t~'1dl8)~(d~'rc4u0n~t~'3655)~(d~'rc4u12~t~'19z1)~(d~'rc5jdl~t~'1v8)~(d~'rc6qbz~t~'13iz)~(d~'rc6qdg~t~'13kg)~(d~'rc6qdv~t~'13kv)~(d~'rc6qe9~t~'13l9)~(d~'rc6qej~t~'13lj)~(d~'rc6qgg~t~'13ng)~(d~'rbzcqr~t~'1jl)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rbgvkj~t~'1d1l))))                   | **56**         |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 10            | [51m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rbqbw3~t~'2c)~(d~'rbq6k1~t~'1ynv)~(d~'rbq9cw~t~'jv)~(d~'rbq9fl~t~'mk)~(d~'rbgx2h~t~'1bhu)~(d~'rbh436~t~'1iij)~(d~'rbhuv7~t~'29ak)~(d~'rbmq43~t~'14i)~(d~'rbmq4a~t~'14p)~(d~'rcc92y~t~'fi)~(d~'rcg6bm~t~'7t)~(d~'rcet3i~t~'6qs)~(d~'rc6wfc~t~'2j)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh))))                                                                                                                                                                                                                                                       | 14             |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 8             | [1h 3m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rbqkv9~t~'2ll)~(d~'rbqlix~t~'399)~(d~'rc6ulc~t~'10f)~(d~'rccotv~t~'df)~(d~'rc746w~t~'ckd)~(d~'rc6tgh~t~'ds)~(d~'rbzlqr~t~'amv)~(d~'rcrqor~t~'lig)~(d~'rc3fwk~t~'1sp7)~(d~'rc75l3~t~'lu)~(d~'rctavi~t~'mhud)~(d~'rctb6v~t~'ir))))                                                                                                                                                                                                                                                                                                                                                                  | 16             |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 6             | [1h 19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rbqff9~t~'6g)~(d~'rc36ga~t~'3n8)~(d~'rc36n7~t~'1kn5)~(d~'rbfoeo~t~'2u1)~(d~'rbh75z~t~'1llc)~(d~'rbmga9~t~'6upm)~(d~'rc73tt~t~'31)~(d~'rcfzf6~t~'27)~(d~'rcvdxd~t~'glr))))                                                                                                                                                                                                                                                                                                                                                                                                                               | 11             |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 6             | [36m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rbf7d7~t~'sa)~(d~'rbzbjk~t~'9r)~(d~'rc55bf~t~'1eh)~(d~'rceg1r~t~'1y3)~(d~'rcctsn~t~'6l5)~(d~'rcuvu4~t~'1h8p))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 5             | [34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rcctyo~t~'52w)~(d~'rcv4s3~t~'m5)~(d~'rcuqdp~t~'11jz)~(d~'rcvb53~t~'1kk))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 4             | [46m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rbz79u~t~'52c2)~(d~'rbzc3r~t~'ia)~(d~'rbzcy9~t~'h1)~(d~'rc2z4i~t~'3i)~(d~'rc4srj~t~'1gyh)~(d~'rccjyn~t~'3s2))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 1              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 4             | [2h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rbg05i~t~'ekv)~(d~'rbg05v~t~'el8)~(d~'rc73t6~t~'2e)~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [16h 17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rchp2w~t~'117k)~(d~'rccu86~t~'ng)~(d~'rc58jg~t~'5ex1)~(d~'rcuvv8~t~'1h9t))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 4             | [10h 52m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rc4y4f~t~'54i0)~(d~'rc50yb~t~'6xn)~(d~'rcjvov~t~'6xr)~(d~'rcuw05~t~'1heq))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 3             | [32m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rbto84~t~'17bn)~(d~'rc73td~t~'2l)~(d~'rc5ble~t~'1hj))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 3             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rbqh6q~t~'1xx)~(d~'rbn1hp~t~'jwn)~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 2              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rcic8f~t~'54))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/doug-s-nava"><img src="https://avatars.githubusercontent.com/u/92806979?u=6b5adf4d0028464ee97e875450768e2efaae7b12&v=4" width="20"></a>        | doug-s-nava        | 1             | [3h 17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92806979~n~'doug-s-nava)~p~30~r~(~(d~'rcthb1~t~'b8j)~(d~'rcv7iu~t~'71h))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 9              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [10h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rbcykq~t~'tt4))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 0              |