### PR TITLE
[Draft] Refractor ErrorComponent

### DIFF
--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -121,7 +121,9 @@ const App = () => {
             <SessionProvider oktaHook={useOktaAuth}>
                 <Suspense fallback={<Spinner size={"fullpage"} />}>
                     <NetworkErrorBoundary
-                        fallbackComponent={() => <ErrorPage type="page" />}
+                        fallbackComponent={(props) => (
+                            <ErrorPage type="page" error={props.error} />
+                        )}
                     >
                         <DAPHeader
                             env={process.env.REACT_APP_ENV?.toString()}

--- a/frontend-react/src/components/Admin/AdminFormWrapper.tsx
+++ b/frontend-react/src/components/Admin/AdminFormWrapper.tsx
@@ -13,9 +13,7 @@ export function AdminFormWrapper({
     children,
 }: React.PropsWithChildren<AdminFormWrapperProps>) {
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
+        <>
             <section className="grid-container margin-bottom-5">
                 {header}
             </section>
@@ -26,8 +24,14 @@ export function AdminFormWrapper({
                     </span>
                 }
             >
-                {children}
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="page" error={props.error} />
+                    )}
+                >
+                    {children}
+                </NetworkErrorBoundary>
             </Suspense>
-        </NetworkErrorBoundary>
+        </>
     );
 }

--- a/frontend-react/src/components/Admin/NewSetting.tsx
+++ b/frontend-react/src/components/Admin/NewSetting.tsx
@@ -108,20 +108,22 @@ export function NewSetting({ match }: RouteComponentProps<Props>) {
     };
 
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
-            <section className="grid-container margin-bottom-5">
-                <Suspense
-                    fallback={
-                        <span className="text-normal text-base">
-                            <Spinner />
-                        </span>
-                    }
+        <section className="grid-container margin-bottom-5">
+            <Suspense
+                fallback={
+                    <span className="text-normal text-base">
+                        <Spinner />
+                    </span>
+                }
+            >
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
                 >
                     <FormComponent />
-                </Suspense>
-            </section>
-        </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
+        </section>
     );
 }

--- a/frontend-react/src/pages/admin/AdminLastMileFailures.tsx
+++ b/frontend-react/src/pages/admin/AdminLastMileFailures.tsx
@@ -9,26 +9,22 @@ import { AdminLastMileFailuresTable } from "../../components/Admin/AdminLastMile
 
 export function AdminLastMileFailures() {
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
+        <>
             <Helmet>
                 <title>Admin | {process.env.REACT_APP_TITLE}</title>
             </Helmet>
-            <section className="grid-container margin-bottom-5">
-                <h3 className="margin-bottom-0">
-                    <Suspense fallback={<Spinner />} />
-                </h3>
-            </section>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
-            >
-                <Suspense fallback={<Spinner />}>
-                    <section className="grid-container margin-top-0" />
+            <Suspense fallback={<Spinner />}>
+                <section className="grid-container margin-top-0" />
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
+                >
                     <AdminLastMileFailuresTable />
-                </Suspense>
-            </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
+
             <HipaaNotice />
-        </NetworkErrorBoundary>
+        </>
     );
 }

--- a/frontend-react/src/pages/admin/AdminMain.tsx
+++ b/frontend-react/src/pages/admin/AdminMain.tsx
@@ -9,26 +9,21 @@ import { OrgsTable } from "../../components/Admin/OrgsTable";
 
 export function AdminMain() {
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
+        <>
             <Helmet>
                 <title>Admin | {process.env.REACT_APP_TITLE}</title>
             </Helmet>
-            <section className="grid-container margin-bottom-5">
-                <h3 className="margin-bottom-0">
-                    <Suspense fallback={<Spinner />} />
-                </h3>
-            </section>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
-            >
-                <Suspense fallback={<Spinner />}>
+            <Suspense fallback={<Spinner />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
+                >
                     <section className="grid-container margin-top-0" />
                     <OrgsTable />
-                </Suspense>
-            </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
             <HipaaNotice />
-        </NetworkErrorBoundary>
+        </>
     );
 }

--- a/frontend-react/src/pages/admin/AdminOrgEdit.tsx
+++ b/frontend-react/src/pages/admin/AdminOrgEdit.tsx
@@ -146,9 +146,7 @@ export function AdminOrgEdit({
     };
 
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
+        <>
             <Helmet>
                 <title>Admin | Org Edit | {process.env.REACT_APP_TITLE}</title>
             </Helmet>
@@ -159,10 +157,12 @@ export function AdminOrgEdit({
                     }`}
                 />
             </section>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
-            >
-                <Suspense fallback={<Spinner />}>
+            <Suspense fallback={<Spinner />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
+                >
                     <section className="grid-container margin-top-0">
                         <GridContainer>
                             <Grid row>
@@ -238,9 +238,9 @@ export function AdminOrgEdit({
                     </section>
                     <OrgSenderTable orgname={orgname} />
                     <OrgReceiverTable orgname={orgname} />
-                </Suspense>
-            </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
             <HipaaNotice />
-        </NetworkErrorBoundary>
+        </>
     );
 }

--- a/frontend-react/src/pages/admin/AdminOrgNew.tsx
+++ b/frontend-react/src/pages/admin/AdminOrgNew.tsx
@@ -94,20 +94,22 @@ export function AdminOrgNew() {
     };
 
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
-            <section className="grid-container margin-bottom-5">
-                <Suspense
-                    fallback={
-                        <span className="text-normal text-base">
-                            <Spinner />
-                        </span>
-                    }
+        <section className="grid-container margin-bottom-5">
+            <Suspense
+                fallback={
+                    <span className="text-normal text-base">
+                        <Spinner />
+                    </span>
+                }
+            >
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
                 >
                     <FormComponent />
-                </Suspense>
-            </section>
-        </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
+        </section>
     );
 }

--- a/frontend-react/src/pages/admin/AdminReceiverDashPage.tsx
+++ b/frontend-react/src/pages/admin/AdminReceiverDashPage.tsx
@@ -1,6 +1,6 @@
 import { NetworkErrorBoundary } from "rest-hooks";
 import { Helmet } from "react-helmet";
-import { Suspense } from "react";
+import React, { Suspense } from "react";
 
 import { ErrorPage } from "../error/ErrorPage";
 import Spinner from "../../components/Spinner";
@@ -13,14 +13,16 @@ export function AdminReceiverDashPage() {
             <Helmet>
                 <title>Admin Destination Dashboard</title>
             </Helmet>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
-            >
-                <Suspense fallback={<Spinner />}>
+            <Suspense fallback={<Spinner />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
+                >
                     <section className="grid-container margin-top-0" />
                     <AdminReceiverDashboard />
-                </Suspense>
-            </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
             <HipaaNotice />
         </>
     );

--- a/frontend-react/src/pages/daily/Daily.tsx
+++ b/frontend-react/src/pages/daily/Daily.tsx
@@ -13,24 +13,24 @@ import ReportsTable from "./Table/ReportsTable";
 function Daily() {
     const orgName: string = useOrgName();
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
+        <>
             <Helmet>
                 <title>Daily data | {process.env.REACT_APP_TITLE}</title>
             </Helmet>
             <section className="grid-container margin-bottom-5 tablet:margin-top-6">
                 <Title preTitle={orgName} title="COVID-19" />
             </section>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
-            >
-                <Suspense fallback={<Spinner />}>
+            <Suspense fallback={<Spinner />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
+                >
                     <ReportsTable />
-                </Suspense>
-            </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
             <HipaaNotice />
-        </NetworkErrorBoundary>
+        </>
     );
 }
 

--- a/frontend-react/src/pages/details/Details.tsx
+++ b/frontend-react/src/pages/details/Details.tsx
@@ -1,5 +1,5 @@
 import { NetworkErrorBoundary } from "rest-hooks";
-import { Suspense } from "react";
+import React, { Suspense } from "react";
 
 import HipaaNotice from "../../components/HipaaNotice";
 import Spinner from "../../components/Spinner";
@@ -36,7 +36,9 @@ const DetailsContent = () => {
             <Summary report={report} />
             <ReportDetails report={report} />
             <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
+                fallbackComponent={(props) => (
+                    <ErrorPage type="message" error={props.error} />
+                )}
             >
                 <Suspense fallback={<Spinner />}>
                     <FacilitiesTable reportId={reportId} />
@@ -50,12 +52,14 @@ const DetailsContent = () => {
 /** @todo Refactor as part of {@link https://github.com/CDCgov/prime-reportstream/issues/4790 #4790} */
 export const Details = () => {
     return (
-        <Suspense fallback={<Spinner size="fullpage" />}>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="page" />}
-            >
+        <NetworkErrorBoundary
+            fallbackComponent={(props) => (
+                <ErrorPage type="page" error={props.error} />
+            )}
+        >
+            <Suspense fallback={<Spinner />}>
                 <DetailsContent />
-            </NetworkErrorBoundary>
-        </Suspense>
+            </Suspense>
+        </NetworkErrorBoundary>
     );
 };

--- a/frontend-react/src/pages/error/ErrorPage.test.tsx
+++ b/frontend-react/src/pages/error/ErrorPage.test.tsx
@@ -67,7 +67,9 @@ describe("testing ErrorPage", () => {
     it("NetworkErrorBoundary 500", () => {
         render(
             <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="page" />}
+                fallbackComponent={(props) => (
+                    <ErrorPage type="page" error={props.error} />
+                )}
             >
                 <Throw500 />
                 <div>never renders</div>

--- a/frontend-react/src/pages/submissions/SubmissionDetails.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionDetails.tsx
@@ -152,13 +152,15 @@ function SubmissionDetails() {
     return (
         <>
             <Crumbs crumbList={crumbs} />
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="page" />}
-            >
-                <Suspense fallback={<Spinner size="fullpage" />}>
+            <Suspense fallback={<Spinner size="fullpage" />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="page" error={props.error} />
+                    )}
+                >
                     <SubmissionDetailsContent />
-                </Suspense>
-            </NetworkErrorBoundary>
+                </NetworkErrorBoundary>
+            </Suspense>
         </>
     );
 }

--- a/frontend-react/src/pages/submissions/SubmissionTable.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionTable.tsx
@@ -239,18 +239,20 @@ function SubmissionTable() {
         FeatureFlagName.NUMBERED_PAGINATION
     );
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="message" />}
-        >
-            <Suspense fallback={<Spinner />}>
+        <Suspense fallback={<Spinner />}>
+            <NetworkErrorBoundary
+                fallbackComponent={(props) => (
+                    <ErrorPage type="message" error={props.error} />
+                )}
+            >
                 {isNumberedPaginationOn && (
                     <SubmissionTableWithNumberedPagination />
                 )}
                 {!isNumberedPaginationOn && (
                     <SubmissionTableWithCursorManager />
                 )}
-            </Suspense>
-        </NetworkErrorBoundary>
+            </NetworkErrorBoundary>
+        </Suspense>
     );
 }
 

--- a/frontend-react/src/pages/submissions/Submissions.tsx
+++ b/frontend-react/src/pages/submissions/Submissions.tsx
@@ -1,10 +1,12 @@
 import { Helmet } from "react-helmet";
 import { NetworkErrorBoundary } from "rest-hooks";
+import React, { Suspense } from "react";
 
 import { useOrgName } from "../../hooks/UseOrgName";
 import { ErrorPage } from "../error/ErrorPage";
 import HipaaNotice from "../../components/HipaaNotice";
 import Title from "../../components/Title";
+import Spinner from "../../components/Spinner";
 
 import SubmissionTable from "./SubmissionTable";
 
@@ -12,18 +14,24 @@ function Submissions() {
     const orgName: string = useOrgName();
 
     return (
-        <NetworkErrorBoundary
-            fallbackComponent={() => <ErrorPage type="page" />}
-        >
+        <>
             <Helmet>
                 <title>Submissions | {process.env.REACT_APP_TITLE}</title>
             </Helmet>
             <section className="grid-container margin-top-5">
                 <Title title="COVID-19" preTitle={orgName} />
             </section>
-            <SubmissionTable />
+            <Suspense fallback={<Spinner />}>
+                <NetworkErrorBoundary
+                    fallbackComponent={(props) => (
+                        <ErrorPage type="message" error={props.error} />
+                    )}
+                >
+                    <SubmissionTable />
+                </NetworkErrorBoundary>
+            </Suspense>
             <HipaaNotice />
-        </NetworkErrorBoundary>
+        </>
     );
 }
 


### PR DESCRIPTION
**Problem:**
Getting logged out was generating a 401 - Unauthorized error, but the NetworkErrorBoundary's ErrorComponent wasn't able to see it. This resulted in getting a generic "Network Error" message when the login would time out.

Easy way to reproduce this bug is to simulate a session timeout:
1. Log into site. Go to an admin page.
2. Using chrome debugger Clear the Okta session cookies.
<img width="450" alt="image" src="https://user-images.githubusercontent.com/74203452/183318644-b072cdbb-1013-43ed-bf06-20a7edf163a0.png">
Warning: debugger doesn't update and still shows after Clear. Click away and black to verify cleared.
3. Navigate to a different page. (NOT refesh)
Result: Get a generic network error message
<img width="450" alt="image" src="https://user-images.githubusercontent.com/74203452/183318731-4e1db351-0872-46fa-8961-383064222c34.png">

**Changes:**

-  Prop drill NetworkError down into ErrorComponent and update NetworkErrorBoundary accordingly. The Unauthorized message now produces:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/74203452/183317782-168f148a-43b2-48ed-8f2a-d9d8c04d9655.png">

- Clean up `<Suspense>` and `<NetworkErrorBoundary>`. The Suspend should be OUTSIDE NetworkErrorBoundary

**How to test:**
 - Use chrome debugger and go into "offline mode" in network tab. (refresh) This is the old error messages (still work).
 - Use chrome debugger and go delete Okta's Session Storage keys in the Application tab . (refresh) This is the new error message (now works).

**To Do before ready to check in:**
- [ ] update tests in ErrorPage.test.tsx
- [ ] Get the Logged Out message (screenshot above) text approved by UX.
- [ ] Handle other network error codes now that the ErrorComponent can see them?


 