### PR TITLE
Update FHIR Transcoder tests to kotlin style assertions

### DIFF
--- a/prime-router/src/test/kotlin/fhirengine/utils/FhirTranscoderTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/utils/FhirTranscoderTests.kt
@@ -1,15 +1,14 @@
 package gov.cdc.prime.router.fhirengine.utils
 
 import assertk.assertThat
-import assertk.assertions.contains
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import org.hl7.fhir.r4.model.Bundle
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Date
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class FhirTranscoderTests {
     @Test
@@ -38,12 +37,12 @@ class FhirTranscoderTests {
         val encodedBundle = FhirTranscoder.encode(testBundle)
 
         assertThat(encodedBundle).isNotEmpty()
-        assertTrue { isValidJSONObject(encodedBundle) }
+        assertThat(isValidJSONObject(encodedBundle)).isTrue()
 
         // Ensure contains id and type
         val jsonObj = JSONObject(encodedBundle)
-        assertThat(jsonObj.get("id") == testBundle.id)
-        assertThat(jsonObj.get("type") == testBundle.type.name.lowercase())
+        assertThat(jsonObj.get("id")).equals(testBundle.id)
+        assertThat(jsonObj.get("type")).equals(testBundle.type.name.lowercase())
     }
 
     @Test
@@ -53,8 +52,8 @@ class FhirTranscoderTests {
         """.trimIndent()
         val decodedBundle = FhirTranscoder.decode(encodedBundle)
         assertThat(decodedBundle).isNotNull()
-        assertThat(decodedBundle.id == "someid")
-        assertThat(decodedBundle.type == Bundle.BundleType.MESSAGE)
+        assertThat(decodedBundle.id).equals("someid")
+        assertThat(decodedBundle.type).equals(Bundle.BundleType.MESSAGE)
     }
 
     @Test
@@ -70,6 +69,6 @@ class FhirTranscoderTests {
         val decodedBundle = FhirTranscoder.decode(encodedBundle)
         // Ensure the decoded output is the same as the input pre-encode
         assertThat(decodedBundle).isNotNull()
-        assertThat(decodedBundle == testBundle)
+        assertThat(decodedBundle).equals(testBundle)
     }
 }


### PR DESCRIPTION
After feedback on a better more kotlin style way of testing, this commit changes == into .equals and assertTrue into .isTrue.

Test Steps:
1. Ran unit test locally

## Changes
- changes == into .equals
- assertTrue into .isTrue

## Checklist

### Testing
- [X] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **22**        | [1h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rc1r6v~t~'r2)~(d~'rcicp0~t~'v9)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcek78~t~'4vo)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1)~(d~'rcjsm1~t~'3ux)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q)~(d~'rd42h4~t~'72e1)~(d~'rd42fd~t~'7hao)~(d~'rcwujj~t~'19a)~(d~'rcuqf6~t~'51)~(d~'rcuq8n~t~'63)~(d~'rd2k06~t~'13b)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)~(d~'rd87eu~t~'b2)~(d~'rd84kg~t~'a9c)~(d~'rdhazs~t~'7f)~(d~'rdh5t0~t~'u5o)~(d~'rcuqhq~t~'idxj))))                                                                                                                                                                               | 0              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 16            | [7h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rcctyo~t~'52w)~(d~'rd48aa~t~'66)~(d~'rd430j~t~'161u)~(d~'rcuqdp~t~'11jz)~(d~'rcwio2~t~'138x)~(d~'rcwirp~t~'1iko)~(d~'rd2p2p~t~'1x)~(d~'rcvb53~t~'1kk)~(d~'rcv4s3~t~'m5)~(d~'rd9p72~t~'my)~(d~'rd7uje~t~'1rii)~(d~'rd2gvk~t~'5ufp)~(d~'rdivoi~t~'15v6)~(d~'rdjfho~t~'c4)~(d~'rdjkhh~t~'2a7g))))                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 13            | [1h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rcc92y~t~'fi)~(d~'rcg6bm~t~'7t)~(d~'rcet3i~t~'6qs)~(d~'rc6wfc~t~'2j)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh)~(d~'rcylp9~t~'1ex2)~(d~'rcx1xd~t~'3x6)~(d~'rcwo18~t~'24b)~(d~'rdfanm~t~'7h13)~(d~'rd89re~t~'205)~(d~'rdf9eu~t~'4y8r)~(d~'rdh0c5~t~'1h1)~(d~'rdh3p6~t~'4u2)~(d~'rdh3r2~t~'4vy)~(d~'rdh42t~t~'57p)~(d~'rdh4gf~t~'5lb)~(d~'rdhf5j~t~'3m)~(d~'rdittj~t~'1329)~(d~'rdjbe5~t~'1kmv)~(d~'rdjbhm~t~'1kqc)~(d~'rdjc01~t~'1l8r)~(d~'rdjcr6~t~'lx)~(d~'rdjczy~t~'up)~(d~'rdjmbz~t~'a6q))))                                                                                | 30             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 13            | [16h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rc1ekb~t~'u)~(d~'rci1nv~t~'1b)~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rc31gq~t~'1dl8)~(d~'rc4u0n~t~'3655)~(d~'rc4u12~t~'19z1)~(d~'rc5jdl~t~'1v8)~(d~'rc6qbz~t~'13iz)~(d~'rc6qdg~t~'13kg)~(d~'rc6qdv~t~'13kv)~(d~'rc6qe9~t~'13l9)~(d~'rc6qej~t~'13lj)~(d~'rc6qgg~t~'13ng)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rd5xi4~t~'3b93)~(d~'rcwlmf~t~'1lfe)~(d~'rcwlno~t~'1lgn)~(d~'rd2qve~t~'g2)~(d~'rd9hdt~t~'1aa1)~(d~'rdgz3k~t~'13r3)~(d~'rdgzuo~t~'7abm)~(d~'rdh128~t~'1i3f)~(d~'rdhh75~t~'49j)~(d~'rdj9h2~t~'1o4u)))) | **69**         |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 9             | [3h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rc6ulc~t~'10f)~(d~'rccotv~t~'df)~(d~'rc746w~t~'ckd)~(d~'rcrqor~t~'lig)~(d~'rcwvo8~t~'1put)~(d~'rcx2yq~t~'64w)~(d~'rd2msm~t~'ery)~(d~'rd80y3~t~'741)~(d~'rdhgi1~t~'28on)~(d~'rd88j3~t~'3gf))))                                                                                                                                                                                                                                                                                                                                                                                                                                 | 15             |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 7             | [42m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rc55bf~t~'1eh)~(d~'rceg1r~t~'1y3)~(d~'rcctsn~t~'6l5)~(d~'rd2q0p~t~'zx)~(d~'rcuvu4~t~'1h8p)~(d~'rd8219~t~'1g0n)~(d~'rdjf6i~t~'y))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 6             | [19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rchp2w~t~'117k)~(d~'rccu86~t~'ng)~(d~'rd2q44~t~'13c)~(d~'rcuvv8~t~'1h9t)~(d~'rd9x55~t~'hk)~(d~'rda190~t~'1l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 6             | [1h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rcjvov~t~'6xr)~(d~'rd2kkn~t~'cu)~(d~'rd4gaa~t~'1pae)~(d~'rcuw05~t~'1heq)~(d~'rdji5q~t~'23d)~(d~'rdjf6s~t~'18))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 6             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rc73tt~t~'31)~(d~'rcfzf6~t~'27)~(d~'rd489j~t~'5f)~(d~'rcvdxd~t~'glr)~(d~'rd2kyx~t~'222)~(d~'rd2qn4~t~'9y)~(d~'rdh86q~t~'69s))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 13             |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 5             | [1h 28m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rc73t6~t~'2e)~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57)~(d~'rda7do~t~'436)~(d~'rda797~t~'9f3))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 2              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 4             | [1h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rc2z4i~t~'3i)~(d~'rccjyn~t~'3s2)~(d~'rcv9gl~t~'1x0i)~(d~'rd61sy~t~'6b7))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 1              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 4             | [40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'rdfbrm~t~'3ml)~(d~'rdfdpf~t~'2zv)~(d~'rdfn6r~t~'ot)~(d~'rdha5c~t~'2y))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/doug-s-nava"><img src="https://avatars.githubusercontent.com/u/92806979?u=6b5adf4d0028464ee97e875450768e2efaae7b12&v=4" width="20"></a>        | doug-s-nava        | 4             | [1h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92806979~n~'doug-s-nava)~p~30~r~(~(d~'rd2njo~t~'4mt)~(d~'rcthb1~t~'b8j)~(d~'rcv7iu~t~'71h)~(d~'rd8b22~t~'3at)~(d~'rda1it~t~'1trk)~(d~'rda1p1~t~'3ux)~(d~'rdjevs~t~'2qj))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 29             |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 2             | [23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rd8797~t~'3k7)~(d~'rd8bld~t~'12v)~(d~'rd9pfv~t~'3b)~(d~'rdix25~t~'185)~(d~'rdjabp~t~'d9))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 2             | [17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rc73td~t~'2l)~(d~'rc5ble~t~'1hj))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 1              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 2             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v)~(d~'rd2jiz~t~'m4)~(d~'rd2x0n~t~'e3s))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 3              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 1             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rcic8f~t~'54))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rd88x7~t~'1tf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |