### PR TITLE
Adds additional metadata columns for ELR and fixes bug with test performed fields

### DIFF
--- a/prime-router/docs/schema_documentation/dcipher-dcipher-monkeypox.md
+++ b/prime-router/docs/schema_documentation/dcipher-dcipher-monkeypox.md
@@ -607,7 +607,7 @@ Additional information specifically about the specimen to be sent in the message
 
 **Name**: sample_type
 
-**ReportStream Internal Name**: specimen_type
+**ReportStream Internal Name**: specimen_type_name
 
 **Type**: TEXT
 
@@ -1596,7 +1596,7 @@ The city of the provider
 
 **ReportStream Internal Name**: ordering_provider_county
 
-**Type**: TABLE
+**Type**: TEXT
 
 **PII**: No
 
@@ -1932,7 +1932,8 @@ The zip code of the provider
 
 **Documentation**:
 
-The SimpleReport concept of organization. It refers to organization for the ordering & performing facility
+The SimpleReport concept of organization. It refers to organization for the 
+ordering & performing facility
 
 
 ---
@@ -4543,70 +4544,49 @@ This is a CUSTOM internal field. DO NOT use this for an AOE residence_type.
 
 ---
 
-**Name**: specimen_collection_method
+**Name**: specimen_collection_method_code
 
-**ReportStream Internal Name**: specimen_collection_method
+**ReportStream Internal Name**: specimen_collection_method_code
 
-**Type**: CODE
+**Type**: TEXT
 
 **PII**: No
 
-**Format**: use value found in the Code column
-
 **Cardinality**: [0..1]
-
-**Value Sets**
-
-Code | Display | System
----- | ------- | ------
-ANP|Plates, Anaerobic|HL7
-BAP|Plates, Blood Agar|HL7
-BCAE|Blood Culture, Aerobic Bottle|HL7
-BCAN|Blood Culture, Anaerobic Bottle|HL7
-BCPD|Blood Culture, Pediatric Bottle|HL7
-BIO|Biopsy|HL7
-CAP|Capillary Specimen|HL7
-CATH|Catheterized|HL7
-CVP|Line, CVP|HL7
-EPLA|Environmental, Plate|HL7
-ESWA|Environmental, Swab|HL7
-FNA|Aspiration, Fine Needle|HL7
-KOFFP|Plate, Cough|HL7
-LNA|Line, Arterial|HL7
-LNV|Line, Venous|HL7
-MARTL|Martin-Lewis Agar|HL7
-ML11|Mod. Martin-Lewis Agar|HL7
-MLP|Plate, Martin-Lewis|HL7
-NYP|Plate, New York City|HL7
-PACE|Pace, Gen-Probe|HL7
-PIN|Pinworm Prep|HL7
-PNA|Aterial puncture|HL7
-PRIME|Pump Prime|HL7
-PUMP|Pump Specimen|HL7
-QC5|Quality Control For Micro|HL7
-SCLP|Scalp, Fetal Vein|HL7
-SCRAPS|Scrapings|HL7
-SHA|Shaving|HL7
-SWA|Swab|HL7
-SWD|Swab, Dacron tipped|HL7
-TMAN|Transport Media, Anaerobic|HL7
-TMCH|Transport Media, Chalamydia|HL7
-TMM4|Transport Media, M4|HL7
-TMMY|Transport Media, Mycoplasma|HL7
-TMOT|Transport Media|HL7
-TMP|Plate, Thayer-Martin|HL7
-TMPV|Transport Media, PVA|HL7
-TMSC|Transport Media, Stool Culture|HL7
-TMUP|Transport Media, Ureaplasma|HL7
-TMVI|Transport Media, Viral|HL7
-VENIP|Venipuncture|HL7
-WOOD|Swab, Wooden Shaft|HL7
 
 ---
 
-**Name**: specimen_collection_site
+**Name**: specimen_collection_method_text
 
-**ReportStream Internal Name**: specimen_collection_site
+**ReportStream Internal Name**: specimen_collection_method_text
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimen_collection_site_code
+
+**ReportStream Internal Name**: specimen_collection_site_code
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.10](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.10) 
+
+---
+
+**Name**: specimen_collection_site_text
+
+**ReportStream Internal Name**: specimen_collection_site_text
 
 **Type**: TEXT
 
@@ -4921,6 +4901,10 @@ The text for the specimen source site
 **PII**: No
 
 **Cardinality**: [0..1]
+
+**Documentation**:
+
+The specimen source, such as Blood or Serum
 
 ---
 

--- a/prime-router/docs/schema_documentation/monkeypox.md
+++ b/prime-router/docs/schema_documentation/monkeypox.md
@@ -800,7 +800,7 @@ The city of the provider
 
 **ReportStream Internal Name**: ordering_provider_county
 
-**Type**: TABLE
+**Type**: TEXT
 
 **PII**: No
 
@@ -1136,7 +1136,8 @@ The zip code of the provider
 
 **Documentation**:
 
-The SimpleReport concept of organization. It refers to organization for the ordering & performing facility
+The SimpleReport concept of organization. It refers to organization for the 
+ordering & performing facility
 
 
 ---
@@ -3935,70 +3936,49 @@ The date which the specimen was collected. The default format is yyyyMMddHHmmssz
 
 ---
 
-**Name**: specimen_collection_method
+**Name**: specimen_collection_method_code
 
-**ReportStream Internal Name**: specimen_collection_method
+**ReportStream Internal Name**: specimen_collection_method_code
 
-**Type**: CODE
+**Type**: TEXT
 
 **PII**: No
 
-**Format**: use value found in the Code column
-
 **Cardinality**: [0..1]
-
-**Value Sets**
-
-Code | Display | System
----- | ------- | ------
-ANP|Plates, Anaerobic|HL7
-BAP|Plates, Blood Agar|HL7
-BCAE|Blood Culture, Aerobic Bottle|HL7
-BCAN|Blood Culture, Anaerobic Bottle|HL7
-BCPD|Blood Culture, Pediatric Bottle|HL7
-BIO|Biopsy|HL7
-CAP|Capillary Specimen|HL7
-CATH|Catheterized|HL7
-CVP|Line, CVP|HL7
-EPLA|Environmental, Plate|HL7
-ESWA|Environmental, Swab|HL7
-FNA|Aspiration, Fine Needle|HL7
-KOFFP|Plate, Cough|HL7
-LNA|Line, Arterial|HL7
-LNV|Line, Venous|HL7
-MARTL|Martin-Lewis Agar|HL7
-ML11|Mod. Martin-Lewis Agar|HL7
-MLP|Plate, Martin-Lewis|HL7
-NYP|Plate, New York City|HL7
-PACE|Pace, Gen-Probe|HL7
-PIN|Pinworm Prep|HL7
-PNA|Aterial puncture|HL7
-PRIME|Pump Prime|HL7
-PUMP|Pump Specimen|HL7
-QC5|Quality Control For Micro|HL7
-SCLP|Scalp, Fetal Vein|HL7
-SCRAPS|Scrapings|HL7
-SHA|Shaving|HL7
-SWA|Swab|HL7
-SWD|Swab, Dacron tipped|HL7
-TMAN|Transport Media, Anaerobic|HL7
-TMCH|Transport Media, Chalamydia|HL7
-TMM4|Transport Media, M4|HL7
-TMMY|Transport Media, Mycoplasma|HL7
-TMOT|Transport Media|HL7
-TMP|Plate, Thayer-Martin|HL7
-TMPV|Transport Media, PVA|HL7
-TMSC|Transport Media, Stool Culture|HL7
-TMUP|Transport Media, Ureaplasma|HL7
-TMVI|Transport Media, Viral|HL7
-VENIP|Venipuncture|HL7
-WOOD|Swab, Wooden Shaft|HL7
 
 ---
 
-**Name**: specimen_collection_site
+**Name**: specimen_collection_method_text
 
-**ReportStream Internal Name**: specimen_collection_site
+**ReportStream Internal Name**: specimen_collection_method_text
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimen_collection_site_code
+
+**ReportStream Internal Name**: specimen_collection_site_code
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+
+**Reference URL**:
+[https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.10](https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.10) 
+
+---
+
+**Name**: specimen_collection_site_text
+
+**ReportStream Internal Name**: specimen_collection_site_text
 
 **Type**: TEXT
 
@@ -4300,22 +4280,6 @@ The text for the specimen source site
 
 ---
 
-**Name**: specimen_type
-
-**ReportStream Internal Name**: specimen_type
-
-**Type**: TEXT
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Documentation**:
-
-The specimen source, such as Blood or Serum
-
----
-
 **Name**: specimen_type_alternate_value
 
 **ReportStream Internal Name**: specimen_type_alternate_value
@@ -4362,6 +4326,10 @@ The specimen source, such as Blood or Serum
 
 **Cardinality**: [0..1]
 
+**Documentation**:
+
+The specimen source, such as Blood or Serum
+
 ---
 
 **Name**: specimen_type_code_system
@@ -4403,6 +4371,18 @@ The specimen source, such as Blood or Serum
 **Name**: specimen_type_modifier_system
 
 **ReportStream Internal Name**: specimen_type_modifier_system
+
+**Type**: TEXT
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+---
+
+**Name**: specimen_type_name
+
+**ReportStream Internal Name**: specimen_type_name
 
 **Type**: TEXT
 

--- a/prime-router/metadata/schemas/dcipher/dcipher-monkeypox.schema
+++ b/prime-router/metadata/schemas/dcipher/dcipher-monkeypox.schema
@@ -43,7 +43,7 @@ elements:
     csvFields: [{ name: sample_condition }]
     documentation: Description of the physical state of the specimen, as in HL7 field SPM-24.2
 
-  - name: specimen_type
+  - name: specimen_type_name
     csvFields: [{ name: sample_type }]
     documentation: Description of the precise nature of the entity that will be the source material for the observation, as in HL7 field SPM-4.2
 

--- a/prime-router/metadata/schemas/monkeypox.schema
+++ b/prime-router/metadata/schemas/monkeypox.schema
@@ -202,7 +202,7 @@ elements:
     documentation: The city of the provider
 
   - name: ordering_provider_county
-    type: TABLE
+    type: TEXT
     pii: false
     table: fips-county
     tableColumn: County
@@ -325,7 +325,8 @@ elements:
   - name: organization_name
     type: TEXT
     documentation: |
-      The SimpleReport concept of organization. It refers to organization for the ordering & performing facility
+      The SimpleReport concept of organization. It refers to organization for the 
+      ordering & performing facility
 
   - name: patient_account_number_id
     type: TEXT

--- a/prime-router/metadata/schemas/monkeypox.schema
+++ b/prime-router/metadata/schemas/monkeypox.schema
@@ -806,14 +806,22 @@ elements:
     documentation: |
       The date which the specimen was collected. The default format is yyyyMMddHHmmsszz
 
-  - name: specimen_collection_method
-    type: CODE
-    hl7Field: SPM-7
-    valueSet: hl70048
+  - name: specimen_collection_method_code
+    type: TEXT
+    hl7Field: SPM-7-1
 
-  - name: specimen_collection_site # collection location
+  - name: specimen_collection_method_text
+    type: TEXT
+    hl7Field: SPM-7-2
+
+  - name: specimen_collection_site_code # collection location
     type: TEXT # CWE without a defined table
-    hl7Field: SPM-10
+    hl7Field: SPM-10-1
+    referenceUrl: https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.10
+
+  - name: specimen_collection_site_text # collection location
+    type: TEXT # CWE without a defined table
+    hl7Field: SPM-10-2
     referenceUrl: https://hl7-definition.caristix.com/v2/HL7v2.5.1/Fields/SPM.10
 
   - name: specimen_condition
@@ -909,12 +917,12 @@ elements:
     hl7Field: SPM-8-3
     documentation: The coding system the sender is using for the specimen source
 
-  - name: specimen_type
+  - name: specimen_type_code
     type: TEXT
     hl7Field: SPM-4-1
     documentation: The specimen source, such as Blood or Serum
 
-  - name: specimen_type_code
+  - name: specimen_type_name
     type: TEXT
     hl7Field: SPM-4-2
 

--- a/prime-router/metadata/valuesets/monkeypox.valuesets
+++ b/prime-router/metadata/valuesets/monkeypox.valuesets
@@ -3,14 +3,89 @@
 - name: monkeypox/specimen_type
   system: SNOMED_CT
   version: 2.67
-  referenceUrl: ""
+  reference: |
+    The specimen type collected for monkeypox. These values are not specified to non-variola
+    orthopox, but we've grouped them into this valueset for now per the CDC guidance
+  referenceUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
   values:
-    - code: "257261003"
-      display: "Swab (specimen)"
+    - code: "435541000124108"
+      display: "Swab specimen (crust)"
+    - code: "472862007"
+      display: "Swab from lesion of skin"
+    - code: "16210971000119108"
+      display: "Swab from lesion"
+    - code: "418932006"
+      display: "Oral swab"
+    - code: "258528007"
+      display: "Rectal swab"
 
 - name: monkeypox/test_result
   system: SNOMED_CT
+  reference: |
+      The test result for monkeypox. These values are not specified to non-variola
+      orthopox, but we've grouped them into this valueset for now per the CDC guidance
+  referenceUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
   values:
-      - code: "260373001"
-        display: "Non-variola Orthopoxvirus DNA detected"
-        version: "2.16.840.1.113883.6.96"
+    - code: "260373001"
+      display: "Detected"
+    - code: "419984006"
+      display: "Inconclusive"
+    - code: "42425007"
+      display: "Equivocal"
+    - code: "260415000"
+      display: "Not detected"
+    - code: "373121007"
+      display: "Test not done"
+
+- name: monkeypox/test_code
+  system: LOINC
+  reference: The short name for a non-variola orthopox test.
+  referencedUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
+  values:
+      - code: "41853-3"
+        display: "Orthopoxvirus"
+      - code: "100434-0"
+        display: "Non-variola Orthopoxvirus"
+      - code: "100383-9"
+        display: "Monkeypox Virus"
+      - code: "100888-7"
+        display: "West African Monkeypox Virus"
+      - code: "100889-5"
+        display: "Congo Basin Monkeypox Virus"
+      - code: "100885-3"
+        display: "Parapoxvirus"
+      - code: "100886-1"
+        display: "Orf Virus"
+      - code: "100887-9"
+        display: "Pseudocowpox Virus"
+      - code: "100891-1"
+        display: "Orthopoxvirus IgG"
+      - code: "100892-9"
+        display: "Orthopoxvirus IgM"
+
+- name: monkeypox/test_long_name
+  system: LOINC
+  reference: The long name for the ordered and performed test for non-variola orthopox
+  referencedUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
+  values:
+      - code: "41853-3"
+        display: "Orthopoxvirus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100434-0"
+        display: "Orthopoxvirus non-variola DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100383-9"
+        display: "Monkeypox virus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100888-7"
+        display: "West African monkeypox virus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100889-5"
+        display: "Congo Basin monkeypox virus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100885-3"
+        display: "Parapoxvirus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100886-1"
+        display: "Orf virus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100887-9"
+        display: "Pseudocowpox virus DNA [Presence] in Specimen by NAA with probe detection"
+      - code: "100891-1"
+        display: "Orthopoxvirus IgG Ab [Presence] in Serum or Plasma by Immunoassay"
+      - code: "100892-9"
+        display: "Orthopoxvirus IgM Ab [Presence] in Serum or Plasma by Immunoassay"
+

--- a/prime-router/metadata/valuesets/monkeypox.valuesets
+++ b/prime-router/metadata/valuesets/monkeypox.valuesets
@@ -40,7 +40,7 @@
 - name: monkeypox/test_code
   system: LOINC
   reference: The short name for a non-variola orthopox test.
-  referencedUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
+  referenceUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
   values:
       - code: "41853-3"
         display: "Orthopoxvirus"
@@ -66,7 +66,7 @@
 - name: monkeypox/test_long_name
   system: LOINC
   reference: The long name for the ordered and performed test for non-variola orthopox
-  referencedUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
+  referenceUrl: "https://www.cdc.gov/poxvirus/monkeypox/lab-personnel/report-results.html"
   values:
       - code: "41853-3"
         display: "Orthopoxvirus DNA [Presence] in Specimen by NAA with probe detection"

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -819,12 +819,19 @@ class Report : Logging {
                     it.patientTribalCitizenshipCode = row.getStringOrNull("patient_tribal_citizenship_code")
                     it.patientPreferredLanguage = row.getStringOrNull("patient_preferred_language")
                     it.patientNationality = row.getStringOrNull("patient_nationality")
+                    it.patientSpecies = row.getStringOrNull("patient_species")
+                    it.patientSpeciesCode = row.getStringOrNull("patient_species_code")
 
                     it.reasonForStudy = row.getStringOrNull("reason_for_study_text")
                     it.reasonForStudyCode = row.getStringOrNull("reason_for_study_id")
 
                     it.testResultCode = row.getStringOrNull("test_result_id").trimToNull()
                     it.testResult = row.getStringOrNull("test_result_text").trimToNull()
+                    it.testResultNormalized = if (it.testResultCode != null) {
+                        metadata.findValueSet("monkeypox/test_result")?.toDisplayFromCode(it.testResultCode)
+                    } else {
+                        null
+                    }
                     it.equipmentModel = row.getStringOrNull("equipment_model_name").trimToNull()
                     it.specimenCollectionDateTime = row.getStringOrNull("specimen_collection_date_time").let { dt ->
                         if (!dt.isNullOrEmpty()) {
@@ -855,17 +862,46 @@ class Report : Logging {
                             null
                         }
                     }
-                    it.specimenCollectionMethod = row.getStringOrNull("specimen_collection_method")
-                    it.specimenCollectionSite = row.getStringOrNull("specimen_collection_site")
-                    it.specimenType = row.getStringOrNull("specimen_type")
+                    it.specimenCollectionMethod = row.getStringOrNull("specimen_collection_method_text")
+                    it.specimenCollectionMethodCode = row.getStringOrNull("specimen_collection_method_code")
+                    it.specimenCollectionSite = row.getStringOrNull("specimen_collection_site_text")
+                    it.specimenCollectionSiteCode = row.getStringOrNull("specimen_collection_site_code")
+                    it.specimenType = row.getStringOrNull("specimen_type_name")
+                    it.specimenTypeCode = row.getStringOrNull("specimen_type_code")
+                    it.specimenTypeNormalized = if (it.specimenTypeCode != null) {
+                        metadata.findValueSet("monkeypox/specimen_type")?.toDisplayFromCode(it.specimenTypeCode)
+                    } else {
+                        null
+                    }
                     it.specimenSourceSite = row.getStringOrNull("specimen_source_site_text")
+                    it.specimenSourceSiteCode = row.getStringOrNull("specimen_source_site_code")
 
                     it.siteOfCare = row.getStringOrNull("site_of_care").trimToNull()
                     it.testKitNameId = row.getStringOrNull("test_kit_name_id").trimToNull()
                     it.testPerformedCode = row.getStringOrNull("test_performed_code").trimToNull()
                     it.testPerformed = row.getStringOrNull("test_performed_name").trimToNull()
+                    it.testPerformedNormalized = if (it.testPerformedCode != null) {
+                        metadata.findValueSet("monkeypox/test_code")?.toDisplayFromCode(it.testPerformedCode)
+                    } else {
+                        null
+                    }
+                    it.testPerformedLongName = if (it.testPerformedCode != null) {
+                        metadata.findValueSet("monkeypox/test_long_name")?.toDisplayFromCode(it.testPerformedCode)
+                    } else {
+                        null
+                    }
                     it.testOrdered = row.getStringOrNull("ordered_test_name").trimToNull()
                     it.testOrderedCode = row.getStringOrNull("ordered_test_code").trimToNull()
+                    it.testOrderedNormalized = if (it.testOrderedCode != null) {
+                        metadata.findValueSet("monkeypox/test_code")?.toDisplayFromCode(it.testOrderedCode)
+                    } else {
+                        null
+                    }
+                    it.testOrderedLongName = if (it.testOrderedCode != null) {
+                        metadata.findValueSet("monkeypox/test_long_name")?.toDisplayFromCode(it.testOrderedCode)
+                    } else {
+                        null
+                    }
                     // trap the processing mode code as well
                     it.processingModeCode = row.getStringOrNull("processing_mode_code").trimToNull()
                 }

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -824,8 +824,8 @@ class Report : Logging {
                     it.reasonForStudy = row.getStringOrNull("reason_for_study_text")
                     it.reasonForStudyCode = row.getStringOrNull("reason_for_study_id")
 
-                    it.testResultCode = row.getStringOrNull("test_result_text").trimToNull()
-                    it.testResult = row.getStringOrNull("test_result_id").trimToNull()
+                    it.testResultCode = row.getStringOrNull("test_result_id").trimToNull()
+                    it.testResult = row.getStringOrNull("test_result_text").trimToNull()
                     it.equipmentModel = row.getStringOrNull("equipment_model_name").trimToNull()
                     it.specimenCollectionDateTime = row.getStringOrNull("specimen_collection_date_time").let { dt ->
                         if (!dt.isNullOrEmpty()) {

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -1463,7 +1463,7 @@ class Report : Logging {
          * Tries to get a value in the underlying row for the column name, and if it doesn't exist, returns null
          */
         private fun Row.getStringOrNull(columnName: String): String? {
-            return this.getStringOrDefault(columnName, null)
+            return this.getStringOrDefault(columnName, null).trimToNull()
         }
     }
 }

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -1088,8 +1088,10 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.reportIndex = td.reportIndex
                             record.sendingApplicationId = td.sendingApplicationId?.take(METADATA_MAX_LENGTH)
                             record.sendingApplicationName = td.sendingApplicationName?.take(METADATA_MAX_LENGTH)
+                            // ordering provider info
                             record.orderingProviderName =
                                 td.orderingProviderName?.take(METADATA_MAX_LENGTH)
+                            record.orderingProviderCity = td.orderingProviderCity?.take(METADATA_MAX_LENGTH)
                             record.orderingProviderCounty =
                                 td.orderingProviderCounty?.take(METADATA_MAX_LENGTH)
                             record.orderingProviderId =
@@ -1097,6 +1099,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.orderingProviderPostalCode = td.orderingProviderPostalCode
                             record.orderingProviderState =
                                 td.orderingProviderState?.take(METADATA_MAX_LENGTH)
+                            // ordering facility info
                             record.orderingFacilityCity =
                                 td.orderingFacilityCity?.take(METADATA_MAX_LENGTH)
                             record.orderingFacilityCounty =
@@ -1107,17 +1110,24 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.orderingFacilityPostalCode = td.orderingFacilityPostalCode
                             record.orderingFacilityState =
                                 td.orderingFacilityState?.take(METADATA_MAX_LENGTH)
-                            record.orderingFacilityCity = td.orderingFacilityCity?.take(METADATA_MAX_LENGTH)
+                            // organization name
                             record.organizationName =
                                 td.organizationName?.take(METADATA_MAX_LENGTH)
-                            record.testResult = td.testResult?.take(METADATA_MAX_LENGTH)
-                            record.testResultCode = td.testResultCode
+                            // test data
                             record.equipmentModel = td.equipmentModel?.take(METADATA_MAX_LENGTH)
+                            // specimen info
                             record.specimenCollectionDateTime = td.specimenCollectionDateTime
                             record.specimenReceivedDateTime = td.specimenReceivedDateTime
                             record.specimenCollectionMethod = td.specimenCollectionMethod
+                            record.specimenCollectionMethodCode = td.specimenCollectionMethodCode
                             record.specimenCollectionSite = td.specimenCollectionSite
+                            record.specimenCollectionSiteCode = td.specimenCollectionSiteCode
                             record.specimenSourceSite = td.specimenSourceSite
+                            record.specimenSourceSiteCode = td.specimenSourceSiteCode
+                            record.specimenType = td.specimenType
+                            record.specimenTypeCode = td.specimenTypeCode
+                            record.specimenTypeNormalized = td.specimenTypeNormalized
+                            // testing facility info
                             record.testingFacilityCity = td.testingFacilityCity?.take(METADATA_MAX_LENGTH)
                             record.testingFacilityId = td.testingFacilityId
                             record.testingFacilityCounty =
@@ -1126,6 +1136,7 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.testingFacilityPostalCode = td.testingFacilityPostalCode
                             record.testingFacilityState =
                                 td.testingFacilityState?.take(METADATA_MAX_LENGTH)
+                            // patient info
                             record.patientAge = td.patientAge
                             record.patientCounty = td.patientCounty?.take(METADATA_MAX_LENGTH)
                             record.patientCountry = td.patientCountry?.take(METADATA_MAX_LENGTH)
@@ -1136,6 +1147,8 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.patientPostalCode = td.patientPostalCode
                             record.patientRace = td.patientRace
                             record.patientRaceCode = td.patientRaceCode
+                            record.patientSpecies = td.patientSpecies
+                            record.patientSpeciesCode = td.patientSpeciesCode
                             record.patientState = td.patientState?.take(METADATA_MAX_LENGTH)
                             record.patientTribalCitizenship = td.patientTribalCitizenship?.take(METADATA_MAX_LENGTH)
                             record.patientTribalCitizenshipCode =
@@ -1143,16 +1156,25 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
                             record.patientPreferredLanguage = td.patientPreferredLanguage?.take(METADATA_MAX_LENGTH)
                             record.patientNationality = td.patientNationality?.take(METADATA_MAX_LENGTH)
                             record.reasonForStudy = td.reasonForStudy?.take(METADATA_MAX_LENGTH)
+                            // more test info
                             record.reasonForStudyCode = td.reasonForStudyCode?.take(METADATA_MAX_LENGTH)
                             record.siteOfCare = td.siteOfCare?.take(METADATA_MAX_LENGTH)
                             record.senderId = td.senderId?.take(METADATA_MAX_LENGTH)
                             record.testKitNameId = td.testKitNameId?.take(METADATA_MAX_LENGTH)
+                            // test performed
                             record.testPerformedCode = td.testPerformedCode?.take(METADATA_MAX_LENGTH)
                             record.testPerformed = td.testPerformed?.take(METADATA_MAX_LENGTH)
+                            record.testPerformedNormalized = td.testPerformedNormalized?.take(METADATA_MAX_LENGTH)
+                            record.testPerformedLongName = td.testPerformedLongName?.take(METADATA_MAX_LENGTH)
+                            // test ordered
                             record.testOrdered = td.testOrdered?.take(METADATA_MAX_LENGTH)
                             record.testOrderedCode = td.testOrderedCode?.take(METADATA_MAX_LENGTH)
+                            record.testOrderedNormalized = td.testOrderedNormalized?.take(METADATA_MAX_LENGTH)
+                            record.testOrderedLongName = td.testOrderedLongName?.take(METADATA_MAX_LENGTH)
+                            // test result
                             record.testResult = td.testResult?.take(METADATA_MAX_LENGTH)
                             record.testResultCode = td.testResultCode?.take(METADATA_MAX_LENGTH)
+                            record.testResultNormalized = td.testResultNormalized?.take(METADATA_MAX_LENGTH)
                             record.processingModeCode = td.processingModeCode?.take(METADATA_MAX_LENGTH)
                         }
                     }

--- a/prime-router/src/main/resources/db/migration/V55__add_normalized_code_values_elr_metadata.sql
+++ b/prime-router/src/main/resources/db/migration/V55__add_normalized_code_values_elr_metadata.sql
@@ -1,0 +1,151 @@
+/*
+ * The Flyway tool applies this migration to create the database.
+ *
+ * Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+ * use VARCHAR(63) for names in organization and schema
+ *
+ * Copy a version of this comment into the next migration
+ *
+ */
+
+/*
+ * V55__add_normalized_code_values_elr_metadata
+ *
+ * Adds a set of "normalized" columns to the ELR metadata table so we can preserve both the raw text that
+ * labs send us for tests, and then map to the preferred SNOMED/LOINC values
+ */
+ALTER TABLE elr_result_metadata ADD test_result_normalized VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD test_ordered_normalized VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD test_ordered_long_name VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD test_performed_normalized VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD test_performed_long_name VARCHAR(512);
+
+-- add an expanded set of specimen-related fields
+ALTER TABLE elr_result_metadata ADD specimen_source_site_code VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD specimen_type_normalized VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD specimen_type_code VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD specimen_collection_method_code VARCHAR(512);
+
+ALTER TABLE elr_result_metadata ADD specimen_collection_site_code VARCHAR(512);
+
+
+-- we will now swap values for the test result fields
+UPDATE
+    elr_result_metadata
+SET
+    test_result_normalized = test_result_code
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    test_result_code = test_result
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    test_result = test_result_normalized
+;
+
+-- now we fill in the normalized values
+-- we are intentionally leaving the normalized field null if it doesn't match
+-- if we can't map it, it's not able to be normalized
+UPDATE
+    elr_result_metadata
+SET
+    test_result_normalized = CASE test_result_code
+        WHEN '260373001'    THEN 'Detected'
+        WHEN '419984006'    THEN 'Inconclusive'
+        WHEN '42425007'     THEN 'Equivocal'
+        WHEN '260415000'    THEN 'Not detected'
+        WHEN '373121007'    THEN 'Test not done'
+    END
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    specimen_type_normalized = CASE specimen_type_code
+        WHEN '435541000124108'      THEN 'Scab specimen (crust)'
+        WHEN '472862007'            THEN 'Swab from lesion of skin'
+        WHEN '16210971000119108'    THEN 'Swab from lesion'
+        WHEN '418932006'            THEN 'Oral swab'
+        WHEN '258528007'            THEN 'Rectal swab'
+    END
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    test_ordered_normalized = case test_ordered_code
+        WHEN '41853-3' THEN 'Orthopoxvirus'
+        WHEN '100434-0' THEN 'Non-variola Orthopoxvirus'
+        WHEN '100383-9' THEN 'Monkeypox Virus'
+        WHEN '100888-7' THEN 'West African Monkeypox Virus'
+        WHEN '100889-5' THEN 'Congo Basin Monkeypox Virus'
+        WHEN '100885-3' THEN 'Parapoxvirus'
+        WHEN '100886-1' THEN 'Orf Virus'
+        WHEN '100887-9' THEN 'Pseudocowpox Virus'
+        WHEN '100891-1' THEN 'Orthopoxvirus IgG'
+        WHEN '100892-9' THEN 'Orthopoxvirus IgM'
+    END
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    test_ordered_long_name = case test_ordered_code
+        WHEN '41853-3' THEN 'Orthopoxvirus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100434-0' THEN 'Orthopoxvirus non-variola DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100383-9' THEN 'Monkeypox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100888-7' THEN 'West African monkeypox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100889-5' THEN 'Congo Basin monkeypox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100885-3' THEN 'Parapoxvirus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100886-1' THEN 'Orf virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100887-9' THEN 'Pseudocowpox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100891-1' THEN 'Orthopoxvirus IgG Ab [Presence] in Serum or Plasma by Immunoassay'
+        WHEN '100892-9' THEN 'Orthopoxvirus IgM Ab [Presence] in Serum or Plasma by Immunoassay'
+END
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    test_performed_normalized = case test_performed_code
+        WHEN '41853-3' THEN 'Orthopoxvirus'
+        WHEN '100434-0' THEN 'Non-variola Orthopoxvirus'
+        WHEN '100383-9' THEN 'Monkeypox Virus'
+        WHEN '100888-7' THEN 'West African Monkeypox Virus'
+        WHEN '100889-5' THEN 'Congo Basin Monkeypox Virus'
+        WHEN '100885-3' THEN 'Parapoxvirus'
+        WHEN '100886-1' THEN 'Orf Virus'
+        WHEN '100887-9' THEN 'Pseudocowpox Virus'
+        WHEN '100891-1' THEN 'Orthopoxvirus IgG'
+        WHEN '100892-9' THEN 'Orthopoxvirus IgM'
+    END
+;
+
+UPDATE
+    elr_result_metadata
+SET
+    test_performed_long_name = case test_performed_code
+        WHEN '41853-3' THEN 'Orthopoxvirus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100434-0' THEN 'Orthopoxvirus non-variola DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100383-9' THEN 'Monkeypox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100888-7' THEN 'West African monkeypox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100889-5' THEN 'Congo Basin monkeypox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100885-3' THEN 'Parapoxvirus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100886-1' THEN 'Orf virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100887-9' THEN 'Pseudocowpox virus DNA [Presence] in Specimen by NAA with probe detection'
+        WHEN '100891-1' THEN 'Orthopoxvirus IgG Ab [Presence] in Serum or Plasma by Immunoassay'
+        WHEN '100892-9' THEN 'Orthopoxvirus IgM Ab [Presence] in Serum or Plasma by Immunoassay'
+    END
+;


### PR DESCRIPTION
This PR adds additional metadata columns for ELR and fixes bug with test performed fields. In specific we are looking to normalize some fields that are coming in with different values from the senders. For example, the test result text field (`OBX-5-2`) has different values per sender, even if they're using the correct code value in `OBX-5-1`. This causes some challenges and discrepancies in reading the data. To that end I've added in a column that normalizes the sender's value to the preferred values for the SNOMED code.

This has also been done for ordered test and performed test data, and I've added a column to collect the long name for the test based on the test code being used.

It also adds the specimen type code, specimen source site code, specimen collection method code, and specimen collection site code to the metadata table so we can group by those values.

It makes some minor convention changes for null-ing out empty fields, updates some of the normalized fields I've added so historical data is filled in, and corrects a bug where the test result and test result code fields were swapped.

Test Steps:
1. Build your local container, and make sure that the V55 script has run against your DB AND jooq has rebuilt. You may need to issue a `gradlew clean` if you encounter errors.
2. Run the application
3. Submit the attached test file to your local instance `curl -X POST -H 'client: mayo-clinic' -H 'Content-Type: application/hl7-v2' --data-binary @"<PATH TO FILE>" "$LOCAL_PRIME/reports"`
4. Once it has completed submission review the contents the `elr_result_metadata` table in your local DB and verify that the results you see in the table match the attached file.

## Changes
- Added new flyway script for migration
- Added new valuesets to use for normalization when saving the metadata
- Wired in the additional fields being added to the `elr_result_metadata` table
- Updated the schemas to normalize some fields (adding code vs name to some fields for clarity)
- Added `trimToNull` call on the `getStringOrNull` method to enforce nullity for empty string values in the DB
- Generated documentation

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Attachments
[monkeypox-e0386067-6d1e-4d6a-b210-c9a4f5862f29-20220720190541.hl7.txt](https://github.com/CDCgov/prime-reportstream/files/9304265/monkeypox-e0386067-6d1e-4d6a-b210-c9a4f5862f29-20220720190541.hl7.txt)

