### PR TITLE
Add PRIME CLI to getting started doc

### DIFF
--- a/prime-router/docs/getting-started/getting-started.md
+++ b/prime-router/docs/getting-started/getting-started.md
@@ -243,13 +243,55 @@ If your agency's network intercepts SSL requests, you might have to disable SSL 
 
 ## Running ReportStream locally
 
-The project's [README](../../README.md) file contains some steps on how to use the PRIME router in a CLI. However, most uses of the PRIME router will be in the Microsoft Azure cloud. The router runs as a container in Azure. The [`DockerFile`](../../Dockerfile) describes what goes in this container.
+Most uses of the PRIME router will be in the Microsoft Azure cloud. The router runs as a container in Azure. The [`DockerFile`](../../Dockerfile) describes what goes in this container.
 
 Developers can also run the router locally with the same Azure runtime and libraries to help develop and debug in an environment that mimics the Azure environment as closely as we can on your local machine. In this case, a developer can use a local Azure storage emulator, called Azurite.
 
 We use docker-compose' to orchestrate running the Azure function(s) code and Azurite. See sections "[Running ReportStream](#running-reportstream)" for more information on building and bringing your environment up.
 
 If you see any SSL errors during this step, follow the directions in [Getting Around SSL Errors](#getting-around-ssl-errors).
+
+# How to use the CLI
+
+The PRIME command line interface allows you to interact with certain parts of report stream functionality without using the API or running all of ReportStream.  A common use case for the CLI is testing while developing mappers for the new FHIR pipeline.
+
+The primary way to access the cli is through the gradle command (although a deprecated bash script exists as well). If you are an IntelliJ user, you can set up the gradle command to be run through your IDE and be run in debug mode to step through your code line by line.
+```bash
+cd ./prime-router
+# Prints out all the available commands
+./gradlew primeCLI
+#  data                      process data
+#  list                      list known schemas, senders, and receivers
+#  livd-table-download       It downloads the latest LOINC test data, extract
+#                            Lookup Table, and the database as a new version.
+#  generate-docs             generate documentation for schemas
+#  create-credential         create credential JSON or persist to store
+#  compare                   compares two CSV files so you can view the
+#                            differences within them
+#  test                      Run tests of the Router functions
+#  login                     Login to the HHS-PRIME authorization service
+#  logout                    Logout of the HHS-PRIME authorization service
+#  organization              Fetch and update settings for an organization
+#  sender                    Fetch and update settings for a sender
+#  receiver                  Fetch and update settings for a receiver
+#  multiple-settings         Fetch and update multiple settings
+#  lookuptables              Manage lookup tables
+#  convert-file
+#  sender-files              For a specified report, trace each item's ancestry
+#                            and retrieve the source files submitted by
+#                            senders.
+#  fhirdata                  Process data into/from FHIR
+#  fhirpath                  Input FHIR paths to be resolved using the input
+#                            FHIR bundle
+#  convert-valuesets-to-csv  This is a development tool that converts
+#                            sender-automation.valuesets to two CSV files
+
+# Converts HL7 to FHIR (IN DEV MODE)
+./gradlew primeCLI --args='fhirdata --input-file "src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.hl7"'
+
+# Converts the FHIR file to HL7 using the provided schema (IN DEV MODE)
+./gradlew primeCLI --args='fhirdata --input-file "src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.fhir" -s metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml'
+```
 
 # Credentials and secrets vault
 

--- a/prime-router/docs/getting-started/getting-started.md
+++ b/prime-router/docs/getting-started/getting-started.md
@@ -21,6 +21,7 @@ This document will walk you through the setup instructions to get a functioning 
     * [Getting around SSL errors](#getting-around-ssl-errors)
 - [Function development with docker-compose](#function-development-with-docker-compose)
     * [Running ReportStream locally](#running-reportstream-locally)
+- [How to use the CLI](#how-to-use-the-cli)
 - [Credentials and secrets vault](#credentials-and-secrets-vault)
     * [Initializing the vault](#initializing-the-vault)
     * [Re-initializing the vault](#re-initializing-the-vault)


### PR DESCRIPTION
This PR ...
Adds a section explaining how to use the prime CLI and the example use case of the HL7 -> FHIR data command.
It also removes the misleading sentence about documentation existing for the CLI in the README.

### Testing
- This is a documentation change and needs to be read for clarity of communication. No unit tests needed