### PR TITLE
Experience/membership hook init

### DIFF
--- a/frontend-react/src/components/Spinner.tsx
+++ b/frontend-react/src/components/Spinner.tsx
@@ -13,7 +13,11 @@ function Spinner({ size = "default", display = true }: SpinnerProps) {
         insidebutton: "rs-spinner-default rs-spinner-tiny",
     }[size];
     return (
-        <div hidden={!display} className={sizeClassName}>
+        <div
+            hidden={!display}
+            className={sizeClassName}
+            data-testid="rs-spinner"
+        >
             <Oval
                 height={60}
                 width={60}

--- a/frontend-react/src/contexts/SessionContext.tsx
+++ b/frontend-react/src/contexts/SessionContext.tsx
@@ -10,7 +10,7 @@ import {
 
 export interface ISessionContext {
     memberships?: Map<string, MembershipSettings>;
-    activeMembership?: MembershipSettings;
+    activeMembership?: MembershipSettings | null;
     oktaToken?: Partial<AccessToken>;
     dispatch: React.Dispatch<MembershipAction>;
     initialized: boolean;
@@ -40,7 +40,7 @@ const SessionProvider = ({
     const { authState } = oktaHook();
 
     const {
-        state: { memberships, activeMembership },
+        state: { memberships, activeMembership, initialized },
         dispatch,
     } = useOktaMemberships(authState);
     return (
@@ -50,7 +50,7 @@ const SessionProvider = ({
                 memberships,
                 activeMembership,
                 dispatch,
-                initialized: authState !== null,
+                initialized: authState !== null && !!initialized,
             }}
         >
             {children}

--- a/frontend-react/src/hooks/UseOktaMemberships.test.ts
+++ b/frontend-react/src/hooks/UseOktaMemberships.test.ts
@@ -237,6 +237,7 @@ describe("useOktaMemberships", () => {
                 parsedName: "PrimeAdmins",
                 memberType: MemberType.PRIME_ADMIN,
             });
+            expect(result.current.state.initialized).toEqual(true);
 
             act(() =>
                 result.current.dispatch({
@@ -245,7 +246,8 @@ describe("useOktaMemberships", () => {
             );
             expect(result.current.state).toEqual({
                 memberships: undefined,
-                activeMembership: undefined,
+                activeMembership: null,
+                initialized: true,
             });
         });
     });
@@ -285,12 +287,14 @@ describe("useOktaMemberships", () => {
                 memberType: MemberType.PRIME_ADMIN,
             });
             expect(result.current.state.memberships).toEqual(fakeMemberships);
+            expect(result.current.state.initialized).toEqual(true);
 
             rerender({
                 isAuthenticated: false,
             });
-            expect(result.current.state.activeMembership).toEqual(undefined);
+            expect(result.current.state.activeMembership).toEqual(null);
             expect(result.current.state.memberships).toEqual(undefined);
+            expect(result.current.state.initialized).toEqual(true);
         });
     });
 });
@@ -300,7 +304,7 @@ describe("helper functions", () => {
         test("can handle token with undefined claims", () => {
             const state = membershipsFromToken(mockToken());
             expect(state).toEqual({
-                activeMembership: undefined,
+                activeMembership: null,
                 memberships: undefined,
             });
         });
@@ -314,7 +318,7 @@ describe("helper functions", () => {
                 })
             );
             expect(state).toEqual({
-                activeMembership: undefined,
+                activeMembership: null,
                 memberships: undefined,
             });
         });
@@ -410,6 +414,7 @@ describe("helper functions", () => {
                 JSON.stringify({
                     activeMembership: fakeMemberships.get("DHPrimeAdmins"),
                     memberships: fakeMemberships,
+                    initialized: true,
                 })
             );
 
@@ -427,7 +432,7 @@ describe("helper functions", () => {
             );
             expect(mockStoreSessionMembershipState).toHaveBeenCalledWith(
                 JSON.stringify({
-                    activeMembership: undefined,
+                    activeMembership: null,
                     memberships: undefined,
                 })
             );

--- a/frontend-react/src/hooks/UseOktaMemberships.ts
+++ b/frontend-react/src/hooks/UseOktaMemberships.ts
@@ -1,5 +1,6 @@
 import React, { useEffect, useReducer, useMemo } from "react";
 import { AccessToken, AuthState } from "@okta/okta-auth-js";
+import omit from "lodash.omit";
 
 import { getOktaGroups, parseOrgName } from "../utils/OrganizationUtils";
 import {
@@ -21,6 +22,7 @@ export enum MembershipActionType {
     ADMIN_OVERRIDE = "override",
     RESET = "reset",
     SET_MEMBERSHIPS_FROM_TOKEN = "setMemberships",
+    INITIALIZE = "initialize",
 }
 
 export interface MembershipSettings {
@@ -33,9 +35,11 @@ export interface MembershipSettings {
 }
 
 export interface MembershipState {
-    activeMembership?: MembershipSettings;
+    // null here points specifically to an uninitialized state
+    activeMembership?: MembershipSettings | null;
     // Key is the OKTA group name, settings has parsedName
     memberships?: Map<string, MembershipSettings>;
+    initialized?: boolean;
 }
 
 export interface MembershipController {
@@ -105,22 +109,23 @@ export const makeMembershipMapFromToken = (
 const defaultState: MembershipState = {
     // note that active will be set to {} rather than undefined in most real world cases on initialization
     // see `calculateMembershipsWithOverride` for logic
-    activeMembership: undefined,
+    activeMembership: null,
     memberships: undefined,
+    initialized: false,
 };
 
 export const membershipsFromToken = (
     token: AccessToken | undefined
-): MembershipState => {
+): Partial<MembershipState> => {
     // One big undefined check to see if we have what we need for the next line
     if (!token?.claims) {
-        return defaultState;
+        return omit(defaultState, "initialized");
     }
     const claimData: Map<string, MembershipSettings> =
         makeMembershipMapFromToken(token);
     // Catch anyone with no claim data
     if (!claimData.size) {
-        return defaultState;
+        return omit(defaultState, "initialized");
     }
     // Get defaults
     const [first] = claimData.keys();
@@ -155,9 +160,12 @@ const calculateNewState = (
             const parsedMemberships = membershipsFromToken(
                 payload as AccessToken
             );
-            return calculateMembershipsWithOverride(
-                parsedMemberships as MembershipState
-            );
+            return {
+                ...calculateMembershipsWithOverride(
+                    parsedMemberships as MembershipState
+                ),
+                initialized: true,
+            };
         case MembershipActionType.ADMIN_OVERRIDE:
             const newActive = {
                 ...state.activeMembership,
@@ -169,20 +177,24 @@ const calculateNewState = (
             };
             storeOrganizationOverride(JSON.stringify(newActive));
             return newState;
+        case MembershipActionType.INITIALIZE:
+            return { ...state, initialized: true };
         case MembershipActionType.RESET:
-            return defaultState;
+            return { ...defaultState, initialized: state.initialized };
         default:
             return state;
     }
 };
 
 // try to read from existing stored state
+// since this is only called on first render, initialized will always be `false`
+// even though we are (needlessly) storing and receving initialized values from store
 export const getInitialState = () => {
     const storedState = getSessionMembershipState();
     const storedStateWithOverride = calculateMembershipsWithOverride(
         storedState || {}
     );
-    return { ...defaultState, ...storedStateWithOverride };
+    return { ...defaultState, ...storedStateWithOverride, initialized: false };
 };
 
 export const membershipReducer = (
@@ -226,10 +238,17 @@ export const useOktaMemberships = (
             payload: token,
         });
         // here we are only concerned about changes to a users orgs / memberships
-    }, [organizations, !!token]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [organizations, token]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    // any time a token change signifies a logout, we should clear our state and storage
     useEffect(() => {
+        // if we're in an uninitialized state, but okta has loaded, set our initialized flag
+        if (!state.initialized && !!authState) {
+            dispatch({
+                type: MembershipActionType.INITIALIZE,
+            });
+            return;
+        }
+        // any time a token change signifies a logout, we should clear our state and storage
         if (authState && !authState.isAuthenticated) {
             // clear override as well. this will error on json parse and result in {} being fed back on a read
             storeOrganizationOverride("");

--- a/frontend-react/src/hooks/UseOktaMemberships.ts
+++ b/frontend-react/src/hooks/UseOktaMemberships.ts
@@ -242,7 +242,7 @@ export const useOktaMemberships = (
             payload: token,
         });
         // here we are only concerned about changes to a users orgs / memberships
-    }, [organizations, token]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [organizations, !!token]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         // if we're in an uninitialized state, but okta has loaded, set our initialized flag

--- a/frontend-react/src/hooks/UseOktaMemberships.ts
+++ b/frontend-react/src/hooks/UseOktaMemberships.ts
@@ -194,6 +194,10 @@ export const getInitialState = () => {
     const storedStateWithOverride = calculateMembershipsWithOverride(
         storedState || {}
     );
+    // ALWAYS setting the `initialized` flag to false on the first render because...
+    // we are prioritizing consistency over minor performance gains. This will always be false
+    // on render 1, and once the `authState` comes in from the oktaHook, we get render 2
+    // which will set `initialized` to true (see the 2nd useEffect in the main hook body)
     return { ...defaultState, ...storedStateWithOverride, initialized: false };
 };
 
@@ -242,6 +246,8 @@ export const useOktaMemberships = (
 
     useEffect(() => {
         // if we're in an uninitialized state, but okta has loaded, set our initialized flag
+        // this should always happen on the second render once the oktaHook initializes and sends
+        // something through
         if (!state.initialized && !!authState) {
             dispatch({
                 type: MembershipActionType.INITIALIZE,


### PR DESCRIPTION
in order to account for lag between:
* okta hook initializing (it returns null on first render even when credentials exist)
* useOktaMemberships hook initializing (it returns null on first render even when an active membership exists)

We have expanded the idea of an `initialized` user state to wait until the membership hook has had a chance to render and return data (we had already made this change to account for the okta hook's initialization in a previous PR https://github.com/CDCgov/prime-reportstream/pull/6811). This change is necessary because cypress runs fast enough that the lag between the okta hook being initialized and the useOktaMemberships hook being initialized is significant.

## Test Steps:
1. cherry pick this commit into https://github.com/CDCgov/prime-reportstream/pull/6719
2. run tests from that PR
3. _VERIFY_: it works
4. also does this fix problems on Tom's branch?

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
