### PR TITLE
Fix/remove dev null for error output from deploy backend/action.yml

### DIFF
--- a/.github/actions/deploy-backend/action.yml
+++ b/.github/actions/deploy-backend/action.yml
@@ -206,5 +206,5 @@ runs:
         -n ${{ env.FUNCTION_APP }} \
         --slot candidate \
         --rule-name GitHubActionIPV4 \
-        > /dev/null 2>&1
+        > /dev/null 
       shell: bash

--- a/.github/actions/deploy-backend/action.yml
+++ b/.github/actions/deploy-backend/action.yml
@@ -176,7 +176,7 @@ runs:
           --action Allow \
           --ip-address $RUNNER_IP \
           --priority 750 \
-          > /dev/null 2>&1
+          > /dev/null
       shell: bash
 
     - uses: Azure/functions-container-action@v1


### PR DESCRIPTION
Tiny PR that changes the backed deploy GHA to write errors out instead of sending them to /dev/null. Regular, non-error output _will_ be discarded