### PR TITLE
Experience/5442: fix to update/activate calls

### DIFF
--- a/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
+++ b/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
@@ -85,10 +85,6 @@ const valueSetDetailColumnConfig: ColumnConfig[] = [
 
 */
 
-const endpointHeaderUpdate = lookupTableApi.saveTableData<ValueSetRow>(
-    LookupTables.VALUE_SET_ROW
-);
-
 const saveData = async (
     row: TableRow | null,
     allRows: SenderAutomationDataRow[],
@@ -98,6 +94,10 @@ const saveData = async (
         showError("A null row was encountered in saveData()");
         return;
     }
+
+    const endpointHeaderUpdate = lookupTableApi.saveTableData<ValueSetRow[]>(
+        LookupTables.VALUE_SET_ROW
+    );
 
     const index = allRows.findIndex((r) => r.id === row.id);
     allRows.splice(index, 1, {
@@ -120,11 +120,11 @@ const saveData = async (
             code: set.code,
             version: set.version,
         })
-    );
+    ) as ValueSetRow[] | undefined;
 
     try {
         let updateResult = await axios
-            .post(endpointHeaderUpdate.url, strippedArray)
+            .post(endpointHeaderUpdate.url, strippedArray, endpointHeaderUpdate)
             .then((response) => response.data);
 
         const endpointHeaderActivate = lookupTableApi.activateTableData(
@@ -133,7 +133,11 @@ const saveData = async (
         );
 
         return await axios
-            .put(endpointHeaderActivate.url, LookupTables.VALUE_SET_ROW)
+            .put(
+                endpointHeaderActivate.url,
+                LookupTables.VALUE_SET_ROW,
+                endpointHeaderActivate
+            )
             .then((response) => response.data);
     } catch (e: any) {
         console.trace(e);

--- a/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
+++ b/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
@@ -120,7 +120,7 @@ const saveData = async (
             code: set.code,
             version: set.version,
         })
-    ) as ValueSetRow[] | undefined;
+    );
 
     try {
         let updateResult = await axios


### PR DESCRIPTION
This PR fixes the update and activate axios calls for saving a Valueset in the UI. It was discovered upon deploying to Staging and identified as the probably culprit by @doug-s-nava thanks Doug!

Test Steps:
1. Login as Admin to ReportStream on **_Staging_**
2. Navigate manually to /admin/value-sets in the URL (or add the "value-sets" feature flag to navigate from the menu itself)
3. Click on any particular valueset name link
4. Click the Edit button on any particular row --> cells become editable
5. Change any or all values and click the Save button --> was an **ERROR**! This PR should fix this and save it properly.

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


