### PR TITLE
Adds a hard check for admin auth in memberships map

### DIFF
--- a/frontend-react/src/components/AuthElement.test.tsx
+++ b/frontend-react/src/components/AuthElement.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import { MemberType } from "../hooks/UseOktaMemberships";
+import { MembershipSettings, MemberType } from "../hooks/UseOktaMemberships";
 import { mockSessionContext } from "../contexts/__mocks__/SessionContext";
 import { mockFeatureFlagContext } from "../contexts/__mocks__/FeatureFlagContext";
 import { FeatureFlagName } from "../pages/misc/FeatureFlags";
@@ -196,5 +196,34 @@ describe("AuthElement unit tests", () => {
         );
         const spinner = await screen.findByTestId("rs-spinner");
         expect(spinner).toBeInTheDocument();
+    });
+    test("Permits admins whose active membership is not DHPrimeAdmins", () => {
+        mockSessionContext.mockReturnValueOnce({
+            oktaToken: {
+                accessToken: "TOKEN",
+            },
+            memberships: new Map<string, MembershipSettings>().set(
+                "DHPrimeAdmins",
+                {
+                    memberType: MemberType.PRIME_ADMIN,
+                    parsedName: "PrimeAdmins",
+                }
+            ),
+            activeMembership: {
+                memberType: MemberType.NON_STAND,
+                parsedName: "IHaveNoGroupsSadFace",
+            },
+            dispatch: () => {},
+            initialized: true,
+            adminHardCheck: true,
+        });
+        render(
+            <AuthElement
+                element={<TestElement />}
+                requiredUserType={MemberType.PRIME_ADMIN}
+            />
+        );
+        expect(screen.getByText("Test Passed")).toBeInTheDocument();
+        expect(mockUseNavigate).not.toHaveBeenCalled();
     });
 });

--- a/frontend-react/src/components/AuthElement.test.tsx
+++ b/frontend-react/src/components/AuthElement.test.tsx
@@ -197,6 +197,11 @@ describe("AuthElement unit tests", () => {
         const spinner = await screen.findByTestId("rs-spinner");
         expect(spinner).toBeInTheDocument();
     });
+    /* This can happen if a user is a member of multiple Okta orgs, and the one set for them
+     * was a non-admin memberType. Because admins are the only ones able to mock memberType, we assign
+     * it based on a users first Okta group.
+     *
+     * In this example, you can see what that session state would look like. */
     test("Permits admins whose active membership is not DHPrimeAdmins", () => {
         mockSessionContext.mockReturnValueOnce({
             oktaToken: {
@@ -210,8 +215,8 @@ describe("AuthElement unit tests", () => {
                 }
             ),
             activeMembership: {
-                memberType: MemberType.NON_STAND,
-                parsedName: "IHaveNoGroupsSadFace",
+                memberType: MemberType.RECEIVER,
+                parsedName: "xx-phd",
             },
             dispatch: () => {},
             initialized: true,

--- a/frontend-react/src/components/AuthElement.tsx
+++ b/frontend-react/src/components/AuthElement.tsx
@@ -21,7 +21,8 @@ export const AuthElement = ({
 }: AuthElementProps): React.ReactElement => {
     // Router's new navigation hook for redirecting
     const navigate = useNavigate();
-    const { oktaToken, activeMembership, initialized } = useSessionContext();
+    const { oktaToken, activeMembership, initialized, adminHardCheck } =
+        useSessionContext();
 
     const { checkFlag } = useFeatureFlags();
 
@@ -33,11 +34,12 @@ export const AuthElement = ({
     );
     // Dynamically authorize user from single or multiple allowed user types
     const authorizeMemberType = useMemo(() => {
-        if (memberType === MemberType.PRIME_ADMIN) return true; // Admin authentication always
+        if (adminHardCheck || memberType === MemberType.PRIME_ADMIN)
+            return true; // Admin authentication always
         return requiredUserType instanceof Array
             ? requiredUserType.includes(memberType)
             : requiredUserType === memberType;
-    }, [requiredUserType, memberType]);
+    }, [adminHardCheck, memberType, requiredUserType]);
     // All the checks before returning the route
 
     const needsLogin = useMemo(

--- a/frontend-react/src/hooks/__mocks__/UseOktaMemberships.ts
+++ b/frontend-react/src/hooks/__mocks__/UseOktaMemberships.ts
@@ -1,0 +1,6 @@
+import * as OktaMembershipsHook from "../UseOktaMemberships";
+
+export const mockUseOktaMemberships = jest.spyOn(
+    OktaMembershipsHook,
+    "useOktaMemberships"
+);


### PR DESCRIPTION
This PR removes the need for Admins to closely manage their Okta groups. Previously, if you okta groups claim contained anything other than PrimeAdmins, it would mess up admin auth depending on the order of claims. Now, instead, we hard check where hard admin requirements are required by looking at the `memberships` map and seeing if you have an admin membership anywhere, not just in your `activeMembership` slot.

Test Steps:
1. Go onto OktaPreview and change your user's Groups to include a receiver (DHxx_phd) and DHPrimeAdmins (in that order)
2. Login to your local on this branch
3. Try to navigate to an admin-only page like `/admin/settings`

You should be redirected back home.

## Changes
- AuthElement now hard checks for admin permissions
- SessionContext now provides a memoized hard check for admin permissions

## Checklist

### Testing
- [X] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [X] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [X] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
