### PR TITLE
Adds processing mode code two to the two results table

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -853,6 +853,8 @@ class Report : Logging {
                     it.testPerformed = row.getStringOrNull("test_performed_name").trimToNull()
                     it.testOrdered = row.getStringOrNull("ordered_test_name").trimToNull()
                     it.testOrderedCode = row.getStringOrNull("ordered_test_code").trimToNull()
+                    // trap the processing mode code as well
+                    it.processingModeCode = row.getStringOrNull("processing_mode_code").trimToNull()
                 }
             }
         } catch (e: Exception) {
@@ -943,6 +945,8 @@ class Report : Logging {
                     it.testKitNameId = row.getStringOrNull("test_kit_name_id").trimToNull()
                     it.testPerformedLoincCode = row.getStringOrNull("test_performed_code").trimToNull()
                     it.organizationName = row.getStringOrNull("organization_name").trimToNull()
+                    // trap the processing mode code from submissions as well
+                    it.processingModeCode = row.getStringOrNull("processing_mode_code").trimToNull()
                 }
             }
         } catch (e: Exception) {

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -1153,6 +1153,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.testOrderedCode = td.testOrderedCode?.take(METADATA_MAX_LENGTH)
                             record.testResult = td.testResult?.take(METADATA_MAX_LENGTH)
                             record.testResultCode = td.testResultCode?.take(METADATA_MAX_LENGTH)
+                            record.processingModeCode = td.processingModeCode?.take(METADATA_MAX_LENGTH)
                         }
                     }
                 )
@@ -1219,6 +1220,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.senderId = td.senderId?.take(METADATA_MAX_LENGTH)
                             record.testKitNameId = td.testKitNameId?.take(METADATA_MAX_LENGTH)
                             record.testPerformedLoincCode = td.testPerformedLoincCode?.take(METADATA_MAX_LENGTH)
+                            record.processingModeCode = td.processingModeCode?.take(METADATA_MAX_LENGTH)
                         }
                     }
                 )

--- a/prime-router/src/main/resources/db/migration/V54__add_processing_mode_code_to_results_tables.sql
+++ b/prime-router/src/main/resources/db/migration/V54__add_processing_mode_code_to_results_tables.sql
@@ -1,0 +1,27 @@
+/*
+ * The Flyway tool applies this migration to create the database.
+ *
+ * Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+ * use VARCHAR(63) for names in organization and schema
+ *
+ * Copy a version of this comment into the next migration
+ *
+ */
+
+/*
+ * Adds 'processed_at' to the task table. This is not strictly needed at this time, but removing all the
+ *  finished action columns is not part of the scope of the 'process async' task
+ */
+ALTER TABLE covid_result_metadata ADD processing_mode_code VARCHAR(64)
+;
+
+COMMENT ON COLUMN covid_result_metadata.processing_mode_code IS
+    'The processing mode for a submission to ReportStream. This typically indicates if a result is for production or testing.'
+;
+
+ALTER TABLE elr_result_metadata ADD processing_mode_code VARCHAR(64)
+;
+
+COMMENT ON COLUMN elr_result_metadata.processing_mode_code IS
+    'The processing mode for a submission to ReportStream. This typically indicates if a result is for production or testing.'
+;


### PR DESCRIPTION
This PR adds the processing mode code to both the covid and the ELR result tables

Test Steps:
1. Submit some files to your local Docker container and query each individual table to verify processing mode code has passed through

## Changes
- Added processing mode code to the covid result metadata table
- Added processing mode code to the elr result metadata tab le

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

