### PR TITLE
Adds NY to the "where we're live" map and list

### DIFF
--- a/frontend-react/src/content/live.json
+++ b/frontend-react/src/content/live.json
@@ -90,6 +90,10 @@
     },
     {
       "status": "Live",
+      "state": "New York"
+    },
+    {
+      "status": "Live",
       "state": "North Dakota"
     },
     {

--- a/frontend-react/src/content/usa_w_territories.svg
+++ b/frontend-react/src/content/usa_w_territories.svg
@@ -47,7 +47,7 @@
     .nj, /* New Jersey */
     .nm, /* New Mexico */
     .nv, /* Nevada */
-    /* .ny, New York */
+    .ny, /* New York */
     .oh, /* Ohio */
     /* .ok, Oklahoma */
     .or, /* Oregon */


### PR DESCRIPTION
This PR adds New York to the "where we're live" map and list

## Changes
<img width="638" alt="Screen Shot 2022-09-09 at 11 05 30 AM" src="https://user-images.githubusercontent.com/640182/189382672-be18bfac-3cf2-4c9c-a39e-02e1b24fe568.png">
<img width="510" alt="Screen Shot 2022-09-09 at 11 05 45 AM" src="https://user-images.githubusercontent.com/640182/189382681-724e35b9-d05e-420d-a85d-aed37e324fba.png">


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?
