### PR TITLE
for non-prod, do not enable an alert about alerts

### DIFF
--- a/operations/app/terraform/modules/application_insights/alert_exception.tf
+++ b/operations/app/terraform/modules/application_insights/alert_exception.tf
@@ -59,7 +59,7 @@ resource "azurerm_monitor_metric_alert" "exception_alert_error" {
 }
 
 resource "azurerm_monitor_metric_alert" "exception_alert_warn" {
-  count               = local.alerting_enabled
+  count               = local.prod_exclusive_alerting
   name                = "One or More Exceptions Raised in the Last Hour"
   description         = "One or More Exceptions Raised in the Last Hour"
   resource_group_name = var.resource_group

--- a/operations/app/terraform/modules/application_insights/main.tf
+++ b/operations/app/terraform/modules/application_insights/main.tf
@@ -1,6 +1,7 @@
 locals {
-  ping_url         = (var.environment == "prod" ? "https://prime.cdc.gov" : "https://${var.environment}.prime.cdc.gov")
-  alerting_enabled = (var.environment == "prod" || var.environment == "staging" ? 1 : 0)
+  ping_url                = (var.environment == "prod" ? "https://prime.cdc.gov" : "https://${var.environment}.prime.cdc.gov")
+  alerting_enabled        = (var.environment == "prod" || var.environment == "staging" ? 1 : 0)
+  prod_exclusive_alerting = (var.environment == "prod" ? 1 : 0)
 }
 
 resource "azurerm_application_insights" "app_insights" {


### PR DESCRIPTION
This PR disables the "One or More Exceptions Raised in the Last Hour" for non-production (staging) environments. Non-production will still receive the actual alert, just not alerts about alerts.

## Changes
- disables the "One or More Exceptions Raised in the Last Hour" for non-production environments

## Checklist

## Linked Issues
- Fixes #5624


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **19**        | [15h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rd48aa~t~'66)~(d~'rd430j~t~'161u)~(d~'rcuqdp~t~'11jz)~(d~'rcwio2~t~'138x)~(d~'rcwirp~t~'1iko)~(d~'rcvb53~t~'1kk)~(d~'rcv4s3~t~'m5)~(d~'rd2gvk~t~'5ufp)~(d~'rdjfho~t~'c4)~(d~'rd7uje~t~'1rii)~(d~'rdkt1f~t~'13aq)~(d~'rdmmpj~t~'3auy)~(d~'rdjkhh~t~'2a7g)~(d~'rdvv8m~t~'vc0)~(d~'rdtzmt~t~'8opz)~(d~'rdmn4e~t~'51ov)~(d~'rdivoi~t~'15v6)~(d~'rdvvad~t~'1a85))))                                                                                                                                                             | 3              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 17            | [1h 37m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rcicp0~t~'v9)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcek78~t~'4vo)~(d~'rcjsm1~t~'3ux)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q)~(d~'rd42h4~t~'72e1)~(d~'rd42fd~t~'7hao)~(d~'rcwujj~t~'19a)~(d~'rd2k06~t~'13b)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)~(d~'rd87eu~t~'b2)~(d~'rd84kg~t~'a9c)~(d~'rdhazs~t~'7f)~(d~'rdh5t0~t~'u5o)~(d~'rdw3hs~t~'46y))))                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 12            | [1h 57m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rcg6bm~t~'7t)~(d~'rcet3i~t~'6qs)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh)~(d~'rcylp9~t~'1ex2)~(d~'rcx1xd~t~'3x6)~(d~'rcwo18~t~'24b)~(d~'rdfanm~t~'7h13)~(d~'rd89re~t~'205)~(d~'rdf9eu~t~'4y8r)~(d~'rdh0c5~t~'1h1)~(d~'rdh3p6~t~'4u2)~(d~'rdh3r2~t~'4vy)~(d~'rdh42t~t~'57p)~(d~'rdh4gf~t~'5lb)~(d~'rdhf5j~t~'3m)~(d~'rdittj~t~'1329)~(d~'rdjbe5~t~'1kmv)~(d~'rdjbhm~t~'1kqc)~(d~'rdjc01~t~'1l8r)~(d~'rdjcr6~t~'lx)~(d~'rdjczy~t~'up)~(d~'rdjmbz~t~'a6q)~(d~'rdl3te~t~'9o)~(d~'rdmyxj~t~'1rb5)))) | 31             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 11            | [17h 17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rci1nv~t~'1b)~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rd5xi4~t~'3b93)~(d~'rcwlmf~t~'1lfe)~(d~'rcwlno~t~'1lgn)~(d~'rd2qve~t~'g2)~(d~'rd9hdt~t~'1aa1)~(d~'rdh128~t~'1i3f)~(d~'rdhh75~t~'49j)~(d~'rdj9h2~t~'1o4u)~(d~'rdgz3k~t~'13r3)~(d~'rdmluj~t~'39zy)~(d~'rdmm8x~t~'3aec))))                                                                                                                        | **32**         |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 8             | [20h 59m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rcrqor~t~'lig)~(d~'rcwvo8~t~'1put)~(d~'rd80y3~t~'741)~(d~'rdhgi1~t~'28on)~(d~'rdmkti~t~'1mar)~(d~'rdmkvi~t~'1mcr)~(d~'rd88j3~t~'3gf)~(d~'rdvy4f~t~'tu)~(d~'rdvvtj~t~'1x91))))                                                                                                                                                                                                                                                                                                                                                                   | 8              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 7             | [1h 5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'rdfbrm~t~'3ml)~(d~'rdfdpf~t~'2zv)~(d~'rdha5c~t~'2y)~(d~'rdfn6r~t~'ot)~(d~'rdmyye~t~'2xu)~(d~'rdn5dl~t~'5mre)~(d~'rdu86s~t~'1e7a))))                                                                                                                                                                                                                                                                                                                                                                                                                       | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 6             | [2h](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57)~(d~'rda7do~t~'436)~(d~'rda797~t~'9f3)~(d~'rduclo~t~'1gq)~(d~'rdwkn6~t~'ayb))))                                                                                                                                                                                                                                                                                                                                                                                                                                          | 2              |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 6             | [1h 38m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rcjvov~t~'6xr)~(d~'rd2kkn~t~'cu)~(d~'rd4gaa~t~'1pae)~(d~'rcuw05~t~'1heq)~(d~'rdji5q~t~'23d)~(d~'rdjf6s~t~'18))))                                                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 5             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rcfzf6~t~'27)~(d~'rd489j~t~'5f)~(d~'rcvdxd~t~'glr)~(d~'rd2kyx~t~'222)~(d~'rd2qn4~t~'9y)~(d~'rdh86q~t~'69s))))                                                                                                                                                                                                                                                                                                                                                                                                                                              | 13             |
| <a href="https://github.com/doug-s-nava"><img src="https://avatars.githubusercontent.com/u/92806979?u=6b5adf4d0028464ee97e875450768e2efaae7b12&v=4" width="20"></a>        | doug-s-nava        | 5             | [1h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92806979~n~'doug-s-nava)~p~30~r~(~(d~'rd2njo~t~'4mt)~(d~'rcthb1~t~'b8j)~(d~'rcv7iu~t~'71h)~(d~'rd8b22~t~'3at)~(d~'rda1it~t~'1trk)~(d~'rda1p1~t~'3ux)~(d~'rdjevs~t~'2qj)~(d~'rdknvz~t~'1bqq)~(d~'rdl34b~t~'48e))))                                                                                                                                                                                                                                                                                                                                                                          | 31             |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [6h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rchp2w~t~'117k)~(d~'rcuvv8~t~'1h9t)~(d~'rd9x55~t~'hk)~(d~'rda190~t~'1l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 3             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rd8797~t~'3k7)~(d~'rd8bld~t~'12v)~(d~'rd9pfv~t~'3b)~(d~'rdix25~t~'185)~(d~'rdjabp~t~'d9)~(d~'rdn2in~t~'8xz))))                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 3             | [18h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rcuvu4~t~'1h8p)~(d~'rd8219~t~'1g0n)~(d~'rdjf6i~t~'y))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 2             | [13h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rcv9gl~t~'1x0i)~(d~'rd61sy~t~'6b7))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 2             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rdl3cq~t~'5h)~(d~'rdvt0l~t~'26o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 2             | [40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rd2jiz~t~'m4)~(d~'rd2x0n~t~'e3s)~(d~'rduh08~t~'1uf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/BerniXiongA6"><img src="https://avatars.githubusercontent.com/u/85254824?u=b001d46ca03abb1c1628ad2214aae47d3635588c&v=4" width="20"></a>       | BerniXiongA6       | 1             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'85254824~n~'BerniXiongA6)~p~30~r~(~(d~'rdw9ba~t~'18d)~(d~'rdw9dq~t~'1at))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 2              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rd88x7~t~'1tf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/PatriciaPerozoUSDS"><img src="https://avatars.githubusercontent.com/u/106171068?v=4" width="20"></a>                                           | PatriciaPerozoUSDS | 1             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'106171068~n~'PatriciaPerozoUSDS)~p~30~r~(~(d~'rdvuiv~t~'7f))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |

## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | **19**        | [15h 4m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rcwirp~t~'1iko)~(d~'rd48aa~t~'66)~(d~'rd430j~t~'161u)~(d~'rcv4s3~t~'m5)~(d~'rcvb53~t~'1kk)~(d~'rcuqdp~t~'11jz)~(d~'rcwio2~t~'138x)~(d~'rd7uje~t~'1rii)~(d~'rd2gvk~t~'5ufp)~(d~'rdkt1f~t~'13aq)~(d~'rdjfho~t~'c4)~(d~'rdmmpj~t~'3auy)~(d~'rdjkhh~t~'2a7g)~(d~'rdmn4e~t~'51ov)~(d~'rdvv8m~t~'vc0)~(d~'rdtzmt~t~'8opz)~(d~'rdvvad~t~'1a85)~(d~'rdivoi~t~'15v6))))                                                                                                                                          | 3              |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | 18            | [1h 31m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rcjsm1~t~'3ux)~(d~'rcht6i~t~'1fuq)~(d~'rcr64u~t~'9c)~(d~'rcrma8~t~'1q)~(d~'rcrcml~t~'786y)~(d~'rcicp0~t~'v9)~(d~'rd42h4~t~'72e1)~(d~'rd42fd~t~'7hao)~(d~'rd2k06~t~'13b)~(d~'rd84kg~t~'a9c)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)~(d~'rcwujj~t~'19a)~(d~'rd87eu~t~'b2)~(d~'rdh5t0~t~'u5o)~(d~'rdhazs~t~'7f)~(d~'rdw3hs~t~'46y)~(d~'rdy6oj~t~'1r)~(d~'rdy5rz~t~'fil))))                                                                                                                                                            | 0              |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 12            | [14h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rcrqor~t~'lig)~(d~'rcwvo8~t~'1put)~(d~'rd80y3~t~'741)~(d~'rdhgi1~t~'28on)~(d~'rdmkti~t~'1mar)~(d~'rdmkvi~t~'1mcr)~(d~'rdvvtj~t~'1x91)~(d~'rdvy4f~t~'tu)~(d~'rdxxxw~t~'1r5t)~(d~'rdy5n1~t~'6jw)~(d~'rdy6n3~t~'bs)~(d~'rdmqcr~t~'1xx2)~(d~'rdy7qa~t~'11w)~(d~'rd88j3~t~'3gf))))                                                                                                                                                                                                                                                | 16             |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 11            | [1h 53m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rcg6bm~t~'7t)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh)~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcwo18~t~'24b)~(d~'rcylp9~t~'1ex2)~(d~'rcx1xd~t~'3x6)~(d~'rdfanm~t~'7h13)~(d~'rd89re~t~'205)~(d~'rdf9eu~t~'4y8r)~(d~'rdh0c5~t~'1h1)~(d~'rdh3p6~t~'4u2)~(d~'rdh3r2~t~'4vy)~(d~'rdh42t~t~'57p)~(d~'rdh4gf~t~'5lb)~(d~'rdhf5j~t~'3m)~(d~'rdittj~t~'1329)~(d~'rdjbe5~t~'1kmv)~(d~'rdjbhm~t~'1kqc)~(d~'rdjc01~t~'1l8r)~(d~'rdjcr6~t~'lx)~(d~'rdjczy~t~'up)~(d~'rdjmbz~t~'a6q)~(d~'rdl3te~t~'9o)~(d~'rdmyxj~t~'1rb5)))) | 28             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 11            | [17h 17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rcr0os~t~'1p63)~(d~'rcr4z1~t~'13m)~(d~'rci1nv~t~'1b)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rcwlmf~t~'1lfe)~(d~'rcwlno~t~'1lgn)~(d~'rd2qve~t~'g2)~(d~'rd5xi4~t~'3b93)~(d~'rd9hdt~t~'1aa1)~(d~'rdgz3k~t~'13r3)~(d~'rdh128~t~'1i3f)~(d~'rdhh75~t~'49j)~(d~'rdj9h2~t~'1o4u)~(d~'rdmluj~t~'39zy)~(d~'rdmm8x~t~'3aec))))                                                                                                     | **32**         |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 7             | [2h 30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rcjvov~t~'6xr)~(d~'rd4gaa~t~'1pae)~(d~'rd2kkn~t~'cu)~(d~'rcuw05~t~'1heq)~(d~'rdjf6s~t~'18)~(d~'rdji5q~t~'23d)~(d~'rdxxpg~t~'1ed2))))                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 7             | [1h 5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'rdfbrm~t~'3ml)~(d~'rdfdpf~t~'2zv)~(d~'rdha5c~t~'2y)~(d~'rdfn6r~t~'ot)~(d~'rdmyye~t~'2xu)~(d~'rdn5dl~t~'5mre)~(d~'rdu86s~t~'1e7a))))                                                                                                                                                                                                                                                                                                                                                                                                    | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 6             | [2h](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rcrdi5~t~'72h)~(d~'rck4y1~t~'57)~(d~'rda7do~t~'436)~(d~'rda797~t~'9f3)~(d~'rduclo~t~'1gq)~(d~'rdwkn6~t~'ayb))))                                                                                                                                                                                                                                                                                                                                                                                                                       | 2              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 5             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rcfzf6~t~'27)~(d~'rd489j~t~'5f)~(d~'rd2kyx~t~'222)~(d~'rd2qn4~t~'9y)~(d~'rcvdxd~t~'glr)~(d~'rdh86q~t~'69s))))                                                                                                                                                                                                                                                                                                                                                                                                                           | 13             |
| <a href="https://github.com/doug-s-nava"><img src="https://avatars.githubusercontent.com/u/92806979?u=6b5adf4d0028464ee97e875450768e2efaae7b12&v=4" width="20"></a>        | doug-s-nava        | 5             | [1h 40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92806979~n~'doug-s-nava)~p~30~r~(~(d~'rd2njo~t~'4mt)~(d~'rcthb1~t~'b8j)~(d~'rcv7iu~t~'71h)~(d~'rd8b22~t~'3at)~(d~'rda1it~t~'1trk)~(d~'rda1p1~t~'3ux)~(d~'rdjevs~t~'2qj)~(d~'rdknvz~t~'1bqq)~(d~'rdl34b~t~'48e))))                                                                                                                                                                                                                                                                                                                                                       | 31             |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [6h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rchp2w~t~'117k)~(d~'rcuvv8~t~'1h9t)~(d~'rd9x55~t~'hk)~(d~'rda190~t~'1l))))                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 3             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rd8797~t~'3k7)~(d~'rd8bld~t~'12v)~(d~'rd9pfv~t~'3b)~(d~'rdix25~t~'185)~(d~'rdjabp~t~'d9)~(d~'rdn2in~t~'8xz))))                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 3             | [18h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rcuvu4~t~'1h8p)~(d~'rd8219~t~'1g0n)~(d~'rdjf6i~t~'y))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 2             | [13h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rd61sy~t~'6b7)~(d~'rcv9gl~t~'1x0i))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 2             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rdl3cq~t~'5h)~(d~'rdvt0l~t~'26o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 2             | [40m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rd2jiz~t~'m4)~(d~'rd2x0n~t~'e3s)~(d~'rduh08~t~'1uf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 2              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 0              |
| <a href="https://github.com/BerniXiongA6"><img src="https://avatars.githubusercontent.com/u/85254824?u=b001d46ca03abb1c1628ad2214aae47d3635588c&v=4" width="20"></a>       | BerniXiongA6       | 1             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'85254824~n~'BerniXiongA6)~p~30~r~(~(d~'rdw9ba~t~'18d)~(d~'rdw9dq~t~'1at))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 2              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rd88x7~t~'1tf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |
| <a href="https://github.com/PatriciaPerozoUSDS"><img src="https://avatars.githubusercontent.com/u/106171068?v=4" width="20"></a>                                           | PatriciaPerozoUSDS | 1             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'106171068~n~'PatriciaPerozoUSDS)~p~30~r~(~(d~'rdvuiv~t~'7f))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 0              |