### PR TITLE
feat: error and success messaging for value sets edits [experience-5443]

### DIFF
--- a/frontend-react/src/components/StaticAlert.test.tsx
+++ b/frontend-react/src/components/StaticAlert.test.tsx
@@ -1,0 +1,19 @@
+import { screen, render } from "@testing-library/react";
+
+import { StaticAlert } from "./StaticAlert";
+
+describe("StaticAlert", () => {
+    test("renders correct class for success", async () => {
+        render(<StaticAlert type={"success"} heading={"any"} />);
+
+        const wrapper = await screen.findByRole("alert");
+        expect(wrapper).toHaveClass("usa-alert--success");
+    });
+
+    test("renders correct class for success", async () => {
+        render(<StaticAlert type={"error"} heading={"any"} />);
+
+        const wrapper = await screen.findByRole("alert");
+        expect(wrapper).toHaveClass("usa-alert--error");
+    });
+});

--- a/frontend-react/src/components/StaticAlert.tsx
+++ b/frontend-react/src/components/StaticAlert.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from "react";
+import classNames from "classnames";
+
+interface StaticAlertProps {
+    type: string;
+    heading: string;
+    message?: string;
+    children?: ReactNode;
+}
+
+export const StaticAlert = ({
+    type,
+    heading,
+    message,
+    children,
+}: StaticAlertProps) => {
+    const alertClasses = classNames({
+        "usa-alert": true,
+        "usa-alert--success": type === "success",
+        "usa-alert--error": type === "error",
+    });
+    return (
+        <div className={alertClasses} role="alert">
+            <div className="usa-alert__body">
+                <h4 className="usa-alert__heading">{heading}</h4>
+                <p className="usa-alert__text">{message}</p>
+                {children}
+            </div>
+        </div>
+    );
+};

--- a/frontend-react/src/hooks/UseLookupTable.test.ts
+++ b/frontend-react/src/hooks/UseLookupTable.test.ts
@@ -25,9 +25,15 @@ describe("useLookupTable and related helper functions", () => {
             expect(createdBy).toEqual("test@example.com");
         });
 
-        test("getLatestVersion returns null when table doesn't exist", async () => {
-            const result = await getLatestVersion(LookupTables.VALUE_SET_ROW);
-            expect(result).toBeFalsy();
+        test("getLatestVersion throws when table doesn't exist", async () => {
+            try {
+                await getLatestVersion(LookupTables.VALUE_SET_ROW);
+                expect(true).toBe(false);
+            } catch (e: any) {
+                expect(e.message).toEqual(
+                    `Table 'sender_automation_value_set_row' was not found!`
+                );
+            }
         });
     });
 
@@ -51,6 +57,6 @@ describe("useLookupTable and related helper functions", () => {
             useLookupTable<ValueSet>(LookupTables.VALUE_SET)
         );
         await waitForNextUpdate();
-        expect(result.current.length).toEqual(3);
+        expect(result.current.valueSetArray.length).toEqual(3);
     });
 });

--- a/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
+++ b/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+    useState,
+    useMemo,
+    useEffect,
+    Dispatch,
+    SetStateAction,
+} from "react";
 import { Helmet } from "react-helmet";
 import { useParams } from "react-router-dom";
 import axios from "axios";
@@ -12,11 +18,16 @@ import Table, {
 import { useValueSetsRowTable } from "../../../hooks/UseLookupTable";
 import { toHumanReadable } from "../../../utils/misc";
 import {
+    LookupTable,
     lookupTableApi,
     LookupTables,
     ValueSetRow,
 } from "../../../network/api/LookupTableApi";
-import { showError } from "../../../components/AlertNotifications";
+import { StaticAlert } from "../../../components/StaticAlert";
+import {
+    ReportStreamAlert,
+    handleErrorWithAlert,
+} from "../../../utils/ErrorUtils";
 
 const valueSetDetailColumnConfig: ColumnConfig[] = [
     {
@@ -89,10 +100,9 @@ const saveData = async (
     row: TableRow | null,
     allRows: SenderAutomationDataRow[],
     valueSetName: string
-) => {
+): Promise<LookupTable> => {
     if (row === null) {
-        showError("A null row was encountered in saveData()");
-        return;
+        throw new Error("A null row was encountered in saveData");
     }
 
     const endpointHeaderUpdate = lookupTableApi.saveTableData<ValueSetRow[]>(
@@ -122,28 +132,23 @@ const saveData = async (
         })
     );
 
-    try {
-        let updateResult = await axios
-            .post(endpointHeaderUpdate.url, strippedArray, endpointHeaderUpdate)
-            .then((response) => response.data);
+    const updateResult = await axios.post(
+        endpointHeaderUpdate.url,
+        strippedArray,
+        endpointHeaderUpdate
+    );
 
-        const endpointHeaderActivate = lookupTableApi.activateTableData(
-            updateResult.tableVersion,
-            LookupTables.VALUE_SET_ROW
-        );
+    const endpointHeaderActivate = lookupTableApi.activateTableData(
+        updateResult.data.tableVersion,
+        LookupTables.VALUE_SET_ROW
+    );
 
-        return await axios
-            .put(
-                endpointHeaderActivate.url,
-                LookupTables.VALUE_SET_ROW,
-                endpointHeaderActivate
-            )
-            .then((response) => response.data);
-    } catch (e: any) {
-        console.trace(e);
-        showError(e.toString());
-        return [];
-    }
+    const activateResult = await axios.put(
+        endpointHeaderActivate.url,
+        LookupTables.VALUE_SET_ROW,
+        endpointHeaderActivate
+    );
+    return activateResult.data;
 };
 
 interface SenderAutomationDataRow extends ValueSetRow {
@@ -151,10 +156,10 @@ interface SenderAutomationDataRow extends ValueSetRow {
 }
 
 const prepareRows = (
-    valueSetRowArray: ValueSetRow[],
+    valueSetArray: ValueSetRow[],
     valueSetName: string
 ): { rowsForDisplay: any[]; allRows: any[] } => {
-    return valueSetRowArray.reduce(
+    return valueSetArray.reduce(
         (acc, row, index) => {
             let mapped: SenderAutomationDataRow = {
                 name: row.name,
@@ -178,20 +183,36 @@ const prepareRows = (
     );
 };
 
-const ValueSetsDetailTable = ({ valueSetName }: { valueSetName: string }) => {
+export const ValueSetsDetailTable = ({
+    valueSetName,
+    setAlert,
+}: {
+    valueSetName: string;
+    setAlert: Dispatch<SetStateAction<ReportStreamAlert | undefined>>;
+}) => {
     const [valueSetRows, setValueSetRows] = useState<ValueSetRow[]>(
         [] as ValueSetRow[]
     );
     const [valueSetsVersion, setValueSetVersion] = useState<number>();
 
-    const valueSetRowArray = useValueSetsRowTable(
+    const { valueSetArray, error } = useValueSetsRowTable(
         valueSetName,
         valueSetsVersion
     );
 
     useEffect(() => {
-        setValueSetRows(valueSetRowArray);
-    }, [valueSetRowArray]);
+        if (error) {
+            handleErrorWithAlert({
+                logMessage: "Error occurred fetching value set",
+                error,
+                setAlert,
+            });
+        }
+    }, [error, setAlert]);
+
+    useEffect(() => {
+        setValueSetRows(valueSetArray);
+    }, [valueSetArray]);
 
     const { allRows, rowsForDisplay } = useMemo(() => {
         return prepareRows(valueSetRows, valueSetName);
@@ -201,20 +222,31 @@ const ValueSetsDetailTable = ({ valueSetName }: { valueSetName: string }) => {
         columns: valueSetDetailColumnConfig,
         rows: rowsForDisplay,
     };
-    /* We make this action do what we need it to to add an item */
+
     const datasetActionItem: DatasetAction = {
         label: "Add item",
     };
+
     return (
         <Table
             title="ReportStream Core Values"
-            datasetAction={datasetActionItem}
+            // assume we don't want to allow creating a row if initial fetch failed
+            datasetAction={error ? undefined : datasetActionItem}
             config={tableConfig}
             enableEditableRows
             editableCallback={async (row) => {
-                const data = await saveData(row, allRows, valueSetName);
-                console.log("!!! saved data", data);
-                setValueSetVersion(data.tableVersion);
+                try {
+                    const data = await saveData(row, allRows, valueSetName);
+                    setValueSetVersion(data.tableVersion);
+                } catch (e: any) {
+                    handleErrorWithAlert({
+                        logMessage: "Error occurred saving value set",
+                        error: e,
+                        setAlert,
+                    });
+                    return;
+                }
+                setAlert({ type: "success", message: "Value Saved" });
             }}
         />
     );
@@ -222,6 +254,8 @@ const ValueSetsDetailTable = ({ valueSetName }: { valueSetName: string }) => {
 
 const ValueSetsDetail = () => {
     const { valueSetName } = useParams<{ valueSetName: string }>();
+    // TODO: when to unset?
+    const [alert, setAlert] = useState<ReportStreamAlert | undefined>();
 
     return (
         <>
@@ -231,7 +265,17 @@ const ValueSetsDetail = () => {
             <section className="grid-container">
                 {/* valueSetsDetailHeader would go here */}
                 <h1>{toHumanReadable(valueSetName)}</h1>
-                <ValueSetsDetailTable valueSetName={valueSetName} />
+                {alert && (
+                    <StaticAlert
+                        type={alert.type}
+                        heading={alert.type.toUpperCase()}
+                        message={alert.message}
+                    />
+                )}
+                <ValueSetsDetailTable
+                    valueSetName={valueSetName}
+                    setAlert={setAlert}
+                />
             </section>
         </>
     );

--- a/frontend-react/src/pages/admin/value-set-editor/ValueSetsIndex.tsx
+++ b/frontend-react/src/pages/admin/value-set-editor/ValueSetsIndex.tsx
@@ -1,5 +1,5 @@
 import { Helmet } from "react-helmet";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import Table, {
     ColumnConfig,
@@ -7,6 +7,11 @@ import Table, {
     TableConfig,
 } from "../../../components/Table/Table";
 import { useValueSetsTable } from "../../../hooks/UseLookupTable";
+import { StaticAlert } from "../../../components/StaticAlert";
+import {
+    handleErrorWithAlert,
+    ReportStreamAlert,
+} from "../../../utils/ErrorUtils";
 
 export const Legend = ({ items }: { items: LegendItem[] }) => {
     const makeItem = (label: string, value: string) => (
@@ -48,21 +53,35 @@ const valueSetColumnConfig: ColumnConfig[] = [
 ];
 
 const ValueSetsTable = () => {
-    const valueSetArray = useValueSetsTable();
+    const [alert, setAlert] = useState<ReportStreamAlert | undefined>();
+    const { valueSetArray, error } = useValueSetsTable();
+
+    useEffect(() => {
+        if (error) {
+            handleErrorWithAlert({
+                logMessage: "Error occurred fetching value sets",
+                error,
+                setAlert,
+            });
+        }
+    }, [error]);
+
     const tableConfig: TableConfig = {
         columns: valueSetColumnConfig,
         rows: valueSetArray,
     };
 
     return (
-        <Table
-            title="ReportStream Value Sets"
-            config={tableConfig}
-            editableCallback={(row) => {
-                console.log("!!! saving row", row);
-                return Promise.resolve();
-            }}
-        />
+        <>
+            {alert && (
+                <StaticAlert
+                    type={alert.type}
+                    heading={alert.type.toUpperCase()}
+                    message={alert.message}
+                />
+            )}
+            <Table title="ReportStream Value Sets" config={tableConfig} />
+        </>
     );
 };
 

--- a/frontend-react/src/utils/ErrorUtils.tsx
+++ b/frontend-react/src/utils/ErrorUtils.tsx
@@ -1,0 +1,32 @@
+import { Dispatch, SetStateAction } from "react";
+
+export interface ReportStreamAlert {
+    type: string;
+    message: string;
+}
+
+// does a few things with an error:
+// - logs a message if passed
+// - parses out the most useful error message to display from the error
+// - sets state using the passed function to alert via the ui in whatever
+// way the implementing component sees fit
+export const handleErrorWithAlert = ({
+    error,
+    logMessage,
+    setAlert,
+}: {
+    error: any;
+    logMessage?: string;
+    setAlert?: Dispatch<SetStateAction<ReportStreamAlert | undefined>>;
+}) => {
+    if (logMessage) {
+        console.error(logMessage);
+    }
+    // attempt to extract more helpful error from response
+    const { response: { data: { error: errorString = null } = {} } = {} } =
+        error;
+    const message = errorString || error.toString();
+    if (setAlert) {
+        setAlert({ type: "error", message });
+    }
+};


### PR DESCRIPTION
Adds messaging for users to display success or error results after editing or adding rows to the value sets table.

Also:
* creates a StaticAlert component based on the alert currently used on the Upload page for use here, and across the app where this sort of messaging is called for
* creates an ErrorUtils file to hold functionality and types related to common error handling

Open question: do we want these alerts to disappear at a particular time? At this point they will stay on the page until:
* they are replaced by a new alert
* the page reloads, or user navigates away

Some options:
* message disappears after a certain length of time
* message disappears when a new update operation is performed (and is likely quickly replaced by a new message)
* message disappears when a new row is open for editing

See Figma designs here: https://www.figma.com/file/fKl2M96ylkxYezwjVVUSIX/Internal-Admin-%26-Tools

## Test Steps:

1. start servers on this branch with `yarn run start:localdev` from `frontend-react` and `./gradlew run` from `prime-router`
2. visit http://localhost:3000/admin/value-sets/state and log in as necessary
3. edit a row and click save
4. _VERIFY_: you see a success message matching the screenshot below
5. to spoof an error, edit line 139 of src/pages/admin/value-set-editor/ValueSetsDetail.tsx to read
```
        endpointHeaderUpdate.url + '/throwAnError',
```
6. attempt to edit and save another row
7. _VERIFY_: you see an error message matching the screenshot below

## Screenshots

### Success

<img width="713" alt="Screen Shot 2022-06-27 at 9 57 44 AM" src="https://user-images.githubusercontent.com/92806979/175959272-7b27cfb4-000c-44f3-8b61-6b61ccfa22f0.png">

### Error

<img width="711" alt="Screen Shot 2022-06-27 at 10 01 42 AM" src="https://user-images.githubusercontent.com/92806979/175959986-e473c3ed-c195-4514-b88e-9db702d59f1c.png">


## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?


## Pull reviewers stats
Stats for the last 30 days:
|                                                                                                                                                                            | User               | Total reviews | Time to review                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Total comments |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
| <a href="https://github.com/jeremy-page"><img src="https://avatars.githubusercontent.com/u/54326889?u=600f8a60859e9b0ca4634227f00b2cd9bee5e9b8&v=4" width="20"></a>        | jeremy-page        | **22**        | [1h 43m](https://app.flowwer.dev/charts/review-time/~(u~(i~'54326889~n~'jeremy-page)~p~30~r~(~(d~'rcicp0~t~'v9)~(d~'rcjsm1~t~'3ux)~(d~'rcrcml~t~'786y)~(d~'rcrma8~t~'1q)~(d~'rcr64u~t~'9c)~(d~'rd84kg~t~'a9c)~(d~'rd87eu~t~'b2)~(d~'rd42fd~t~'7hao)~(d~'rd42h4~t~'72e1)~(d~'rcwujj~t~'19a)~(d~'rcuphg~t~'1l0a)~(d~'rcuwl1~t~'4sh)~(d~'rdh5t0~t~'u5o)~(d~'rdhazs~t~'7f)~(d~'rdw3hs~t~'46y)~(d~'rdy5rz~t~'fil)~(d~'rdy6oj~t~'1r)~(d~'rdzrk6~t~'1kur)~(d~'rdzukw~t~'1nv3)~(d~'rdzreq~t~'42)~(d~'rdzgao~t~'19o5)~(d~'rdzlek~t~'pyrb)~(d~'rdzy62~t~'ko))))                                                             | 0              |
| <a href="https://github.com/MauriceReeves-usds"><img src="https://avatars.githubusercontent.com/u/74194189?u=f81b3f069b28469e1fb39322ba3c17112c1dd1d0&v=4" width="20"></a> | MauriceReeves-usds | 20            | [15h 8m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74194189~n~'MauriceReeves-usds)~p~30~r~(~(d~'rcr50d~t~'14y)~(d~'rd430j~t~'161u)~(d~'rd48aa~t~'66)~(d~'rcv4s3~t~'m5)~(d~'rcwirp~t~'1iko)~(d~'rcvb53~t~'1kk)~(d~'rcuqdp~t~'11jz)~(d~'rcwio2~t~'138x)~(d~'rd7uje~t~'1rii)~(d~'rdkt1f~t~'13aq)~(d~'rd2gvk~t~'5ufp)~(d~'rdjfho~t~'c4)~(d~'rdmmpj~t~'3auy)~(d~'rdmn4e~t~'51ov)~(d~'rdvv8m~t~'vc0)~(d~'rdjkhh~t~'2a7g)~(d~'rdvvad~t~'1a85)~(d~'rdtzmt~t~'8opz)~(d~'rdivoi~t~'15v6)~(d~'rdzsgy~t~'1g80)~(d~'rdzwyb~t~'1h7y))))                                                                                | 10             |
| <a href="https://github.com/clediggins-usds"><img src="https://avatars.githubusercontent.com/u/89804087?u=5b03415b2bc7766f96908dd40f522633187e4b02&v=4" width="20"></a>    | clediggins-usds    | 12            | [14h 22m](https://app.flowwer.dev/charts/review-time/~(u~(i~'89804087~n~'clediggins-usds)~p~30~r~(~(d~'rcrqor~t~'lig)~(d~'rd80y3~t~'741)~(d~'rcwvo8~t~'1put)~(d~'rdhgi1~t~'28on)~(d~'rdmkti~t~'1mar)~(d~'rdmkvi~t~'1mcr)~(d~'rdvy4f~t~'tu)~(d~'rdvvtj~t~'1x91)~(d~'rdxxxw~t~'1r5t)~(d~'rdmqcr~t~'1xx2)~(d~'rdy7qa~t~'11w)~(d~'rdy5n1~t~'6jw)~(d~'rdy6n3~t~'bs)~(d~'rd88j3~t~'3gf))))                                                                                                                                                                                                                              | 16             |
| <a href="https://github.com/carlosfelix2"><img src="https://avatars.githubusercontent.com/u/63804190?u=009d26bf9914817d2f9a066811541d0f6f3155c9&v=4" width="20"></a>       | carlosfelix2       | 11            | [17h 17m](https://app.flowwer.dev/charts/review-time/~(u~(i~'63804190~n~'carlosfelix2)~p~30~r~(~(d~'rcr0os~t~'1p63)~(d~'rci1nv~t~'1b)~(d~'rcr4z1~t~'13m)~(d~'rchxnw~t~'1bgl)~(d~'rchxzf~t~'1bs4)~(d~'rchy5i~t~'1by7)~(d~'rchy7n~t~'1c0c)~(d~'rchyad~t~'1c32)~(d~'rchyd4~t~'1c5t)~(d~'rct8ty~t~'35q)~(d~'rd9hdt~t~'1aa1)~(d~'rd5xi4~t~'3b93)~(d~'rcwlmf~t~'1lfe)~(d~'rcwlno~t~'1lgn)~(d~'rd2qve~t~'g2)~(d~'rdgz3k~t~'13r3)~(d~'rdh128~t~'1i3f)~(d~'rdhh75~t~'49j)~(d~'rdj9h2~t~'1o4u)~(d~'rdmluj~t~'39zy)~(d~'rdmm8x~t~'3aec))))                                                                                   | **32**         |
| <a href="https://github.com/kevinhaube"><img src="https://avatars.githubusercontent.com/u/4022304?u=c0f80e2ad03386621394d1830dc33b7b5cc23680&v=4" width="20"></a>          | kevinhaube         | 10            | [1h 57m](https://app.flowwer.dev/charts/review-time/~(u~(i~'4022304~n~'kevinhaube)~p~30~r~(~(d~'rcs3pb~t~'lta)~(d~'rct01z~t~'1i5y)~(d~'rct02w~t~'1i6v)~(d~'rcifmu~t~'vn)~(d~'rct9ap~t~'3mh)~(d~'rdfanm~t~'7h13)~(d~'rd89re~t~'205)~(d~'rdf9eu~t~'4y8r)~(d~'rcwo18~t~'24b)~(d~'rcylp9~t~'1ex2)~(d~'rcx1xd~t~'3x6)~(d~'rdh0c5~t~'1h1)~(d~'rdh3p6~t~'4u2)~(d~'rdh3r2~t~'4vy)~(d~'rdh42t~t~'57p)~(d~'rdh4gf~t~'5lb)~(d~'rdhf5j~t~'3m)~(d~'rdittj~t~'1329)~(d~'rdjbe5~t~'1kmv)~(d~'rdjbhm~t~'1kqc)~(d~'rdjc01~t~'1l8r)~(d~'rdjcr6~t~'lx)~(d~'rdjczy~t~'up)~(d~'rdjmbz~t~'a6q)~(d~'rdl3te~t~'9o)~(d~'rdmyxj~t~'1rb5)))) | 27             |
| <a href="https://github.com/jorg3lopez"><img src="https://avatars.githubusercontent.com/u/49923512?v=4" width="20"></a>                                                    | jorg3lopez         | 7             | [2h 30m](https://app.flowwer.dev/charts/review-time/~(u~(i~'49923512~n~'jorg3lopez)~p~30~r~(~(d~'rcjvov~t~'6xr)~(d~'rd2kkn~t~'cu)~(d~'rd4gaa~t~'1pae)~(d~'rcuw05~t~'1heq)~(d~'rdjf6s~t~'18)~(d~'rdji5q~t~'23d)~(d~'rdxxpg~t~'1ed2))))                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/jbiskie"><img src="https://avatars.githubusercontent.com/u/84460447?v=4" width="20"></a>                                                       | jbiskie            | 7             | [1h 5m](https://app.flowwer.dev/charts/review-time/~(u~(i~'84460447~n~'jbiskie)~p~30~r~(~(d~'rdfbrm~t~'3ml)~(d~'rdfdpf~t~'2zv)~(d~'rdfn6r~t~'ot)~(d~'rdha5c~t~'2y)~(d~'rdmyye~t~'2xu)~(d~'rdn5dl~t~'5mre)~(d~'rdu86s~t~'1e7a))))                                                                                                                                                                                                                                                                                                                                                                                  | 0              |
| <a href="https://github.com/ahay-agile6"><img src="https://avatars.githubusercontent.com/u/19178435?u=aa7d4ddd31665f83e677e20967502557741345e4&v=4" width="20"></a>        | ahay-agile6        | 5             | [1h 28m](https://app.flowwer.dev/charts/review-time/~(u~(i~'19178435~n~'ahay-agile6)~p~30~r~(~(d~'rck4y1~t~'57)~(d~'rda7do~t~'436)~(d~'rda797~t~'9f3)~(d~'rduclo~t~'1gq)~(d~'rdwkn6~t~'ayb))))                                                                                                                                                                                                                                                                                                                                                                                                                    | 2              |
| <a href="https://github.com/oslynn"><img src="https://avatars.githubusercontent.com/u/20068283?u=bcad2a3d00ffe648463e3fbe1894762aeab72404&v=4" width="20"></a>             | oslynn             | 4             | [6h 47m](https://app.flowwer.dev/charts/review-time/~(u~(i~'20068283~n~'oslynn)~p~30~r~(~(d~'rchp2w~t~'117k)~(d~'rd9x55~t~'hk)~(d~'rcuvv8~t~'1h9t)~(d~'rda190~t~'1l))))                                                                                                                                                                                                                                                                                                                                                                                                                                           | 0              |
| <a href="https://github.com/doug-s-nava"><img src="https://avatars.githubusercontent.com/u/92806979?u=6b5adf4d0028464ee97e875450768e2efaae7b12&v=4" width="20"></a>        | doug-s-nava        | 4             | [2h 2m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92806979~n~'doug-s-nava)~p~30~r~(~(d~'rd8b22~t~'3at)~(d~'rda1it~t~'1trk)~(d~'rda1p1~t~'3ux)~(d~'rcthb1~t~'b8j)~(d~'rcv7iu~t~'71h)~(d~'rdjevs~t~'2qj)~(d~'rdknvz~t~'1bqq)~(d~'rdl34b~t~'48e))))                                                                                                                                                                                                                                                                                                                                                         | 30             |
| <a href="https://github.com/TurkeyFried"><img src="https://avatars.githubusercontent.com/u/2624105?u=675395bdf4c1b121eb2f291338079089107daf74&v=4" width="20"></a>         | TurkeyFried        | 3             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'2624105~n~'TurkeyFried)~p~30~r~(~(d~'rd8797~t~'3k7)~(d~'rd8bld~t~'12v)~(d~'rd9pfv~t~'3b)~(d~'rdix25~t~'185)~(d~'rdjabp~t~'d9)~(d~'rdn2in~t~'8xz))))                                                                                                                                                                                                                                                                                                                                                                                                      | 0              |
| <a href="https://github.com/TomNUSDS"><img src="https://avatars.githubusercontent.com/u/74203452?u=6eccca154e9d5c808c5269d9604648aec3c9a412&v=4" width="20"></a>           | TomNUSDS           | 3             | [2h 15m](https://app.flowwer.dev/charts/review-time/~(u~(i~'74203452~n~'TomNUSDS)~p~30~r~(~(d~'rd489j~t~'5f)~(d~'rcvdxd~t~'glr)~(d~'rdh86q~t~'69s))))                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/brick-green"><img src="https://avatars.githubusercontent.com/u/86254221?u=894ef5a4773dd01e92be595af8f1879041f85002&v=4" width="20"></a>        | brick-green        | 3             | [18h 44m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86254221~n~'brick-green)~p~30~r~(~(d~'rd8219~t~'1g0n)~(d~'rcuvu4~t~'1h8p)~(d~'rdjf6i~t~'y))))                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/bgantick"><img src="https://avatars.githubusercontent.com/u/640182?u=901de0e5fa2ff06da055ee0949aa806a6c82dcb8&v=4" width="20"></a>             | bgantick           | 2             | [13h 34m](https://app.flowwer.dev/charts/review-time/~(u~(i~'640182~n~'bgantick)~p~30~r~(~(d~'rd61sy~t~'6b7)~(d~'rcv9gl~t~'1x0i))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 1              |
| <a href="https://github.com/JosiahSiegel"><img src="https://avatars.githubusercontent.com/u/5522990?v=4" width="20"></a>                                                   | JosiahSiegel       | 2             | [25m](https://app.flowwer.dev/charts/review-time/~(u~(i~'5522990~n~'JosiahSiegel)~p~30~r~(~(d~'rdl3cq~t~'5h)~(d~'rdvt0l~t~'26o))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 0              |
| <a href="https://github.com/sethdarragile6"><img src="https://avatars.githubusercontent.com/u/92405130?u=b36435069928f7e5f03109c9f478cdc7158fc01e&v=4" width="20"></a>     | sethdarragile6     | 2             | [41m](https://app.flowwer.dev/charts/review-time/~(u~(i~'92405130~n~'sethdarragile6)~p~30~r~(~(d~'rduh08~t~'1uf)~(d~'re021t~t~'1yk))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | 0              |
| <a href="https://github.com/jimduff-usds"><img src="https://avatars.githubusercontent.com/u/62258514?u=b7ce81d1478c472fb5bf6f3d31edb1a4454d55dd&v=4" width="20"></a>       | jimduff-usds       | 1             | [12h 26m](https://app.flowwer.dev/charts/review-time/~(u~(i~'62258514~n~'jimduff-usds)~p~30~r~(~(d~'rcundc~t~'yjm))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | 0              |
| <a href="https://github.com/BerniXiongA6"><img src="https://avatars.githubusercontent.com/u/85254824?u=b001d46ca03abb1c1628ad2214aae47d3635588c&v=4" width="20"></a>       | BerniXiongA6       | 1             | [27m](https://app.flowwer.dev/charts/review-time/~(u~(i~'85254824~n~'BerniXiongA6)~p~30~r~(~(d~'rdw9ba~t~'18d)~(d~'rdw9dq~t~'1at))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 2              |
| <a href="https://github.com/cwinters-usds"><img src="https://avatars.githubusercontent.com/u/86251310?u=e7f46bd48ca250dea43f9e0d6433a7fb8627ed30&v=4" width="20"></a>      | cwinters-usds      | 1             | [10m](https://app.flowwer.dev/charts/review-time/~(u~(i~'86251310~n~'cwinters-usds)~p~30~r~(~(d~'rdzwqp~t~'hb))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | 0              |
| <a href="https://github.com/snesm"><img src="https://avatars.githubusercontent.com/u/94193373?v=4" width="20"></a>                                                         | snesm              | 1             | [39m](https://app.flowwer.dev/charts/review-time/~(u~(i~'94193373~n~'snesm)~p~30~r~(~(d~'rd88x7~t~'1tf))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |
| <a href="https://github.com/PatriciaPerozoUSDS"><img src="https://avatars.githubusercontent.com/u/106171068?v=4" width="20"></a>                                           | PatriciaPerozoUSDS | 1             | [**4m**](https://app.flowwer.dev/charts/review-time/~(u~(i~'106171068~n~'PatriciaPerozoUSDS)~p~30~r~(~(d~'rdvuiv~t~'7f))))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 0              |