### PR TITLE
Onboarding ops/5798/testkit and equip uid for sr

### DIFF
--- a/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
+++ b/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md
@@ -62,6 +62,26 @@ Is the patient employed in health care?
 
 ---
 
+**Name**: Equipment_Model_ID
+
+**ReportStream Internal Name**: equipment_model_id
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2
+
+**Table Column**: Equipment UID
+
+---
+
 **Name**: Device_ID
 
 **ReportStream Internal Name**: equipment_model_name
@@ -2246,6 +2266,30 @@ Is the patient symptomatic?
 **PII**: Yes
 
 **Cardinality**: [0..1]
+
+---
+
+**Name**: Test_Kit_Name_ID
+
+**ReportStream Internal Name**: test_kit_name_id
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification](https://confluence.hl7.org/display/OO/Proposed+HHS+ELR+Submission+Guidance+using+HL7+v2+Messages#ProposedHHSELRSubmissionGuidanceusingHL7v2Messages-DeviceIdentification) 
+
+**Table**: LIVD-SARS-CoV-2
+
+**Table Column**: Testkit Name ID
+
+**Documentation**:
+
+Follows guidence for OBX-17 as defined in the HL7 Confluence page
 
 ---
 

--- a/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
+++ b/prime-router/metadata/schemas/PrimeDataInput/pdi-covid-19.schema
@@ -36,9 +36,15 @@ elements:
   - name: specimen_type
     csvFields: [{name: Specimen_type_code}]
 
+  - name: test_kit_name_id
+    csvFields: [{name: Test_Kit_Name_ID}]
+
   # The type of device used for the test.  eg, BinaxNOW COVID-19 Ag Card
   - name: equipment_model_name
     csvFields: [{name: Device_ID}]
+
+  - name: equipment_model_id
+    csvFields: [{name: Equipment_Model_ID}]
 
   # Identifier for the specific piece of equipment used.
   - name: equipment_instance_id


### PR DESCRIPTION
This PR adds test_kit_name_id and equipment_model_id to the simple report schema. These fields are needed to uniquely identify test types in the LIVD table.

Test Steps:
1. Run test file through system locally
     - ```./prime data --input /PATH/TO/FILE/SR-test-2.csv --input-schema primedatainput/pdi-covid-19 --output-dir /PATH/TO/DIR --route```
2. Ensure OBR-4 and OBX-3 fields are complete in output HL7

Test file: [SR-test-2.csv](https://github.com/CDCgov/prime-reportstream/files/9169604/SR-test-2.csv)

## Changes
- test_kit_name_id and equipment_model_id to the simple report schema

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

## Linked Issues
- Fixes #5798 

## To Be Done
- inform SR of new fields and coordinate sending based on LIVD table
