### PR TITLE
experience/6091-human-readable: truncate an error message if stack trace

### DIFF
--- a/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
@@ -55,16 +55,24 @@ type FileErrorDisplayProps = {
 /***
  * This function attempts to truncate an error message if it contains
  * a full stack trace
- * @param errorMsg - the error message to potentially reformat
+ * @param truncateErrorMessage - the error message to potentially reformat
  * @returns - the original or transformed error message
  */
-const reformat = (errorMsg: string | undefined): string => {
-    if (!errorMsg) return "";
+const reformat = (truncateErrorMessage: string | undefined): string => {
+    if (!truncateErrorMessage) return "";
 
-    if (errorMsg.includes("\n") && errorMsg.includes("Exception:"))
-        return errorMsg.substring(0, errorMsg.indexOf("\n")) + " ...";
+    if (
+        truncateErrorMessage.includes("\n") &&
+        truncateErrorMessage.includes("Exception:")
+    )
+        return (
+            truncateErrorMessage.substring(
+                0,
+                truncateErrorMessage.indexOf("\n")
+            ) + " ..."
+        );
 
-    return errorMsg;
+    return truncateErrorMessage;
 };
 
 export const FileErrorDisplay = ({

--- a/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
@@ -52,6 +52,21 @@ type FileErrorDisplayProps = {
     errorType: string;
 };
 
+/***
+ * This function attempts to truncate an error message if it contains
+ * a full stack trace
+ * @param errorMsg - the error message to potentially reformat
+ * @returns - the original or transformed error message
+ */
+const reformat = (errorMsg: string | undefined): string => {
+    if (!errorMsg) return "";
+
+    if (errorMsg.includes("\n") && errorMsg.includes("Exception:"))
+        return errorMsg.substring(0, errorMsg.indexOf("\n")) + " ...";
+
+    return errorMsg;
+};
+
 export const FileErrorDisplay = ({
     fileName,
     errors,
@@ -97,7 +112,7 @@ export const FileErrorDisplay = ({
                         {errors.map((e, i) => {
                             return (
                                 <tr key={"error_" + i}>
-                                    <td>{e.message}</td>
+                                    <td>{reformat(e.message)}</td>
                                     <td>
                                         {e.rowList && (
                                             <span>Row(s): {e.rowList}</span>


### PR DESCRIPTION
This PR truncates an error message if it has the token "Exception:" and the newline character ("\n") - truncating at the first occurrence of the newline character

Since it's a very minor change and based on your refactor branch, I thought it made sense to just do a PR to it instead of going against master and then refactoring again to make it play nice with this branch. If there are any objections to this, I can redo vs master instead.

Test Steps:
1. Via the "/verify" admin page, upload a test file that normally produces a long unsightly stack trace
2. Observe its abbreviated form

## Changes
- Added smol helper method to FileHandlerMessaging.tsx, to be called on each error row rendered
- *before*
![image](https://user-images.githubusercontent.com/92405130/179633268-e951f347-c627-4662-b53b-fc75fff2ff6f.png)

*after*
![image](https://user-images.githubusercontent.com/92405130/179633169-b836aba9-44e3-427a-b6dd-055ff68e4616.png)


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Addresses #6091 
