### PR TITLE
6233 Fix submissions list returning multiple entries for one submission

### DIFF
--- a/prime-router/docs/api/waters-submissions.yml
+++ b/prime-router/docs/api/waters-submissions.yml
@@ -50,7 +50,7 @@ components:
       type: object
       properties:
         submissionId:
-          description: the row number for this report's action log
+          description: the ID for this submission
           type: integer
         timestamp:
           description: the timestamp for this report submission
@@ -63,7 +63,7 @@ components:
           description: response given to the sender upon submission
           type: integer
         id:
-          description: the uuid for this submission
+          description: the report uuid of this submission
           type: string
           format: uuid
         topic:
@@ -72,6 +72,9 @@ components:
         reportItemCount:
           description: total number of individual reports sent to the Hub (in a csv, the number of data lines sent)
           type: integer
+        externalName:
+          description: custom report name if one was specified by the sender
+          type: string
 
   securitySchemes:
     OAuth2:

--- a/prime-router/src/main/kotlin/Sender.kt
+++ b/prime-router/src/main/kotlin/Sender.kt
@@ -138,7 +138,7 @@ abstract class Sender(
     }
 
     @get:JsonIgnore
-    val fullName: String get() = "$organizationName${fullNameSeparator}$name"
+    val fullName: String get() = ClientSource(organizationName, name).name
 
     /**
      * Calculate the customer's default processingModeCode based on their

--- a/prime-router/src/main/kotlin/history/SubmissionHistory.kt
+++ b/prime-router/src/main/kotlin/history/SubmissionHistory.kt
@@ -40,18 +40,33 @@ open class SubmissionHistory(
     reportId: String? = null,
     @JsonProperty("topic")
     schemaTopic: String? = null,
-    reportItemCount: Int? = null,
-    @JsonProperty("sender")
+    @JsonProperty("reportItemCount")
+    itemCount: Int? = null,
+    @JsonIgnore
     val sendingOrg: String? = "",
     val httpStatus: Int? = null,
+    @JsonIgnore
+    val sendingOrgClient: String? = "",
 ) : ReportHistory(
     actionId,
     createdAt,
     externalName,
     reportId,
     schemaTopic,
-    reportItemCount,
-)
+    itemCount,
+) {
+    /**
+     * The sender of the input report.
+     */
+    var sender: String? = ""
+    init {
+        sender = when {
+            sendingOrg.isNullOrBlank() -> ""
+            sendingOrgClient.isNullOrBlank() -> sendingOrg
+            else -> ClientSource(sendingOrg, sendingOrgClient).name
+        }
+    }
+}
 
 /**
  * This class provides a detailed view for data in the `report_file` table and data from other related sources.
@@ -124,11 +139,6 @@ class DetailedSubmissionHistory(
      * The destinations.
      */
     var destinations = mutableListOf<Destination>()
-
-    /**
-     * The sender of the input report.
-     */
-    var sender: String? = null
 
     /**
      * The step in the delivery process for a submission
@@ -412,14 +422,14 @@ class DetailedSubmissionHistory(
         realDestinations.forEach {
             var sentItemCount = 0
 
-            it.sentReports.forEach {
-                sentItemCount += it.itemCount
+            it.sentReports.forEach { sentReport ->
+                sentItemCount += sentReport.itemCount
             }
 
             var downloadedItemCount = 0
 
-            it.downloadedReports.forEach {
-                downloadedItemCount += it.itemCount
+            it.downloadedReports.forEach { downloadedReport ->
+                downloadedItemCount += downloadedReport.itemCount
             }
 
             if (sentItemCount >= it.itemCount || downloadedItemCount >= it.itemCount) {

--- a/prime-router/src/main/kotlin/history/azure/DatabaseSubmissionsAccess.kt
+++ b/prime-router/src/main/kotlin/history/azure/DatabaseSubmissionsAccess.kt
@@ -33,10 +33,10 @@ class DatabaseSubmissionsAccess(
         orgService: String?
     ): Condition {
         var senderFilter = ACTION.ACTION_NAME.eq(TaskAction.receive)
-            .and(ACTION.SENDING_ORG.eq(organization))
+            .and(REPORT_FILE.SENDING_ORG.eq(organization))
 
         if (orgService != null) {
-            senderFilter = senderFilter.and(ACTION.SENDING_ORG_CLIENT.eq(orgService))
+            senderFilter = senderFilter.and(REPORT_FILE.SENDING_ORG_CLIENT.eq(orgService))
         }
 
         return senderFilter

--- a/prime-router/src/main/kotlin/history/azure/HistoryDatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/history/azure/HistoryDatabaseAccess.kt
@@ -75,7 +75,7 @@ abstract class HistoryDatabaseAccess(
             val query = DSL.using(txn)
                 // Note the report file and action tables have columns with the same name, so we must specify what we need.
                 .select(
-                    ACTION.ACTION_ID, ACTION.CREATED_AT, ACTION.SENDING_ORG,
+                    ACTION.ACTION_ID, ACTION.CREATED_AT, ACTION.SENDING_ORG, ACTION.SENDING_ORG_CLIENT,
                     REPORT_FILE.RECEIVING_ORG, REPORT_FILE.RECEIVING_ORG_SVC,
                     ACTION.HTTP_STATUS, ACTION.EXTERNAL_NAME, REPORT_FILE.REPORT_ID, REPORT_FILE.SCHEMA_TOPIC,
                     REPORT_FILE.ITEM_COUNT, REPORT_FILE.BODY_URL, REPORT_FILE.SCHEMA_NAME, REPORT_FILE.BODY_FORMAT

--- a/prime-router/src/main/kotlin/history/azure/SubmissionsFacade.kt
+++ b/prime-router/src/main/kotlin/history/azure/SubmissionsFacade.kt
@@ -24,7 +24,7 @@ class SubmissionsFacade(
      * Serializes a list of Actions into a String.
      *
      * @param organization from JWT Claim.
-     * @param sendingOrgClient is a specifier for the sending organization's client.
+     * @param sendingOrgService is a specifier for the sending organization's client.
      * @param sortDir sort the table by date in ASC or DESC order.
      * @param sortColumn sort the table by a specific column; defaults to sorting by created_at.
      * @param cursor is the OffsetDateTime of the last result in the previous list.
@@ -37,7 +37,7 @@ class SubmissionsFacade(
      */
     fun findSubmissionsAsJson(
         organization: String,
-        sendingOrgClient: String?,
+        sendingOrgService: String?,
         sortDir: HistoryDatabaseAccess.SortDir,
         sortColumn: HistoryDatabaseAccess.SortColumn,
         cursor: OffsetDateTime?,
@@ -48,7 +48,7 @@ class SubmissionsFacade(
     ): String {
         val result = findSubmissions(
             organization,
-            sendingOrgClient,
+            sendingOrgService,
             sortDir,
             sortColumn,
             cursor,
@@ -64,7 +64,7 @@ class SubmissionsFacade(
      * Find submissions based on various parameters.
      *
      * @param organization from JWT Claim.
-     * @param sendingOrgClient is a specifier for the sending organization's client.
+     * @param sendingOrgService is a specifier for the sending organization's client.
      * @param sortDir sort the table by date in ASC or DESC order; defaults to DESC.
      * @param sortColumn sort the table by a specific column; defaults to sorting by CREATED_AT.
      * @param cursor is the OffsetDateTime of the last result in the previous list.
@@ -77,7 +77,7 @@ class SubmissionsFacade(
      */
     private fun findSubmissions(
         organization: String,
-        sendingOrgClient: String?,
+        sendingOrgService: String?,
         sortDir: HistoryDatabaseAccess.SortDir,
         sortColumn: HistoryDatabaseAccess.SortColumn,
         cursor: OffsetDateTime?,
@@ -92,7 +92,7 @@ class SubmissionsFacade(
 
         return dbSubmissionAccess.fetchActions(
             organization,
-            sendingOrgClient,
+            sendingOrgService,
             sortDir,
             sortColumn,
             cursor,

--- a/prime-router/src/test/kotlin/history/SubmissionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/history/SubmissionHistoryTests.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isFailure
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isNullOrEmpty
 import assertk.assertions.isTrue
 import com.microsoft.azure.functions.HttpStatus
 import gov.cdc.prime.router.ActionLogLevel
@@ -315,7 +316,7 @@ class SubmissionHistoryTests {
             assertThat(createdAt).isNotNull()
             assertThat(reportId).isNull()
             assertThat(httpStatus).isNull()
-            assertThat(sender).isNull()
+            assertThat(sender).isNullOrEmpty()
             assertThat(topic).isNull()
             assertThat(reportItemCount).isNull()
             assertThat(externalName).isEqualTo("")
@@ -336,7 +337,7 @@ class SubmissionHistoryTests {
             assertThat(createdAt).isNotNull()
             assertThat(reportId).isNull()
             assertThat(httpStatus).isEqualTo(201)
-            assertThat(sender).isNull()
+            assertThat(sender).isNullOrEmpty()
             assertThat(topic).isNull()
             assertThat(reportItemCount).isNull()
             assertThat(externalName).isEqualTo("")
@@ -358,7 +359,7 @@ class SubmissionHistoryTests {
             assertThat(createdAt).isNotNull()
             assertThat(reportId).isNull()
             assertThat(httpStatus).isNull()
-            assertThat(sender).isNull()
+            assertThat(sender).isNullOrEmpty()
             assertThat(topic).isNull()
             assertThat(reportItemCount).isNull()
             assertThat(externalName).isEqualTo("")
@@ -805,7 +806,7 @@ class SubmissionHistoryTests {
         )
         val refUUID = UUID.randomUUID()
         val now = OffsetDateTime.now()
-        var reports = listOf(
+        val reports = listOf(
             inputReport,
             DetailedReport(
                 refUUID, "recvOrg1",
@@ -844,7 +845,7 @@ class SubmissionHistoryTests {
             emptyList(),
         ).run {
             // First destination has a transport set therefore sendingAt
-            assertThat(destinations.first().sendingAt).equals(now)
+            assertThat(destinations.first().sendingAt).isEqualTo(now)
             assertThat(destinations.last().sendingAt).isNull()
         }
     }

--- a/prime-router/src/test/kotlin/history/azure/SubmissionFunctionTests.kt
+++ b/prime-router/src/test/kotlin/history/azure/SubmissionFunctionTests.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.net.HttpHeaders
 import com.microsoft.azure.functions.HttpStatus
+import gov.cdc.prime.router.ClientSource
 import gov.cdc.prime.router.CovidSender
 import gov.cdc.prime.router.CustomerStatus
 import gov.cdc.prime.router.Metadata
@@ -49,6 +50,7 @@ class SubmissionFunctionTests : Logging {
     private val mapper = JacksonMapperUtilities.allowUnknownsMapper
 
     private val organizationName = "test-lab"
+    private val organizationClient = "default"
     private val oktaClaimsOrganizationName = "DHSender_$organizationName"
     private val otherOrganizationName = "test-lab-2"
 
@@ -91,8 +93,9 @@ class SubmissionFunctionTests : Logging {
             externalName = "test-name.csv",
             reportId = "a2cf1c46-7689-4819-98de-520b5007e45f",
             schemaTopic = "covid-19",
-            reportItemCount = 3,
+            itemCount = 3,
             sendingOrg = organizationName,
+            sendingOrgClient = organizationClient,
             httpStatus = 201,
         ),
         SubmissionHistory(
@@ -101,8 +104,9 @@ class SubmissionFunctionTests : Logging {
             externalName = "test-name.csv",
             reportId = null,
             schemaTopic = null,
-            reportItemCount = null,
+            itemCount = null,
             sendingOrg = organizationName,
+            sendingOrgClient = organizationClient,
             httpStatus = 400,
         )
     )
@@ -134,7 +138,7 @@ class SubmissionFunctionTests : Logging {
                         ExpectedSubmissionList(
                             submissionId = 8,
                             timestamp = OffsetDateTime.parse("2021-11-30T16:36:54.919Z"),
-                            sender = organizationName,
+                            sender = ClientSource(organizationName, organizationClient).name,
                             httpStatus = 201,
                             externalName = "test-name.csv",
                             id = ReportId.fromString("a2cf1c46-7689-4819-98de-520b5007e45f"),
@@ -144,7 +148,7 @@ class SubmissionFunctionTests : Logging {
                         ExpectedSubmissionList(
                             submissionId = 7,
                             timestamp = OffsetDateTime.parse("2021-11-30T16:36:48.307Z"),
-                            sender = organizationName,
+                            sender = ClientSource(organizationName, organizationClient).name,
                             httpStatus = 400,
                             externalName = "test-name.csv",
                             id = null,


### PR DESCRIPTION
This PR fixes the submissions list returning multiple entries for one submission.  I also got together with the UI team to verify all the fields they are using and updated the OpenAPI to match what is in the response.

Test Steps:
1. Check out this branch and run report stream.
2. Submit a report using your favorite sender.  Include the header `payloadname` with a custom report name, so you can see it in the response.
3. Do a GET on `api/waters/org/{{senderOrg}}/submissions` for the sender you used and verify 
   a. `reporItemCount` has the correct number of items
   b. `externalName` has your custom payloadname
   c. `sender` has the complete sender name as in <org>.<service>
   d. There is only one report per submission ID
4. Verify the OpenAPI spec matches this output.

Sample new API response:
```
[
    {
        "submissionId": 84,
        "timestamp": "2022-08-05T14:19:42.405Z",
        "externalName": "thepayloadname",
        "id": "b4deb5f4-569e-4a30-a1af-d1dac49ee240",
        "topic": "covid-19",
        "reportItemCount": 25,
        "httpStatus": 201,
        "sender": "careevolution.default"
    },
    {
        "submissionId": 23,
        "timestamp": "2022-08-04T18:34:43.729Z",
        "id": "c8e29164-3199-430f-850e-0b1b388c817a",
        "topic": "covid-19",
        "reportItemCount": 25,
        "httpStatus": 201,
        "sender": "careevolution.default"
    },
    {
        "submissionId": 21,
        "timestamp": "2022-08-04T18:34:35.003Z",
        "id": "aa7f1858-b57a-4cdf-9c34-bf946e8932a5",
        "topic": "covid-19",
        "reportItemCount": 25,
        "httpStatus": 201,
        "sender": "careevolution.default"
    },
```

## Changes
- fixed the submissions list returning multiple entries for one submission
- Fixed reportItemCount returning the correct number
- Fixed sender having the full sender name

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- #6233

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to
