### PR TITLE
Sender-files tool fix

### DIFF
--- a/prime-router/src/main/kotlin/cli/SenderFilesCommand.kt
+++ b/prime-router/src/main/kotlin/cli/SenderFilesCommand.kt
@@ -216,14 +216,28 @@ class SenderFilesCommand : CliktCommand(
      * Echo verbose information to the console respecting the --silent and --verbose flag
      */
     private fun echo(message: String) {
-        if (!silent) echo(message)
+        // clikt moved the echo command into the CliktCommand class, which means this needs to call
+        // into the parent class, but Kotlin doesn't allow calls to super with default parameters
+        if (!silent) super.echo(
+            message,
+            trailingNewline = true,
+            err = false,
+            currentContext.console.lineSeparator
+        )
     }
 
     /**
      * Echo verbose information to the console respecting the --silent and --verbose flag
      */
     private fun verbose(message: String) {
-        if (verbose) echo(message)
+        // clikt moved the echo command into the CliktCommand class, which means this needs to call
+        // into the parent class, but Kotlin doesn't allow calls to super with default parameters
+        if (verbose) super.echo(
+            message,
+            trailingNewline = true,
+            err = false,
+            currentContext.console.lineSeparator
+        )
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug introduced via dependabot. A library was updated that deprecated a function being used by the sender-files tool. The echo function started failing. 

Test Steps:
1. docker down
2. ./gradlew clean package
3. docker up
4. query local database
     - `select *
from covid_result_metadata`
5. Select message ID for a result
6. run sender-files command
     - `./prime sender-files --message-id <messageID> -o /path/to/folder`
7. check that file was provided

## Changes
- changed echo function

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

## Linked Issues
- Fixes #6705 

