### PR TITLE
updating dns container to 3.15.4

### DIFF
--- a/operations/dnsmasq/Dockerfile
+++ b/operations/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.15.4
 
 # Install dnsmasq
 RUN apk --no-cache add dnsmasq


### PR DESCRIPTION
This PR updates the dns container to 3.15.4, after testing confirmed 3.16.0 breaks dns
