### PR TITLE
Intrivo - ORC-22-4 Blank

### DIFF
--- a/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-careevolution-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/direct-hca-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-hca-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/direct-hca-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-hca-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/direct-hca-covid-19.md
+++ b/prime-router/docs/schema_documentation/direct-hca-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-detect-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-detect-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-detect-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-detect-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-detect-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-detect-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-hcintegrations-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hcintegrations-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-hcintegrations-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hcintegrations-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-hcintegrations-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hcintegrations-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-prod.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-prod.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-prod.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-prod.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-prod.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-prod.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-training.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-training.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-training.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-training.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-training.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19-training.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-hl7-ingest-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-lifepoint-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-lifepoint-covid-19.md
@@ -924,6 +924,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-lifepoint-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-lifepoint-covid-19.md
@@ -876,6 +876,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -921,22 +937,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-mns-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-mns-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-mns-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-mns-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-mns-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-mns-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-prescryptive-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-primary-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-signetic-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-signetic-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-signetic-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-signetic-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-signetic-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-signetic-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/docs/schema_documentation/hl7-test-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-test-covid-19.md
@@ -918,6 +918,22 @@ The zip code of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_provider_city
 
 **ReportStream Internal Name**: ordering_provider_city

--- a/prime-router/docs/schema_documentation/hl7-test-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-test-covid-19.md
@@ -870,6 +870,22 @@ The state of the facility which the test was ordered from
 
 ---
 
+**Name**: ordering_facility_state_zip_lookup
+
+**ReportStream Internal Name**: ordering_facility_state_zip_lookup
+
+**Type**: TABLE
+
+**PII**: No
+
+**Cardinality**: [0..1]
+
+**Table**: zip-code-data
+
+**Table Column**: state_abbr
+
+---
+
 **Name**: ordering_facility_street
 
 **ReportStream Internal Name**: ordering_facility_street
@@ -915,22 +931,6 @@ The secondary address of the facility which the test was ordered from
 **Documentation**:
 
 The zip code of the facility which the test was ordered from
-
----
-
-**Name**: ordering_facility_zip_lookup
-
-**ReportStream Internal Name**: ordering_facility_zip_lookup
-
-**Type**: TABLE
-
-**PII**: No
-
-**Cardinality**: [0..1]
-
-**Table**: zip-code-data
-
-**Table Column**: state_abbr
 
 ---
 

--- a/prime-router/docs/schema_documentation/hl7-test-covid-19.md
+++ b/prime-router/docs/schema_documentation/hl7-test-covid-19.md
@@ -858,7 +858,7 @@ The phone number of the facility which the test was ordered from
 
 **PII**: No
 
-**Cardinality**: [1..1]
+**Cardinality**: [0..1]
 
 **Table**: fips-county
 

--- a/prime-router/metadata/schemas/HL7/hl7-ingest-covid-19.schema
+++ b/prime-router/metadata/schemas/HL7/hl7-ingest-covid-19.schema
@@ -80,3 +80,18 @@ elements:
     natFlatFileField: Patient_state
     hhsGuidanceField:
     hl7Field: PID-11-4
+
+  - name: ordering_facility_zip_code
+    type: POSTAL_CODE
+    natFlatFileField: Ordering_facility_zip_code
+    hhsGuidanceField:
+    hl7Field: ORC-22-5
+    documentation: The zip code of the facility which the test was ordered from
+
+  - name: ordering_facility_state
+    mapper: use(ordering_facility_state, ordering_facility_state_zip_lookup)
+    cardinality: ZERO_OR_ONE
+    natFlatFileField: Ordering_facility_state
+    hhsGuidanceField:
+    hl7Field: ORC-22-4
+    documentation: The state of the facility which the test was ordered from

--- a/prime-router/metadata/schemas/HL7/hl7-ingest-covid-19.schema
+++ b/prime-router/metadata/schemas/HL7/hl7-ingest-covid-19.schema
@@ -81,12 +81,12 @@ elements:
     hhsGuidanceField:
     hl7Field: PID-11-4
 
-  - name: ordering_facility_zip_code
-    type: POSTAL_CODE
-    natFlatFileField: Ordering_facility_zip_code
-    hhsGuidanceField:
-    hl7Field: ORC-22-5
-    documentation: The zip code of the facility which the test was ordered from
+  - name: ordering_facility_zip_lookup
+    type: TABLE
+    pii: false
+    table: zip-code-data
+    tableColumn: state_abbr
+    mapper: zipCodeToState(ordering_facility_zip_code)
 
   - name: ordering_facility_state
     mapper: use(ordering_facility_state, ordering_facility_state_zip_lookup)

--- a/prime-router/metadata/schemas/HL7/hl7-ingest-covid-19.schema
+++ b/prime-router/metadata/schemas/HL7/hl7-ingest-covid-19.schema
@@ -81,7 +81,7 @@ elements:
     hhsGuidanceField:
     hl7Field: PID-11-4
 
-  - name: ordering_facility_zip_lookup
+  - name: ordering_facility_state_zip_lookup
     type: TABLE
     pii: false
     table: zip-code-data

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -289,8 +289,10 @@ elements:
     documentation: The phone number of the facility which the test was ordered from
 
   - name: ordering_facility_state
-    mapper: use(ordering_facility_state, ordering_facility_state_zip_lookup)
-    cardinality: ZERO_OR_ONE
+    type: TABLE
+    table: fips-county
+    tableColumn: State
+    cardinality: ONE
     natFlatFileField: Ordering_facility_state
     hhsGuidanceField:
     hl7Field: ORC-22-4
@@ -316,13 +318,6 @@ elements:
     hhsGuidanceField:
     hl7Field: ORC-22-5
     documentation: The zip code of the facility which the test was ordered from
-
-  - name: ordering_facility_state_zip_lookup
-    type: TABLE
-    pii: false
-    table: zip-code-data
-    tableColumn: state_abbr
-    mapper: zipCodeToState(ordering_facility_zip_code)
 
   - name: ordering_provider_city
     type: CITY

--- a/prime-router/metadata/schemas/covid-19.schema
+++ b/prime-router/metadata/schemas/covid-19.schema
@@ -289,10 +289,8 @@ elements:
     documentation: The phone number of the facility which the test was ordered from
 
   - name: ordering_facility_state
-    type: TABLE
-    table: fips-county
-    tableColumn: State
-    cardinality: ONE
+    mapper: use(ordering_facility_state, ordering_facility_state_zip_lookup)
+    cardinality: ZERO_OR_ONE
     natFlatFileField: Ordering_facility_state
     hhsGuidanceField:
     hl7Field: ORC-22-4
@@ -318,6 +316,13 @@ elements:
     hhsGuidanceField:
     hl7Field: ORC-22-5
     documentation: The zip code of the facility which the test was ordered from
+
+  - name: ordering_facility_state_zip_lookup
+    type: TABLE
+    pii: false
+    table: zip-code-data
+    tableColumn: state_abbr
+    mapper: zipCodeToState(ordering_facility_zip_code)
 
   - name: ordering_provider_city
     type: CITY


### PR DESCRIPTION
This PR addresses the issue where OTC data came without ORC-22-4 (ordering_facility_state) and this was causing our api filters to exclude these OTC messages, coming from intrivo. The solution was to use the zip code lookup mapper to display the state.

Test Steps:
1. Create fake data for intrivo
2. Blank out ORC-22-4
3. Fire up docker
4. reloadtables and reloadsettings
5. Send to api and verify generated files have the state in ORC-22-4
6. Repeat with fake data having ORC-22-4 populated

## Changes
- added new entry to hl7-ingest-covid-19.schema: `-name: ordering_facility_zip_lookup` and `-name: ordering_facility_state`

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Linked Issues
- Fixes #6780 



