### PR TITLE
Transition cli tool livd-table-download to livd-table-update

### DIFF
--- a/prime-router/docs/getting-started/getting-started.md
+++ b/prime-router/docs/getting-started/getting-started.md
@@ -263,8 +263,7 @@ cd ./prime-router
 ./gradlew primeCLI
 #  data                      process data
 #  list                      list known schemas, senders, and receivers
-#  livd-table-download       It downloads the latest LOINC test data, extract
-#                            Lookup Table, and the database as a new version.
+#  livd-table-download       This updates the LIVD lookup table with a new version.
 #  generate-docs             generate documentation for schemas
 #  create-credential         create credential JSON or persist to store
 #  compare                   compares two CSV files so you can view the

--- a/prime-router/docs/playbooks/how-to-update-LIVD-table.md
+++ b/prime-router/docs/playbooks/how-to-update-LIVD-table.md
@@ -14,7 +14,7 @@ The LIVD table needs to be updated locally, in production, and in staging.
 
 For prod and staging use --env and assign the prod or staging. For local don't include --env option.
 
-1. Run ./prime livd-table-download --activate --env < prod or staging >
+1. Run ./prime livd-table-update --activate --env < prod or staging >
 
 ### Note:
 

--- a/prime-router/metadata/tables/README.md
+++ b/prime-router/metadata/tables/README.md
@@ -5,11 +5,11 @@ Contains lookup tables loaded directly from files.
 
 ## _livd_ folder 
 Contains the LIVD supplemental table that gets merged into the downloaded LIVD table by
-running the command `./prime livd-table-download`. 
+running the command `./prime livd-table-update`. 
 
 To update the LIVD Supplemental table:
 1. Make the needed updates to the [LIVD-Supplemental.csv](livd/LIVD-Supplemental.csv) file.
-2. Run `./prime livd-table-download -a`, verify the diff looks correct, then create the new lookup table version.
+2. Run `./prime livd-table-update -a`, verify the diff looks correct, then create the new lookup table version.
 3. Test the changes locally.
 4. Once the changes are verified, deploy the updated lookup table to staging and production.
 

--- a/prime-router/src/main/kotlin/cli/LivdTableDownload.kt
+++ b/prime-router/src/main/kotlin/cli/LivdTableDownload.kt
@@ -34,7 +34,7 @@ import java.io.FileOutputStream
 import java.net.URL
 
 /**
- * LivdTableDownload is the command line interface for the livd-table-download command. It parses the command line
+ * LivdTableUpdate is the command line interface for the livd-table-download command. It parses the command line
  * for option given as below.
  *
  * It looks for the LIVD-SAR-CoV-2-yyyy-MM-dd.xlsx file from $cdcLOINCTestCodeMappingPageUrl.  If the file is found,
@@ -50,7 +50,7 @@ import java.net.URL
  * The command below will download the latest LIVD mapping catalogue and create a new lookup tables as needed.
  * It took "LIVD mapping catalogue" from the CDC website.
  *
- *  ./prime livd-table-download
+ *  ./prime livd-table-update
  *
  */
 interface LivdTableInterface {
@@ -58,10 +58,10 @@ interface LivdTableInterface {
     fun downloadFile(outputDir: String): File
 }
 
-class LivdTableDownload : CliktCommand(
-    name = "livd-table-download",
+class LivdTableUpdate : CliktCommand(
+    name = "livd-table-update",
     help = """
-    It downloads the latest LOINC test data, extract Lookup Table, and the database as a new version. 
+        This updates the LIVD lookup table with a new version.
     """
 ) {
     /**
@@ -97,13 +97,30 @@ class LivdTableDownload : CliktCommand(
         help = "The path to the LIVD supplemental file. Defaults to $defaultSupplFile"
     ).file(true).default(File(defaultSupplFile))
 
+    private val download by option(
+        "-d", "--download", help = "Download the current LIVD table from $loincMappingBaseUrl$loincMappingPageUrl"
+    ).flag()
+
+    private val inputFile by option(
+        "-i", "--input-file", help = "Input file to update LIVD table"
+    ).file()
+
     override fun run() {
-        echo("Downloading the LIVD table ...")
+        echo("Updating the LIVD table ...")
         FileUtils.forceMkdir(File(defaultOutputDir))
 
-        // Download the file from CDC website.
-        val downloadedFile = downloadFile(defaultOutputDir)
-        val tempRawLivdOutFile = extractLivdTable(sheetName, downloadedFile, defaultOutputDir)
+        val livdFile: File = if (download) {
+            // Download the file from CDC website.
+            downloadFile(defaultOutputDir)
+        } else if (inputFile != null) {
+            // Intake file from user
+            inputFile as File
+        } else {
+            // A file must be provided by the user or downloaded from the CDC website
+            error("The --download flag must be set or an --input-file must be provided.")
+        }
+
+        val tempRawLivdOutFile = extractLivdTable(sheetName, livdFile, defaultOutputDir)
         // Merge the supplemental LIVD table with the raw.
         val tempMergedLivdOutFile = mergeLivdSupplementalTable(tempRawLivdOutFile)
         tempRawLivdOutFile.delete()

--- a/prime-router/src/main/kotlin/cli/LivdTableDownload.kt
+++ b/prime-router/src/main/kotlin/cli/LivdTableDownload.kt
@@ -34,15 +34,15 @@ import java.io.FileOutputStream
 import java.net.URL
 
 /**
- * LivdTableUpdate is the command line interface for the livd-table-download command. It parses the command line
+ * LivdTableUpdate is the command line interface for the livd-table-update command. It parses the command line
  * for option given as below.
  *
- * It looks for the LIVD-SAR-CoV-2-yyyy-MM-dd.xlsx file from $cdcLOINCTestCodeMappingPageUrl.  If the file is found,
- * it downloads the file into the ./build directory.  If not found, it will prompt error accordingly.  Next, it builds
- * the output Lookup Table (<./build/LIVD-SARS-CoV-2.csv> file) with the table name.  Finally, it updates the
- * LIVD-SARS-CoV-2 lookup tables in the database as the new version of the table.
- * It updates new version of the lookup table in the given --env [local, test, staging, or prod] with the default
- * to "local" environment.
+ * If the --download parameter is added this tool looks for the LIVD-SAR-CoV-2-yyyy-MM-dd.xlsx file from
+ * $cdcLOINCTestCodeMappingPageUrl.If the file is found, it downloads the file into the ./build directory. If not
+ * found, it will prompt error accordingly. A LIVD file can also be supplied directly using the --input-file parameter.
+ * Next, it builds the output Lookup Table (<./build/LIVD-SARS-CoV-2.csv> file) with the table name. Finally, it updates
+ * the LIVD-SARS-CoV-2 lookup tables in the database as the new version of the table. It updates new version of the
+ * lookup table in the given --env [local, test, staging, or prod] with the default to "local" environment.
  *
  * Note, this command will always create new version of the lookup table.
  *

--- a/prime-router/src/main/kotlin/cli/main.kt
+++ b/prime-router/src/main/kotlin/cli/main.kt
@@ -256,7 +256,7 @@ fun main(args: Array<String>) = RouterCli()
     .subcommands(
         ProcessData(),
         ListSchemas(),
-        LivdTableDownload(),
+        LivdTableUpdate(),
         GenerateDocs(),
         CredentialsCli(),
         CompareCsvFiles(),


### PR DESCRIPTION
This PR changes the CLI tool from livd-table-download to livd-table-update. Additionally, two new parameters are added to the tool: `--download` and `--input-file`. The `--download` parameter instructs the cli to download the current livd table from cdc.gov. The `--input-file` parameter takes a file as the parameter argument. This will allow us to add custom LIVD tables that differ from the table offered on cdc.gov.

Test Steps:

Test `--download`:
1. package
2. run command: `./prime livd-table-update --download -a -s`
3. run command `./prime lookuptables list`
4. Look in the list and find "LIVD-SARS-CoV-2" in the Table Name column. For that record, look at the version number
5. run command `./prime lookuptables get --name LIVD-SARS-CoV-2 --version <VERSION NUM> --output-file path/to/output/`
6. Compare the output file to the LOINC Mapping tab in the LIVD table from cdc
     - https://www.cdc.gov/csels/dls/sars-cov-2-livd-codes.html

Test `--input-file`
1. package
2. Retrieve custom livd file and save locally
     - https://cdc.sharepoint.com/:x:/t/USDSatCDC/ESvjr4Az0a9DkdOc5MXlsagB9ovThoQPQWeYPNqYKvmp9g?e=sllaDV
3. run command: `./prime livd-table-update --input-file path/to/custom/file -a -s`
4. run command `./prime lookuptables list`
5. Look in the list and find "LIVD-SARS-CoV-2" in the Table Name column. For that record, look at the version number
6. run command `./prime lookuptables get --name LIVD-SARS-CoV-2 --version <VERSION NUM> --output-file path/to/output/`
7. Compare the output file to the LOINC Mapping tab in the custom file from saved in step 2 

## Changes
- changed name and documentation from livd-table-download to livd-table-update
- added `--download` as boolean parameter
- added `--input-file` as a file parameter

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?