### PR TITLE
974: extend REST transport for OK

### DIFF
--- a/.environment/rest_service/data.json
+++ b/.environment/rest_service/data.json
@@ -61,7 +61,8 @@
       ],
       "enabled": true,
       "randomResponse": false
-    },    {
+    },    
+    {
       "uuid": "",
       "documentation": "Submit a report",
       "method": "post",
@@ -70,6 +71,33 @@
         {
           "uuid": "",
           "body": "{\r\n  \"status\": \"Success\",\r\n  \"statusDesc\": \"Received. LIN:4299844\",\r\n  \"respTrackingId\": \"UT-20211119-746000000-54\"\r\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Created",
+          "headers": [
+            {
+              "key": "",
+              "value": ""
+            }
+          ],
+          "filePath": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false
+        }
+      ],
+      "enabled": true,
+      "randomResponse": false
+      },    {
+        "uuid": "",
+      "documentation": "Submit an HL7 report",
+      "method": "post",
+      "endpoint": "hl7",
+      "responses": [
+        {
+          "uuid": "",
+          "body": "{\r\n \"fileName\": \"file-name-assigned-to-the-message-by-GCP-system\",\r\n \"status\": \"fileName received successfully. Processing in progress\"\r\n }",
           "latency": 0,
           "statusCode": 200,
           "label": "Created",

--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -3389,7 +3389,7 @@
       transport:
         type: REST
         authTokenUrl: http://rest-webservice:3001/idtoken
-        reportUrl:  http://rest-webservice:3001/report
+        reportUrl:  http://rest-webservice:3001/hl7
         #authTokenUrl: https://labupload-uat.health.ok.gov/api/auth/token #test URL
         #reportUrl:  https://labupload-uat.health.ok.gov/api/document/hl7 #test URL
         #authTokenUrl: https://labupload.health.ok.gov/api/auth/token #PRODUCTION URL
@@ -3397,8 +3397,8 @@
         tlsKeystore: null
         headers:
           RecordId: 'header.reportFile.reportId'
-          senderLabName: 'CDC PRIME - Atlanta, Georgia' #name-of-the-lab-the-sending-user-belongs-to
-          sourceLabName: 'CDC PRIME - Atlanta, Georgia' #name-of-the-lab-that-originally-sent-this-hl7-message-to-OSDH
+          senderLabName: 'CDC PRIME REPORTSTREAM' #name-of-the-lab-the-sending-user-belongs-to
+          sourceLabName: 'CDC PRIME REPORTSTREAM' #name-of-the-lab-that-originally-sent-this-hl7-message-to-OSDH
 
 - name: or-phd
   description: Oregon Public Health Department

--- a/prime-router/src/main/kotlin/transport/RESTTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RESTTransport.kt
@@ -42,9 +42,13 @@ import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMessageBuilder
 import io.ktor.http.Parameters
+import io.ktor.http.content.TextContent
+import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import net.schmizz.sshj.common.Base64
 import java.io.InputStream
 import java.security.KeyStore
@@ -87,36 +91,44 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
             // run our call to the endpoint in a blocking fashion
             runBlocking {
                 launch {
-                    val tokenClient = httpClient ?: createDefaultHttpClient(jksCredential, null)
-                    // get the credential and use it to request an OAuth token
-                    // Usually credential is a UserApiKey, with an apiKey field (NY)
-                    // if not, try as UserPass with pass field (OK)
-                    val tokenInfo: TokenInfo = when (credential) {
-                        is UserApiKeyCredential -> getAuthTokenWithUserApiKey(
-                            restTransportInfo.authTokenUrl,
-                            credential,
-                            context,
-                            tokenClient
-                        )
-                        is UserPassCredential -> getAuthTokenWithUserPass(
-                            restTransportInfo.authTokenUrl,
-                            credential,
-                            context,
-                            tokenClient
-                        )
-                        else -> error("UserApiKey or UserPass credential required for ${receiver.fullName}")
-                    }
-
-                    // if successful, add the token returned to the token storage
-                    val bearerTokens = BearerTokens(tokenInfo.accessToken, tokenInfo.refreshToken ?: "")
-                    context.logger.info("Token successfully added!")
-                    val httpHeaders = restTransportInfo.headers.mapValues {
+                    // parse headers for any dynamic values, OK needs the report ID
+                    var httpHeaders = restTransportInfo.headers.mapValues {
                         if (it.value == "header.reportFile.reportId") {
                             "${header.reportFile.reportId}"
                         } else {
                             it.value
                         }
                     }
+                    val tokenClient = httpClient ?: createDefaultHttpClient(jksCredential, null)
+                    // get the credential and use it to request an OAuth token
+                    // Usually credential is a UserApiKey, with an apiKey field (NY)
+                    // if not, try as UserPass with pass field (OK)
+                    val tokenInfo: TokenInfo
+                    var bearerTokens: BearerTokens? = null
+                    when (credential) {
+                        is UserApiKeyCredential -> {
+                            tokenInfo = getAuthTokenWithUserApiKey(
+                                restTransportInfo.authTokenUrl,
+                                credential,
+                                context,
+                                tokenClient
+                            )
+                            // if successful, add the token returned to the token storage
+                            bearerTokens = BearerTokens(tokenInfo.accessToken, tokenInfo.refreshToken ?: "")
+                        }
+                        is UserPassCredential -> {
+                            tokenInfo = getAuthTokenWithUserPass(
+                                restTransportInfo.authTokenUrl,
+                                credential,
+                                context,
+                                tokenClient
+                            )
+                            // if successful, add token as "Authorization:" header
+                            httpHeaders = httpHeaders + Pair("Authorization", tokenInfo.accessToken)
+                        }
+                        else -> error("UserApiKey or UserPass credential required for ${receiver.fullName}")
+                    }
+                    context.logger.info("Token successfully added!")
 
                     // post the report
                     val reportClient = httpClient ?: createDefaultHttpClient(jksCredential, bearerTokens)
@@ -274,19 +286,14 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
         httpClient: HttpClient
     ): TokenInfo {
         httpClient.use { client ->
-            val idTokenInfo: IdToken = client.submitForm(
-                restUrl,
-                formParameters = Parameters.build {
-                    append("email", credential.user)
-                    append("password", credential.pass)
-                }
-
-            ) {
+            val idTokenInfoString: String = client.post(restUrl) {
                 expectSuccess = true // throw an exception if not successful
-                accept(ContentType.Application.Json)
+                contentType(ContentType.Application.Json)
+                setBody(mapOf("email" to credential.user, "password" to credential.pass))
             }.body()
             context.logger.info("Got Token with UserPass")
-            return TokenInfo(idTokenInfo.idToken, idTokenInfo.expiresIn, idTokenInfo.refreshToken)
+            val idTokenInfo = Json.decodeFromString<IdToken>(idTokenInfoString)
+            return TokenInfo(accessToken = idTokenInfo.idToken, expiresIn = 3600)
         }
     }
 
@@ -317,18 +324,24 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
                     headers
                 )
                 setBody(
-                    MultiPartFormDataContent(
-                        formData {
-                            append(
-                                "payload", message,
-                                Headers.build {
-                                    append(HttpHeaders.ContentType, "text/plain")
-                                    append(HttpHeaders.ContentDisposition, "filename=\"${fileName}\"")
-                                }
-                            )
-                        },
-                        boundary
-                    )
+                    // for OK
+                    if (restUrl.endsWith("hl7")) {
+                        TextContent(message.toString(Charsets.UTF_8), ContentType.Text.Plain)
+                    } else {
+                        // for NY
+                        MultiPartFormDataContent(
+                            formData {
+                                append(
+                                    "payload", message,
+                                    Headers.build {
+                                        append(HttpHeaders.ContentType, "text/plain")
+                                        append(HttpHeaders.ContentDisposition, "filename=\"${fileName}\"")
+                                    }
+                                )
+                            },
+                            boundary
+                        )
+                    }
                 )
                 accept(ContentType.Application.Json)
             }.bodyAsText()
@@ -338,7 +351,7 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
 
     companion object {
         /** A default value for the timeouts to connect and send messages */
-        private const val TIMEOUT = 50_000
+        private const val TIMEOUT = 120_000
 
         /** Our default Http Client, with an optional SSL context, and optional auth token */
         private fun createDefaultHttpClient(jks: UserJksCredential?, bearerTokens: BearerTokens?): HttpClient {
@@ -346,7 +359,7 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
                 // installs logging into the call to post to the server
                 install(Logging) {
                     logger = io.ktor.client.plugins.logging.Logger.Companion.SIMPLE
-                    level = LogLevel.INFO
+                    level = LogLevel.ALL // LogLevel.INFO for prod, LogLevel.ALL to view full request
                 }
                 // if we have a token, install it
                 bearerTokens?.let {
@@ -360,7 +373,13 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
                 }
                 // install contentNegotiation to handle json response
                 install(ContentNegotiation) {
-                    json()
+                    json(
+                        Json {
+                            prettyPrint = true
+                            isLenient = true
+                            ignoreUnknownKeys = true
+                        }
+                    )
                 }
                 // configures the Apache client with our specified timeouts
                 // if we have a JKS, create an SSL context with it

--- a/prime-router/src/main/kotlin/transport/TokenInfo.kt
+++ b/prime-router/src/main/kotlin/transport/TokenInfo.kt
@@ -27,7 +27,7 @@ data class TokenInfo(
  * IdToken models the authentication token used by OK
  * https:/labupload.health.ok.gov/api/auth/token
  *
- * @param email username used to login to the app
+ * @param email username used to log in to the app
  * @param idToken id-token used in Authorization header
  * @param expiresIn seconds until token expires
  * @param refreshToken get new access tokens without having to log in again
@@ -36,6 +36,6 @@ data class TokenInfo(
 data class IdToken(
     val email: String,
     val idToken: String,
-    val expiresIn: Int,
-    val refreshToken: String
+    val expiresIn: Int? = null,
+    val refreshToken: String? = null
 )

--- a/prime-router/src/testIntegration/kotlin/transport/RESTTransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/RESTTransportIntegrationTests.kt
@@ -11,6 +11,7 @@ import gov.cdc.prime.router.azure.WorkflowEngine
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.azure.db.tables.pojos.Task
 import gov.cdc.prime.router.credentials.UserApiKeyCredential
+import gov.cdc.prime.router.credentials.UserPassCredential
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -31,87 +32,70 @@ class RESTTransportIntegrationTests : TransportIntegrationTests() {
     private val settings = FileSettings(FileSettings.defaultSettingsDirectory)
     private val responseHeaders = headersOf("Content-Type" to listOf("application/json;charset=UTF-8"))
 
-    private val mockClientAuthOk = HttpClient(MockEngine) {
-        engine {
-            addHandler {
-                respond(
-                    """{"access_token": "AYjcyMzY3ZDhiNmJkNTY", 
+    private val mockClientAuthOk = mockJsonResponseWithSuccess(
+        """{"access_token": "AYjcyMzY3ZDhiNmJkNTY", 
                         |"refresh_token": "RjY2NjM5NzA2OWJjuE7c", 
-                        |"token_type": "Bearer", "expires_in": 3600}
-                    """.trimMargin(),
-                    HttpStatusCode.OK,
-                    responseHeaders
-                )
-            }
-        }
-        install(ClientContentNegotiation) { json() }
-    }
+                        |"token_type": "Bearer", "expires_in": 3600}"""
+    )
 
-    private val mockClientAuthError = HttpClient(MockEngine) {
-        engine {
-            addHandler {
-                respond(
-                    """{"error": {"code": 500,"message": "Mock internal server error."}}""",
-                    HttpStatusCode.InternalServerError,
-                    responseHeaders
-                )
-            }
-        }
-        install(ClientContentNegotiation) { json() }
-    }
+    private val mockClientAuthIDTokenOk = mockJsonResponseWithSuccess(
+        """{"email": "test-email@test.com",
+                        "idToken": "AYjcyMzY3ZDhiNmJkNTY", 
+                        |"expiresIn": 3600,
+                        "refreshToken": "RjY2NjM5NzA2OWJjuE7c"}"""
+    )
 
-    private val mockClientUnauthorized = HttpClient(MockEngine) {
-        engine {
-            addHandler {
-                respond(
-                    """{"error": {"code": 401,"message": "Mock unauthorized error."}}""",
-                    HttpStatusCode.Unauthorized,
-                    responseHeaders
-                )
-            }
-        }
-        install(ClientContentNegotiation) { json() }
-    }
+    private val mockClientAuthError = mockJsonResponseWithError(
+        """{"error": {"code": 500,"message": "Mock internal server error."}}"""
+    )
 
-    private val mockClientPostOk = HttpClient(MockEngine) {
-        engine {
-            addHandler { _ ->
-                respond(
-                    """{"status": "Success", 
+    private val mockClientUnauthorized = mockJsonResponseWithUnauthorized(
+        """{"error": {"code": 401,"message": "Mock unauthorized error."}}"""
+    )
+
+    private val mockClientPostOk = mockJsonResponseWithSuccess(
+        """{"status": "Success", 
                         |"statusDesc": "Received. LIN:4299844", 
-                        |"respTrackingId": "UT-20211119-746000000-54"}""".trimMargin(),
-                    HttpStatusCode.OK,
-                    responseHeaders
-                )
-            }
-        }
-        install(ClientContentNegotiation) { json() }
+                        |"respTrackingId": "UT-20211119-746000000-54"}"""
+    )
+
+    private val mockClientPostError = mockJsonResponseWithError(
+        """{"error": {"code": 500,"message": "Mock internal server error."}}"""
+    )
+
+    private val mockClientUnknownError = mockJsonResponseWithUnknown(
+        """{"error": {"code": 999,"message": "Mock internal server error."}}"""
+    )
+
+    private fun mockJsonResponseWithSuccess(jsonResponse: String): HttpClient {
+        return mockJsonResponse(jsonResponse, HttpStatusCode.OK)
     }
 
-    private val mockClientPostError = HttpClient(MockEngine) {
-        engine {
-            addHandler {
-                respond(
-                    """{"error": {"code": 500,"message": "Mock internal server error."}}""",
-                    HttpStatusCode.InternalServerError,
-                    responseHeaders
-                )
-            }
-        }
-        install(ClientContentNegotiation) { json() }
+    private fun mockJsonResponseWithError(jsonResponse: String): HttpClient {
+        return mockJsonResponse(jsonResponse, HttpStatusCode.InternalServerError)
     }
 
-    private val mockClientUnknownError = HttpClient(MockEngine) {
-        engine {
-            addHandler {
-                respond(
-                    """{"error": {"code": 999,"message": "Mock internal server error."}}""",
-                    HttpStatusCode(999, "Unknown error"),
-                    responseHeaders
-                )
+    private fun mockJsonResponseWithUnauthorized(jsonResponse: String): HttpClient {
+        return mockJsonResponse(jsonResponse, HttpStatusCode.Unauthorized)
+    }
+
+    private fun mockJsonResponseWithUnknown(jsonResponse: String): HttpClient {
+        return mockJsonResponse(jsonResponse, HttpStatusCode(999, "Uknown Error"))
+    }
+
+    private fun mockJsonResponse(jsonResponse: String, whatStatusCode: HttpStatusCode): HttpClient {
+        return HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond(
+                        jsonResponse.trimMargin(),
+                        whatStatusCode,
+                        responseHeaders
+                    )
+                }
             }
+            install(ClientContentNegotiation) { json() }
         }
-        install(ClientContentNegotiation) { json() }
     }
 
     private var actionHistory = ActionHistory(TaskAction.send)
@@ -164,7 +148,34 @@ class RESTTransportIntegrationTests : TransportIntegrationTests() {
         val header = makeHeader()
         val mockRestTransport = spyk(RESTTransport(mockClientAuthOk))
         every { mockRestTransport.lookupDefaultCredential(any()) }.returns(
-            UserApiKeyCredential("test-user", "test-key")
+            UserApiKeyCredential(
+                "test-user",
+                "test-key"
+            )
+        )
+        every { runBlocking { mockRestTransport.postReport(any(), any(), any(), any(), any(), any()) } }.returns("")
+        val retryItems = mockRestTransport.send(transportType, header, reportId, null, context, actionHistory)
+        assertThat(retryItems).isNull()
+    }
+
+    @Test
+    fun `test connecting to mock service getIdToken happy path`() {
+        val header = makeHeader()
+        val mockRestTransport = spyk(RESTTransport(mockClientAuthIDTokenOk))
+        every { mockRestTransport.lookupDefaultCredential(any()) }.returns(
+            UserPassCredential("test-user", "test-pass")
+        )
+        every { runBlocking { mockRestTransport.postReport(any(), any(), any(), any(), any(), any()) } }.returns("")
+        val retryItems = mockRestTransport.send(transportType, header, reportId, null, context, actionHistory)
+        assertThat(retryItems).isNull()
+    }
+
+    @Test
+    fun `test connecting to mock service credential happy path`() {
+        val header = makeHeader()
+        val mockRestTransport = spyk(RESTTransport(mockClientAuthIDTokenOk))
+        every { mockRestTransport.lookupDefaultCredential(any()) }.returns(
+            UserPassCredential("test-user", "test-pass")
         )
         every { runBlocking { mockRestTransport.postReport(any(), any(), any(), any(), any(), any()) } }.returns("")
         val retryItems = mockRestTransport.send(transportType, header, reportId, null, context, actionHistory)


### PR DESCRIPTION
This PR extends the REST transport for OK. they had a different token, and wanted raw HL7, 

Test Steps:
Pull down the entire branch
Do a gradle clean and package, run dev environment
Do gradle end to end test
run integration tests for RestTransport

## Changes
- Extended REST transport
- added credential type for OK
- refactored REST transport test to support OK and clean up mocks

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #974

