### PR TITLE
set function app runtime as parameter and set test env to ~4

### DIFF
--- a/operations/app/terraform/modules/function_app/candidate_slot.tf
+++ b/operations/app/terraform/modules/function_app/candidate_slot.tf
@@ -15,7 +15,7 @@ resource "azurerm_function_app_slot" "candidate" {
   storage_account_access_key = var.primary_access_key
   https_only                 = true
   os_type                    = "linux"
-  version                    = "~3"
+  version                    = var.function_runtime_version
   enable_builtin_logging     = false
 
   site_config {

--- a/operations/app/terraform/modules/function_app/main.tf
+++ b/operations/app/terraform/modules/function_app/main.tf
@@ -106,7 +106,7 @@ resource "azurerm_function_app" "function_app" {
   storage_account_access_key = var.primary_access_key
   https_only                 = true
   os_type                    = "linux"
-  version                    = "~3"
+  version                    = var.function_runtime_version
   enable_builtin_logging     = false
 
   site_config {

--- a/operations/app/terraform/modules/function_app/~inputs.tf
+++ b/operations/app/terraform/modules/function_app/~inputs.tf
@@ -76,3 +76,8 @@ variable "okta_base_url" {}
 variable "subnets" {
   description = "A set of all available subnet combinations"
 }
+
+variable "function_runtime_version" {
+  type        = string
+  description = "function app runtime version"
+}

--- a/operations/app/terraform/vars/prod/locals.tf
+++ b/operations/app/terraform/vars/prod/locals.tf
@@ -37,8 +37,9 @@ locals {
     db_replica          = true
   }
   app = {
-    app_tier = "PremiumV2"
-    app_size = "P3v2"
+    app_tier                 = "PremiumV2"
+    app_size                 = "P3v2"
+    function_runtime_version = "~3"
   }
   network = {
     use_cdc_managed_vnet        = true

--- a/operations/app/terraform/vars/prod/main.tf
+++ b/operations/app/terraform/vars/prod/main.tf
@@ -144,6 +144,7 @@ module "function_app" {
   client_config_key_vault_id        = module.key_vault.client_config_key_vault_id
   app_config_key_vault_id           = module.key_vault.app_config_key_vault_id
   dns_ip                            = local.network.dns_ip
+  function_runtime_version          = local.app.function_runtime_version
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/staging/locals.tf
+++ b/operations/app/terraform/vars/staging/locals.tf
@@ -37,8 +37,9 @@ locals {
     db_replica          = true
   }
   app = {
-    app_tier = "PremiumV2"
-    app_size = "P3v2"
+    app_tier                 = "PremiumV2"
+    app_size                 = "P3v2"
+    function_runtime_version = "~3"
   }
   network = {
     use_cdc_managed_vnet        = true

--- a/operations/app/terraform/vars/staging/main.tf
+++ b/operations/app/terraform/vars/staging/main.tf
@@ -144,6 +144,7 @@ module "function_app" {
   client_config_key_vault_id        = module.key_vault.client_config_key_vault_id
   app_config_key_vault_id           = module.key_vault.app_config_key_vault_id
   dns_ip                            = local.network.dns_ip
+  function_runtime_version          = local.app.function_runtime_version
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/test/locals.tf
+++ b/operations/app/terraform/vars/test/locals.tf
@@ -37,8 +37,9 @@ locals {
     db_replica          = true
   }
   app = {
-    app_tier = "PremiumV2"
-    app_size = "P3v2"
+    app_tier                 = "PremiumV2"
+    app_size                 = "P3v2"
+    function_runtime_version = "~4"
   }
   network = {
     use_cdc_managed_vnet        = true

--- a/operations/app/terraform/vars/test/main.tf
+++ b/operations/app/terraform/vars/test/main.tf
@@ -147,6 +147,7 @@ module "function_app" {
   client_config_key_vault_id        = module.key_vault.client_config_key_vault_id
   app_config_key_vault_id           = module.key_vault.app_config_key_vault_id
   dns_ip                            = local.network.dns_ip
+  function_runtime_version          = local.app.function_runtime_version
 }
 
 module "front_door" {


### PR DESCRIPTION
This PR upgrades the function app runtime to version ~4 in the test environment, as support for lower versions will soon end.
The function app runtime version is parameterized to allow easy updates for staging and prod when we are ready.

Test Steps:
1. Confirm all function app functionality remains after the update

## Changes
- Parameterize function app runtime version
- Change version in test environment from ~3 to ~4

## Checklist

## Linked Issues
- Fixes #6070
