### PR TITLE
fix trigger for legacy sftp check

### DIFF
--- a/.github/workflows/validate_resources.yml
+++ b/.github/workflows/validate_resources.yml
@@ -69,7 +69,7 @@ jobs:
             az container restart --name pdh${{ needs.pre_job.outputs.env_name }}-dns 
             -g prime-data-hub-${{ needs.pre_job.outputs.env_name }}
       - name: Restart legacy SFTP if wrong ip
-        if: ${{ needs.pre_job.outputs.env_name }} != 'prod'
+        if: needs.pre_job.outputs.env_name != 'prod'
         uses: nick-fields/retry@b4fa57557dda8c2f30bcb2d19372cc3237190f7f
         with:
           timeout_seconds: 60


### PR DESCRIPTION
This PR fixes the condition check to make sure the legacy sftp check occurs only for non-prod environments.

Test Steps:
1. Fix legacy sftp check conditional

## Linked Issues
- Fixes #6380 
