### PR TITLE
6634 remove name property from FHIRtoHL7 conversion

### DIFF
--- a/prime-router/metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml
@@ -1,12 +1,10 @@
-name: ORU-R01-Base
 hl7Type: ORU_R01
 hl7Version: 2.5.1
 constants:
   # Prefix for RS custom extension URLs
   rsext: '"https://reportstream.cdc.gov/fhir/StructureDefinition/"'
 elements:
-  - name: message-headers
-    condition: >
+  - condition: >
       Bundle.entry.resource.ofType(MessageHeader).exists() and
       Bundle.entry.resource.ofType(Provenance).exists() and
       Bundle.entry.resource.ofType(Provenance).activity.coding.code = 'R01'
@@ -14,29 +12,24 @@ elements:
     required: true
     schema: base/message-header
 
-  - name: software-segment
-    condition: 'Bundle.entry.resource.ofType(MessageHeader).exists()'
+  - condition: 'Bundle.entry.resource.ofType(MessageHeader).exists()'
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
     schema: base/software
 
-  - name: patient-information
-    resource: 'Bundle.entry.resource.ofType(Patient)'
+  - resource: 'Bundle.entry.resource.ofType(Patient)'
     condition: '%resource.count() = 1'
     required: true
     schema: base/patient
 
-  - name: patient-contact
-    resource: 'Bundle.entry.resource.ofType(Patient).contact'
+  - resource: 'Bundle.entry.resource.ofType(Patient).contact'
     condition: '%resource.exists()'
     schema: base/patient-contact
 
-  - name: patient-visit
-    resource: 'Bundle.entry.resource.ofType(Encounter)'
+  - resource: 'Bundle.entry.resource.ofType(Encounter)'
     condition: '%resource.count() = 1'
     schema: base/patient-visit
 
-  - name: order-observations
-    resource: 'Bundle.entry.resource.ofType(DiagnosticReport)'
+  - resource: 'Bundle.entry.resource.ofType(DiagnosticReport)'
     condition: '%resource.count() > 0'
     required: true
     schema: base/order-observation

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/ce-coded-element.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/ce-coded-element.yml
@@ -1,59 +1,49 @@
-name: ORU-R01-coded-element
 elements:
-  - name: code-identifier
-    value:
+  - value:
       - '%resource.coding.code'
       - '%resource.code'
     hl7Spec: [ '%{ceFieldPath}-1' ]
 
-  - name: code-text
-    value:
+  - value:
       - '%resource.text'
       - '%resource.coding.display'
       - '%resource.display'
     hl7Spec: [ '%{ceFieldPath}-2' ]
 
-  - name: system-url
-    resource: '%resource.coding.system'
+  - resource: '%resource.coding.system'
     # Important to only check http since there are urls defined in the Linux4Health
     # coding system map file that are http and others that are https
     condition: '%resource is URI and %resource.value.startsWith("http")'
     value: [ '%resource.getCodingSystemMapping()' ]
     hl7Spec: [ '%{ceFieldPath}-3' ]
 
-  - name: code-system-url-2
     # Important to only check http since there are urls defined in the Linux4Health
     # coding system map file that are http and others that are https
-    condition: '%resource.system.startsWith("http")'
+  - condition: '%resource.system.startsWith("http")'
     value: [ '%resource.system.getCodingSystemMapping()' ]
     hl7Spec: [ '%{ceFieldPath}-3' ]
 
-  - name: code-system
-    resource: '%resource.coding.system'
+  - resource: '%resource.coding.system'
     condition: '%resource is URI and %resource.value.startsWith("http").not()'
     value:
       - '%resource.value'
       - '%resource.system'
     hl7Spec: [ '%{ceFieldPath}-3' ]
 
-  - name: alternate-identifier
-    value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.code' ]
+  - value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.code' ]
     hl7Spec: [ '%{ceFieldPath}-4' ]
 
-  - name: alternate-text
-    value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.display' ]
+  - value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.display' ]
     hl7Spec: [ '%{ceFieldPath}-5' ]
 
-  - name: alternate-display-url
-    resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.system'
+  - resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.system'
     # Important to only check http since there are urls defined in the Linux4Health
     # coding system map file that are http and others that are https
     condition: '%resource is URI and %resource.value.startsWith("http")'
     value: [ '%resource.getCodingSystemMapping()' ]
     hl7Spec: [ '%{ceFieldPath}-6' ]
 
-  - name: alternate-display
-    resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.system'
+  - resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.system'
     condition: '%resource is URI and %resource.value.startsWith("http").not()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{ceFieldPath}-6' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/ce-coded-with-exceptions.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/ce-coded-with-exceptions.yml
@@ -1,16 +1,12 @@
-name: ORU-R01-coded-with-exceptions
 elements:
-  - name: coded-element
-    constants:
+  - constants:
       ceFieldPath: '%{cweFieldPath}'
     schema: ce-coded-element
 
-  - name: coding-system-version-id
-    resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.version'
+  - resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.version'
     value: [ '%resource']
     hl7Spec: [ '%{cweFieldPath}-7' ]
 
-  - name: coding-system-alternate-version-id
-    resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.extension(%`rsext-alternate-version`)'
+  - resource: '%resource.extension(%`rsext-alternate-identifier`).value.coding.extension(%`rsext-alternate-version`)'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{cweFieldPath}-8' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/cnn-composite-number-name.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/cnn-composite-number-name.yml
@@ -1,34 +1,26 @@
-name: ORU-R01-composite-number-name
 # Practitioner to CNN
 elements:
-  - name: cnn-id
-    value: [ '%resource.identifier[0].value' ]
+  - value: [ '%resource.identifier[0].value' ]
     hl7Spec: [ '%{cnnFieldPath}-1' ]
 
-  - name: cnn-family-name
-    value: [ '%resource.name.family' ]
+  - value: [ '%resource.name.family' ]
     hl7Spec: [ '%{cnnFieldPath}-2' ]
 
-  - name: cnn-given-name
-    condition: '%resource.name.exists()'
+  - condition: '%resource.name.exists()'
     value: [ '%resource.name.given[0]' ]
     hl7Spec: [ '%{cnnFieldPath}-3' ]
 
-  - name: cnn-other-given-names
-    condition: '%resource.name.given.count() > 1'
+  - condition: '%resource.name.given.count() > 1'
     value: [ '%resource.name.given.tail().toString().replace('','', '' '')' ]
     hl7Spec: [ '%{cnnFieldPath}-4' ]
 
-  - name: cnn-suffix
-    value: [ '%resource.name.suffix.toString()' ]
+  - value: [ '%resource.name.suffix.toString()' ]
     hl7Spec: [ '%{cnnFieldPath}-5' ]
 
-  - name: cnn-prefix
-    value: [ '%resource.name.prefix.toString()' ]
+  - value: [ '%resource.name.prefix.toString()' ]
     hl7Spec: [ '%{cnnFieldPath}-6' ]
 
-  - name: cnn-namespace-id
-    condition: '%resource.identifier.exists()'
+  - condition: '%resource.identifier.exists()'
     value: [ '%resource.identifier[0].system.getId()' ]
     hl7Spec: [ '%{cnnFieldPath}-9' ]
 

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/cx-extended-composite-id.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/cx-extended-composite-id.yml
@@ -1,25 +1,20 @@
-name: ORU-R01-cx-extended-composite-id
 constants:
   hl7CXFieldPath: '%{hl7CXField}(%{idIndex})'
 elements:
-  - name: id-number
-    value: [ '%resource.value' ]
+  - value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7CXFieldPath}-1' ]
 
-  - name: assigning-authority
-    constants:
+  - constants:
       hl7HDField: '%{hl7CXFieldPath}-4'
       # cannot use %`rext due to mix of constant and fhirpath substitution syntax
       namespaceExtName: '"https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id"'
       universalIdExtName: '"https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id"'
     schema: hd-hierarchic-designator
 
-  - name: id-type-code
-    value: [ '%resource.type.coding.code' ]
+  - value: [ '%resource.type.coding.code' ]
     hl7Spec: [ '%{hl7CXFieldPath}-5' ]
 
-  - name: assigning-facility
-    constants:
+  - constants:
       hl7HDField: '%{hl7CXFieldPath}-6'
       # cannot use %`rext due to mix of constant and fhirpath substitution syntax
       namespaceExtName: '"https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility-namespace-id"'

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/ei-entity-identifier.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/ei-entity-identifier.yml
@@ -1,20 +1,15 @@
-name: ORU-R01-entity-identifier
 # Identifier to EI mapping
 elements:
-  - name: entity-identifier
-    value: [ '%resource.value' ]
+  - value: [ '%resource.value' ]
     hl7Spec: [ '%{entityIdFieldPath}-1' ]
 
-  - name: entity-namespace-id
-    value:
+  - value:
       - '%resource.system.getId()'
       - '%resource.system'
     hl7Spec: [ '%{entityIdFieldPath}-2' ]
 
-  - name: entity-universal-id
-    value: [ '%resource.extension(%`rsext-universal-id`).value.getId()' ]
+  - value: [ '%resource.extension(%`rsext-universal-id`).value.getId()' ]
     hl7Spec: [ '%{entityIdFieldPath}-3' ]
 
-  - name: entity-id-type
-    value: [ '%resource.extension(%`rsext-universal-id`).value.getIdType()' ]
+  - value: [ '%resource.extension(%`rsext-universal-id`).value.getIdType()' ]
     hl7Spec: [ '%{entityIdFieldPath}-4' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/hd-hierarchic-designator.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/hd-hierarchic-designator.yml
@@ -1,19 +1,15 @@
-name: ORU-R01-hd-hierarchic-designator
 elements:
-  - name: designator-namespace-id-from-namespace
-    condition: '%resource.extension(%`namespaceExtName`).exists()'
+  - condition: '%resource.extension(%`namespaceExtName`).exists()'
     value: [ '%resource.extension(%`namespaceExtName`).value' ]
     hl7Spec: [ '%{hl7HDField}-1' ]
 
-  - name: designator-namespace-id-from-system
-    condition: >
+  - condition: >
       %resource.extension(%`namespaceExtName`).exists().not() and 
       %resource.system.startsWith('urn:id:')
     value: [ '%resource.system.replace(''urn:id:'', '''').replace(''_'', '' '')' ]
     hl7Spec: [ '%{hl7HDField}-1' ]
 
-  - name: designator-namespace-id-from-value
-    condition: >
+  - condition: >
       %resource.system.exists().not() and 
       %resource.extension(%`namespaceExtName`).exists().not() and 
       %resource.value.exists() and
@@ -22,8 +18,7 @@ elements:
     value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7HDField}-1' ]
 
-  - name: designator-namespace-id-from-name
-    condition: >
+  - condition: >
       %resource.system.exists().not() and 
       %resource.extension(%`namespaceExtName`).exists().not() and 
       %resource.value.exists().not() and 
@@ -31,10 +26,8 @@ elements:
     value: [ '%resource.name' ]
     hl7Spec: [ '%{hl7HDField}-1' ]
 
-  - name: designator-universal-id
-    value: [ '%resource.extension(%`universalIdExtName`).value.getId()' ]
+  - value: [ '%resource.extension(%`universalIdExtName`).value.getId()' ]
     hl7Spec: [ '%{hl7HDField}-2' ]
 
-  - name: designator-universal-id-type
-    value: [ '%resource.extension(%`universalIdExtName`).value.getIdType()' ]
+  - value: [ '%resource.extension(%`universalIdExtName`).value.getIdType()' ]
     hl7Spec: [ '%{hl7HDField}-3' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/sn-structured-numeric.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/sn-structured-numeric.yml
@@ -1,24 +1,18 @@
-name: ORU-R01-structured-numeric
 elements:
   # FHIR Spec does not support "=" and "<>" comparators, so those are in an extension
-  - name: observation-value-sn-comparator-1
-    condition: '%resource.numerator.comparator.exists().not()'
+  - condition: '%resource.numerator.comparator.exists().not()'
     value: [ '%resource.numerator.extension(%`rsext-comparator`).value' ]
     hl7Spec: [ '%{hl7OBXField}-5-1' ]
 
-  - name: observation-value-sn-comparator-2
-    condition: '%resource.numerator.comparator.exists()'
+  - condition: '%resource.numerator.comparator.exists()'
     value: [ '%resource.numerator.comparator' ]
     hl7Spec: [ '%{hl7OBXField}-5-1' ]
 
-  - name: observation-value-sn-value
-    value: [ '%resource.numerator.value' ]
+  - value: [ '%resource.numerator.value' ]
     hl7Spec: [ '%{hl7OBXField}-5-2' ]
 
-  - name: observation-value-sn-separator
-    value: [ '%resource.numerator.extension(%`rsext-separator`).value' ]
+  - value: [ '%resource.numerator.extension(%`rsext-separator`).value' ]
     hl7Spec: [ '%{hl7OBXField}-5-3' ]
 
-  - name: observation-value-sn-denominator
-    value: [ '%resource.denominator.value' ]
+  - value: [ '%resource.denominator.value' ]
     hl7Spec: [ '%{hl7OBXField}-5-4' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xad-extended-address.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xad-extended-address.yml
@@ -1,39 +1,30 @@
-name: ORU-R01-xad-extended-address
 constants:
   # if orderIndex is provided, we use the "-ordered" elements to support multiple entries
   hl7XADField: '%{hl7AddressField}'
 elements:
-  - name: xad-street-address
-    condition: '%resource.line.count() > 0'
+  - condition: '%resource.line.count() > 0'
     value: [ '%resource.line[0]' ]
     hl7Spec: [ '%{hl7XADField}-1' ]
 
-  - name: xad-other-designation
-    condition: '%resource.line[1].exists()'
+  - condition: '%resource.line[1].exists()'
     value: [ '%resource.line[1]' ]
     hl7Spec: [ '%{hl7XADField}-2' ]
 
-  - name: xad-city
-    value: [ '%resource.city' ]
+  - value: [ '%resource.city' ]
     hl7Spec: [ '%{hl7XADField}-3' ]
 
-  - name: xad-state-or-province
-    value: [ '%resource.state' ]
+  - value: [ '%resource.state' ]
     hl7Spec: [ '%{hl7XADField}-4' ]
 
-  - name: xad-zip-or-postal-code
-    value: [ '%resource.postalCode' ]
+  - value: [ '%resource.postalCode' ]
     hl7Spec: [ '%{hl7XADField}-5' ]
 
-  - name: xad-country
-    value: [ '%resource.country' ]
+  - value: [ '%resource.country' ]
     hl7Spec: [ '%{hl7XADField}-6' ]
 
-  - name: xad-use
-    condition: '%resource.use.exists()'
+  - condition: '%resource.use.exists()'
     value: [ '%resource.use.value.getAddressUse()' ]
     hl7Spec: [ '%{hl7XADField}-7' ]
 
-  - name: xad-county
-    value: [ '%resource.district' ]
+  - value: [ '%resource.district' ]
     hl7Spec: [ '%{hl7XADField}-9' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xcn-contact.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xcn-contact.yml
@@ -1,34 +1,26 @@
-name: ORU-R01-xcn-contact
 constants:
   hl7XCNFieldPath: '%{hl7XCNField}(%{contactIndex})'
 # Practitioner to XCN mapping
 elements:
-  - name: xcn-id-number
-    value: [ '%resource.identifier.value' ]
+  - value: [ '%resource.identifier.value' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-1' ]
 
-  - name: xcn-family-name
-    value: [ '%resource.name.family' ]
+  - value: [ '%resource.name.family' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-2' ]
 
-  - name: xcn-given-name
-    value: [ '%resource.name.given[0]' ]
+  - value: [ '%resource.name.given[0]' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-3' ]
 
-  - name: xcn-other-given-names
-    value: [ '%resource.name.given.tail()' ]
+  - value: [ '%resource.name.given.tail()' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-4' ]
 
-  - name: xcn-suffix
-    value: [ '%resource.name.suffix.toString()' ]
+  - value: [ '%resource.name.suffix.toString()' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-5' ]
 
-  - name: xcn-prefix
-    value: [ '%resource.name.prefix.toString()' ]
+  - value: [ '%resource.name.prefix.toString()' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-6' ]
 
-  - name: xcn-assigning-authority
-    resource: '%resource.identifier[0]'
+  - resource: '%resource.identifier[0]'
     condition: '%resource.exists()'
     constants:
       hl7HDField: '%{hl7XCNFieldPath}-9'
@@ -37,17 +29,14 @@ elements:
       universalIdExtName: '"https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id"'
     schema: hd-hierarchic-designator
 
-  - name: xcn-name-type-code
-    condition: '%resource.name.use.exists() and %resource.name.use = "official"'
+  - condition: '%resource.name.use.exists() and %resource.name.use = "official"'
     value: [ '"L"']
     hl7Spec: [ '%{hl7XCNFieldPath}(%{contactIndex})-10' ]
 
-  - name: xcn-identifier-type
-    value: [ '%resource.extension(%`rsext-identifier-type`).value.coding.code' ]
+  - value: [ '%resource.extension(%`rsext-identifier-type`).value.coding.code' ]
     hl7Spec: [ '%{hl7XCNFieldPath}-13' ]
 
-  - name: xcn-assigning-facility
-    resource: '%resource.extension(%`rsext-assigning-facility`).value.resolve()'
+  - resource: '%resource.extension(%`rsext-assigning-facility`).value.resolve()'
     condition: '%resource.exists()'
     constants:
       hl7HDField: '%{hl7XCNFieldPath}-14'

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xon-organization.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xon-organization.yml
@@ -1,45 +1,35 @@
-name: ORU-R01-xcn-contact
 elements:
-  - name: xon-organization-name
-    value: [ '%resource.name' ]
+  - value: [ '%resource.name' ]
     hl7Spec: [ '%{hl7OrgField}-1' ]
 
-  - name: xon-organization-type
-    resource: '%resource.extension(%`rsext-organization-name-type`)'
+  - resource: '%resource.extension(%`rsext-organization-name-type`)'
     condition: '%resource.exists()'
     value: [ '%resource.value.coding[0].code' ]
     hl7Spec: [ '%{hl7OrgField}-2' ]
 
-  - name: xon-organization-type
-    resource: '%resource.extension(%`rsext-namespace-id`)'
+  - resource: '%resource.extension(%`rsext-namespace-id`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7OrgField}-6-1' ]
 
-  - name: xon-organization-type
-    value: [ '%resource.extension(%`rsext-universal-id`).value.getId()' ]
+  - value: [ '%resource.extension(%`rsext-universal-id`).value.getId()' ]
     hl7Spec: [ '%{hl7OrgField}-6-2' ]
 
-  - name: xon-software-vendor-assigning-authority-system
-    value: [ '%resource.extension(%`rsext-universal-id`).value.getIdType()' ]
+  - value: [ '%resource.extension(%`rsext-universal-id`).value.getIdType()' ]
     hl7Spec: [ '%{hl7OrgField}-6-3' ]
 
-  - name: xon-organization-id-type
-    resource: '%resource.type.where(coding.system = ''http://terminology.hl7.org/CodeSystem/v2-0203'')'
+  - resource: '%resource.type.where(coding.system = ''http://terminology.hl7.org/CodeSystem/v2-0203'')'
     condition: '%resource.exists()'
     value: [ '%resource.coding[0].code' ]
     hl7Spec: [ '%{hl7OrgField}-7' ]
 
-  - name: xon-assigning-facility
-    condition: false # We have no data for this field yet
+  - condition: false # We have no data for this field yet
     value: [ '' ]
     hl7Spec: [ '%{hl7OrgField}-8' ]
 
-  - name: xon-name-representation-code
-    condition: false # We have no data for this field yet
+  - condition: false # We have no data for this field yet
     value: [ '' ]
     hl7Spec: [ '%{hl7OrgField}-9' ]
 
-  - name: xon-organization-id
-    value: [ '%resource.identifier[0].value' ]
+  - value: [ '%resource.identifier[0].value' ]
     hl7Spec: [ '%{hl7OrgField}-10' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xpn-person-name.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xpn-person-name.yml
@@ -1,20 +1,15 @@
-name: ORU-R01-human-name
 elements:
-  - name: family-name
-    value: [ '%resource.family' ]
+  - value: [ '%resource.family' ]
     hl7Spec: [ '%{hl7NameField}-1' ]
 
-  - name: given-name
-    condition: '%resource.given.exists()'
+  - condition: '%resource.given.exists()'
     value: [ '%resource.given[0]' ]
     hl7Spec: [ '%{hl7NameField}-2' ]
 
-  - name: second-name
-    condition: '%resource.given.count() >= 2'
+  - condition: '%resource.given.count() >= 2'
     value: [ '%resource.given.tail().toString().replace('','', '' '')' ]
     hl7Spec: [ '%{hl7NameField}-3' ]
 
-  - name: use
-    condition: '%resource.use.exists()'
+  - condition: '%resource.use.exists()'
     value: [ '%resource.use.getNameUseCode()' ]
     hl7Spec: [ '%{hl7NameField}-7' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xtn-telecom.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/datatype/xtn-telecom.yml
@@ -1,41 +1,32 @@
-name: ORU-R01-xtn-telecom
 elements:
-  - name: xtn-use-code
-    condition: '%resource.use.exists()'
+  - condition: '%resource.use.exists()'
     value: [ '%resource.use.getTelecomUseCode()' ]
     hl7Spec: [ '%{hl7TelecomField}-2' ]
 
-  - name: xtn-system
-    condition: '%resource.system.exists() and %resource.system = "phone"'
+  - condition: '%resource.system.exists() and %resource.system = "phone"'
     value: [ '"PH"' ]
     hl7Spec: [ '%{hl7TelecomField}-3' ]
 
-  - name: xtn-country-code
-    condition: '%resource.value.exists()'
+  - condition: '%resource.value.exists()'
     value: [ '%resource.value.getPhoneNumberCountryCode()' ]
     hl7Spec: [ '%{hl7TelecomField}-5' ]
 
-  - name: xtn-area-code
-    condition: '%resource.value.exists()'
+  - condition: '%resource.value.exists()'
     value: [ '%resource.value.getPhoneNumberAreaCode()' ]
     hl7Spec: [ '%{hl7TelecomField}-6' ]
 
-  - name: xtn-local-number
-    condition: '%resource.value.exists()'
+  - condition: '%resource.value.exists()'
     value: [ '%resource.value.getPhoneNumberLocalNumber()' ]
     hl7Spec: [ '%{hl7TelecomField}-7' ]
 
-  - name: xtn-extension
-    condition: '%resource.value.hasExtension()'
+  - condition: '%resource.value.hasExtension()'
     value: [ '%resource.value.getPhoneNumberExtension()' ]
     hl7Spec: [ '%{hl7TelecomField}-8' ]
 
-  - name: xtn-text
-    condition: '%resource.extension(%`rsext-text`).exists()'
+  - condition: '%resource.extension(%`rsext-text`).exists()'
     value: [ '%resource.extension(%`rsext-text`).value' ]
     hl7Spec: [ '%{hl7TelecomField}-9' ]
 
-  - name: xtn-unformatted-text
-    condition: '%resource.value.exists()'
+  - condition: '%resource.value.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7TelecomField}-12' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/message-header.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/message-header.yml
@@ -1,72 +1,54 @@
-name: ORU-R01-message-header
 elements:
-  - name: sending-application-namespace-id
-    value: [ '%resource.source.name' ]
+  - value: [ '%resource.source.name' ]
     hl7Spec: [ MSH-3-1 ]
 
-  - name: sending-application-universal-id
-    value: [ '%resource.source.endpoint.getId()' ]
+  - value: [ '%resource.source.endpoint.getId()' ]
     hl7Spec: [ MSH-3-2 ]
 
-  - name: sending-application-universal-id-type
-    value: [ '%resource.source.endpoint.getIdType()' ]
+  - value: [ '%resource.source.endpoint.getIdType()' ]
     hl7Spec: [ MSH-3-3 ]
 
-  - name: sending-facility_namespace-id
-    value: [ '%resource.sender.resolve().name' ]
+  - value: [ '%resource.sender.resolve().name' ]
     hl7Spec: [ MSH-4-1 ]
 
-  - name: sending-facility-universal-id
-    value: [ '%resource.sender.resolve().identifier[0].value.getId()' ]
+  - value: [ '%resource.sender.resolve().identifier[0].value.getId()' ]
     hl7Spec: [ MSH-4-2 ]
 
-  - name: sending-facility-universal-id-type
-    value: [ '%resource.sender.resolve().identifier[0].value.getIdType()' ]
+  - value: [ '%resource.sender.resolve().identifier[0].value.getIdType()' ]
     hl7Spec: [ MSH-4-3 ]
 
-  - name: receiving-application-namespace-id
-    value: [ '%resource.destination.name' ]
+  - value: [ '%resource.destination.name' ]
     hl7Spec: [ MSH-5-1 ]
 
-  - name: receiving-application-universal-id
-    value: [ '%resource.destination.extension(%`rsext-application-identifier`).value.getId()' ]
+  - value: [ '%resource.destination.extension(%`rsext-application-identifier`).value.getId()' ]
     hl7Spec: [ MSH-5-2 ]
 
-  - name: receiving-application-universal-id-type
-    value: [ '%resource.destination.extension(%`rsext-application-identifier`).value.getIdType()' ]
+  - value: [ '%resource.destination.extension(%`rsext-application-identifier`).value.getIdType()' ]
     hl7Spec: [ MSH-5-3]
 
-  - name: receiving-facility-namespace-id
-    value: [ '%resource.destination.endpoint' ]
+  - value: [ '%resource.destination.endpoint' ]
     hl7Spec: [ MSH-6-1 ]
 
-  - name: receiving-facility-universal-id
-    value: [ '%resource.destination.extension(%`rsext-facility-identifier`).value.getId()' ]
+  - value: [ '%resource.destination.extension(%`rsext-facility-identifier`).value.getId()' ]
     hl7Spec: [ MSH-6-2 ]
 
-  - name: receiving-facility-universal-id-type
-    value: [ '%resource.destination.extension(%`rsext-facility-identifier`).value.getIdType()' ]
+  - value: [ '%resource.destination.extension(%`rsext-facility-identifier`).value.getIdType()' ]
     hl7Spec: [ MSH-6-3 ]
 
-  - name: message-date-time
-    value: [ 'Bundle.entry.resource.ofType(Provenance).recorded' ]
+  - value: [ 'Bundle.entry.resource.ofType(Provenance).recorded' ]
     required: true
     hl7Spec: [ MSH-7 ]
 
-  - name: security
-    value: [ 'Bundle.meta.security.code' ]
+  - value: [ 'Bundle.meta.security.code' ]
     hl7Spec: [ MSH-8-1 ]
 
-  - name: message-control-id
-    value: [ 'Bundle.identifier.value' ]
+  - value: [ 'Bundle.identifier.value' ]
     required: true
     hl7Spec: [ MSH-10 ]
 
-  - name: processing-id
-    resource: '%resource.meta.extension(%`rsext-source-processing-id`).value'
+  - resource: '%resource.meta.extension(%`rsext-source-processing-id`).value'
     value: [ '%resource.coding.code' ]
     hl7Spec: [ MSH-11-1 ]
 
-  - name: country-code
-    value: [ '%resource.sender.resolve().address.country' ]
+  - value: [ '%resource.sender.resolve().address.country' ]
     hl7Spec: [ MSH-17 ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/note.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/note.yml
@@ -1,42 +1,32 @@
-name: ORU-R01-note
 elements:
-  - name: note-id
-    value: [ '%noteIndex + 1' ]
+  - value: [ '%noteIndex + 1' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-1' ]
 
-  - name: note-source
-    value:
+  - value:
       - '%noteDetails.extension(%`rsext-note-source`).value.coding.code'
       - '"L"'
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-2' ]
 
-  - name: note-comment
-    value: [ '%resource' ]
+  - value: [ '%resource' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-3' ]
 
-  - name: note-comment-type-identifier
-    value: [ '%noteDetails.extension(%`rsext-note-type`).value.coding.code' ]
+  - value: [ '%noteDetails.extension(%`rsext-note-type`).value.coding.code' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-4-1' ]
 
-  - name: note-comment-type-text
-    value: [ '%noteDetails.extension(%`rsext-note-type`).value.text' ]
+  - value: [ '%noteDetails.extension(%`rsext-note-type`).value.text' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-4-2' ]
 
-  - name: note-comment-type-coding-system
-    value: [ '%noteDetails.extension(%`rsext-note-type`).value.coding.system' ]
+  - value: [ '%noteDetails.extension(%`rsext-note-type`).value.coding.system' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-4-3' ]
 
-  - name: note-comment-type-alt-identifier
-    resource: '%noteDetails.extension(%`rsext-note-type`).value.extension(%`rsext-alternate-identifier`)'
+  - resource: '%noteDetails.extension(%`rsext-note-type`).value.extension(%`rsext-alternate-identifier`)'
     value: [ '%resource.value.coding.code' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-4-4' ]
 
-  - name: note-comment-type-alt-text
-    resource: '%noteDetails.extension(%`rsext-note-type`).value.extension(%`rsext-alternate-identifier`)'
+  - resource: '%noteDetails.extension(%`rsext-note-type`).value.extension(%`rsext-alternate-identifier`)'
     value: [ '%resource.value.coding.display' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-4-5' ]
 
-  - name: note-comment-type-alt-coding-system
-    resource: '%noteDetails.extension(%`rsext-note-type`).value.extension(%`rsext-alternate-identifier`)'
+  - resource: '%noteDetails.extension(%`rsext-note-type`).value.extension(%`rsext-alternate-identifier`)'
     value: [ '%resource.value.coding.system' ]
     hl7Spec: [ '%{hl7NotePath}/NTE(%{noteIndex})-4-6' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/observation-request.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/observation-request.yml
@@ -1,157 +1,131 @@
-name: ORU-R01-observation-request
 constants:
   fieldPath: /PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/OBR
 elements:
-  - name: request-set-ID
-    value: [ '%orderIndex  + 1' ]
+  - value: [ '%orderIndex  + 1' ]
     hl7Spec: [ '%{fieldPath}-1' ]
 
-  - name: placer-order
-    resource: '%resource.identifier.where(type.coding.code = "PLAC")'
+  - resource: '%resource.identifier.where(type.coding.code = "PLAC")'
     condition: '%resource.exists()'
     constants:
       entityIdFieldPath: '%{fieldPath}(%{entityIdIndex})-2'
     schema: datatype/ei-entity-identifier
     resourceIndex: entityIdIndex
 
-  - name: filler-order
-    resource: '%resource.identifier.where(type.coding.code = "FILL")'
+  - resource: '%resource.identifier.where(type.coding.code = "FILL")'
     condition: '%resource.exists()'
     constants:
       entityIdFieldPath: '%{fieldPath}(%{entityIdIndex})-3'
     schema: datatype/ei-entity-identifier
     resourceIndex: entityIdIndex
 
-  - name: universal-service
-    resource: '%resource.code'
+  - resource: '%resource.code'
     constants:
       ceFieldPath: '%{fieldPath}-4'
     schema: datatype/ce-coded-element
 
-  - name: observation-date-time
-    condition: '%resource.effective is dateTime'
+  - condition: '%resource.effective is dateTime'
     value: [ '%resource.effective' ]
     hl7Spec: [ '%{fieldPath}-7' ]
 
-  - name: observation-date-time-start
-    condition: '%resource.effective is Period'
+  - condition: '%resource.effective is Period'
     value: [ '%resource.effective.start' ]
     hl7Spec: [ '%{fieldPath}-7' ]
 
-  - name: observation-date-time-end
-    condition: '%resource.effective is Period'
+  - condition: '%resource.effective is Period'
     value: [ '%resource.effective.end' ]
     hl7Spec: [ '%{fieldPath}-8' ]
 
-  - name: collector-identifier
-    resource: '%service.extension(%`rsext-collector-identifier`).value.resolve()'
+  - resource: '%service.extension(%`rsext-collector-identifier`).value.resolve()'
     constants:
       hl7XCNField: '%{fieldPath}-10'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: relevant-clinical-information
-    resource: '%service.extension(%`rsext-clinical-information`)'
+  - resource: '%service.extension(%`rsext-clinical-information`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{fieldPath}-13' ]
 
-  - name: ordering-provider
-    resource: '%service.requester.resolve().practitioner.resolve()'
+  - resource: '%service.requester.resolve().practitioner.resolve()'
     constants:
       hl7XCNField: '%{fieldPath}-16'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: callback-phone-number
-    resource: '%service.requester.resolve().practitioner.resolve().extension(%`rsext-callback-number`).value'
+  - resource: '%service.requester.resolve().practitioner.resolve().extension(%`rsext-callback-number`).value'
     condition: '%resource.exists()'
     constants:
       hl7TelecomField: '%{fieldPath}-17(%{callbackIndex})'
     schema: datatype/xtn-telecom
     resourceIndex: callbackIndex
 
-  - name: placer-field
-    resource: '%service.extension(%`rsext-placer-field-1`)'
+  - resource: '%service.extension(%`rsext-placer-field-1`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{fieldPath}-18' ]
 
-  - name: placer-field-2
-    resource: '%service.extension(%`rsext-placer-field-2`)'
+  - resource: '%service.extension(%`rsext-placer-field-2`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{fieldPath}-19' ]
 
-  - name: filler-field-2
-    resource: '%service.extension(%`rsext-filler-field-1`)'
+  - resource: '%service.extension(%`rsext-filler-field-1`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{fieldPath}-20' ]
 
-  - name: filler-field-2
-    resource: '%service.extension(%`rsext-filler-field-2`)'
+  - resource: '%service.extension(%`rsext-filler-field-2`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{fieldPath}-21' ]
 
-  - name: results-reported-at
-    value: [ '%resource.issued' ]
+  - value: [ '%resource.issued' ]
     hl7Spec: [ '%{fieldPath}-22' ]
 
-  - name: diganostic-serv-sect-id
-    value: [ '%resource.category' ]
+  - value: [ '%resource.category' ]
     hl7Spec: [ '%{fieldPath}-24' ]
 
-  - name: result-status
-    resource: '%resource.status'
+  - resource: '%resource.status'
     condition: '%resource.exists()'
     value: [ '%resource.getObservationResultsStatus()' ]
     hl7Spec: [ '%{fieldPath}-25' ]
 
-  - name: parent-observation-link
-    resource: '%resource.identifier.where(type.coding.system = "http://loinc.org").type'
+  - resource: '%resource.identifier.where(type.coding.system = "http://loinc.org").type'
     constants:
       ceFieldPath: '%{fieldPath}-26-1'
     schema: datatype/ce-coded-element
 
-  - name: parent-observation-sub-id
-    resource: '%resource.extension(%`rsext-parent-observation-sub-id`)'
+  - resource: '%resource.extension(%`rsext-parent-observation-sub-id`)'
     condition: '%resource.exists()'
     value: ['%resource.value']
     hl7Spec: [ '%{fieldPath}-26-2' ]
 
-  - name: parent-observation-value-descriptor
-    resource: '%resource.extension(%`rsext-parent-observation-value-descriptor`)'
+  - resource: '%resource.extension(%`rsext-parent-observation-value-descriptor`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{fieldPath}-26-3' ]
 
-  - name: placer-assigned-identifier
-    resource: '%resource.extension(%`rsext-placer-assigned-identifier`).value'
+  - resource: '%resource.extension(%`rsext-placer-assigned-identifier`).value'
     condition: '%resource.exists()'
     constants:
       entityIdFieldPath: '%{fieldPath}(%{entityIdIndex})-29-1'
     schema: datatype/ei-entity-identifier
     resourceIndex: entityIdIndex
 
-  - name: filler-assigned-identifier
-    resource: '%resource.extension(%`rsext-filler-assigned-identifier`).value'
+  - resource: '%resource.extension(%`rsext-filler-assigned-identifier`).value'
     condition: '%resource.exists()'
     constants:
       entityIdFieldPath: '%{fieldPath}(%{entityIdIndex})-29-2'
     schema: datatype/ei-entity-identifier
     resourceIndex: entityIdIndex
 
-  - name: reason-for-study
-    resource: '%service.reasonCode'
+  - resource: '%service.reasonCode'
     constants:
       ceFieldPath: '%{fieldPath}-31(%{reasonIndex})'
     schema: datatype/ce-coded-element
     resourceIndex: reasonIndex
 
-  - name: result-interpreter
-    resource: '%resource.resultsInterpreter.resolve()'
+  - resource: '%resource.resultsInterpreter.resolve()'
     constants:
       cnnFieldPath: '%{fieldPath}-32-1'
     schema: datatype/cnn-composite-number-name

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/observation-result.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/observation-result.yml
@@ -1,189 +1,151 @@
-name: ORU-R01-observation-result
 constants:
   hl7ObservationPath: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/OBSERVATION(%{resultIndex})'
   hl7OBXField: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/OBSERVATION(%{resultIndex})/OBX'
   observation: '%diagnostic.result[%resultIndex].resolve()'
 elements:
-  - name: result-set-ID
-    value: [ '%resultIndex + 1' ]
+  - value: [ '%resultIndex + 1' ]
     hl7Spec: [ '%{hl7OBXField}-1' ]
 
-  - name: result-value-type-st
-    condition: '%resource.value is String or %resource.value.exists().not()'
+  - condition: '%resource.value is String or %resource.value.exists().not()'
     value: [ '"ST"' ]
     hl7Spec: [ '%{hl7OBXField}-2' ]
 
-  - name: result-value-type-ce
-    condition: '%resource.value is CodeableConcept'
+  - condition: '%resource.value is CodeableConcept'
     # Note that for v.2.5 and earlier CWE does not exist.
     value: [ '"CE"' ]
     hl7Spec: [ '%{hl7OBXField}-2' ]
 
-  - name: result-value-type-sn
-    condition: '%resource.value is Ratio'
+  - condition: '%resource.value is Ratio'
     value: [ '"SN"' ]
     hl7Spec: [ '%{hl7OBXField}-2' ]
 
-  - name: observation-identifier-code
-    value: [ '%resource.code.coding.code' ]
+  - value: [ '%resource.code.coding.code' ]
     hl7Spec: [ '%{hl7OBXField}-3-1' ]
 
-  - name: observation-identifier-text
-    value: [ '%resource.code.text' ]
+  - value: [ '%resource.code.text' ]
     hl7Spec: [ '%{hl7OBXField}-3-2' ]
 
-  - name: observation-identifier-coding-system
-    value: [ '%resource.code.coding.system' ]
+  - value: [ '%resource.code.coding.system' ]
     hl7Spec: [ '%{hl7OBXField}-3-3' ]
 
   # override to handle LN translated to loinc L on HL7->FHIR conversion
-  - name: observation-identifier-coding-system-ln
-    resource: '%resource.code.coding'
+  - resource: '%resource.code.coding'
     condition: '%resource.system = "http://loinc.org" and %resource.version = "L"'
     value: [ '"LN"' ]
     hl7Spec: [ '%{hl7OBXField}-3-3' ]
 
-  - name: observation-identifier-alternate-code
-    value: [ '%resource.code.extension(%`rsext-alternate-identifier`).value.coding.code' ]
+  - value: [ '%resource.code.extension(%`rsext-alternate-identifier`).value.coding.code' ]
     hl7Spec: [ '%{hl7OBXField}-3-4' ]
 
-  - name: observation-identifier-alternate-text
-    value: [ '%resource.code.extension(%`rsext-alternate-identifier`).value.coding.display' ]
+  - value: [ '%resource.code.extension(%`rsext-alternate-identifier`).value.coding.display' ]
     hl7Spec: [ '%{hl7OBXField}-3-5' ]
 
-  - name: observation-identifier-alternate-system
-    value: [ '%resource.code.extension(%`rsext-alternate-identifier`).value.coding.system' ]
+  - value: [ '%resource.code.extension(%`rsext-alternate-identifier`).value.coding.system' ]
     hl7Spec: [ '%{hl7OBXField}-3-6' ]
 
-  - name: observation-value-sub-id
-    value: [ '%resource.extension(%`rsext-sub-id`).value' ]
+  - value: [ '%resource.extension(%`rsext-sub-id`).value' ]
     hl7Spec: [ '%{hl7OBXField}-4' ]
 
-  - name: observation-value-st
-    condition: '%resource.value is string'
+  - condition: '%resource.value is string'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7OBXField}-5' ]
 
-  - name: observation-value-cwe
-    resource: '%resource.value'
+  - resource: '%resource.value'
     condition: '%resource is CodeableConcept'
     constants:
       cweFieldPath: '%{hl7OBXField}-5'
     schema: datatype/ce-coded-with-exceptions
 
-  - name: observation-value-numeric
-    resource: '%resource.value'
+  - resource: '%resource.value'
     condition: '%resource is Ratio'
     schema: datatype/sn-structured-numeric
 
-  - name: observation-units-identifier
-    value: [ '%resource.extension(%`rsext-units`).value.coding.code' ]
+  - value: [ '%resource.extension(%`rsext-units`).value.coding.code' ]
     hl7Spec: [ '%{hl7OBXField}-6-1' ]
 
-  - name: observation-units-text
-    value: [ '%resource.extension(%`rsext-units`).value.text' ]
+  - value: [ '%resource.extension(%`rsext-units`).value.text' ]
     hl7Spec: [ '%{hl7OBXField}-6-2' ]
 
-  - name: observation-units-system
-    condition: >
+  - condition: >
       %resource.extension(%`rsext-units`).exists() and 
       %resource.extension(%`rsext-units`).value.coding.system = "http://unitsofmeasure.org"
     value: [ '"UCUM"' ]
     hl7Spec: [ '%{hl7OBXField}-6-3' ]
 
-  - name: observation-units-alternate-identifier
-    resource: '%resource.extension(%`rsext-units`).value.extension(%`rsext-alternate-identifier`).value'
+  - resource: '%resource.extension(%`rsext-units`).value.extension(%`rsext-alternate-identifier`).value'
     value: [ '%resource.coding.code' ]
     hl7Spec: [ '%{hl7OBXField}-6-4' ]
 
-  - name: observation-units-alternate-text
-    resource: '%resource.extension(%`rsext-units`).value.extension(%`rsext-alternate-identifier`).value'
+  - resource: '%resource.extension(%`rsext-units`).value.extension(%`rsext-alternate-identifier`).value'
     value: [ '%resource.coding.display' ]
     hl7Spec: [ '%{hl7OBXField}-6-5' ]
 
-  - name: observation-units-alternate-system
-    resource: '%resource.extension(%`rsext-units`).value.extension(%`rsext-alternate-identifier`).value'
+  - resource: '%resource.extension(%`rsext-units`).value.extension(%`rsext-alternate-identifier`).value'
     value: [ '%resource.coding.system' ]
     hl7Spec: [ '%{hl7OBXField}-6-6' ]
 
-  - name: observation-reference-range
-    value: [ '%resource.referenceRange.text' ]
+  - value: [ '%resource.referenceRange.text' ]
     hl7Spec: [ '%{hl7OBXField}-7' ]
 
-  - name: observation-abnormal-flag
-    value: [ '%resource.interpretation.coding.code' ]
+  - value: [ '%resource.interpretation.coding.code' ]
     hl7Spec: [ '%{hl7OBXField}-8' ]
 
-  - name: observation-result-status-preliminary
-    condition: '%resource.status = "preliminary"'
+  - condition: '%resource.status = "preliminary"'
     value: [ '"P"' ]
     hl7Spec: [ '%{hl7OBXField}-11' ]
 
-  - name: observation-result-status-corrected
-    condition: '%resource.status = "corrected"'
+  - condition: '%resource.status = "corrected"'
     value: [ '"C"' ]
     hl7Spec: [ '%{hl7OBXField}-11' ]
 
-  - name: observation-result-status-corrected
-    condition: '%resource.status = "final"'
+  - condition: '%resource.status = "final"'
     value: [ '"F"' ]
     hl7Spec: [ '%{hl7OBXField}-11' ]
 
-  - name: observation-date-time
-    value: [ '%resource.effective' ]
+  - value: [ '%resource.effective' ]
     hl7Spec: [ '%{hl7OBXField}-14' ]
 
-  - name: observation-producer-id
-    resource: '%resource.extension(%`rsext-producer-id`).value.resolve().identifier'
+  - resource: '%resource.extension(%`rsext-producer-id`).value.resolve().identifier'
     constants:
       ceFieldPath: '%{hl7OBXField}-15'
     schema: datatype/ce-coded-element
 
-  - name: observation-producer-id-identifier
-    resource: '%resource.extension(%`rsext-producer-id`).value.resolve()'
+  - resource: '%resource.extension(%`rsext-producer-id`).value.resolve()'
     value: [ '%resource.identifier.value' ]
     hl7Spec: [ '%{hl7OBXField}-15-1' ]
 
-  - name: observation-producer-id-text
-    resource: '%resource.extension(%`rsext-producer-id`).value.resolve()'
+  - resource: '%resource.extension(%`rsext-producer-id`).value.resolve()'
     value: [ '%resource.name' ]
     hl7Spec: [ '%{hl7OBXField}-15-2' ]
 
-  - name: observation-producer-id-system
-    resource: '%resource.extension(%`rsext-producer-id`).value.resolve().identifier.extension(%`rsext-coding-system`).value'
+  - resource: '%resource.extension(%`rsext-producer-id`).value.resolve().identifier.extension(%`rsext-coding-system`).value'
     value: [ '%resource.coding.code' ]
     hl7Spec: [ '%{hl7OBXField}-15-3' ]
 
-  - name: observation-method
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7OBXField}-17' ]
 
-  - name: analysis-date-time
-    value: [ '%resource.issued' ]
+  - value: [ '%resource.issued' ]
     hl7Spec: [ '%{hl7OBXField}-19' ]
 
-  - name: performing-organization-name
-    resource: '%resource.performer.resolve().organization.resolve()'
+  - resource: '%resource.performer.resolve().organization.resolve()'
     schema: datatype/xon-organization
     constants:
       hl7OrgField: '%{hl7OBXField}-23'
 
-  - name: performing-organization-address
-    resource: '%resource.performer.resolve().organization.resolve().address'
+  - resource: '%resource.performer.resolve().organization.resolve().address'
     constants:
       hl7AddressField: '%{hl7OBXField}-24'
     schema: datatype/xad-extended-address
     resourceIndex: contactIndex
 
-  - name: performing-organization-director
-    resource: '%resource.performer.resolve().practitioner.resolve()'
+  - resource: '%resource.performer.resolve().practitioner.resolve()'
     constants:
       hl7XCNField: '%{hl7OBXField}-25'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: observation-note
-    condition: '%observation.note.exists()'
+  - condition: '%observation.note.exists()'
     resource: '%resource.note.text.split(''\n'')'
     schema: note
     resourceIndex: noteIndex

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/order-observation.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/order-observation.yml
@@ -1,4 +1,3 @@
-name: ORU-R01-order-observation
 constants:
   hl7Order: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})'
   diagnostic: 'Bundle.entry.resource.ofType(DiagnosticReport)[%orderIndex]'
@@ -6,22 +5,18 @@ constants:
   hl7ObservationNotes: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/OBSERVATION'
   hl7ObservationPath: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/OBSERVATION'
 elements:
-  - name: order-segment
     # Only create the segment if we have data for it
-    condition: '%service.extension(%`rsext-order-control`).exists()'
+  - condition: '%service.extension(%`rsext-order-control`).exists()'
     schema: order
 
-  - name: observation-request
     # Condition from ORU_RO1 covers this schema as well
-    schema: observation-request
+  - schema: observation-request
 
-  - name: specimen
-    resource: '%resource.specimen.resolve()'
+  - resource: '%resource.specimen.resolve()'
     condition: '%resource.exists()'
     schema: specimen
 
-  - name: timing-segment
-    resource: '%service'
+  - resource: '%service'
     # Only create the segment if we have data for it
     condition: >
       %resource.extension(%`rsext-start-of-service`).exists() or
@@ -29,13 +24,11 @@ elements:
       %resource.extension(%`rsext-service-priority`).exists()
     schema: timing-quantity
 
-  - name: observation-result
-    resource: '%resource.result.resolve()'
+  - resource: '%resource.result.resolve()'
     schema: observation-result
     resourceIndex: resultIndex
 
-  - name: order-note
-    resource: '%service.note.text.split(''\n'')'
+  - resource: '%service.note.text.split(''\n'')'
     condition: '%service.note.exists()'
     schema: note
     resourceIndex: noteIndex

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/order.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/order.yml
@@ -1,15 +1,12 @@
-name: ORU-R01-order
 constants:
   hl7Order: /PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/ORC
 elements:
-  - name: order-control
-    resource: '%service'
+  - resource: '%service'
     condition: '%resource.extension(%`rsext-order-control`).exists()'
     value: [ '%resource.extension(%`rsext-order-control`).value.coding.code' ]
     hl7Spec: [ '%{hl7Order}-1' ]
 
-  - name: order-placer-order-number
-    resource: >
+  - resource: >
       %service.identifier.where(type.coding.system = 'http://terminology.hl7.org/CodeSystem/v2-0203')
       .where(type.coding.code = 'PLAC')
     condition: '%resource.count() > 0'
@@ -18,8 +15,7 @@ elements:
     resourceIndex: entityIdIndex
     schema: datatype/ei-entity-identifier
 
-  - name: order-filler-order-number
-    resource: >
+  - resource: >
       %service.identifier.where(type.coding.system = 'http://terminology.hl7.org/CodeSystem/v2-0203')
       .where(type.coding.code = 'FILL')
     condition: '%resource.count() > 0'
@@ -28,8 +24,7 @@ elements:
     resourceIndex: entityIdIndex
     schema: datatype/ei-entity-identifier
 
-  - name: order-placer-group-number
-    resource: >
+  - resource: >
       %service.identifier.where(type.coding.system = 'http://terminology.hl7.org/CodeSystem/v2-0203')
       .where(type.coding.code = 'PGN')
     condition: '%resource.count() > 0'
@@ -38,65 +33,54 @@ elements:
     resourceIndex: entityIdIndex
     schema: datatype/ei-entity-identifier
 
-  - name: order-response-flag
-    resource: '%resource.extension(%`rsext-response-flag`)'
+  - resource: '%resource.extension(%`rsext-response-flag`)'
     condition: '%resource.exists()'
     value: [ '%resource.value.coding[0].code' ]
     hl7Spec: [ '%{hl7Order}-6' ]
 
-  - name: order-transaction-time
-    value: [ '%service.authoredOn' ]
+  - value: [ '%service.authoredOn' ]
     hl7Spec: [ '%{hl7Order}-9' ]
 
-  - name: order-entered-by
-    condition: false
+  - condition: false
     value: [ '' ] # Don't have data yet
     hl7Spec: [ '%{hl7Order}-10' ]
 
-  - name: order-ordering-provider
-    resource: '%service.requester.resolve().practitioner.resolve()'
+  - resource: '%service.requester.resolve().practitioner.resolve()'
     constants:
       hl7XCNField: '%{hl7Order}-12'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: order-callback-phone-number
-    resource: '%service.requester.resolve().practitioner.resolve().extension(%`rsext-callback-number`).value'
+  - resource: '%service.requester.resolve().practitioner.resolve().extension(%`rsext-callback-number`).value'
     condition: '%resource.exists()'
     constants:
       hl7TelecomField: '%{hl7Order}-14'
     schema: datatype/xtn-telecom
 
-  - name: order-effective-date
-    value: [ '%service.occurrence' ]
+  - value: [ '%service.occurrence' ]
     hl7Spec: [ '%{hl7Order}-15' ]
 
-  - name: ordering-organization
-    resource: '%service.extension(%`rsext-entering-organization`)'
+  - resource: '%service.extension(%`rsext-entering-organization`)'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7Order}-17' ]
 
-  - name: ordering-facility-name
-    resource: '%service.requester.resolve().organization.resolve()'
+  - resource: '%service.requester.resolve().organization.resolve()'
     schema: datatype/xon-organization
     constants:
       hl7OrgField: '%{hl7Order}-21'
 
-  - name: ordering-facility-address
-    resource: '%service.requester.resolve().organization.resolve().address'
+  - resource: '%service.requester.resolve().organization.resolve().address'
     schema: datatype/xad-extended-address
     constants:
       hl7AddressField: '%{hl7Order}-22'
 
-  - name: ordering-facility-phone
-    resource: '%service.requester.resolve().organization.resolve().contact[0].telecom'
+  - resource: '%service.requester.resolve().organization.resolve().contact[0].telecom'
     schema: datatype/xtn-telecom
     constants:
       hl7TelecomField: '%{hl7Order}-23'
 
-  - name: ordering-facility-address
-    resource: '%service.requester.resolve().practitioner.resolve().address'
+  - resource: '%service.requester.resolve().practitioner.resolve().address'
     schema: datatype/xad-extended-address
     constants:
       hl7AddressField: '%{hl7Order}-24'

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/patient-contact.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/patient-contact.yml
@@ -1,67 +1,54 @@
-name: ORU-R01-contact
 elements:
-  - name: id
-    value: [ 1 ]
+  - value: [ 1 ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-1' ]
 
-  - name: contact-name
-    resource: '%resource.name'
+  - resource: '%resource.name'
     condition: '%resource.exists()'
     constants:
       hl7NameField: '/PATIENT_RESULT/PATIENT/NK1-2'
     schema: datatype/xpn-person-name
 
-  - name: contact-relationship-id
-    value: [ '%resource.relationship.where(coding.system != "http://hl7.org/fhir/ValueSet/patient-contactrelationship").coding.code' ]
+  - value: [ '%resource.relationship.where(coding.system != "http://hl7.org/fhir/ValueSet/patient-contactrelationship").coding.code' ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-3-1' ]
 
-  - name: contact-relationship-text
-    value: [ '%resource.relationship.where(coding.system != "http://hl7.org/fhir/ValueSet/patient-contactrelationship").text' ]
+  - value: [ '%resource.relationship.where(coding.system != "http://hl7.org/fhir/ValueSet/patient-contactrelationship").text' ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-3-2' ]
 
-  - name: contact-relationship-system
-    value: [ '%resource.relationship.where(coding.system != "http://hl7.org/fhir/ValueSet/patient-contactrelationship").coding.system' ]
+  - value: [ '%resource.relationship.where(coding.system != "http://hl7.org/fhir/ValueSet/patient-contactrelationship").coding.system' ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-3-3' ]
 
-  - name: contact-relationship-alternate-id
-    resource: '%resource.relationship.extension(%`rsext-alternate-identifier`).value'
+  - resource: '%resource.relationship.extension(%`rsext-alternate-identifier`).value'
     value: [ '%resource.coding.code' ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-3-4' ]
 
-  - name: contact-relationship-alternate-text
-    resource: '%resource.relationship.extension(%`rsext-alternate-identifier`).value'
+  - resource: '%resource.relationship.extension(%`rsext-alternate-identifier`).value'
     value: [ '%resource.coding.display' ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-3-5' ]
 
-  - name: contact-relationship-alternate-system
-    resource: '%resource.relationship.extension(%`rsext-alternate-identifier`).value'
+  - resource: '%resource.relationship.extension(%`rsext-alternate-identifier`).value'
     value: [ '%resource.coding.system' ]
     hl7Spec: [ '/PATIENT_RESULT/PATIENT/NK1-3-6' ]
 
-  - name: contact-address
-    resource: '%resource.address'
+  - resource: '%resource.address'
     condition: '%resource.exists()'
     constants:
       hl7AddressField: '/PATIENT_RESULT/PATIENT/NK1-4'
     schema: datatype/xad-extended-address
     resourceIndex: orderIndex
 
-  - name: phone-number
-    resource: '%resource.telecom'
+  - resource: '%resource.telecom'
     condition: '%resource.exists()'
     constants:
       hl7TelecomField: '/PATIENT_RESULT/PATIENT/NK1-5'
     schema: datatype/xtn-telecom
 
-  - name: contact-persons-phone-number
-    resource: '%resource.organization.resolve().contact.telecom'
+  - resource: '%resource.organization.resolve().contact.telecom'
     condition: '%resource.exists()'
     constants:
       hl7TelecomField: '/PATIENT_RESULT/PATIENT/NK1-31'
     schema: datatype/xtn-telecom
 
-  - name: contact-persons-address
-    resource: '%resource.organization.resolve().contact.address'
+  - resource: '%resource.organization.resolve().contact.address'
     condition: '%resource.exists()'
     constants:
       hl7AddressField: '/PATIENT_RESULT/PATIENT/NK1-32'

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/patient-visit.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/patient-visit.yml
@@ -1,95 +1,75 @@
-name: ORU-R01-patient-visit
 constants:
   hl7PV1Field: /PATIENT_RESULT/PATIENT/VISIT/PV1
 elements:
-  - name: set-id
-    value: [ '"1"' ]
+  - value: [ '"1"' ]
     hl7Spec: [ '%{hl7PV1Field}-1' ]
 
-  - name: patient-class
-    condition: '%resource.class.code.exists()'
+  - condition: '%resource.class.code.exists()'
     value: [ '%resource.class.code.getPatientClass()' ]
     hl7Spec: [ '%{hl7PV1Field}-2' ]
 
-  - name: patient-assigned-location-point-of-care
-    value: [ '%resource.location[0].location.resolve().extension(%`rsext-point-of-care`).value' ]
+  - value: [ '%resource.location[0].location.resolve().extension(%`rsext-point-of-care`).value' ]
     hl7Spec: [ '%{hl7PV1Field}-3-1' ]
 
-  - name: patient-assigned-location-room
-    resource: '%resource.location[0].location.resolve().identifier.value[0]'
+  - resource: '%resource.location[0].location.resolve().identifier.value[0]'
     value: [ '%resource.substring(0, %resource.indexOf(","))' ]
     hl7Spec: [ '%{hl7PV1Field}-3-2' ]
 
-  - name: patient-assigned-location-bed
-    resource: '%resource.location[0].location.resolve().identifier.value[0]'
+  - resource: '%resource.location[0].location.resolve().identifier.value[0]'
     condition: '%resource.indexOf(",") > -1'
     value: [ '%resource.substring(%resource.indexOf(",") + 1)' ]
     hl7Spec: [ '%{hl7PV1Field}-3-3' ]
 
-  - name: patient-admission-type
-    value: [ '%resource.type.coding.code' ]
+  - value: [ '%resource.type.coding.code' ]
     hl7Spec: [ '%{hl7PV1Field}-4' ]
 
-  - name: patient-attending-doctor
-    resource: '%resource.participant.where(type.coding.code = "ATND").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
+  - resource: '%resource.participant.where(type.coding.code = "ATND").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
     constants:
       hl7XCNField: '%{hl7PV1Field}-7'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: patient-referring-doctor
-    resource: '%resource.participant.where(type.coding.code = "REF").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
+  - resource: '%resource.participant.where(type.coding.code = "REF").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
     constants:
       hl7XCNField: '%{hl7PV1Field}-8'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: patient-consulting-doctor
-    resource: '%resource.participant.where(type.coding.code = "CON").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
+  - resource: '%resource.participant.where(type.coding.code = "CON").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
     constants:
       hl7XCNField: '%{hl7PV1Field}-9'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: patient-hospital-service
-    value: [ '%resource.serviceType.coding.code' ]
+  - value: [ '%resource.serviceType.coding.code' ]
     hl7Spec: [ '%{hl7PV1Field}-10' ]
 
-  - name: patient-admit-source
-    value: [ '%resource.hospitalization.admitSource.coding.code' ]
+  - value: [ '%resource.hospitalization.admitSource.coding.code' ]
     hl7Spec: [ '%{hl7PV1Field}-14' ]
 
-  - name: patient-admitting-doctor
-    resource: '%resource.participant.where(type.coding.code = "ADM").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
+  - resource: '%resource.participant.where(type.coding.code = "ADM").where(type.coding.system = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType").individual.resolve()'
     constants:
       hl7XCNField: '%{hl7PV1Field}-17'
     schema: datatype/xcn-contact
     resourceIndex: contactIndex
 
-  - name: patient-type
-    value: [ '%resource.extension(%`rsext-patient-type`).value' ]
+  - value: [ '%resource.extension(%`rsext-patient-type`).value' ]
     hl7Spec: [ '%{hl7PV1Field}-18' ]
 
-  - name: patient-financial-class
-    value: [ '%resource.extension(%`rsext-financial-class`).value' ]
+  - value: [ '%resource.extension(%`rsext-financial-class`).value' ]
     hl7Spec: [ '%{hl7PV1Field}-20' ]
 
-  - name: patient-discharge-disposition
-    value: [ '%resource.hospitalization.dischargeDisposition.coding.code' ]
+  - value: [ '%resource.hospitalization.dischargeDisposition.coding.code' ]
     hl7Spec: [ '%{hl7PV1Field}-36' ]
 
-  - name: patient-servicing-facility
-    value: [ '%resource.extension(%`rsext-servicing-facility`).value' ]
+  - value: [ '%resource.extension(%`rsext-servicing-facility`).value' ]
     hl7Spec: [ '%{hl7PV1Field}-39' ]
 
-  - name: patient-account-status
-    value: [ '%resource.extension(%`rsext-account-status`).value' ]
+  - value: [ '%resource.extension(%`rsext-account-status`).value' ]
     hl7Spec: [ '%{hl7PV1Field}-41' ]
 
-  - name: patient-admit-datetime
-    value: [ '%resource.period.start' ]
+  - value: [ '%resource.period.start' ]
     hl7Spec: [ '%{hl7PV1Field}-44' ]
 
-  - name: patient-admit-datetime
-    value: [ '%resource.period.end' ]
+  - value: [ '%resource.period.end' ]
     hl7Spec: [ '%{hl7PV1Field}-45' ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/patient.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/patient.yml
@@ -1,173 +1,140 @@
-name: ORU-R01-patient
 constants:
   hl7PIDField: '/PATIENT_RESULT/PATIENT/PID'
   hl7PatientGroup: '/PATIENT_RESULT/PATIENT'
 elements:
-  - name: set-id
-    value: [ '"1"' ]
+  - value: [ '"1"' ]
     hl7Spec: [ '%{hl7PIDField}-1' ]
 
-  - name: patient-identifier-list
-    resource: '%resource.identifier'
+  - resource: '%resource.identifier'
     constants:
       hl7CXField: '%{hl7PIDField}-3'
     schema: datatype/cx-extended-composite-id
     resourceIndex: idIndex
 
-  - name: patient-name
-    resource: '%resource.name'
+  - resource: '%resource.name'
     condition: '%resource.exists()'
     constants:
       hl7NameField: '%{hl7PIDField}-5'
     schema: datatype/xpn-person-name
 
-  - name: patient-mothers-maiden-name
-    resource: '%resource.extension(%`ext-patient-mothersMaidenName`).value'
+  - resource: '%resource.extension(%`ext-patient-mothersMaidenName`).value'
     condition: '%resource.exists()'
     constants:
       hl7NameField: '%{hl7PIDField}-6'
     schema: datatype/xpn-person-name
 
-  - name: patient-dob
-    value: [ '%resource.birthDate' ]
+  - value: [ '%resource.birthDate' ]
     hl7Spec: [ '%{hl7PIDField}-7' ]
 
-  - name: patient-sex
-    value: [ '%resource.gender.GetAdministrativeGenderCode()' ]
+  - value: [ '%resource.gender.GetAdministrativeGenderCode()' ]
     hl7Spec: [ '%{hl7PIDField}-8' ]
 
   #race
-  - name: patient-race-identifier
-    value: [ '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value.coding.code' ]
+  - value: [ '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value.coding.code' ]
     hl7Spec: [ '%{hl7PIDField}-10-1' ]
 
-  - name: patient-race-text
-    value: [ '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value.text' ]
+  - value: [ '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value.text' ]
     hl7Spec: [ '%{hl7PIDField}-10-2' ]
 
   # this value just confirms that this segment part is HL7-Race
-  - name: patient-race-coding-system
-    value: [ '"HL70005"' ]
+  - value: [ '"HL70005"' ]
     hl7Spec: [ '%{hl7PIDField}-10-3' ]
 
-  - name: patient-race-alternate-identifier
-    resource: '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value'
+  - resource: '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value'
     value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.code' ]
     hl7Spec: [ '%{hl7PIDField}-10-4' ]
 
-  - name: patient-race-alternate-text
-    resource: '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value'
+  - resource: '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value'
     value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.display' ]
     hl7Spec: [ '%{hl7PIDField}-10-5' ]
 
-  - name: patient-race-alternate-system
-    resource: '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value'
+  - resource: '%resource.extension("http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd").value'
     value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.system' ]
     hl7Spec: [ '%{hl7PIDField}-10-6' ]
 
-  - name: patient-address
-    resource: '%resource.address'
+  - resource: '%resource.address'
     condition: '%resource.exists()'
     constants:
       hl7AddressField: '%{hl7PIDField}-11'
     schema: datatype/xad-extended-address
     resourceIndex: orderIndex
 
-  - name: phone-number-home
-    resource: '%resource.telecom.where(use = "home")'
+  - resource: '%resource.telecom.where(use = "home")'
     constants:
       hl7TelecomField: '%{hl7PIDField}-13'
     schema: datatype/xtn-telecom
 
-  - name: phone-number-business
-    resource: '%resource.telecom.where(use = "work")'
+  - resource: '%resource.telecom.where(use = "work")'
     constants:
       hl7TelecomField: '%{hl7PIDField}-14'
     schema: datatype/xtn-telecom
 
-  - name: patient-marital-status
-    value: [ '%resource.maritalStatus.where(coding.system = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus").coding.code' ]
+  - value: [ '%resource.maritalStatus.where(coding.system = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus").coding.code' ]
     hl7Spec: [ '%{hl7PIDField}-16' ]
 
-  - name: patient-religion
-    resource: '%resource.extension(%`ext-patient-religion`).value.coding.where(system = "http://terminology.hl7.org/CodeSystem/v2-0006")'
+  - resource: '%resource.extension(%`ext-patient-religion`).value.coding.where(system = "http://terminology.hl7.org/CodeSystem/v2-0006")'
     constants:
       ceFieldPath: '%{hl7PIDField}-17'
     schema: datatype/ce-coded-element
 
-  - name: patient-ethnicity
-    resource: '%resource.extension(%`rsext-ethnic-group`).value'
+  - resource: '%resource.extension(%`rsext-ethnic-group`).value'
     constants:
       ceFieldPath: '%{hl7PIDField}-22'
     schema: datatype/ce-coded-element
 
-  - name: patient-death-date-time
-    condition: '%resource.deceased.exists() and %resource.deceased is DateTime'
+  - condition: '%resource.deceased.exists() and %resource.deceased is DateTime'
     value: [ '%resource.deceased' ]
     hl7Spec: [ '%{hl7PIDField}-29' ]
 
-  - name: patient-death-indicator-1
-    condition: '%resource.deceased.exists() and %resource.deceased is DateTime'
+  - condition: '%resource.deceased.exists() and %resource.deceased is DateTime'
     value: [ '"Y"']
     hl7Spec: [ '%{hl7PIDField}-30' ]
 
-  - name: patient-death-indicator-2
-    condition: '%resource.deceased.exists() and %resource.deceased is Boolean'
+  - condition: '%resource.deceased.exists() and %resource.deceased is Boolean'
     value: [ '%resource.deceased.GetYesNoValue()' ]
     hl7Spec: [ '%{hl7PIDField}-30' ]
 
-  - name: patient-last-updated-at
-    value: [ '%resource.meta.lastUpdated' ]
+  - value: [ '%resource.meta.lastUpdated' ]
     hl7Spec: [ '%{hl7PIDField}-33' ]
 
-  - name: last-update-facility-namespace-id
-    resource: '%resource.meta.extension(%`rsext-last-updated-facility-namespace-id`)'
+  - resource: '%resource.meta.extension(%`rsext-last-updated-facility-namespace-id`)'
     condition: '%resource.exists()'
     value: [ '%resource.value.getId()' ]
     hl7Spec: [ '%{hl7PIDField}-34-1' ]
 
-  - name: last-update-facility-universal-id
-    resource: '%resource.meta.extension(%`rsext-last-updated-facility-universal-id`)'
+  - resource: '%resource.meta.extension(%`rsext-last-updated-facility-universal-id`)'
     condition: '%resource.exists()'
     value: [ '%resource.value.getId()' ]
     hl7Spec: [ '%{hl7PIDField}-34-2' ]
 
-  - name: last-update-facility-universal-type
-    resource: '%resource.meta.extension(%`rsext-last-updated-facility-universal-id`)'
+  - resource: '%resource.meta.extension(%`rsext-last-updated-facility-universal-id`)'
     condition: '%resource.exists()'
     value: [ '%resource.value.getIdType()' ]
     hl7Spec: [ '%{hl7PIDField}-34-3' ]
 
-  - name: patient-species-identifier
-    value: [ '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value.coding.code' ]
+  - value: [ '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value.coding.code' ]
     hl7Spec: [ '%{hl7PIDField}-35-1' ]
 
-  - name: patient-species-text
-    value: [ '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value.text' ]
+  - value: [ '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value.text' ]
     hl7Spec: [ '%{hl7PIDField}-35-2' ]
 
   # need to check why the value we get here is SCT instead of HL70446
-  - name: patient-species-coding-system
-    value: [ '"SCT"' ]
+  - value: [ '"SCT"' ]
     hl7Spec: [ '%{hl7PIDField}-35-3' ]
 
-  - name: patient-species-alternate-identifier
-    resource: '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value'
+  - resource: '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value'
     value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.code' ]
     hl7Spec: [ '%{hl7PIDField}-35-4' ]
 
-  - name: patient-species-alternate-text
-    resource: '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value'
+  - resource: '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value'
     value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.display' ]
     hl7Spec: [ '%{hl7PIDField}-35-5' ]
 
-  - name: patient-species-alternate-system
-    resource: '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value'
+  - resource: '%resource.extension("http://hl7.org/fhir/StructureDefinition/patient-animal").value'
     value: [ '%resource.extension(%`rsext-alternate-identifier`).value.coding.system' ]
     hl7Spec: [ '%{hl7PIDField}-35-6' ]
 
-  - name: patient-note
-    resource: '%resource.extension(%`rsext-patient-notes`).value.text.split(''\n'')'
+  - resource: '%resource.extension(%`rsext-patient-notes`).value.text.split(''\n'')'
     condition: 'Bundle.entry.resource.ofType(Patient).extension(%`rsext-patient-notes`).exists()'
     schema: note
     resourceIndex: noteIndex

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/software.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/software.yml
@@ -1,21 +1,18 @@
 name: ORU-R01-software
 elements:
-  - name: software-vendor-name
-    value: [ '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve().name' ]
+  - value: [ '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve().name' ]
     hl7Spec: [ SFT-1-1 ]
 
-  - name: software-vendor-name-type
-    # software-vendor-org is a reference
-    resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
+  # software-vendor-org is a reference
+  - resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
     condition: '%resource.name.exists()'
     value:
       - '%resource.extension(%`rsext-organization-name-type`).value.coding.code'
       - '''L'''
     hl7Spec: [ SFT-1-2 ]
 
-  - name: software-vendor-assigning-authority
     # software-vendor-org is a reference
-    resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
+  - resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
     constants:
       hl7HDField: 'SFT-1-6'
       # cannot use %`rext due to mix of constant and fhirpath substitution syntax
@@ -23,34 +20,27 @@ elements:
       universalIdExtName: '"https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id"'
     schema: datatype/hd-hierarchic-designator
 
-  - name: software-vendor-identifier-code
     # software-vendor-org is a reference
-    resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
+  - resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
     value: [ '%resource.type.coding.code' ]
     hl7Spec: [ SFT-1-7 ]
 
-  - name: software-vendor-identifier
     # software-vendor-org is a reference
-    resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
+  - resource: '%resource.source.extension(%`rsext-software-vendor-org`).value.resolve()'
     value: [ '%resource.identifier[0].value' ]
     hl7Spec: [ SFT-1-10 ]
 
-  - name: software-version
-    value: [ '%resource.source.version']
+  - value: [ '%resource.source.version']
     hl7Spec: [ SFT-2 ]
 
-  - name: software-name
-    value: [ '%resource.source.software' ]
+  - value: [ '%resource.source.software' ]
     hl7Spec: [ SFT-3 ]
 
-  - name: software-id
-    value: [ '%resource.source.extension(%`rsext-software-binary-id`).value' ]
+  - value: [ '%resource.source.extension(%`rsext-software-binary-id`).value' ]
     hl7Spec: [ SFT-4 ]
 
-  - name: software-description
-    value: [ '%resource.source.extension(%`rsext-software-description`).value' ]
+  - value: [ '%resource.source.extension(%`rsext-software-description`).value' ]
     hl7Spec: [ SFT-5 ]
 
-  - name: software-install-date
-    value: [ '%resource.source.extension(%`rsext-software-install-date`).value' ]
+  - value: [ '%resource.source.extension(%`rsext-software-install-date`).value' ]
     hl7Spec: [ SFT-6 ]

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/specimen.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/specimen.yml
@@ -1,100 +1,80 @@
-name: ORU-R01-specimen
 constants:
   hl7SpecimenFieldPath: /PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/SPECIMEN/SPM
 elements:
-  - name: specimen-set-ID
-    value: [ '"1"' ]
+  - value: [ '"1"' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-1' ]
 
-  - name: specimen-identifier-placer
-    resource: '%resource.identifier.where(type.empty())'
+  - resource: '%resource.identifier.where(type.empty())'
     condition: '%resource.exists()'
     constants:
       entityIdFieldPath: '%{hl7SpecimenFieldPath}-2-1'
     schema: datatype/ei-entity-identifier
     resourceIndex: entityIdIndex
 
-  - name: specimen-identifier-filler
-    resource: '%resource.identifier.where(type.coding.code = "FGN")'
+  - resource: '%resource.identifier.where(type.coding.code = "FGN")'
     condition: '%resource.exists()'
     constants:
       entityIdFieldPath: '%{hl7SpecimenFieldPath}-2-2'
     schema: datatype/ei-entity-identifier
     resourceIndex: entityIdIndex
 
-  - name: specimen-type
-    resource: '%resource.type'
+  - resource: '%resource.type'
     constants:
       cweFieldPath: '%{hl7SpecimenFieldPath}-4'
     schema: datatype/ce-coded-with-exceptions
 
-  - name: specimen-type-modifier
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-5' ]
 
-  - name: specimen-additives
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-6' ]
 
-  - name: specimen-collection-method
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-7' ]
 
-  - name: specimen-source-site
-    resource: '%resource.collection.bodySite'
+  - resource: '%resource.collection.bodySite'
     condition: '%resource.exists()'
     constants:
       cweFieldPath: '%{hl7SpecimenFieldPath}-8'
     schema: datatype/ce-coded-with-exceptions
 
-  - name: specimen-source-site-modifier
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-9' ]
 
-  - name: specimen-role
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-11' ]
 
-  - name: specimen-description
-    value: [ '%resource.note.text' ]
+  - value: [ '%resource.note.text' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-14' ]
 
-  - name: specimen-collection-time
-    condition: '%resource.collection.collected is dateTime'
+  - condition: '%resource.collection.collected is dateTime'
     value: [ '%resource.collection.collected' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-17-1' ]
 
-  - name: specimen-observation-date-time-start
-    condition: '%resource.collection.collected is Period'
+  - condition: '%resource.collection.collected is Period'
     value: [ '%resource.collection.collected.start' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-17-1' ]
 
-  - name: specimen-observation-date-time-end
-    condition: '%resource.collection.collected is Period'
+  - condition: '%resource.collection.collected is Period'
     value: [ '%resource.collection.collected.end' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-17-2' ]
 
-  - name: specimen-received-time
-    condition: '%resource.receivedTime is dateTime'
+  - condition: '%resource.receivedTime is dateTime'
     value: [ '%resource.receivedTime' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-18' ]
 
-  - name: specimen-reject-reason
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-21' ]
 
-  - name: specimen-condition
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-24' ]
 
-  - name: specimen-number-of-containers
-    resource: '%resource.container.specimenQuantity'
+  - resource: '%resource.container.specimenQuantity'
     condition: '%resource.exists()'
     value: [ '%resource.value' ]
     hl7Spec: [ '%{hl7SpecimenFieldPath}-26' ]
 
-  - name: specimen-container-type
-    resource: '%resource.container.type'
+  - resource: '%resource.container.type'
     constants:
       cweFieldPath: '%{hl7SpecimenFieldPath}-27'
     schema: datatype/ce-coded-with-exceptions

--- a/prime-router/metadata/hl7_mapping/ORU_R01/base/timing-quantity.yml
+++ b/prime-router/metadata/hl7_mapping/ORU_R01/base/timing-quantity.yml
@@ -1,22 +1,17 @@
-name: ORU-R01-order-observation-timing
 constants:
   hl7TQ1: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/TIMING_QTY/TQ1'
 elements:
-  - name: tq1-set-id
-    value: [ '1' ]
+  - value: [ '1' ]
     hl7Spec: [ '%{hl7TQ1}-1' ]
 
-  - name: tq1-start-of-service
-    condition: '%resource.extension(%`rsext-start-of-service`).exists()'
+  - condition: '%resource.extension(%`rsext-start-of-service`).exists()'
     value: [ '%resource.extension(%`rsext-start-of-service`).value' ]
     hl7Spec: [ '%{hl7TQ1}-7' ]
 
-  - name: tq1-end-of-service
-    condition: '%resource.extension(%`rsext-end-of-service`).exists()'
+  - condition: '%resource.extension(%`rsext-end-of-service`).exists()'
     value: [ '%resource.extension(%`rsext-end-of-service`).value' ]
     hl7Spec: [ '%{hl7TQ1}-8' ]
 
-  - name: tq1-service-priority
-    condition: '%resource.extension(%`rsext-service-priority`).exists()'
+  - condition: '%resource.extension(%`rsext-service-priority`).exists()'
     value: [ '%resource.extension(%`rsext-service-priority`).value.coding.code' ]
     hl7Spec: [ '%{hl7TQ1}-9-1' ]

--- a/prime-router/metadata/hl7_mapping/STLTs/CO/CO.yml
+++ b/prime-router/metadata/hl7_mapping/STLTs/CO/CO.yml
@@ -1,4 +1,3 @@
-name: CO
 hl7Type: ORU_R01
 hl7Version: 2.5.1
 extends: ../../ORU_R01/ORU_R01-base
@@ -6,40 +5,31 @@ elements:
   #########################
   # ReportStream specific #
   #########################
-  - name: sending-application-namespace-id
-    value: [ '"CDC PRIME - Atlanta, Georgia (Dekalb)"' ]
+  - value: [ '"CDC PRIME - Atlanta, Georgia (Dekalb)"' ]
 
-  - name: sending-application-universal-id
-    value: [ '"2.16.840.1.114222.4.1.237821"' ]
+  - value: [ '"2.16.840.1.114222.4.1.237821"' ]
 
   ######################################################
   # Source: ReportStream CO Requirements from settings #
   ######################################################
-  - name: receiving-application-namespace-id
-    value: [ '''CO-ELR''' ]
+  - value: [ '''CO-ELR''' ]
 
-  - name: receiving-application-universal-id
-    condition: false
+  - condition: false
 
-  - name: receiving-application-universal-id-type
-    condition: false
+  - condition: false
 
-  - name: receiving-facility-namespace-id
-    value: [ '''CO''' ]
+  - value: [ '''CO''' ]
 
-  - name: receiving-facility-universal-id
-    condition: false
+  - condition: false
 
-  - name: receiving-facility-universal-id-type
-    condition: false
+  - condition: false
 
   # Reporting facility name: CO requested to keep original MSH-4 from HCA.  ReportStream hard codes it to
   # CDC PRIME^11D2030855^CLIA
   # TODO - How does this change for other senders?
 
   # TODO - These are HCA specific configs that should go in the sender transformation, but these may be CO specific too
-  - name: co-order-observations
-    resource: 'Bundle.entry.resource.ofType(DiagnosticReport)'
+  - resource: 'Bundle.entry.resource.ofType(DiagnosticReport)'
     condition: '%resource.count() > 0'
     schema: co-order-observation
     resourceIndex: orderIndex
@@ -49,45 +39,34 @@ elements:
   # TODO These could be done as sender transforms, but may not work for all states
   ###############################
   # Always replace ORC-10 with NULL for all OBR segments
-  - name: collector-identifier
-    condition: false
+  - condition: false
 
   # Always replace OBX-17 with NULL for all OBX segments
-  - name: observation-method
-    condition: false
+  - condition: false
 
   # Always replace SPM-5 with NULL for all Specimen segments
-  - name: specimen-type-modifier
-    condition: false
+  - condition: false
 
   # Always replace SPM-6 with NULL for all Specimen segments
-  - name: specimen-additives
-    condition: false
+  - condition: false
 
   # Always replace SPM-7 with NULL for all Specimen segments
-  - name: specimen-collection-method
-    condition: false
+  - condition: false
 
   # Always replace SPM-8 with NULL for all Specimen segments
-  - name: specimen-source-site
-    condition: false
+  - condition: false
 
   # Always replace SPM-9 with NULL for all Specimen segments
-  - name: specimen-source-site-modifier
-    condition: false
+  - condition: false
 
   # Always replace SPM-11 with NULL for all Specimen segments
-  - name: specimen-role
-    condition: false
+  - condition: false
 
   # Always replace SPM-21 with NULL for all Specimen segments
-  - name: specimen-reject-reason
-    condition: false
+  - condition: false
 
   # Always replace SPM-24 with NULL for all Specimen segments
-  - name: specimen-condition
-    condition: false
+  - condition: false
 
   # Suppress all instances of the TQ1 segment
-  - name: timing-segment
-    condition: false
+  - condition: false

--- a/prime-router/metadata/hl7_mapping/STLTs/CO/co-observation-result.yml
+++ b/prime-router/metadata/hl7_mapping/STLTs/CO/co-observation-result.yml
@@ -1,12 +1,10 @@
-name: co-observation-result
 constants:
   hl7ObservationPath: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})/OBSERVATION(%{resultIndex})'
 elements:
   # If OBX-3.4 is equals to “HCVRNA” or “HCVLOG” AND OBX-5.2 is NON-Numeric result, AND OBX-15.1 equals to “QDI”,
   # THEN replace the OBX-2 with “CWE” and remove OBX-5.1.
   # Follow this same rule for all non-numeric results
-  - name: co-result-value-type-fix-sn-obx2
-    resource: '%resource.value'
+  - resource: '%resource.value'
     condition: >
       %resource is Ratio and
       %resource.numerator.value.exists().not() and
@@ -14,8 +12,7 @@ elements:
     value: [ '"CE"' ]
     hl7Spec: [ '%{hl7ObservationPath}/OBX-2' ]
 
-  - name: co-result-value-type-fix-sn-obx5
-    resource: '%resource.value'
+  - resource: '%resource.value'
     condition: >
       %resource is Ratio and
       %resource.numerator.value.exists().not() and

--- a/prime-router/metadata/hl7_mapping/STLTs/CO/co-order-observation.yml
+++ b/prime-router/metadata/hl7_mapping/STLTs/CO/co-order-observation.yml
@@ -1,24 +1,20 @@
-name: co-order-observation
 constants:
   hl7Order: '/PATIENT_RESULT/ORDER_OBSERVATION(%{orderIndex})'
 elements:
   # Source: HCA CO Requirements
   # Always replace ORC-21.8 with NULL
-  - name: co-ordering-facility-assigning-facility
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7Order}/ORC-21-8' ]
 
   # Source: HCA CO Requirements
   # Always replace ORC-21.9 with NULL
-  - name: co-ordering-facility-name-code
-    value: [ '""' ]
+  - value: [ '""' ]
     hl7Spec: [ '%{hl7Order}/ORC-21-9' ]
 
   # Source: HCA CO Requirements
   # If ORC-21.6 is populated then replace ORC-21.10 with value present in ORC-21.6.1
   # We overwrite this field with a new element as XON elements are generic and reused in other conversions
-  - name: co-ordering-facility-organization-id
-    resource: '%resource.basedOn.resolve().requester.resolve().organization.resolve()'
+  - resource: '%resource.basedOn.resolve().requester.resolve().organization.resolve()'
     value:
       # ORC-21.6.1
       - '%resource.extension(%`rsext-namespace-id`).value'
@@ -26,7 +22,6 @@ elements:
       - '%resource.identifier.value'
     hl7Spec: [ '%{hl7Order}/ORC-21-10' ]
 
-  - name: co-observation-result
-    resource: '%resource.result.resolve()'
+  - resource: '%resource.result.resolve()'
     schema: co-observation-result
     resourceIndex: resultIndex

--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchema.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchema.kt
@@ -190,10 +190,6 @@ data class ConfigSchemaElement(
             validationErrors.add("[$name]: $msg")
         }
 
-        if (name.isNullOrBlank()) {
-            addError("Element name cannot be blank")
-        }
-
         when {
             resource.isNullOrBlank() && !resourceIndex.isNullOrBlank() ->
                 addError("Resource property is required to use the resourceIndex property")

--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReader.kt
@@ -75,8 +75,11 @@ object ConfigSchemaReader : Logging {
             throw SchemaException(msg, e)
         }
 
-        if (ancestry.contains(rawSchema.name))
+        if (rawSchema.name == null) rawSchema.name = schemaName
+
+        if (ancestry.contains(rawSchema.name)) {
             throw HL7ConversionException("Circular reference detected for schema ${rawSchema.name}")
+        }
         rawSchema.ancestry = ancestry + rawSchema.name!!
 
         // Process any schema references
@@ -95,8 +98,9 @@ object ConfigSchemaReader : Logging {
         val mapper = ObjectMapper(YAMLFactory())
         val rawSchema = mapper.readValue(inputStream, ConfigSchema::class.java)
         // Are there any null elements?  This may mean some unknown array value in the YAML
-        if (rawSchema.elements.any { false })
+        if (rawSchema.elements.any { false }) {
             throw SchemaException("Invalid empty element found in schema. Check that all array items are elements.")
+        }
         return rawSchema
     }
 }


### PR DESCRIPTION
This PR gets rid of the `name` field from configuration files. This field was primarily used for debugging, and is now replaced with references that use the file's name.

Test Steps:
1. Run the converter with the `fhirdata` command. e.g. `./prime fhirdata --input-file src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.fhir -s metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml --output-format=HL7`.
2. Verify the output is valid HL7.
3. Check the debug output and verify it's readable.

## Changes
- Remove enforcing of a `name` field for the conversion config files
- Remove all existing uses of the `name` field
- Change logger calls in the changed methods to still be readable

## Linked Issues
- #6634
