### PR TITLE
Fetch Refactor: New RSErrorBoundary and RSNetworkError

### DIFF
--- a/frontend-react/docs/rs-error-boundary-and-suspense.md
+++ b/frontend-react/docs/rs-error-boundary-and-suspense.md
@@ -7,7 +7,7 @@ The system is simple: we throw errors from anywhere in our app, and the first bo
 Steps to use:
 
 - [Wrap your components](#helper-functions)
-- Call the network (this will activate the suspense)
+- Make a network request (this will activate the suspense)
 - Throw an error if your call fails (handled by our fetch system)
 
 ## Helper functions

--- a/frontend-react/docs/rs-error-boundary-and-suspense.md
+++ b/frontend-react/docs/rs-error-boundary-and-suspense.md
@@ -14,13 +14,13 @@ Steps to use:
 
 To begin using the error boundary, you can wrap components in your jsx using the included helper functions:
 
-- `withThrowableError`: Wraps your component with boundary
-- `withSuspense`: Wraps your component with a suspense that renders a spinner until fetch called inside the component has returned
-- `withNetworkCall`: Wraps your component with boundary and suspense
+- `withCatch`: Wraps your component with `RSErrorBoundary` to catch errors at that level of the DOM
+- `withSuspense`: Wraps your component with `Suspense`, providing a spinner UI while data further down the DOM fetches
+- `withCatchAndSuspense`: Wraps with both wrappers at the same level of the DOM
 
 ```typescript jsx
-import {withNetworkCall} from "./RSErrorBoundary";
-const MyComponent = () => withNetworkCall(<MyComponentContent/>);
+import {withCatchAndSuspense} from "./RSErrorBoundary";
+const MyComponent = () => withCatchAndSuspense(<MyComponentContent/>);
 // OR
 const App = () => {
     return (
@@ -31,7 +31,7 @@ const App = () => {
                 </title>
             </Helmet>
             <section className="grid-container">
-                {withNetworkCall(<MyComponentContent />)}
+                {withCatchAndSuspense(<MyComponentContent />)}
             </section>
         </>
     );
@@ -60,7 +60,3 @@ export class RSMyNewError extends Error {
     }
 }
 ```
-
-### Add a new `ErrorName` value(s) to enum
-
-The `ErrorName` enum drives the error page rendering system. Every code can be linked to one or two UIs: a page and message (banner). You can find this enum in the `RSNetworkError.ts` file.

--- a/frontend-react/docs/rs-error-boundary-and-suspense.md
+++ b/frontend-react/docs/rs-error-boundary-and-suspense.md
@@ -42,8 +42,7 @@ const App = () => {
 
 Custom error types help us name and display errors according to members not present on a default `Error`. Currently, there are two extensions:
 
-- `code` will take an `ErrorName` enum value to identify the specific error type when it gets to the error boundary
-- `displayAsPage` (default: `false`) will tell the boundary if this error should display as a non-intrusive message banner or replace the entire page with an error ui
+- `name` will take an `ErrorName` enum value to identify the specific error type when it gets to the error boundary
 
 #### Boilerplate
 

--- a/frontend-react/docs/rs-error-boundary-and-suspense.md
+++ b/frontend-react/docs/rs-error-boundary-and-suspense.md
@@ -1,0 +1,67 @@
+                                                                                                                                                                                             How to use `<RSErrorBoundary>` && `<Suspense>` with React components
+
+The boundary/suspense pattern helps alleviate error and loading state management from every component into two easily-managed components that wrap your page or component. First in the tree, you'll have an `ErrorBoundary` to catch any errors thrown and render a UI for the user, then, nested below that, a `Suspense` to handle the UI while the data is fetched.
+
+The system is simple: we throw errors from anywhere in our app, and the first boundary on the way up the tree will catch and render it. This functionality has been extended by adding `RSNetworkError` and some custom logic that lets us render _different_ UIs depending on an error's status code.
+
+Steps to use:
+
+- [Wrap your components](#helper-functions)
+- Call the network (this will activate the suspense)
+- Throw an error if your call fails (handled by our fetch system)
+
+## Helper functions
+
+To begin using the error boundary, you can wrap components in your jsx using the included helper functions:
+
+- `withThrowableError`: Wraps your component with boundary
+- `withSuspense`: Wraps your component with a suspense that renders a spinner until fetch called inside the component has returned
+- `withNetworkCall`: Wraps your component with boundary and suspense
+
+```typescript jsx
+import {withNetworkCall} from "./RSErrorBoundary";
+const MyComponent = () => withNetworkCall(<MyComponentContent/>);
+// OR
+const App = () => {
+    return (
+        <>
+            <Helmet>
+                <title>
+                    Sample | {process.env.REACT_APP_TITLE}
+                </title>
+            </Helmet>
+            <section className="grid-container">
+                {withNetworkCall(<MyComponentContent />)}
+            </section>
+        </>
+    );
+};
+```
+
+## Add a custom error type
+
+Custom error types help us name and display errors according to members not present on a default `Error`. Currently, there are two extensions:
+
+- `code` will take an `ErrorName` enum value to identify the specific error type when it gets to the error boundary
+- `displayAsPage` (default: `false`) will tell the boundary if this error should display as a non-intrusive message banner or replace the entire page with an error ui
+
+#### Boilerplate
+
+```typescript
+/** Throw from any failing network calls, and pass in the status code to
+ * match it with the right display */
+export class RSMyNewError extends Error {
+    /* Used for identifying unique content to display for error */
+    name: ErrorName;
+    /* Build a new RSMyNewError */
+    constructor(message: string, code: ErrorName, displayAsPage?: boolean) {
+        super(message); // Sets message
+        this.name = name;
+        Object.setPrototypeOf(this, RSMyNewError.prototype);
+    }
+}
+```
+
+### Add a new `ErrorName` value(s) to enum
+
+The `ErrorName` enum drives the error page rendering system. Every code can be linked to one or two UIs: a page and message (banner). You can find this enum in the `RSNetworkError.ts` file.

--- a/frontend-react/docs/rs-error-boundary-and-suspense.md
+++ b/frontend-react/docs/rs-error-boundary-and-suspense.md
@@ -40,7 +40,7 @@ const App = () => {
 
 ## Add a custom error type
 
-Custom error types help us name and display errors according to members not present on a default `Error`. Currently, there are two extensions:
+Custom error types help us implement ReportStream specific error functionality for different error cases. For example, in the current system, the custom `RSNetworkError` takes a `name` parameter, with values from will the `ErrorName` enum, to identify the specific error type when it gets to the error boundary, and allow the boundary to take specific actions based on the error name.
 
 - `name` will take an `ErrorName` enum value to identify the specific error type when it gets to the error boundary
 

--- a/frontend-react/src/components/RSErrorBoundary.test.tsx
+++ b/frontend-react/src/components/RSErrorBoundary.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 
 import { RSNetworkError } from "../utils/RSNetworkError";
 
-import { withThrowableError } from "./RSErrorBoundary";
+import { withCatch } from "./RSErrorBoundary";
 
 // Dummy components for testing
 const ThrowsRSError = ({ error = true }: { error: boolean }): JSX.Element => {
@@ -20,11 +20,10 @@ const ThrowsGenericError = ({
 const ThrowsNoError = (): JSX.Element => <div>Success!</div>;
 
 // Wrap them with error boundary
-const ThrowsRSErrorWrapped = () =>
-    withThrowableError(<ThrowsRSError error={true} />);
+const ThrowsRSErrorWrapped = () => withCatch(<ThrowsRSError error={true} />);
 const ThrowsGenericErrorWrapped = () =>
-    withThrowableError(<ThrowsGenericError error={true} />);
-const ThrowsNoErrorWrapped = () => withThrowableError(<ThrowsNoError />);
+    withCatch(<ThrowsGenericError error={true} />);
+const ThrowsNoErrorWrapped = () => withCatch(<ThrowsNoError />);
 
 // Silences console.error and console.log of error stack
 jest.spyOn(global.console, "error");

--- a/frontend-react/src/components/RSErrorBoundary.test.tsx
+++ b/frontend-react/src/components/RSErrorBoundary.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+
+import { RSNetworkError } from "../utils/RSNetworkError";
+
+import { withThrowableError } from "./RSErrorBoundary";
+
+// Dummy components for testing
+const ThrowsRSError = ({ error = true }: { error: boolean }): JSX.Element => {
+    if (error) throw new RSNetworkError("");
+    return <></>;
+};
+const ThrowsGenericError = ({
+    error = true,
+}: {
+    error: boolean;
+}): JSX.Element => {
+    if (error) throw Error("");
+    return <></>;
+};
+const ThrowsNoError = (): JSX.Element => <div>Success!</div>;
+
+// Wrap them with error boundary
+const ThrowsRSErrorWrapped = () =>
+    withThrowableError(<ThrowsRSError error={true} />);
+const ThrowsGenericErrorWrapped = () =>
+    withThrowableError(<ThrowsGenericError error={true} />);
+const ThrowsNoErrorWrapped = () => withThrowableError(<ThrowsNoError />);
+
+// Silences console.error and console.log of error stack
+jest.spyOn(global.console, "error");
+jest.spyOn(global.console, "log");
+
+describe("RSErrorBoundary", () => {
+    test("Catches RSError", () => {
+        render(<ThrowsRSErrorWrapped />);
+        expect(screen.getByText("An error has occurred")).toBeInTheDocument();
+    });
+
+    test("Catches legacy errors", () => {
+        render(<ThrowsGenericErrorWrapped />);
+        expect(screen.getByText("An error has occurred")).toBeInTheDocument();
+    });
+
+    test("Renders component when no error", () => {
+        render(<ThrowsNoErrorWrapped />);
+        expect(screen.getByText("Success!")).toBeInTheDocument();
+    });
+});

--- a/frontend-react/src/components/RSErrorBoundary.tsx
+++ b/frontend-react/src/components/RSErrorBoundary.tsx
@@ -65,7 +65,7 @@ export default class RSErrorBoundary extends React.Component<
  *      {withThrowableError(<MyComponent />)}
  *  </div>
  * )*/
-export const withThrowableError = (component: JSX.Element) => (
+export const withCatch = (component: JSX.Element) => (
     <RSErrorBoundary>{component}</RSErrorBoundary>
 );
 /** For wrapping with Suspense when a spinner is required while data loads for a component
@@ -82,7 +82,7 @@ export const withSuspense = (component: JSX.Element) => (
     <Suspense fallback={<Spinner />}>{component}</Suspense>
 );
 /** For wrapping with an RSErrorBoundary and Suspense when making network calls.
- * To use these two wrappers at varying DOM levels, use {@link withThrowableError}
+ * To use these two wrappers at varying DOM levels, use {@link withCatch}
  * and {@link withSuspense}
  * @example
  * // As proxy
@@ -94,6 +94,6 @@ export const withSuspense = (component: JSX.Element) => (
  *  </div>
  * )
  * */
-export const withNetworkCall = (component: JSX.Element) => {
-    return withThrowableError(withSuspense(component));
+export const withCatchAndSuspense = (component: JSX.Element) => {
+    return withCatch(withSuspense(component));
 };

--- a/frontend-react/src/components/RSErrorBoundary.tsx
+++ b/frontend-react/src/components/RSErrorBoundary.tsx
@@ -1,0 +1,103 @@
+import React, { ErrorInfo, ReactNode, Suspense } from "react";
+
+import {
+    ErrorName,
+    isRSNetworkError,
+    RSNetworkError,
+} from "../utils/RSNetworkError";
+import { ErrorPage } from "../pages/error/ErrorPage";
+
+import Spinner from "./Spinner";
+
+interface ErrorBoundaryProps {
+    children?: ReactNode;
+}
+interface ErrorBoundaryState {
+    hasError: boolean;
+    errorName?: ErrorName;
+}
+/** Used to define default state values on render */
+const initState: ErrorBoundaryState = {
+    hasError: false,
+};
+/** Wrap components with this error boundary to catch errors thrown */
+export default class RSErrorBoundary extends React.Component<
+    ErrorBoundaryProps,
+    ErrorBoundaryState
+> {
+    constructor(props: any) {
+        super(props);
+        this.state = initState;
+    }
+    /** Handles parsing error and setting up state accordingly */
+    static getDerivedStateFromError(error: RSNetworkError): ErrorBoundaryState {
+        /* This WILL catch non-RS errors despite our typescript type definition in the method params.
+         * This is a runtime check to help with non RS errors */
+        const notRSError = !isRSNetworkError(error);
+        if (notRSError) {
+            console.warn(
+                "Please work to migrate all non RSError throws to use an RSError object."
+            );
+        }
+        return {
+            hasError: true,
+            errorName: notRSError ? ErrorName.NON_RS_ERROR : error.name,
+        };
+    }
+    /** Any developer logging needed (i.e. log the error in console, push to
+     * analytics, etc.) */
+    componentDidCatch(error: RSNetworkError, errorInfo: ErrorInfo) {
+        console.error(error, errorInfo);
+    }
+    /** Renders the right error page for the right error type, OR the wrapped
+     * component if no error is thrown */
+    render() {
+        if (this.state.hasError) {
+            return <ErrorPage type={"message"} />;
+        }
+        return this.props.children;
+    }
+}
+/** A nice way to keep individual uses of RSErrorBoundary out of jsx since it
+ * does not take props but may live at many levels of the tree.
+ * @example
+ * // As proxy
+ * export const MyWrappedComponent = () = withThrowableError(<MyComponent />)
+ * // or in-line
+ * return (
+ *  <div>
+ *      {withThrowableError(<MyComponent />)}
+ *  </div>
+ * )*/
+export const withThrowableError = (component: JSX.Element) => (
+    <RSErrorBoundary>{component}</RSErrorBoundary>
+);
+/** A nice way to keep individual uses of Suspense out of jsx since it
+ * takes a non-dynamic prop.
+ * @example
+ * // As proxy
+ * export const MyWrappedComponent = () = withSuspense(<MyComponent />)
+ * // or in-line
+ * return (
+ *  <div>
+ *      {withSuspense(<MyComponent />)}
+ *  </div>
+ * )*/
+export const withSuspense = (component: JSX.Element) => (
+    <Suspense fallback={<Spinner />}>{component}</Suspense>
+);
+/** Use in exports and JSX calls to wrap an element in an error boundary and suspense
+ * Convenient for use when whole pages rely on network calls.
+ * @example
+ * // As proxy
+ * export const MyWrappedComponent = () = withNetworkCall(<MyComponent />)
+ * // or in-line
+ * return (
+ *  <div>
+ *      {withNetworkCall(<MyComponent />)}
+ *  </div>
+ * )
+ * */
+export const withNetworkCall = (component: JSX.Element) => {
+    return withThrowableError(withSuspense(component));
+};

--- a/frontend-react/src/components/RSErrorBoundary.tsx
+++ b/frontend-react/src/components/RSErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { ErrorInfo, ReactNode, Suspense } from "react";
+import React, { ErrorInfo, PropsWithChildren, Suspense } from "react";
 
 import {
     ErrorName,
@@ -9,9 +9,6 @@ import { ErrorPage } from "../pages/error/ErrorPage";
 
 import Spinner from "./Spinner";
 
-interface ErrorBoundaryProps {
-    children?: ReactNode;
-}
 interface ErrorBoundaryState {
     hasError: boolean;
     errorName?: ErrorName;
@@ -22,7 +19,7 @@ const initState: ErrorBoundaryState = {
 };
 /** Wrap components with this error boundary to catch errors thrown */
 export default class RSErrorBoundary extends React.Component<
-    ErrorBoundaryProps,
+    PropsWithChildren<{}>,
     ErrorBoundaryState
 > {
     constructor(props: any) {
@@ -58,8 +55,7 @@ export default class RSErrorBoundary extends React.Component<
         return this.props.children;
     }
 }
-/** A nice way to keep individual uses of RSErrorBoundary out of jsx since it
- * does not take props but may live at many levels of the tree.
+/** For wrapping with RSErrorBoundary when a catch is required for a component
  * @example
  * // As proxy
  * export const MyWrappedComponent = () = withThrowableError(<MyComponent />)
@@ -72,8 +68,7 @@ export default class RSErrorBoundary extends React.Component<
 export const withThrowableError = (component: JSX.Element) => (
     <RSErrorBoundary>{component}</RSErrorBoundary>
 );
-/** A nice way to keep individual uses of Suspense out of jsx since it
- * takes a non-dynamic prop.
+/** For wrapping with Suspense when a spinner is required while data loads for a component
  * @example
  * // As proxy
  * export const MyWrappedComponent = () = withSuspense(<MyComponent />)
@@ -86,8 +81,9 @@ export const withThrowableError = (component: JSX.Element) => (
 export const withSuspense = (component: JSX.Element) => (
     <Suspense fallback={<Spinner />}>{component}</Suspense>
 );
-/** Use in exports and JSX calls to wrap an element in an error boundary and suspense
- * Convenient for use when whole pages rely on network calls.
+/** For wrapping with an RSErrorBoundary and Suspense when making network calls.
+ * To use these two wrappers at varying DOM levels, use {@link withThrowableError}
+ * and {@link withSuspense}
  * @example
  * // As proxy
  * export const MyWrappedComponent = () = withNetworkCall(<MyComponent />)

--- a/frontend-react/src/hooks/UseCreateFetch.ts
+++ b/frontend-react/src/hooks/UseCreateFetch.ts
@@ -3,6 +3,7 @@ import { AccessToken } from "@okta/okta-auth-js";
 import axios from "axios";
 
 import { RSEndpoint, AxiosOptionsWithSegments } from "../config/endpoints";
+import { RSNetworkError } from "../utils/RSNetworkError";
 
 import { MembershipSettings } from "./UseOktaMemberships";
 
@@ -45,7 +46,11 @@ function createTypeWrapperForAuthorizedFetch(
             ...options,
             headers,
         });
-        return axios(axiosConfig).then(({ data }) => data);
+        return axios(axiosConfig)
+            .then(({ data }) => data)
+            .catch((e: any) => {
+                throw new RSNetworkError(e.message, e.response.status);
+            });
     };
 }
 

--- a/frontend-react/src/pages/error/ErrorPage.tsx
+++ b/frontend-react/src/pages/error/ErrorPage.tsx
@@ -32,7 +32,7 @@ const ErrorPageWrapper = (props: React.PropsWithChildren<ErrorPageProps>) => {
     );
 };
 
-const ErrorMessageWrapper = (
+export const ErrorMessageWrapper = (
     props: React.PropsWithChildren<ErrorPageProps>
 ) => {
     return <div className="grid-container">{props.children}</div>;

--- a/frontend-react/src/utils/RSNetworkError.ts
+++ b/frontend-react/src/utils/RSNetworkError.ts
@@ -17,7 +17,7 @@ export class RSNetworkError extends Error {
     name: ErrorName;
     /* Build a new RSNetworkError */
     constructor(message: string, statusCode?: number) {
-        super(`(RSNetworkError) ${message}`); // Sets message
+        super(message); // Sets message
         this.name = this.parseStatus(statusCode); // Sets code using child's parseStatus
         Object.setPrototypeOf(this, RSNetworkError.prototype);
     }

--- a/frontend-react/src/utils/RSNetworkError.ts
+++ b/frontend-react/src/utils/RSNetworkError.ts
@@ -1,0 +1,40 @@
+/** For consistency, when passing the code prop, please use these values
+ * e.g. <ErrorComponent code={RSError.NOT_FOUND} /> */
+export enum ErrorName {
+    UNAUTHORIZED = "unauthorized", //401
+    NOT_FOUND = "not-found", //404
+    SERVER_ERROR = "server-error", //500-599
+    // Any error thrown that cannot be parsed by RSError.parseStatus()
+    UNKNOWN = "unknown-error",
+    // Any generic error
+    NON_RS_ERROR = "non-rs-error",
+}
+
+/** Throw from any failing network calls, and pass in the status code to
+ * match it with the right display */
+export class RSNetworkError extends Error {
+    /* Used for identifying unique content to display for error */
+    name: ErrorName;
+    /* Build a new RSNetworkError */
+    constructor(message: string, statusCode?: number) {
+        super(`(RSNetworkError) ${message}`); // Sets message
+        this.name = this.parseStatus(statusCode); // Sets code using child's parseStatus
+        Object.setPrototypeOf(this, RSNetworkError.prototype);
+    }
+    /** Map response status code to error name */
+    parseStatus(statusCode?: number) {
+        switch (true) {
+            case statusCode === 401:
+                return ErrorName.UNAUTHORIZED;
+            case statusCode === 404:
+                return ErrorName.NOT_FOUND;
+            case statusCode!! >= 500 && statusCode!! <= 599:
+                return ErrorName.SERVER_ERROR;
+            case statusCode === undefined:
+            default:
+                return ErrorName.UNKNOWN;
+        }
+    }
+}
+/** Easy boolean check to validate error is of RSError descent */
+export const isRSNetworkError = (e: object) => e instanceof RSNetworkError;


### PR DESCRIPTION
This PR creates and tests the new `RSErrorBoundary` (set to replace `NetworkErrorBoundary` from `rest-hooks`) and `RSNetworkError`, the first custom error type for our app that allows us to parse incoming network errors and (later) determine what content to display.

Test Steps:
1. `yarn test` to ensure no tests are broken
2. No integrations to test in the UI

## Changes
- Adds new ErrorBoundary
- Adds new error type
- UseCreateFetch's axios call now will throw RSNetworkError instead of a normal error

## Checklist

### Testing
- [X] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [X] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [X] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
