### PR TITLE
Enable HistoryFunction to accept both dashes and underscores

### DIFF
--- a/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
@@ -455,6 +455,8 @@ open class BaseHistoryFunction : Logging {
         /**
          * @return true if the [oktaOrgs] list included a PrimeAdmin role,
          * or if [requestedOrgName] is one of the organizations in [oktaOrgs].
+         * In all other cases, the user is not authorized, and this returns false.
+         *
          * The comparison treats dashes and underscores as identical.
          *
          * This is needed, temporarily, as a step to support fixing group names in Okta to exactly match
@@ -464,9 +466,9 @@ open class BaseHistoryFunction : Logging {
             if (requestedOrgName.isBlank()) return false
             oktaOrgs.forEach {
                 when {
-                    it == null -> { } // do nothing ; skip
+                    it == null -> { } // do nothing ; skip.
                     it.contains("DHPrimeAdmins") -> return true
-                    it.replace("_", "-") == "DH${requestedOrgName.replace('_', '-')}"
+                    it.replace('_', '-') == "DH${requestedOrgName.replace('_', '-')}"
                     -> return true
                 }
             }

--- a/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
@@ -433,11 +433,7 @@ open class BaseHistoryFunction : Logging {
             @Suppress("UNCHECKED_CAST")
             oktaOrganizations = jwt.claims["organization"] as List<String>
 
-            accessOrgName = when {
-                oktaOrganizations.contains("DHPrimeAdmins") ||
-                    oktaOrganizations.contains(toOktaOrgName(requestOrgName)) -> requestOrgName
-                else -> null
-            }
+            accessOrgName = if (isAuthorizedIgnoreDashes(oktaOrganizations, requestOrgName)) requestOrgName else null
         } catch (ex: Throwable) {
             logger.warn("Unable authenticate user: ${ex.message}: ${ex.cause?.message ?: ""}")
             logger.debug(ex)
@@ -445,9 +441,7 @@ open class BaseHistoryFunction : Logging {
         }
 
         if (userName.isNullOrBlank() || accessOrgName.isNullOrBlank()) return null
-        /*   NOTE: This was noted as taking an Okta org name and converting it, but that was prior to
-         *   the React front-end sending the org in the proper format xx-phd.
-         */
+
         val dbOrganization = workflowEngine.settings.findOrganization(accessOrgName)
         return if (dbOrganization != null) {
             AuthClaims(userName, dbOrganization)
@@ -457,7 +451,26 @@ open class BaseHistoryFunction : Logging {
         }
     }
 
-    private fun toOktaOrgName(orgNameHeader: String): String {
-        return "DH${orgNameHeader.replace('-', '_')}"
+    companion object {
+        /**
+         * @return true if the [oktaOrgs] list included a PrimeAdmin role,
+         * or if [requestedOrgName] is one of the organizations in [oktaOrgs].
+         * The comparison treats dashes and underscores as identical.
+         *
+         * This is needed, temporarily, as a step to support fixing group names in Okta to exactly match
+         * organization names in settings.   Detailed explanation is in #6263.
+         */
+        fun isAuthorizedIgnoreDashes(oktaOrgs: List<String?>, requestedOrgName: String): Boolean {
+            if (requestedOrgName.isBlank()) return false
+            oktaOrgs.forEach {
+                when {
+                    it == null -> { } // do nothing ; skip
+                    it.contains("DHPrimeAdmins") -> return true
+                    it.replace("_", "-") == "DH${requestedOrgName.replace('_', '-')}"
+                    -> return true
+                }
+            }
+            return false
+        }
     }
 }

--- a/prime-router/src/test/kotlin/azure/HistoryFunctionsTests.kt
+++ b/prime-router/src/test/kotlin/azure/HistoryFunctionsTests.kt
@@ -1,0 +1,37 @@
+package gov.cdc.prime.router.azure
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+
+class HistoryFunctionsTests {
+
+    @Test
+    fun `test isAuthorizedIgnoreDashes`() {
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(emptyList<String>(), "md-phd")).isFalse()
+        var oktaOrgs = listOf<String?>("DHPrimeAdmins")
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "")).isFalse()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "foo")).isTrue()
+        oktaOrgs = listOf("DHPrimeAdmins", "DHmd-phd")
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "")).isFalse()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "foo")).isTrue()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md-phd")).isTrue()
+        oktaOrgs = listOf(null, "DHmd-phd")
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "foo")).isFalse()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md-phd")).isTrue()
+        oktaOrgs = listOf("DHmd-phd")
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md_phd")).isTrue()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md-phd")).isTrue()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md-phd-")).isFalse()
+        oktaOrgs = listOf("DHmd_phd")
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md_phd")).isTrue()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md-phd")).isTrue()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "md-phd-")).isFalse()
+        oktaOrgs = listOf("DHfoobar")
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "foobar")).isTrue()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "FOOBAR")).isFalse()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "foo")).isFalse()
+        assertThat(BaseHistoryFunction.isAuthorizedIgnoreDashes(oktaOrgs, "PrimeAdmin")).isFalse()
+    }
+}


### PR DESCRIPTION
Many of our DHxxxxx group names in Okta are wrong, because they don't match the organization names in settings.   The problem is that the group names in Okta mostly use `_` where the settings mostly use `-`.  This has a been a continuing source of confusion, messy fixes, and bugs.

I've been experimenting with simply changing all the group names in Okta to be correct, to exactly match the settings names.  (eg, change from DHmd_phd to DHmd-phd)

This lovely fix appears to work (yay!), with one exception:  the old deprecated HistoryFunctions.kt has strange code in it that depends on the group name being wrong, that is, having a `_`.  (eg, DHmd_phd)  

This PR fixes that code, so that HistoryFunctions.kt will succeed even with good correct group names (eg, DHmd-phd) and also still work with wrong names (eg DHmd_phd).    Since both old and new will both work, this will enable us to fix the erroneous names in production, without having to carefully time those Okta changes with this PR release.    

Note that HistoryFunctions.kt is deprecated code, so this fix will no longer be needed once the full Deliveries API is available. Double Yay!

## Test Steps:
1.  Run both reportstream and the frontend locally.
2. Via the front-end, login with an OktaPreview user that only has permissions to group DHmd-phd. (which used to be incorrectly called DHmd_phd, until I changed it)
3. Confirm that the download page works.
4. Change the group name back to the old bad DHmd_phd
5. Logout, clear browser cache, log back in, and confirm the download page still works.

## Changes
- replaced the auth check in HistoryFunctions.kt that depended on `_` to one that matches user's claims with requested claim, ignoring underscores and dashes.

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [X] Added tests?

### Process
- [N] Are there licensing issues with any new dependencies introduced?
- [Y] Includes a summary of what a code reviewer should test/verify?
- [N/A] Updated the release notes?
- [N/A] Database changes are submitted as a separate PR?
- [N/A] DevOps team has been notified if PR requires ops support?

## Linked Issues
- #6263

## To Be Done
- After this goes live in Prod, need to go into Okta in Prod and fix all the darn group names!

## Specific Security-related subjects a reviewer should pay specific attention to
- This PR includes changes in authentication and/or authorization of existing endpoints?  **Yes**.

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated

**Answer**:   The authentication code in HistoryFunctions.kt has not been touched.   However, the authorization check (_Does the user belong to an Okta group that matches the organization for which they are requesting access?_) has been replaced with new code.   The danger would be that I have inadvertently introduced a bug in the logic that might somehow allow improper access.    

This has been mitigated by placing the auth check in a separate function and writing thorough unit tests for that function, and by making as few other changes to the logic in HistoryFunctions.kt as possible. 

- Have you ensured logging does not contain sensitive data?  **Answer: Yes**
- Have you received any additional approvals needed for this change?  **Answer: Yes**

