### PR TITLE
Experience/5304 deprecate meta

### DIFF
--- a/frontend-react/src/__mocks__/OrganizationMockServer.ts
+++ b/frontend-react/src/__mocks__/OrganizationMockServer.ts
@@ -21,11 +21,9 @@ const fakeOrg = {
     description: "A county for testing",
     filters: [],
     jurisdiction: "TC",
-    meta: {
-        version: 1,
-        createdBy: "OrganizationMockServer",
-        createdAt: "now",
-    },
+    version: 1,
+    createdBy: "OrganizationMockServer",
+    createdAt: "now",
     name: "Fake Org",
     stateCode: "TC",
 };

--- a/frontend-react/src/components/Admin/DisplayMeta.test.tsx
+++ b/frontend-react/src/components/Admin/DisplayMeta.test.tsx
@@ -1,12 +1,10 @@
 import { render, screen } from "@testing-library/react";
 
-import { MetaData } from "../../resources/OrgSettingsBaseResource";
-
 import { DisplayMeta } from "./DisplayMeta";
 
 describe("DisplayMeta rendering object", () => {
     beforeEach(() => {
-        const metaobj: MetaData = {
+        const metaobj = {
             version: 2,
             createdBy: "McTest@example.com",
             createdAt: "1/1/2000 00:00",

--- a/frontend-react/src/components/Admin/DisplayMeta.tsx
+++ b/frontend-react/src/components/Admin/DisplayMeta.tsx
@@ -1,24 +1,38 @@
 import { useEffect, useState } from "react";
 
-import { MetaData } from "../../resources/OrgSettingsBaseResource";
+import { MetaTaggedResource } from "../../resources/OrgSettingsBaseResource";
 import { formatDate } from "../../utils/misc";
 
-type Props = {
-    metaObj?: MetaData | undefined;
+type DisplayMetaProps = {
+    metaObj?: MetaTaggedResource;
 };
 
-export const DisplayMeta = (props: Props) => {
-    const [metaData, setMetaData] = useState<MetaData>();
+export const DisplayMeta = ({ metaObj }: DisplayMetaProps) => {
+    const [metaData, setMetaData] = useState<MetaTaggedResource>();
 
     useEffect(() => {
-        if (!props.metaObj) {
+        if (!metaObj) {
             return;
         }
-        setMetaData(props.metaObj);
-    }, [props]);
+        setMetaData(metaObj);
+    }, [metaObj]);
 
-    return metaData ? (
-        <>{`v${metaData.version} [${formatDate(metaData.createdAt)}] 
-        ${metaData.createdBy}`}</>
-    ) : null;
+    // if there is no object with data to display
+    // we can return early. If the metadata object is present but
+    // version, createdAt, and/or createdBy are missing
+    // that case is handled below
+    if (!metaData) {
+        return null;
+    }
+
+    const { version, createdAt, createdBy } = metaData;
+
+    // handle cases where individual metadata are not available
+    const versionDisplay = version || version === 0 ? `v${version} ` : "";
+    const createdAtDisplay = createdAt
+        ? `[${formatDate(metaData.createdAt)}] `
+        : "";
+    const createdByDisplay = createdBy ?? "";
+
+    return <>{`${versionDisplay}${createdAtDisplay}${createdByDisplay}`}</>;
 };

--- a/frontend-react/src/components/Admin/EditReceiverSettings.tsx
+++ b/frontend-react/src/components/Admin/EditReceiverSettings.tsx
@@ -91,11 +91,7 @@ const EditReceiverSettingsForm: React.FC<EditReceiverSettingsFormProps> = ({
             setOrgReceiverSettingsNewJson(
                 JSON.stringify(orgReceiverSettings, jsonSortReplacer, 2)
             );
-
-            if (
-                latestResponse?.meta?.version !==
-                orgReceiverSettings?.meta?.version
-            ) {
+            if (latestResponse?.version !== orgReceiverSettings?.version) {
                 showError(getVersionWarning(VersionWarningType.POPUP));
                 confirmModalRef?.current?.setWarning(
                     getVersionWarning(VersionWarningType.FULL, latestResponse)
@@ -130,10 +126,7 @@ const EditReceiverSettingsForm: React.FC<EditReceiverSettingsFormProps> = ({
             setLoading(true);
 
             const latestResponse = await getLatestReceiverResponse();
-            if (
-                latestResponse.meta?.version !==
-                orgReceiverSettings?.meta?.version
-            ) {
+            if (latestResponse.version !== orgReceiverSettings?.version) {
                 // refresh left-side panel in compare modal to make it obvious what has changed
                 setOrgReceiverSettingsOldJson(
                     JSON.stringify(latestResponse, jsonSortReplacer, 2)

--- a/frontend-react/src/components/Admin/EditSenderSettings.tsx
+++ b/frontend-react/src/components/Admin/EditSenderSettings.tsx
@@ -85,10 +85,7 @@ const EditSenderSettingsForm: React.FC<EditSenderSettingsFormProps> = ({
                 JSON.stringify(orgSenderSettings, jsonSortReplacer, 2)
             );
 
-            if (
-                latestResponse?.meta?.version !==
-                orgSenderSettings?.meta?.version
-            ) {
+            if (latestResponse?.version !== orgSenderSettings?.version) {
                 showError(getVersionWarning(VersionWarningType.POPUP));
                 confirmModalRef?.current?.setWarning(
                     getVersionWarning(VersionWarningType.FULL, latestResponse)
@@ -122,10 +119,7 @@ const EditSenderSettingsForm: React.FC<EditSenderSettingsFormProps> = ({
         try {
             setLoading(true);
             const latestResponse = await getLatestSenderResponse();
-            if (
-                latestResponse.meta?.version !==
-                orgSenderSettings?.meta?.version
-            ) {
+            if (latestResponse.version !== orgSenderSettings?.version) {
                 // refresh left-side panel in compare modal to make it obvious what has changed
                 setOrgSenderSettingsOldJson(
                     JSON.stringify(latestResponse, jsonSortReplacer, 2)

--- a/frontend-react/src/components/Admin/OrgReceiverTable.tsx
+++ b/frontend-react/src/components/Admin/OrgReceiverTable.tsx
@@ -96,7 +96,7 @@ export function OrgReceiverTable(props: OrgSettingsTableProps) {
                             <td>{eachOrgSetting.topic || ""}</td>
                             <td>{eachOrgSetting.customerStatus || ""}</td>
                             <td>
-                                <DisplayMeta metaObj={eachOrgSetting.meta} />
+                                <DisplayMeta metaObj={eachOrgSetting} />
                             </td>
                             <td colSpan={2}>
                                 <ButtonGroup type="segmented">

--- a/frontend-react/src/components/Admin/OrgSenderTable.tsx
+++ b/frontend-react/src/components/Admin/OrgSenderTable.tsx
@@ -94,7 +94,7 @@ export function OrgSenderTable(props: OrgSettingsTableProps) {
                             <td>{eachOrgSetting.topic || ""}</td>
                             <td>{eachOrgSetting.customerStatus || ""}</td>
                             <td>
-                                <DisplayMeta metaObj={eachOrgSetting.meta} />
+                                <DisplayMeta metaObj={eachOrgSetting} />
                             </td>
                             <td colSpan={2}>
                                 <ButtonGroup type="segmented">

--- a/frontend-react/src/components/Admin/OrgsTable.tsx
+++ b/frontend-react/src/components/Admin/OrgsTable.tsx
@@ -62,7 +62,6 @@ export function OrgsTable() {
     };
 
     const saveListToCSVFile = () => {
-        // generate a lines that has "value","value","value"... each line is a
         const csvbody = orgs
             .filter((eachOrg) => eachOrg.filterMatch(filter))
             .map((eachOrg) =>
@@ -74,13 +73,16 @@ export function OrgsTable() {
                         eachOrg.jurisdiction,
                         eachOrg.stateCode,
                         eachOrg.countyName,
-                        new Date(eachOrg.meta.createdAt).toDateString(),
                     ].join(`","`),
                     `"`,
                 ].join("")
             )
             .join(`\n`); // join result of .map() lines
-        const csvheader = `Name,Description,Jurisdiction,State,County,Created\n`;
+        // Note that this csv previously included a `Created` column with a createdAt
+        // date taken from organization metadata. Currently this metadata is not being returned
+        // in the API call for organizations, so we have removed the created column. It
+        // should be added back whenever this API handler is adjusted to send back metadata - DWS
+        const csvheader = `Name,Description,Jurisdiction,State,County\n`;
         const filecontent = [
             "data:text/csv;charset=utf-8,", // this makes it a csv file
             csvheader,

--- a/frontend-react/src/pages/admin/AdminOrgEdit.tsx
+++ b/frontend-react/src/pages/admin/AdminOrgEdit.tsx
@@ -86,7 +86,7 @@ export function AdminOrgEdit({
                 JSON.stringify(orgSettings, jsonSortReplacer, 2)
             );
 
-            if (latestResponse?.meta?.version !== orgSettings?.meta?.version) {
+            if (latestResponse?.version !== orgSettings?.version) {
                 showError(getVersionWarning(VersionWarningType.POPUP));
                 confirmModalRef?.current?.setWarning(
                     getVersionWarning(VersionWarningType.FULL, latestResponse)
@@ -108,7 +108,7 @@ export function AdminOrgEdit({
     const saveOrgData = async () => {
         try {
             const latestResponse = await getLatestOrgResponse();
-            if (latestResponse.meta?.version !== orgSettings?.meta?.version) {
+            if (latestResponse.version !== orgSettings?.version) {
                 // refresh left-side panel in compare modal to make it obvious what has changed
                 setOrgSettingsOldJson(
                     JSON.stringify(latestResponse, jsonSortReplacer, 2)
@@ -168,7 +168,7 @@ export function AdminOrgEdit({
                             <Grid row>
                                 <Grid col={3}>Meta:</Grid>
                                 <Grid col={9}>
-                                    <DisplayMeta metaObj={orgSettings.meta} />
+                                    <DisplayMeta metaObj={orgSettings} />
                                     <br />
                                 </Grid>
                             </Grid>

--- a/frontend-react/src/pages/admin/AdminOrgNew.test.tsx
+++ b/frontend-react/src/pages/admin/AdminOrgNew.test.tsx
@@ -40,7 +40,9 @@ const testNewOrgJson = JSON.stringify({
     jurisdiction: "STATE",
     stateCode: "CA",
     countyName: null,
-    meta: null,
+    version: null,
+    createdAt: null,
+    createdBy: null,
 });
 
 describe("AdminOrgNew", () => {

--- a/frontend-react/src/resources/OrgSettingsBaseResource.ts
+++ b/frontend-react/src/resources/OrgSettingsBaseResource.ts
@@ -1,6 +1,6 @@
 import AuthResource from "./AuthResource";
 
-export interface MetaData {
+export interface MetaTaggedResource {
     version: number;
     createdBy: string;
     createdAt: string;
@@ -11,7 +11,9 @@ export interface MetaData {
  */
 export default abstract class OrgSettingsBaseResource extends AuthResource {
     name: string = "";
-    readonly meta: MetaData = { version: 0, createdBy: "", createdAt: "" };
+    readonly version: number = 0;
+    readonly createdBy: string = "";
+    readonly createdAt: string = "";
 
     pk() {
         return this.name;

--- a/frontend-react/src/resources/OrgSettingsResource.ts
+++ b/frontend-react/src/resources/OrgSettingsResource.ts
@@ -40,7 +40,7 @@ export default class OrgSettingsResource extends OrgSettingsBaseResource {
         }
         // combine all elements to be searched.
         const fullstr =
-            `${this.name} ${this.description} ${this.jurisdiction} ${this.stateCode} ${this.stateCode}`.toLowerCase();
+            `${this.name} ${this.description} ${this.jurisdiction} ${this.stateCode} ${this.countyName}`.toLowerCase();
         return fullstr.includes(`${search.toLowerCase()}`);
     }
 }

--- a/frontend-react/src/resources/TestResponse.ts
+++ b/frontend-react/src/resources/TestResponse.ts
@@ -112,11 +112,9 @@ export class TestResponse {
             throw new Error("Function not implemented.");
         },
         name: "",
-        meta: {
-            version: 0,
-            createdBy: "mctest@example.com",
-            createdAt: "1/1/2000 00:00:00",
-        },
+        version: 0,
+        createdBy: "mctest@example.com",
+        createdAt: "1/1/2000 00:00:00",
         url: "",
     };
 

--- a/frontend-react/src/utils/JsonSortReplacer.test.ts
+++ b/frontend-react/src/utils/JsonSortReplacer.test.ts
@@ -59,17 +59,17 @@ test("JsonSortReplacer to sort complex json data correctly", () => {
             credentialName: "DEFAULT-SFTP",
             type: "SFTP",
         },
-        meta: {
-            version: 0,
-            createdBy: "local@test.com",
-            createdAt: "2022-02-22T17:40:41.219439Z",
-        },
+        version: 0,
+        createdBy: "local@test.com",
+        createdAt: "2022-02-22T17:40:41.219439Z",
         externalName: null,
     };
 
     const result = JSON.stringify(COMPLEX_JSON, jsonSortReplacer, 2);
 
-    expect(result).toBe(`{
+    expect(result).toEqual(`{
+  "createdAt": "2022-02-22T17:40:41.219439Z",
+  "createdBy": "local@test.com",
   "customerStatus": "active",
   "deidentify": true,
   "description": "",
@@ -78,11 +78,6 @@ test("JsonSortReplacer to sort complex json data correctly", () => {
     "hasAtLeastOneOf(waters_submitter, sender_id)",
     "orEquals(patient_state, GH, ordering_facility_state, GH)"
   ],
-  "meta": {
-    "createdAt": "2022-02-22T17:40:41.219439Z",
-    "createdBy": "local@test.com",
-    "version": 0
-  },
   "name": "giang",
   "organizationName": "waters",
   "processingModeFilter": [],
@@ -117,6 +112,7 @@ test("JsonSortReplacer to sort complex json data correctly", () => {
     "host": "sftp",
     "port": "22",
     "type": "SFTP"
-  }
+  },
+  "version": 0
 }`);
 });

--- a/frontend-react/src/utils/misc.test.ts
+++ b/frontend-react/src/utils/misc.test.ts
@@ -42,16 +42,14 @@ const objResource: OrgSettingsBaseResource = {
     name: "test setting",
     url: "http://localhost",
     pk: () => "10101",
-    meta: {
-        version: 5,
-        createdBy: "test@example.com",
-        createdAt: "1/1/2000 00:00",
-    },
+    version: 5,
+    createdBy: "test@example.com",
+    createdAt: "1/1/2000 00:00",
 };
 
 test("getVersionWarning test", async () => {
     const fullWarning = getVersionWarning(VersionWarningType.FULL, objResource);
-    expect(fullWarning).toContain(objResource.meta?.createdBy);
+    expect(fullWarning).toContain(objResource.createdBy);
 
     const popupWarning = getVersionWarning(VersionWarningType.POPUP);
     expect(popupWarning).toContain("WARNING!");

--- a/frontend-react/src/utils/misc.ts
+++ b/frontend-react/src/utils/misc.ts
@@ -83,19 +83,20 @@ export function getVersionWarning(
 ): string {
     switch (warningType) {
         case VersionWarningType.POPUP:
-            return `WARNING! A newer version of this setting now exists in the database'`;
+            return "WARNING! A newer version of this setting now exists in the database";
         case VersionWarningType.FULL:
             return `WARNING! A change has been made to the setting you're trying to update by 
-                    '${settings?.meta?.createdBy}'. Please coordinate with that user and return to update the setting 
+                    '${
+                        settings?.createdBy || "UNKNOWN"
+                    }'. Please coordinate with that user and return to update the setting 
                     again, if needed`;
     }
-
-    return "";
 }
 
 export function formatDate(date: string): string {
     try {
         // 'Thu, 3/31/2022, 4:50 AM'
+        // Note that this returns Epoch when receiving a null date string
         return new Intl.DateTimeFormat("en-US", {
             weekday: "short",
             year: "numeric",


### PR DESCRIPTION
The pipeline team is in the process of deprecating a `meta` object that exists on `organization/ settings` entities returned by the API, moving any data from the meta object on the entity itself, one level up. In order to safely deprecate this object fully, the frontend needs to refactor any pieces of code that rely on it to instead look one level up at the `createdBy`, `createdAt` and `version` data that is now located there. This change refactors the necessary frontend code to deal with this change.

Also addresses some metadata related bugs:
* removes `createdAt` field from csvs generated on the organization settings page, as this data is not available from the API call for the organizations list
* adds `county` as a searchable field for organizations
* cleans up some code and messaging in version mismatch warnings

## Test Steps:

1. start servers on this branch with `yarn run start:localdev` from `frontend-react` and `./gradlew run` from `prime-router`

#### sender
1. visit http://localhost:3000/admin/orgsettings/org/abbott
3. click edit
4. change CSV to HL7
5. click preview
6. _VERIFY_: the preview loads with no errors
7. click save
8. _VERIFY_: organization is saved with no errors
9. _VERIFY_: meta for sender appears correctly on org page after save, see screenshot below

#### receiver
1. visit http://localhost:3000/admin/orgsettings/org/ak-phd
3. click edit
4. fill in description field
5. click preview
6. _VERIFY_: the preview loads with no errors
7. click save
8. _VERIFY_: organization is saved with no errors
9. _VERIFY_: meta for sender appears correctly on org page after save, see screenshot below

## Screenshots

### Receiver with metadata
<img width="1129" alt="Screen Shot 2022-06-28 at 5 13 29 PM" src="https://user-images.githubusercontent.com/92806979/176289036-87f76e9c-5b96-4701-a5a2-2a23ef9f7c94.png">


### Sender with metadata

<img width="1393" alt="Screen Shot 2022-06-28 at 5 12 30 PM" src="https://user-images.githubusercontent.com/92806979/176288896-0c43973c-0e26-46df-a35b-ccdb97b3fcbc.png">

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
