### PR TITLE
add index for item-scoped error message for invalid message type

### DIFF
--- a/prime-router/src/main/kotlin/SubmissionReceiver.kt
+++ b/prime-router/src/main/kotlin/SubmissionReceiver.kt
@@ -295,6 +295,10 @@ class ELRReceiver : SubmissionReceiver {
         )
     }
 
+    /**
+     * Checks that a [message] is of the supported type(s), and uses the [actionLogs] to add an error
+     * message for item with index [itemIndex] if it is not.
+     */
     internal fun checkValidMessageType(message: Message, actionLogs: ActionLogger, itemIndex: Int) {
         val header = message.get("MSH")
         check(header is MSH)

--- a/prime-router/src/main/kotlin/SubmissionReceiver.kt
+++ b/prime-router/src/main/kotlin/SubmissionReceiver.kt
@@ -265,7 +265,7 @@ class ELRReceiver : SubmissionReceiver {
         )
 
         // check for valid message type
-        messages.forEach { checkValidMessageType(it, actionLogs) }
+        messages.forEachIndexed { idx, element -> checkValidMessageType(element, actionLogs, idx + 1) }
 
         // if there are any errors, kick this out.
         if (actionLogs.hasErrors()) {
@@ -295,7 +295,7 @@ class ELRReceiver : SubmissionReceiver {
         )
     }
 
-    internal fun checkValidMessageType(message: Message, actionLogs: ActionLogger) {
+    internal fun checkValidMessageType(message: Message, actionLogs: ActionLogger, itemIndex: Int) {
         val header = message.get("MSH")
         check(header is MSH)
         val messageType = header.messageType.msg1_MessageCode.value +
@@ -305,7 +305,8 @@ class ELRReceiver : SubmissionReceiver {
         // TODO: This may need to be a configurable value in the future, if we ever support message types other
         //  than ORU_RO1. As of 6/15/2022 multiple message type support is out of scope
         if (messageType != "ORU_R01") {
-            actionLogs.error(InvalidHL7Message("Ignoring unsupported HL7 message type $messageType"))
+            actionLogs.getItemLogger(itemIndex)
+                .error(InvalidHL7Message("Ignoring unsupported HL7 message type $messageType"))
         }
     }
 }


### PR DESCRIPTION
This PR ensures the correct error message is returned for incorrect HL7 message types when submitted to the full ELR pipeline.

Test Steps:
1. Submit an HL7 message with a type other than OR_R01 to the full ELR pipeline
2. Verify the error message returned specifies that the type submitted is not supported.

## Changes
- Update item logger to include index

## Checklist

### Testing
- [x] Tested locally?