### PR TITLE
set dns image alpine:3.14.2

### DIFF
--- a/operations/dnsmasq/Dockerfile
+++ b/operations/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.14.2
 
 # Install dnsmasq
 RUN apk --no-cache add dnsmasq


### PR DESCRIPTION
This PR forces the dns alpine image to 3.14.2, as there is a potential failure running 3.16

## Changes
- Set dns image to alpine 3.14.2

## Linked Issues
- Fixes #5952

