### PR TITLE
FHIR to HL7 library allows use of primitives in resource schema property

### DIFF
--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -22,7 +22,6 @@ import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Reference
-import org.hl7.fhir.r4.model.Resource
 import org.hl7.fhir.r4.utils.FHIRLexer.FHIRLexerException
 
 /**
@@ -236,21 +235,14 @@ class FhirPathCommand : CliktCommand(
             val resourceList = FhirPathUtils.pathEngine.evaluate(
                 fhirPathContext, focusResource!!, bundle, bundle, pathExpression
             )
-            when {
-                resourceList.size != 1 ->
-                    echo("Resource path must evaluate to 1 resource, but got ${resourceList.size}")
-
-                resourceList[0].isResource -> {
-                    setFocusPath(path)
-                    focusResource = resourceList[0] as Resource
-                }
-
-                else ->
-                    echo(
-                        "Resource path must evaluate to a Resource, but was " +
-                            resourceList[0].fhirType()
-                    )
-            }
+            if (resourceList.size == 1) {
+                setFocusPath(path)
+                focusResource = resourceList[0] as Base
+            } else
+                echo(
+                    "Resource path must evaluate to 1 resource, but got a collection of " +
+                        "${resourceList.size} resources"
+                )
         }
     }
 

--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/FhirToHl7Converter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/FhirToHl7Converter.kt
@@ -162,11 +162,6 @@ class FhirToHl7Converter(
             evaluatedResource
         }
 
-        // This must be resources
-        resourceList.forEach {
-            if (it.isPrimitive)
-                throw SchemaException("Invalid FHIR path ${element.resource}: must evaluate to a FHIR resource.")
-        }
         return resourceList
     }
 

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/FhirToHl7ConverterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/FhirToHl7ConverterTests.kt
@@ -127,14 +127,17 @@ class FhirToHl7ConverterTests {
         assertThat(focusResources).isEmpty()
 
         element = ConfigSchemaElement("name", resource = "1")
-        assertThat { converter.getFocusResources(element, bundle, customContext) }.isFailure()
-            .hasClass(SchemaException::class.java)
+        focusResources = converter.getFocusResources(element, bundle, customContext)
+        assertThat(focusResources).isNotEmpty()
+        assertThat(focusResources[0].isPrimitive).isTrue()
+        assertThat(focusResources[0].primitiveValue()).isEqualTo("1")
 
         element = ConfigSchemaElement(
             "name", resource = "Bundle.entry.resource.ofType(MessageHeader).destination[0].name"
         )
-        assertThat { converter.getFocusResources(element, bundle, customContext) }.isFailure()
-            .hasClass(SchemaException::class.java)
+        focusResources = converter.getFocusResources(element, bundle, customContext)
+        assertThat(focusResources).isNotEmpty()
+        assertThat(focusResources[0].isEmpty).isFalse()
 
         // Let's test how the FHIR library handles the focus resource
         element = ConfigSchemaElement(


### PR DESCRIPTION
This PR allows the FHIR to HL7 library to use primitives in resource schema properties.

Test Steps:
1. Check out this branch.
2. Start the FHIR Path tool.  E.g. `./prime fhirpath -i src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.fhir`
3. Set the resource to a primitive value (e.g. `resource = Bundle.id`)
4. Verify that just typing `%resource` returns the proper value for the resource.
5. Run the FHIR to HL7 conversion to verify that the conversion still works.  E.g., `./prime fhirdata --input-file src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.fhir -s metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml`

## Changes
- FHIR to HL7 library allows use of primitives in resource schema property
- FHIR path CLI tool uses the same rule

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- N/A

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to
