### PR TITLE
fix: do not make useQuery requests with uninitialized okta [experience-unticketed]

### DIFF
--- a/frontend-react/src/components/AuthElement.test.tsx
+++ b/frontend-react/src/components/AuthElement.test.tsx
@@ -29,6 +29,7 @@ describe("AuthElement unit tests", () => {
                 parsedName: "PrimeAdmins",
             },
             dispatch: () => {},
+            initialized: true,
         });
         mockCheckFeatureFlag.mockImplementation((arg: string) => {
             return arg === FeatureFlagName.FOR_TEST;
@@ -49,6 +50,7 @@ describe("AuthElement unit tests", () => {
             oktaToken: undefined,
             activeMembership: undefined,
             dispatch: () => {},
+            initialized: true,
         });
         render(
             <AuthElement
@@ -67,6 +69,7 @@ describe("AuthElement unit tests", () => {
                 parsedName: "all-in-one-health-ca",
             },
             dispatch: () => {},
+            initialized: true,
         });
         render(
             <AuthElement
@@ -88,6 +91,7 @@ describe("AuthElement unit tests", () => {
                 parsedName: "all-in-one-health-ca",
             },
             dispatch: () => {},
+            initialized: true,
         });
         render(
             <AuthElement
@@ -109,6 +113,7 @@ describe("AuthElement unit tests", () => {
                 parsedName: "all-in-one-health-ca",
             },
             dispatch: () => {},
+            initialized: true,
         });
         mockCheckFeatureFlag.mockImplementation((arg: string) => {
             return arg !== FeatureFlagName.FOR_TEST;
@@ -132,6 +137,7 @@ describe("AuthElement unit tests", () => {
                 parsedName: "PrimeAdmins",
             },
             dispatch: () => {},
+            initialized: true,
         });
         render(
             <AuthElement
@@ -153,6 +159,7 @@ describe("AuthElement unit tests", () => {
                 parsedName: "PrimeAdmins",
             },
             dispatch: () => {},
+            initialized: true,
         });
         render(
             <AuthElement

--- a/frontend-react/src/components/SenderModeBanner.test.tsx
+++ b/frontend-react/src/components/SenderModeBanner.test.tsx
@@ -22,6 +22,7 @@ describe("SenderModeBanner", () => {
                 senderName: "testSender",
             },
             dispatch: () => {},
+            initialized: true,
         });
         renderWithSession(
             <SenderModeBanner />,

--- a/frontend-react/src/components/header/ReportStreamHeader.test.tsx
+++ b/frontend-react/src/components/header/ReportStreamHeader.test.tsx
@@ -55,6 +55,7 @@ describe("ReportStreamHeader", () => {
                 parsedName: "PrimeAdmins",
             },
             dispatch: () => {},
+            initialized: true,
         });
         renderWithSession(<ReportStreamHeader />);
         expect(screen.getByText("Admin")).toBeInTheDocument();
@@ -88,6 +89,7 @@ describe("ReportStreamHeader", () => {
                 parsedName: "ignore",
             },
             dispatch: () => {},
+            initialized: true,
         });
         renderWithSession(<ReportStreamHeader />);
         expect(screen.queryByText("Daily data")).not.toBeInTheDocument();
@@ -120,6 +122,7 @@ describe("ReportStreamHeader", () => {
                 parsedName: "ignore",
             },
             dispatch: () => {},
+            initialized: true,
         });
         renderWithSession(<ReportStreamHeader />);
         expect(screen.getByText("Daily data")).toBeInTheDocument();

--- a/frontend-react/src/contexts/AuthorizedFetchContext.test.tsx
+++ b/frontend-react/src/contexts/AuthorizedFetchContext.test.tsx
@@ -1,0 +1,33 @@
+import { wrapUseQuery } from "./AuthorizedFetchContext";
+
+const mockUseQuery = jest.fn();
+
+jest.mock("@tanstack/react-query", () => ({
+    ...jest.requireActual("@tanstack/react-query"),
+    useQuery: (key: unknown, fn: unknown, opts: unknown) =>
+        mockUseQuery(key, fn, opts),
+}));
+
+describe("wrapUseQuery", () => {
+    test("returns a fn that calls useQuery with `enabled` key correctly overloaded by passed initialized arg", () => {
+        const initializedUseQuery = wrapUseQuery(true);
+        const uninitializedUseQuery = wrapUseQuery(false);
+
+        uninitializedUseQuery([], () => {});
+        initializedUseQuery([], () => {});
+        initializedUseQuery([], () => {}, { enabled: false });
+
+        expect(mockUseQuery).toHaveBeenCalledTimes(3);
+
+        const [firstCall, secondCall, thirdCall] = mockUseQuery.mock.calls;
+
+        // wrap called with initialized === false
+        expect(firstCall[2]).toEqual({ enabled: false });
+
+        // wrap called with initialized === true
+        expect(secondCall[2]).toEqual({ enabled: true });
+
+        // wrap called with initialized === true, but overridden by options on useQuery call
+        expect(thirdCall[2]).toEqual({ enabled: false });
+    });
+});

--- a/frontend-react/src/contexts/AuthorizedFetchContext.tsx
+++ b/frontend-react/src/contexts/AuthorizedFetchContext.tsx
@@ -1,5 +1,12 @@
 import React, { createContext, useContext } from "react";
 import { AccessToken } from "@okta/okta-auth-js";
+import {
+  QueryFunction,
+  QueryKey,
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from "@tanstack/react-query";
 
 import {
     useCreateFetch,
@@ -10,18 +17,64 @@ import { MembershipSettings } from "../hooks/UseOktaMemberships";
 
 import { useSessionContext } from "./SessionContext";
 
+// this is synthesized copy pasta from the react query codebase since they don't export function types
+// see https://github.com/TanStack/query/blob/f6eeab079d88df811fd827767db1457083e85b01/packages/react-query/src/useQuery.ts
+type RSUseQuery<
+    TQueryFnData = unknown,
+    TError = unknown,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey
+> = {
+    (
+        queryKey: QueryKey,
+        queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+        options?: Omit<
+            UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+            "queryKey" | "queryFn" | "initialData"
+        > & { initialData?: () => undefined }
+    ): UseQueryResult<TData, TError>;
+};
+
 interface IAuthorizedFetchContext {
     authorizedFetchGenerator: AuthorizedFetchTypeWrapper;
+    initialized: boolean;
 }
 export const AuthorizedFetchContext = createContext<IAuthorizedFetchContext>({
     authorizedFetchGenerator: () => () =>
         Promise.reject("fetcher uninitialized"),
+    initialized: false,
 });
+
+function wrapUseQuery<TQueryFnData, TError, TData, TQueryKey extends QueryKey>(
+  initialized: boolean
+) {
+  return function (
+      queryKey: QueryKey,
+      queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+      options?: Omit<
+          UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+          "queryKey" | "queryFn" | "initialData"
+      > & { initialData?: () => undefined }
+  ) {
+      return useQuery<TQueryFnData, TError, TData, TQueryKey>(
+          queryKey as TQueryKey,
+          queryFn,
+          {
+              enabled: options?.enabled
+                  ? options.enabled && initialized
+                  : initialized,
+              ...options,
+          }
+      );
+  };
+}
+
+
 
 export const AuthorizedFetchProvider = ({
     children,
 }: React.PropsWithChildren<{}>) => {
-    const { oktaToken, activeMembership } = useSessionContext();
+    const { oktaToken, activeMembership, initialized } = useSessionContext();
     const generator = useCreateFetch(
         oktaToken as AccessToken,
         activeMembership as MembershipSettings
@@ -31,6 +84,7 @@ export const AuthorizedFetchProvider = ({
         <AuthorizedFetchContext.Provider
             value={{
                 authorizedFetchGenerator: generator,
+                initialized,
             }}
         >
             {children}
@@ -39,7 +93,21 @@ export const AuthorizedFetchProvider = ({
 };
 
 // an extra level of indirection here to allow for generic typing of the returned fetch function
-export const useAuthorizedFetch = <T,>(): AuthorizedFetcher<T> => {
-    const { authorizedFetchGenerator } = useContext(AuthorizedFetchContext);
-    return authorizedFetchGenerator<T>();
-};
+export const useAuthorizedFetch = <
+    TQueryFnData = unknown,
+    TError = unknown,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey
+>(): {
+    authorizedFetch: AuthorizedFetcher<TQueryFnData>;
+    rsUseQuery: RSUseQuery<TQueryFnData, TError, TData, TQueryKey>;
+} => {
+    const { authorizedFetchGenerator, initialized } = useContext(
+        AuthorizedFetchContext
+    );
+    return {
+        authorizedFetch: authorizedFetchGenerator<TQueryFnData>(),
+        rsUseQuery: wrapUseQuery<TQueryFnData, TError, TData, TQueryKey>(
+            initialized
+        ),
+    };

--- a/frontend-react/src/contexts/AuthorizedFetchContext.tsx
+++ b/frontend-react/src/contexts/AuthorizedFetchContext.tsx
@@ -1,11 +1,11 @@
 import React, { createContext, useContext } from "react";
 import { AccessToken } from "@okta/okta-auth-js";
 import {
-  QueryFunction,
-  QueryKey,
-  useQuery,
-  UseQueryOptions,
-  UseQueryResult,
+    QueryFunction,
+    QueryKey,
+    useQuery,
+    UseQueryOptions,
+    UseQueryResult,
 } from "@tanstack/react-query";
 
 import {
@@ -45,35 +45,37 @@ export const AuthorizedFetchContext = createContext<IAuthorizedFetchContext>({
     initialized: false,
 });
 
-function wrapUseQuery<TQueryFnData, TError, TData, TQueryKey extends QueryKey>(
-  initialized: boolean
-) {
-  return function (
-      queryKey: QueryKey,
-      queryFn: QueryFunction<TQueryFnData, TQueryKey>,
-      options?: Omit<
-          UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-          "queryKey" | "queryFn" | "initialData"
-      > & { initialData?: () => undefined }
-  ) {
-      return useQuery<TQueryFnData, TError, TData, TQueryKey>(
-          queryKey as TQueryKey,
-          queryFn,
-          {
-              enabled: options?.enabled
-                  ? options.enabled && initialized
-                  : initialized,
-              ...options,
-          }
-      );
-  };
+export function wrapUseQuery<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey extends QueryKey
+>(initialized: boolean) {
+    return function (
+        queryKey: QueryKey,
+        queryFn: QueryFunction<TQueryFnData, TQueryKey>,
+        options?: Omit<
+            UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+            "queryKey" | "queryFn" | "initialData"
+        > & { initialData?: () => undefined }
+    ) {
+        return useQuery<TQueryFnData, TError, TData, TQueryKey>(
+            queryKey as TQueryKey,
+            queryFn,
+            {
+                enabled: options?.enabled
+                    ? options.enabled && initialized
+                    : initialized,
+                ...options,
+            }
+        );
+    };
 }
-
-
 
 export const AuthorizedFetchProvider = ({
     children,
-}: React.PropsWithChildren<{}>) => {
+    initializedOverride = false,
+}: React.PropsWithChildren<{ initializedOverride?: boolean }>) => {
     const { oktaToken, activeMembership, initialized } = useSessionContext();
     const generator = useCreateFetch(
         oktaToken as AccessToken,
@@ -84,7 +86,7 @@ export const AuthorizedFetchProvider = ({
         <AuthorizedFetchContext.Provider
             value={{
                 authorizedFetchGenerator: generator,
-                initialized,
+                initialized: initializedOverride || initialized,
             }}
         >
             {children}
@@ -111,3 +113,4 @@ export const useAuthorizedFetch = <
             initialized
         ),
     };
+};

--- a/frontend-react/src/contexts/SessionContext.test.tsx
+++ b/frontend-react/src/contexts/SessionContext.test.tsx
@@ -6,12 +6,14 @@ import { MemberType } from "../hooks/UseOktaMemberships";
 import { SessionContext } from "./SessionContext";
 
 const TestComponent = () => {
-    const { activeMembership, oktaToken } = useContext(SessionContext);
+    const { activeMembership, oktaToken, initialized } =
+        useContext(SessionContext);
     return (
         <>
             <div>{activeMembership?.parsedName || ""}</div>
             <div>{activeMembership?.memberType || ""}</div>
             <div>{oktaToken?.accessToken || ""}</div>
+            <div>{initialized ? "INITIALIZED" : "NOT INITIALIZED"}</div>
         </>
     );
 };
@@ -27,6 +29,7 @@ describe("SessionContext", () => {
                         memberType: MemberType.SENDER,
                     },
                     dispatch: () => {},
+                    initialized: true,
                 }}
             >
                 <TestComponent />
@@ -35,8 +38,10 @@ describe("SessionContext", () => {
         const orgDiv = await screen.findByText("testOrg");
         const senderDiv = await screen.findByText(MemberType.SENDER);
         const tokenDiv = await screen.findByText("testToken");
+        const initializedDiv = await screen.findByText("INITIALIZED");
         expect(orgDiv).toBeInTheDocument();
         expect(senderDiv).toBeInTheDocument();
         expect(tokenDiv).toBeInTheDocument();
+        expect(initializedDiv).toBeInTheDocument();
     });
 });

--- a/frontend-react/src/contexts/SessionContext.tsx
+++ b/frontend-react/src/contexts/SessionContext.tsx
@@ -13,6 +13,7 @@ export interface ISessionContext {
     activeMembership?: MembershipSettings;
     oktaToken?: Partial<AccessToken>;
     dispatch: React.Dispatch<MembershipAction>;
+    initialized: boolean;
 }
 
 export type OktaHook = (_init?: Partial<IOktaContext>) => IOktaContext;
@@ -26,6 +27,7 @@ export const SessionContext = createContext<ISessionContext>({
     memberships: new Map(),
     activeMembership: {} as MembershipSettings,
     dispatch: () => {},
+    initialized: false,
 });
 
 // accepts `oktaHook` as a parameter in order to allow mocking of this provider's okta based
@@ -48,6 +50,7 @@ const SessionProvider = ({
                 memberships,
                 activeMembership,
                 dispatch,
+                initialized: authState !== null,
             }}
         >
             {children}

--- a/frontend-react/src/hooks/UseValueSets.ts
+++ b/frontend-react/src/hooks/UseValueSets.ts
@@ -54,23 +54,23 @@ export interface ValueSetsTableResponse<T> {
 export const useValueSetsTable = <T extends ValueSet[] | ValueSetRow[]>(
     dataTableName: string
 ): ValueSetsTableResponse<T> => {
-    const dataFetch = useAuthorizedFetch<T>();
+    const { authorizedFetch, rsUseQuery } = useAuthorizedFetch<T>();
 
     // create the function to use for fetching table data from the API
     const memoizedDataFetch = useCallback(
         () =>
-            dataFetch(getTableData, {
+            authorizedFetch(getTableData, {
                 segments: {
                     tableName: dataTableName,
                 },
             }),
-        [dataFetch, dataTableName]
+        [authorizedFetch, dataTableName]
     );
 
     // not entirely accurate typing. What is sent back by the api is actually ApiValueSet[] rather than ValueSet[]
     // does not seem entirely worth it to add the complexity needed to account for that on the frontend, better
     // to make the API conform better to the frontend's expectations. TODO: look at this when refactoring the API
-    const { data: valueSetData } = useQuery<T>(
+    const { data: valueSetData } = rsUseQuery(
         [getTableData.queryKey, dataTableName],
         memoizedDataFetch
     );
@@ -91,12 +91,11 @@ export interface ValueSetsMetaResponse {
 export const useValueSetsMeta = (
     dataTableName: string = LookupTables.VALUE_SET
 ): ValueSetsMetaResponse => {
-    const lookupTableFetch = useAuthorizedFetch<LookupTable[]>();
+    const { authorizedFetch, rsUseQuery } = useAuthorizedFetch<LookupTable[]>();
 
     // get all lookup tables in order to get metadata
-    const { data: tableData } = useQuery<LookupTable[]>(
-        [getTableList.queryKey],
-        () => lookupTableFetch(getTableList)
+    const { data: tableData } = rsUseQuery([getTableList.queryKey], () =>
+        authorizedFetch(getTableList)
     );
 
     const tableMeta = findTableMetaByName(tableData, dataTableName);
@@ -121,10 +120,10 @@ interface ActivateValueSetOptions {
 }
 
 export const useValueSetUpdate = () => {
-    const valueSetFetch = useAuthorizedFetch<LookupTable>();
+    const { authorizedFetch } = useAuthorizedFetch<LookupTable>();
 
     const updateValueSet = ({ data, tableName }: UpdateValueSetOptions) => {
-        return valueSetFetch(updateTable, {
+        return authorizedFetch(updateTable, {
             segments: { tableName: tableName },
             data,
         });
@@ -144,12 +143,12 @@ export const useValueSetUpdate = () => {
 };
 
 export const useValueSetActivation = () => {
-    const valueSetFetch = useAuthorizedFetch<LookupTable>();
+    const { authorizedFetch } = useAuthorizedFetch<LookupTable>();
     const activateValueSet = ({
         tableVersion,
         tableName,
     }: ActivateValueSetOptions) => {
-        return valueSetFetch(activateTable, {
+        return authorizedFetch(activateTable, {
             segments: {
                 tableName,
                 version: `${tableVersion}`,

--- a/frontend-react/src/hooks/UseValueSets.ts
+++ b/frontend-react/src/hooks/UseValueSets.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
 import { useAuthorizedFetch } from "../contexts/AuthorizedFetchContext";
 import {

--- a/frontend-react/src/hooks/network/History/DeliveryHooks.test.ts
+++ b/frontend-react/src/hooks/network/History/DeliveryHooks.test.ts
@@ -21,6 +21,7 @@ describe("DeliveryHooks", () => {
                 senderName: undefined,
             },
             dispatch: () => {},
+            initialized: true,
         });
         const { result, waitForNextUpdate } = renderHook(() =>
             useReportsList("testOrg", "testService")
@@ -43,6 +44,7 @@ describe("DeliveryHooks", () => {
                 senderName: undefined,
             },
             dispatch: () => {},
+            initialized: true,
         });
         const { result, waitForNextUpdate } = renderHook(() =>
             useReportsDetail("123")

--- a/frontend-react/src/hooks/network/Organizations/ReceiversHooks.test.ts
+++ b/frontend-react/src/hooks/network/Organizations/ReceiversHooks.test.ts
@@ -18,6 +18,7 @@ const fakeSession = {
         senderName: undefined,
     },
     dispatch: () => {},
+    initialized: true,
 };
 const handlers = [
     rest.get(

--- a/frontend-react/src/pages/submissions/SubmissionTable.test.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionTable.test.tsx
@@ -38,6 +38,7 @@ describe("SubmissionTable", () => {
                 senderName: "testSender",
             },
             dispatch: () => {},
+            initialized: true,
         });
         const fixtures: Fixture[] = [
             {
@@ -88,6 +89,7 @@ describe("SubmissionTable", () => {
                     senderName: "testSender",
                 },
                 dispatch: () => {},
+                initialized: true,
             });
             const fixtures: Fixture[] = [
                 {

--- a/frontend-react/src/utils/CustomRenderUtils.tsx
+++ b/frontend-react/src/utils/CustomRenderUtils.tsx
@@ -58,7 +58,9 @@ export const QueryWrapper =
     ({ children }: PropsWithChildren<{}>) =>
         (
             <QueryClientProvider client={client}>
-                <AuthorizedFetchProvider>{children}</AuthorizedFetchProvider>
+                <AuthorizedFetchProvider initializedOverride={true}>
+                    {children}
+                </AuthorizedFetchProvider>
             </QueryClientProvider>
         );
 


### PR DESCRIPTION
Currently there exists the possibility of making a request using the function output by `useAuthorizedFetch` before the js okta library has fully initialized. This means that requests can go out without an auth headers if made quickly enough after page load.

This change fixes this bug by:
* adding an `initialized` flag to tell the `useAuthorizedFetch` internals whether okta is ready to be used yet
* based on the value of this flag, telling useQuery whether or not it should be `enabled` (if an `enabled: false` option is passed to a `useQuery` invocation the hook will not run)
* outputting from `useAuthorizedFetch` an `rsUseQuery` function that is basically just `useQuery` with the `initialized / enabled` state management mentioned above folded into it
* using `rsUseQuery` instead of `useQuery` in existing hooks

## Test Steps:

Value sets regression testing, see https://github.com/CDCgov/prime-reportstream/pull/6476

### Bonus:

Make sure Tom's PR works with this commit cherry picked, and `rsUseQuery` thrown in in the correct place https://github.com/CDCgov/prime-reportstream/pull/6769

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
