### PR TITLE
Experience/5442 add table row

### DIFF
--- a/frontend-react/src/components/Table/Table.test.tsx
+++ b/frontend-react/src/components/Table/Table.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { within, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 
@@ -13,7 +13,6 @@ import { TestTable } from "./TestTable";
 import Table, { ColumnConfig, TableConfig, TableRow } from "./Table";
 import { TableRows } from "./TableRows";
 import { ColumnData } from "./ColumnData";
-
 /* Table generation tools */
 
 const getSetOfRows = (count: number, linkable: boolean = true) => {
@@ -531,5 +530,34 @@ describe("ColumnData", () => {
             `${initialValue}fakeItem`,
             "editableColumn"
         );
+    });
+});
+
+describe("Adding New Rows", () => {
+    test("When custom datasetAction method not passed, adds editable row to table on datasetAction click", () => {
+        render(<TestTable linkable={false} editable={true} />);
+
+        let rows = screen.getAllByRole("row");
+        expect(rows).toHaveLength(3); // 2 data rows and 1 header row
+
+        const addRowButton = screen.getByText("Test Action");
+        userEvent.click(addRowButton);
+
+        rows = screen.getAllByRole("row");
+        expect(rows).toHaveLength(4);
+    });
+
+    test("All fields on new editable row are editable", () => {
+        render(<TestTable linkable={false} editable={true} />);
+
+        const addRowButton = screen.getByText("Test Action");
+        userEvent.click(addRowButton);
+
+        const rows = screen.getAllByRole("row");
+        expect(rows).toHaveLength(4);
+
+        const newRow = rows[3];
+        const inputs = within(newRow).getAllByRole("textbox");
+        expect(inputs).toHaveLength(4);
     });
 });

--- a/frontend-react/src/components/Table/Table.test.tsx
+++ b/frontend-react/src/components/Table/Table.test.tsx
@@ -331,13 +331,17 @@ describe("TableRows", () => {
         const fakeRows = getSetOfRows(2, false);
         const fakeColumns = makeConfigs(fakeRows[0]);
         const fakeSave = jest.fn(() => Promise.resolve());
-        renderWithCustomWrapper(
+        const fakeRowSetter = jest.fn();
+
+        const { rerender } = renderWithCustomWrapper(
             <TableRows
                 rows={fakeRows}
                 onSave={fakeSave}
                 enableEditableRows={true}
                 filterManager={mockFilterManager}
                 columns={fakeColumns}
+                setRowToEdit={fakeRowSetter}
+                rowToEdit={undefined}
             />,
             "tbody"
         );
@@ -347,6 +351,23 @@ describe("TableRows", () => {
         const firstButton = screen.getAllByText("Edit")[0];
         expect(firstButton).toBeInTheDocument();
         userEvent.click(firstButton);
+        expect(fakeRowSetter).toHaveBeenCalled();
+        expect(fakeRowSetter).toHaveBeenCalledWith(0);
+
+        // `rowToEdit` state is managed in the parent component
+        // as we've confirmed that the state setter has been called with 0,
+        // we can rerender with that state value passed in to check the next step
+        rerender(
+            <TableRows
+                rows={fakeRows}
+                onSave={fakeSave}
+                enableEditableRows={true}
+                filterManager={mockFilterManager}
+                columns={fakeColumns}
+                setRowToEdit={fakeRowSetter}
+                rowToEdit={0}
+            />
+        );
 
         // click save
         const saveButton = screen.getAllByText("Save")[0];
@@ -361,13 +382,17 @@ describe("TableRows", () => {
         const fakeRows = getSetOfRows(2, false);
         const fakeColumns = makeConfigs(fakeRows[0]);
         const fakeSave = jest.fn(() => Promise.resolve());
-        renderWithCustomWrapper(
+        const fakeRowSetter = jest.fn();
+
+        const { rerender } = renderWithCustomWrapper(
             <TableRows
                 rows={fakeRows}
                 onSave={fakeSave}
                 enableEditableRows={true}
                 filterManager={mockFilterManager}
                 columns={fakeColumns}
+                setRowToEdit={fakeRowSetter}
+                rowToEdit={undefined}
             />,
             "tbody"
         );
@@ -377,6 +402,23 @@ describe("TableRows", () => {
         const firstButton = screen.getAllByText("Edit")[0];
         expect(firstButton).toBeInTheDocument();
         userEvent.click(firstButton);
+        expect(fakeRowSetter).toHaveBeenCalled();
+        expect(fakeRowSetter).toHaveBeenCalledWith(0);
+
+        // `rowToEdit` state is managed in the parent component
+        // as we've confirmed that the state setter has been called with 0,
+        // we can rerender with that state value passed in to check the next step
+        rerender(
+            <TableRows
+                rows={fakeRows}
+                onSave={fakeSave}
+                enableEditableRows={true}
+                filterManager={mockFilterManager}
+                columns={fakeColumns}
+                setRowToEdit={fakeRowSetter}
+                rowToEdit={0}
+            />
+        );
 
         // click second edit button
         // note: at this point the first button will be a save button, as save has been
@@ -393,13 +435,17 @@ describe("TableRows", () => {
         const fakeRows = getSetOfRows(1, false);
         const fakeColumns = makeConfigs(fakeRows[0]);
         const fakeSave = jest.fn(() => Promise.resolve());
-        renderWithCustomWrapper(
+        const fakeRowSetter = jest.fn();
+
+        const { rerender } = renderWithCustomWrapper(
             <TableRows
                 rows={fakeRows}
                 onSave={fakeSave}
                 enableEditableRows={true}
                 filterManager={mockFilterManager}
                 columns={fakeColumns}
+                setRowToEdit={fakeRowSetter}
+                rowToEdit={undefined}
             />,
             "tbody"
         );
@@ -409,6 +455,23 @@ describe("TableRows", () => {
         const editButton = screen.getByText("Edit");
         expect(editButton).toBeInTheDocument();
         userEvent.click(editButton);
+        expect(fakeRowSetter).toHaveBeenCalled();
+        expect(fakeRowSetter).toHaveBeenCalledWith(0);
+
+        // `rowToEdit` state is managed in the parent component
+        // as we've confirmed that the state setter has been called with 0,
+        // we can rerender with that state value passed in to check the next step
+        rerender(
+            <TableRows
+                rows={fakeRows}
+                onSave={fakeSave}
+                enableEditableRows={true}
+                filterManager={mockFilterManager}
+                columns={fakeColumns}
+                setRowToEdit={fakeRowSetter}
+                rowToEdit={0}
+            />
+        );
 
         // update value
         // this assumes that an input is being rendered by `ColumnData`

--- a/frontend-react/src/components/Table/Table.tsx
+++ b/frontend-react/src/components/Table/Table.tsx
@@ -71,6 +71,10 @@ export interface DatasetAction {
     method: Function;
 }
 
+export interface DatasetActionProps extends DatasetAction {
+    currentlyEditing: boolean;
+}
+
 export type RowSideEffect = (row: TableRow | null) => Promise<void>;
 
 export interface TableProps {
@@ -92,14 +96,6 @@ export interface LegendItem {
     label: string;
     value: string;
 }
-
-// const createRowForColumns = (columns: ColumnConfig[]) => {
-//     return columns.reduce((acc, column) => {
-//         const { dataAttr } = column;
-//         acc[dataAttr] = undefined;
-//         return acc;
-//     }, {} as TableRow);
-// };
 
 const Table = ({
     config,
@@ -149,10 +145,8 @@ const Table = ({
     }, [config.rows, filterManager?.sortSettings]);
 
     const addRow = useCallback(() => {
-        // const newRow = createRowForColumns(config.columns);
-        // memoizedRows.push(newRow);
         setRowToEdit(memoizedRows.length);
-    }, [memoizedRows, setRowToEdit, rowToEdit]);
+    }, [memoizedRows, setRowToEdit]);
 
     const renderArrow = () => {
         const { order, localOrder, locally } = filterManager?.sortSettings || {
@@ -261,7 +255,11 @@ const Table = ({
         );
     };
 
-    const DatasetActionButton = ({ label, method }: DatasetAction) => {
+    const DatasetActionButton = ({
+        label,
+        method,
+        currentlyEditing,
+    }: DatasetActionProps) => {
         // TODO: disable this button if a new row is currently under edit?
         // ATM the flow is something like:
         // * Table component tells TableRows that a new row is under edit
@@ -273,7 +271,11 @@ const Table = ({
         // solution to this problem and make sure control is passed in a way that doesn't
         // cause problems.
         return (
-            <Button type={"button"} onClick={() => method()}>
+            <Button
+                type={"button"}
+                onClick={() => method()}
+                disabled={currentlyEditing}
+            >
                 {label}
             </Button>
         );
@@ -290,7 +292,8 @@ const Table = ({
                     {datasetAction ? (
                         <DatasetActionButton
                             label={datasetAction.label}
-                            method={addRow}
+                            method={datasetAction.method || addRow}
+                            currentlyEditing={!!rowToEdit}
                         />
                     ) : null}
                 </div>

--- a/frontend-react/src/components/Table/TableRows.tsx
+++ b/frontend-react/src/components/Table/TableRows.tsx
@@ -155,7 +155,7 @@ export const TableRows = ({
     );
 
     const addingNewRow: boolean = useMemo(
-        () => !!(rowToEdit && rowToEdit === rows.length),
+        () => !!(rowToEdit !== undefined && rowToEdit === rows.length),
         [rowToEdit, rows.length]
     );
 

--- a/frontend-react/src/components/Table/TableRows.tsx
+++ b/frontend-react/src/components/Table/TableRows.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { Button } from "@trussworks/react-uswds";
 
 import { FilterManager } from "../../hooks/filters/UseFilterManager";
@@ -28,7 +28,6 @@ interface TableRowProps {
     isNew: boolean;
 }
 
-// what if this takes an `isNew` prop, and based on that we set everything editable?
 const TableRow = ({
     rowIndex,
     columns,
@@ -96,6 +95,7 @@ export const TableRows = ({
     setRowToEdit,
     rowToEdit,
 }: TableRowsProps) => {
+    console.log("!!! rowToEdit", rowToEdit);
     // tracks data changes to row currently being edited
     // TODO: build proper loading state
     const [updatedRow, setUpdatedRow] = useState<TableRowData | null>(null);
@@ -153,15 +153,16 @@ export const TableRows = ({
         [rowToEdit, rows.length]
     );
 
-    // decouple the rows we are displaying from the rows that have been fetched from the database to allow
-    // easier editing. see useEffect below
+    // decouple the rows we are displaying from the rows that have been persisted to allow
+    // easier editing
     const rowsToDisplay = useMemo(() => {
         if (!addingNewRow) {
             return [...rows];
         }
+        // if the row is currently under edit, use that row, otherwise create a blank one
         const newRow = updatedRow || createBlankRowForColumns(columns);
         return [...rows].concat([newRow]);
-    }, [rows, addingNewRow, updatedRow]);
+    }, [rows, addingNewRow, updatedRow, columns]);
 
     return (
         <>

--- a/frontend-react/src/components/Table/TableRows.tsx
+++ b/frontend-react/src/components/Table/TableRows.tsx
@@ -1,119 +1,195 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo, useEffect } from "react";
 import { Button } from "@trussworks/react-uswds";
 
 import { FilterManager } from "../../hooks/filters/UseFilterManager";
 
-import { RowSideEffect, TableRow, ColumnConfig } from "./Table";
+import { RowSideEffect, TableRow as TableRowData, ColumnConfig } from "./Table";
 import { ColumnData } from "./ColumnData";
 
-interface TableRowProps {
-    rows: TableRow[];
+interface TableRowsProps {
+    rows: TableRowData[];
     columns: ColumnConfig[];
     filterManager?: FilterManager;
     enableEditableRows?: boolean;
     onSave?: RowSideEffect;
+    setRowToEdit: Function; // TODO
+    rowToEdit: number | undefined;
 }
+
+interface TableRowProps {
+    rowData: TableRowData;
+    columns: ColumnConfig[];
+    enableEditableRows?: boolean;
+    rowIndex: number;
+    rowToEdit: number | undefined;
+    editButtonLabel?: string;
+    updateRow: (value: string, field: string) => void;
+    saveRowOrSetEditing: (index?: number) => void;
+    isNew: boolean;
+}
+
+// what if this takes an `isNew` prop, and based on that we set everything editable?
+const TableRow = ({
+    rowIndex,
+    columns,
+    rowData,
+    rowToEdit,
+    enableEditableRows,
+    updateRow,
+    saveRowOrSetEditing,
+    editButtonLabel,
+    isNew,
+}: TableRowProps) => {
+    const columnsForDisplay = useMemo(() => {
+        if (!isNew) {
+            return columns;
+        }
+        return columns.map((column) => ({
+            ...column,
+            editable: true,
+        }));
+    }, [isNew, columns]);
+    return (
+        <tr key={rowIndex}>
+            {columnsForDisplay.map((colConfig, colIndex) => (
+                <ColumnData
+                    key={`${rowIndex}:${colIndex}:TOP`}
+                    rowIndex={rowIndex}
+                    colIndex={colIndex}
+                    columnConfig={colConfig}
+                    rowData={rowData}
+                    editing={rowToEdit === rowIndex}
+                    setUpdatedRow={updateRow}
+                />
+            ))}
+            {enableEditableRows ? (
+                <td key={`${rowIndex}:EDIT`}>
+                    <Button
+                        type="submit"
+                        onClick={() => saveRowOrSetEditing(rowIndex)}
+                    >
+                        {editButtonLabel}
+                    </Button>
+                </td>
+            ) : null}
+        </tr>
+    );
+};
+
+const createBlankRowForColumns = (columns: ColumnConfig[]) => {
+    return columns.reduce((acc, column) => {
+        const { dataAttr } = column;
+        acc[dataAttr] = undefined;
+        return acc;
+    }, {} as TableRowData);
+};
 
 /* Iterates each row, and then uses the key value from columns.keys()
  * to render each cell in the appropriate column. */
+// do we want to split out the editing stuff into a plugin / hook / different component?
 export const TableRows = ({
     rows,
     onSave = () => Promise.resolve(),
     enableEditableRows,
     filterManager,
     columns,
-}: TableRowProps) => {
-    // tracks which row is currently being edited
-    const [editing, setEditing] = useState<number | undefined>();
+    setRowToEdit,
+    rowToEdit,
+}: TableRowsProps) => {
     // tracks data changes to row currently being edited
     // TODO: build proper loading state
-    const [updatedRow, setUpdatedRow] = useState<TableRow | null>(null);
-
-    const editableRowButtonValue = (isEditing: boolean) =>
-        isEditing ? "Save" : "Edit";
+    const [updatedRow, setUpdatedRow] = useState<TableRowData | null>(null);
 
     // TODO: typing this input as a string for now
     // but may need to cast it to a number, Date, or parse a JSON string in the future
     // especially if we're dealing with non text type inputs. Otherwise we may end up
     // with difficulty working with new data, or pushing to API without errors
-    const updateRow = (value: string, field: string) => {
-        // largely here for typecheck reasons, this represents a case
-        // where we're somehow trying to update a row without editing enabled
-        if (editing === undefined) {
-            console.error("Editing not enabled?");
-            return;
-        }
-        const rowToUpdate = rows[editing];
-        const rowValues = { ...rowToUpdate };
-        // update the field value in the given row
-        rowValues[field] = value;
-        setUpdatedRow(rowValues);
-    };
+    const updateFieldForRow =
+        // (rowToUpdate: TableRowData | undefined) =>
+        (value: string, field: string) => {
+            // largely here for typecheck reasons, this represents a case
+            // where we're somehow trying to update a row without editing enabled
+            if (rowToEdit === undefined) {
+                console.error("Editing not enabled or no row to edit");
+                return;
+            }
+
+            const rowToUpdate = rowsToDisplay[rowToEdit];
+            const rowValues = { ...rowToUpdate };
+            // update the field value in the given row
+            rowValues[field] = value;
+            setUpdatedRow(rowValues);
+        };
 
     // note that this function does not update the data displayed in the table directly
     // it will be the responsibility of the parent component to handle any data updates by
     // updating props passed to the table as a result of the onSave function
     const saveRowOrSetEditing = useCallback(
-        (rowIndex) => {
+        (rowIndex?: number) => {
             // if we are in edit mode, and the row being edited matches the
             // row of the button being clicked, then we want to save
-            if (editing !== undefined && editing === rowIndex) {
+            if (rowToEdit !== undefined && rowToEdit === rowIndex) {
                 // but if there are no changes to save, just back out of editing
                 if (!updatedRow) {
                     console.log("No changes to save");
-                    setEditing(undefined);
+                    setRowToEdit(undefined);
                     return;
                 }
                 // TODO: implement a loading state here
                 return onSave(updatedRow).then(() => {
-                    setEditing(undefined);
+                    setRowToEdit(undefined);
                     setUpdatedRow(null);
                 });
             }
             // otherwise, enable editing mode for this row
             setUpdatedRow(null); // in case we have some weird old irrelevant data in the state
-            setEditing(rowIndex);
+            setRowToEdit(rowIndex);
         },
-        [editing, updatedRow, onSave]
+        [rowToEdit, setRowToEdit, updatedRow, onSave]
     );
+
+    const addingNewRow: boolean = useMemo(
+        () => !!(rowToEdit && rowToEdit === rows.length),
+        [rowToEdit, rows.length]
+    );
+
+    // decouple the rows we are displaying from the rows that have been fetched from the database to allow
+    // easier editing. see useEffect below
+    const rowsToDisplay = useMemo(() => {
+        if (!addingNewRow) {
+            return [...rows];
+        }
+        const newRow = updatedRow || createBlankRowForColumns(columns);
+        return [...rows].concat([newRow]);
+    }, [rows, addingNewRow, updatedRow]);
 
     return (
         <>
-            {rows.map((object: TableRow, rowIndex: number) => {
+            {rowsToDisplay.map((object: TableRowData, rowIndex: number) => {
                 // Caps page size when filterManager exists
                 if (
                     filterManager &&
                     rowIndex >= filterManager?.pageSettings.size
-                )
+                ) {
                     return null;
+                }
+                const isNewRow =
+                    addingNewRow && rowIndex === rowsToDisplay.length;
                 return (
-                    <tr key={rowIndex}>
-                        {columns.map((colConfig, colIndex) => (
-                            <ColumnData
-                                key={`${rowIndex}:${colIndex}:TOP`}
-                                rowIndex={rowIndex}
-                                colIndex={colIndex}
-                                columnConfig={colConfig}
-                                rowData={object}
-                                editing={editing === rowIndex}
-                                setUpdatedRow={updateRow}
-                            />
-                        ))}
-                        {enableEditableRows ? (
-                            <td key={`${rowIndex}:EDIT`}>
-                                <Button
-                                    type="submit"
-                                    onClick={() =>
-                                        saveRowOrSetEditing(rowIndex)
-                                    }
-                                >
-                                    {editableRowButtonValue(
-                                        editing === rowIndex
-                                    )}
-                                </Button>
-                            </td>
-                        ) : null}
-                    </tr>
+                    <TableRow
+                        rowIndex={rowIndex}
+                        columns={columns}
+                        rowData={object}
+                        rowToEdit={rowToEdit}
+                        updateRow={updateFieldForRow}
+                        enableEditableRows={enableEditableRows}
+                        saveRowOrSetEditing={saveRowOrSetEditing}
+                        editButtonLabel={
+                            rowToEdit === rowIndex ? "Save" : "Edit"
+                        }
+                        key={rowIndex}
+                        isNew={isNewRow}
+                    />
                 );
             })}
         </>

--- a/frontend-react/src/components/Table/TestTable.tsx
+++ b/frontend-react/src/components/Table/TestTable.tsx
@@ -30,7 +30,13 @@ export const sampleCallback = () => {
 
 /* This component is specifically configured to help test the
  * Table component. Any  */
-export const TestTable = () => {
+export const TestTable = ({
+    editable,
+    linkable = true,
+}: {
+    editable?: boolean;
+    linkable?: boolean;
+}) => {
     const filterManager = useFilterManager();
     const {
         cursors,
@@ -75,12 +81,8 @@ export const TestTable = () => {
             dataAttr: "two",
             columnHeader: "Column Two",
             sortable: true,
-            feature: {
-                link: true,
-                linkBasePath: "/test/",
-            },
         },
-        { dataAttr: "one", columnHeader: "Column One" },
+        { dataAttr: "one", columnHeader: "Column One", editable: !!editable },
         {
             dataAttr: "five",
             columnHeader: "Transform Column",
@@ -92,6 +94,13 @@ export const TestTable = () => {
             valueMap: new Map([["test", "mapped value"]]),
         },
     ];
+
+    if (linkable) {
+        fakeColumns[0].feature = {
+            link: true,
+            linkBasePath: "/test/",
+        };
+    }
 
     const config: TableConfig = {
         columns: fakeColumns,
@@ -120,7 +129,7 @@ export const TestTable = () => {
 
     const datasetAction: DatasetAction = {
         label: "Test Action",
-        method: sampleCallback,
+        method: editable ? undefined : sampleCallback,
     };
 
     return (

--- a/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
+++ b/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
@@ -56,9 +56,6 @@ const ValueSetsDetailTable = ({ valueSetName }: { valueSetName: string }) => {
     /* We make this action do what we need it to to add an item */
     const datasetActionItem: DatasetAction = {
         label: "Add item",
-        method: () => {
-            console.log("!!!! will add a new value. Functionality to come...");
-        },
     };
     return (
         <Table


### PR DESCRIPTION
With this change, tables will allow for creating a new row from the UI. This builds off of the previous row edit functionality, and will persist changes based on the same handler function passed to the table that is used to handle edits.

Notes:

* as with edit functionality, the new row will not be persisted to the table view yet. That will be dependent on the implementation within the value sets page (or other Table parent implementing this behavior)
* when adding a new row, all fields are editable
* table implementations can still use datasetAction to do pretty much whatever, but if a function is not provided, it will be used to add a row
* future consideration: is all of the logic built out to support editing going to make things slower or otherwise in any way worse for the experience of read only tables? Do we want to split out work to encapsulate editability in its own component / plugin / hooks?



## Test Steps:
1. start a local frontend server: `yarn run start:localdev` from `frontend-react` directory
2. start a local backend server: `./gradlew run` from `prime-router` directory
3. visit http://localhost:3000/admin/value-sets/gender, logging in as necessary
4. click `Add Item`
5. _VERIFY_: a new row with blank inputs for each row field appears at the bottom of the table
6. _VERIFY_: `Add Item` button is disabled
7. 8. open your browser's dev tools console
8. enter data in all fields and click save
9. _VERIFY_: you see a console message prefixed with `!!! saving row` that displays the data you entered in the fields represented as a JS object.
6. _VERIFY_: `Add Item` button is enabled

## Changes
* datasetAction modified to make `method` optional
* state managing which row is currently being edited moved up to `Table` component to allow the `Add Item` button in the header to open a new row for editing
* created new component to represent an individual Table Row as logic for `TableRows` was getting hefty (this could also allow us to be more flexible with table formation in the future)
* added some props to `TestTable` to make it more dynamic
* removed `datasetAction` method declaration in `ValuesetDetail`
* some variable renaming


## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **21**        | [1h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rcicp0~t~'v9)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcek78~t~'4vo)~(d~'rcc7ng~t~'59wr)~(d~'rccf34~t~'58e1)~(d~'rcjsm1~t~'3ux)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q)~(d~'rd42h4~t~'72e1)~(d~'rd42fd~t~'7hao)~(d~'rcwujj~t~'19a)~(d~'rcuqf6~t~'51)~(d~'rcuq8n~t~'63)~(d~'rd2k06~t~'13b)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)~(d~'rd87eu~t~'b2)~(d~'rd84kg~t~'a9c)~(d~'rcuqhq~t~'idxj)~(d~'rdhazs~t~'7f)~(d~'rdh5t0~t~'u5o))))                                                                                                                                    | 0              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 17            | [13h 31m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rcctyo~t~'52w)~(d~'rd48aa~t~'66)~(d~'rd430j~t~'161u)~(d~'rcuqdp~t~'11jz)~(d~'rcwio2~t~'138x)~(d~'rcwirp~t~'1iko)~(d~'rd2p2p~t~'1x)~(d~'rcvb53~t~'1kk)~(d~'rcv4s3~t~'m5)~(d~'rd9p72~t~'my)~(d~'rd2gvk~t~'5ufp)~(d~'rdjfho~t~'c4)~(d~'rdjkhh~t~'2a7g)~(d~'rd7uje~t~'1rii)~(d~'rdkt1f~t~'13aq)~(d~'rdivoi~t~'15v6))))                                                                                                                                                                                                                        | 2              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 13            | [1h 46m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rcc92y~t~'fi)~(d~'rcg6bm~t~'7t)~(d~'rcet3i~t~'6qs)~(d~'rc6wfc~t~'2j)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh)~(d~'rcylp9~t~'1ex2)~(d~'rcx1xd~t~'3x6)~(d~'rcwo18~t~'24b)~(d~'rdfanm~t~'7h13)~(d~'rd89re~t~'205)~(d~'rdf9eu~t~'4y8r)~(d~'rdh0c5~t~'1h1)~(d~'rdh3p6~t~'4u2)~(d~'rdh3r2~t~'4vy)~(d~'rdh42t~t~'57p)~(d~'rdh4gf~t~'5lb)~(d~'rdhf5j~t~'3m)~(d~'rdittj~t~'1329)~(d~'rdjbe5~t~'1kmv)~(d~'rdjbhm~t~'1kqc)~(d~'rdjc01~t~'1l8r)~(d~'rdjcr6~t~'lx)~(d~'rdjczy~t~'up)~(d~'rdjmbz~t~'a6q)~(d~'rdl3te~t~'9o)))) | 30             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 11            | [17h 16m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rci1nv~t~'1b)~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rd5xi4~t~'3b93)~(d~'rcwlmf~t~'1lfe)~(d~'rcwlno~t~'1lgn)~(d~'rd2qve~t~'g2)~(d~'rd9hdt~t~'1aa1)~(d~'rdgzuo~t~'7abm)~(d~'rdh128~t~'1i3f)~(d~'rdhh75~t~'49j)~(d~'rdj9h2~t~'1o4u)~(d~'rdgz3k~t~'13r3))))                                                                                                                                                            | **38**         |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 9             | [3h 33m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rc6ulc~t~'10f)~(d~'rccotv~t~'df)~(d~'rc746w~t~'ckd)~(d~'rcrqor~t~'lig)~(d~'rcwvo8~t~'1put)~(d~'rcx2yq~t~'64w)~(d~'rd2msm~t~'ery)~(d~'rd80y3~t~'741)~(d~'rdhgi1~t~'28on)~(d~'rd88j3~t~'3gf))))                                                                                                                                                                                                                                                                                                                                                                    | 15             |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 7             | [42m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rc55bf~t~'1eh)~(d~'rceg1r~t~'1y3)~(d~'rcctsn~t~'6l5)~(d~'rd2q0p~t~'zx)~(d~'rcuvu4~t~'1h8p)~(d~'rd8219~t~'1g0n)~(d~'rdjf6i~t~'y))))                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 6             | [19m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rchp2w~t~'117k)~(d~'rccu86~t~'ng)~(d~'rd2q44~t~'13c)~(d~'rcuvv8~t~'1h9t)~(d~'rd9x55~t~'hk)~(d~'rda190~t~'1l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 6             | [1h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rcjvov~t~'6xr)~(d~'rd2kkn~t~'cu)~(d~'rd4gaa~t~'1pae)~(d~'rcuw05~t~'1heq)~(d~'rdji5q~t~'23d)~(d~'rdjf6s~t~'18))))                                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 6             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rc73tt~t~'31)~(d~'rcfzf6~t~'27)~(d~'rd489j~t~'5f)~(d~'rcvdxd~t~'glr)~(d~'rd2kyx~t~'222)~(d~'rd2qn4~t~'9y)~(d~'rdh86q~t~'69s))))                                                                                                                                                                                                                                                                                                                                                                                                                                             | 13             |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 5             | [1h 28m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rc73t6~t~'2e)~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57)~(d~'rda7do~t~'436)~(d~'rda797~t~'9f3))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/doug-s-nava"><img src="https://avatars.githubusercontent.com/u/92806979?u=6b5adf4d0028464ee97e875450768e2efaae7b12&v=4" width="20"></a>        | doug-s-nava        | 5             | [1h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92806979~n~'doug-s-nava)~p~30~r~(~(d~'rd2njo~t~'4mt)~(d~'rcthb1~t~'b8j)~(d~'rcv7iu~t~'71h)~(d~'rd8b22~t~'3at)~(d~'rda1it~t~'1trk)~(d~'rda1p1~t~'3ux)~(d~'rdl34b~t~'48e)~(d~'rdjevs~t~'2qj)~(d~'rdknvz~t~'1bqq))))                                                                                                                                                                                                                                                                                                                                                                                          | 31             |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 4             | [1h 49m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rc2z4i~t~'3i)~(d~'rccjyn~t~'3s2)~(d~'rcv9gl~t~'1x0i)~(d~'rd61sy~t~'6b7))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 4             | [40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'rdfbrm~t~'3ml)~(d~'rdfdpf~t~'2zv)~(d~'rdha5c~t~'2y)~(d~'rdfn6r~t~'ot))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 2             | [23m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rd8797~t~'3k7)~(d~'rd8bld~t~'12v)~(d~'rd9pfv~t~'3b)~(d~'rdix25~t~'185)~(d~'rdjabp~t~'d9))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 0              |
| <a href="https://github.com/mreifman"><img src="https://avatars.githubusercontent.com/u/2730338?u=73b7df0da42b98f7eaec3fad11d501f35e9ef05a&v=4" width="20"></a>            | mreifman           | 2             | [17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2730338~n~'mreifman)~p~30~r~(~(d~'rc73td~t~'2l)~(d~'rc5ble~t~'1hj))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 2             | [**3m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rcic8f~t~'54)~(d~'rdl3cq~t~'5h))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 2             | [1h 50m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rc6w8u~t~'4ya)~(d~'rc6wkf~t~'59v)~(d~'rd2jiz~t~'m4)~(d~'rd2x0n~t~'e3s))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 3              |
| <a href="https://github.com/RickHawesUSDS"><img src="https://avatars.githubusercontent.com/u/48692522?u=323d76e6f867d8ed0b3e56d7e5808313bfcc2ccf&v=4" width="20"></a>      | RickHawesUSDS      | 1             | [6m](https://app.flowwer.dev/charts/review-time/~(u~(i~'48692522~n~'RickHawesUSDS)~p~30~r~(~(d~'rccu9x~t~'9j))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rd88x7~t~'1tf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |