### PR TITLE
Experience/6392 react query mutate value sets

### DIFF
--- a/frontend-react/src/__mocks__/LookupTableMockServer.ts
+++ b/frontend-react/src/__mocks__/LookupTableMockServer.ts
@@ -5,6 +5,7 @@ import {
     lookupTableApi,
     LookupTable,
     ApiValueSet,
+    LookupTables,
 } from "../network/api/LookupTableApi";
 
 const tableList = lookupTableApi.getTableList();
@@ -15,6 +16,14 @@ const tableData = lookupTableApi.getTableData<LookupTable>(
 const tableDataAlternate = lookupTableApi.getTableData<LookupTable>(
     3,
     "sender_automation_value_set"
+);
+const updateTableData = lookupTableApi.saveTableData(
+    LookupTables.VALUE_SET_ROW
+);
+
+const activateTableData = lookupTableApi.activateTableData(
+    1,
+    LookupTables.VALUE_SET_ROW
 );
 
 const lookupTables: LookupTable[] = [1, 2, 3].map((i) => ({
@@ -45,6 +54,12 @@ const handlers = [
     }),
     rest.get(tableDataAlternate.url, (_req, res, ctx) => {
         return res(ctx.json(lookupTableData), ctx.status(200));
+    }),
+    rest.post(updateTableData.url, (_req, res, ctx) => {
+        return res(ctx.json(lookupTables[1]), ctx.status(200));
+    }),
+    rest.put(activateTableData.url, (_req, res, ctx) => {
+        return res(ctx.json(lookupTables[1]), ctx.status(200));
     }),
 ];
 

--- a/frontend-react/src/hooks/UseValueSets.test.ts
+++ b/frontend-react/src/hooks/UseValueSets.test.ts
@@ -18,15 +18,28 @@ import {
 } from "./UseValueSets";
 
 describe("useValueSetsTable", () => {
+    const renderWithQueryWrapper = (
+        tableName: LookupTables,
+        version?: number
+    ) =>
+        renderHook(() => useValueSetsTable<ValueSet>(tableName, version), {
+            wrapper: QueryWrapper(
+                new QueryClient({
+                    // to allow for faster testable failures
+                    defaultOptions: { queries: { retry: false } },
+                })
+            ),
+        });
+
     beforeAll(() => lookupTableServer.listen());
     afterEach(() => lookupTableServer.resetHandlers());
     afterAll(() => lookupTableServer.close());
 
     test("returns expected values when fetching table version", async () => {
-        const { result, waitFor } = renderHook(
-            () => useValueSetsTable<ValueSet>(LookupTables.VALUE_SET),
-            { wrapper: QueryWrapper() }
+        const { result, waitFor } = renderWithQueryWrapper(
+            LookupTables.VALUE_SET
         );
+
         await waitFor(() => !!result.current.valueSetArray.length);
         const { name, system, createdAt, createdBy } =
             result.current.valueSetArray[0];
@@ -37,9 +50,9 @@ describe("useValueSetsTable", () => {
     });
 
     test("returns expected values when using supplied table version", async () => {
-        const { result, waitFor } = renderHook(
-            () => useValueSetsTable<ValueSet>(LookupTables.VALUE_SET, 3),
-            { wrapper: QueryWrapper() }
+        const { result, waitFor } = renderWithQueryWrapper(
+            LookupTables.VALUE_SET,
+            3
         );
         await waitFor(() => !!result.current.valueSetArray.length);
         const { name, system, createdAt, createdBy } =
@@ -51,9 +64,8 @@ describe("useValueSetsTable", () => {
     });
 
     test("returns error when the passed table name doesn't exist in returned list of tables", async () => {
-        const { result, waitFor } = renderHook(
-            () => useValueSetsTable(LookupTables.VALUE_SET_ROW),
-            { wrapper: QueryWrapper() }
+        const { result, waitFor } = renderWithQueryWrapper(
+            LookupTables.VALUE_SET_ROW
         );
         await waitFor(() => !!result.current.error);
         expect(result.current.error.message).toEqual(
@@ -67,15 +79,8 @@ describe("useValueSetsTable", () => {
                 return res.once(ctx.json([]), ctx.status(400));
             })
         );
-        const { result, waitForNextUpdate } = renderHook(
-            () => useValueSetsTable(LookupTables.VALUE_SET),
-            {
-                wrapper: QueryWrapper(
-                    new QueryClient({
-                        defaultOptions: { queries: { retry: false } },
-                    })
-                ),
-            }
+        const { result, waitForNextUpdate } = renderWithQueryWrapper(
+            LookupTables.VALUE_SET
         );
         await waitForNextUpdate();
         expect(result.current.error.message).toEqual(
@@ -95,15 +100,8 @@ describe("useValueSetsTable", () => {
                 }
             )
         );
-        const { result, waitFor } = renderHook(
-            () => useValueSetsTable(LookupTables.VALUE_SET),
-            {
-                wrapper: QueryWrapper(
-                    new QueryClient({
-                        defaultOptions: { queries: { retry: false } },
-                    })
-                ),
-            }
+        const { result, waitFor } = renderWithQueryWrapper(
+            LookupTables.VALUE_SET
         );
         await waitFor(() => result.current.error);
         expect(result.current.error.message).toEqual(
@@ -124,10 +122,13 @@ describe("useValueSetUpdate", () => {
     afterEach(() => lookupTableServer.resetHandlers());
     afterAll(() => lookupTableServer.close());
 
-    test("returns trigger, loading indicator and error", async () => {
-        const { result } = renderHook(useValueSetUpdate, {
+    const renderWithQueryWrapper = () =>
+        renderHook(() => useValueSetUpdate(), {
             wrapper: QueryWrapper(),
         });
+
+    test("returns trigger, loading indicator and error", async () => {
+        const { result } = renderWithQueryWrapper();
         const { saveData, saveError, isSaving } = result.current;
         expect(saveError).toEqual(null);
         expect(isSaving).toEqual(false);
@@ -135,9 +136,7 @@ describe("useValueSetUpdate", () => {
     });
 
     test("mutation trigger returns expected values and tracks loading state", async () => {
-        const { result, waitForNextUpdate } = renderHook(useValueSetUpdate, {
-            wrapper: QueryWrapper(),
-        });
+        const { result, waitForNextUpdate } = renderWithQueryWrapper();
         const { saveData, isSaving } = result.current;
         expect(isSaving).toEqual(false);
 
@@ -178,10 +177,13 @@ describe("useValueSetActivation", () => {
     afterEach(() => lookupTableServer.resetHandlers());
     afterAll(() => lookupTableServer.close());
 
-    test("returns trigger, loading indicator and error", async () => {
-        const { result } = renderHook(useValueSetActivation, {
+    const renderWithQueryWrapper = () =>
+        renderHook(() => useValueSetActivation(), {
             wrapper: QueryWrapper(),
         });
+
+    test("returns trigger, loading indicator and error", async () => {
+        const { result } = renderWithQueryWrapper();
         const { activateTable, activationError, isActivating } = result.current;
         expect(activationError).toEqual(null);
         expect(isActivating).toEqual(false);
@@ -189,12 +191,7 @@ describe("useValueSetActivation", () => {
     });
 
     test("mutation trigger returns expected values and tracks loading state", async () => {
-        const { result, waitForNextUpdate } = renderHook(
-            useValueSetActivation,
-            {
-                wrapper: QueryWrapper(),
-            }
-        );
+        const { result, waitForNextUpdate } = renderWithQueryWrapper();
         const { activateTable, isActivating } = result.current;
         expect(isActivating).toEqual(false);
 

--- a/frontend-react/src/hooks/UseValueSets.ts
+++ b/frontend-react/src/hooks/UseValueSets.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 
 import {
     LookupTable,
@@ -47,6 +47,31 @@ const getLatestData = <T>(tableName: LookupTables, version: number) => {
 // returns a list of all lookup tables to be filtered
 const getLookupTables = () =>
     axios(lookupTableApi.getTableList()).then(({ data }) => data);
+
+const endpointHeaderUpdate = lookupTableApi.saveTableData(
+    LookupTables.VALUE_SET_ROW
+);
+
+const updateValueSet = (data: ValueSetRow[]) =>
+    axios
+        .post(endpointHeaderUpdate.url, data, endpointHeaderUpdate)
+        .then(({ data }) => data);
+
+const activateValueSet = (tableVersion: number) => {
+    const endpointHeaderActivate = lookupTableApi.activateTableData(
+        tableVersion,
+        LookupTables.VALUE_SET_ROW
+    );
+
+    return axios
+        .put(
+            endpointHeaderActivate.url,
+            LookupTables.VALUE_SET_ROW,
+            endpointHeaderActivate
+        )
+        .then(({ data }) => data)
+        .catch((e) => console.error("***", e));
+};
 
 /*
 
@@ -142,4 +167,31 @@ export const useValueSetsTable = <T extends ValueSet | ValueSetRow>(
         : [];
 
     return { error, valueSetArray };
+};
+
+/* 
+
+  Mutation Hooks
+
+  */
+export const useValueSetUpdate = () => {
+    // generic signature is defined here https://github.com/TanStack/query/blob/4690b585722d2b71d9b87a81cb139062d3e05c9c/packages/react-query/src/useMutation.ts#L66
+    // <type of data returned, type of error returned, type of variables passed to mutate fn, type of context (?)>
+    const mutation = useMutation<LookupTable, Error, ValueSetRow[]>(
+        updateValueSet
+    );
+    return {
+        saveData: mutation.mutateAsync,
+        isSaving: mutation.isLoading,
+        saveError: mutation.error,
+    };
+};
+
+export const useValueSetActivation = () => {
+    const mutation = useMutation<LookupTable, Error, number>(activateValueSet);
+    return {
+        activateTable: mutation.mutateAsync,
+        isActivating: mutation.isLoading,
+        activationError: mutation.error,
+    };
 };


### PR DESCRIPTION
depends on https://github.com/CDCgov/prime-reportstream/pull/6476

part two of the react query refactor work.

This one introduces react query based mutation hooks to handle value sets updates


## Test Steps:

see https://github.com/CDCgov/prime-reportstream/pull/6476


### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?
