### PR TITLE
Experience/7190: [Message ID][Details][UI][API] Complete

### DIFF
--- a/frontend-react/src/__mocks__/MessageTrackerMockServer.ts
+++ b/frontend-react/src/__mocks__/MessageTrackerMockServer.ts
@@ -1,0 +1,29 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+import config from "../config";
+import { RSMessageDetail } from "../config/endpoints/messageTracker";
+
+export const makeMessageDetailsFixture = (
+    id: number,
+    overrides?: Partial<RSMessageDetail>
+): RSMessageDetail => ({
+    id: id || 1,
+    messageId: overrides?.messageId || "",
+    sender: overrides?.sender || "",
+    submittedDate: overrides?.submittedDate || "",
+    reportId: overrides?.reportId || "e46339c7-408a-49aa-af4f-29712c8c20df",
+    fileName: overrides?.fileName || "",
+    fileUrl: overrides?.fileUrl || "",
+    warnings: overrides?.warnings || [],
+    errors: overrides?.errors || [],
+    receiverData: overrides?.receiverData || [],
+});
+
+const { RS_API_URL } = config;
+const handlers = [
+    rest.get(`${RS_API_URL}/api/message/11`, (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(makeMessageDetailsFixture(11)));
+    }),
+];
+export const messageTrackerServer = setupServer(...handlers);

--- a/frontend-react/src/components/MessageTracker/MessageDetails.test.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageDetails.test.tsx
@@ -1,36 +1,162 @@
 import { render, screen } from "@testing-library/react";
 
+import { mockUseMessageDetails } from "../../hooks/network/MessageTracker/__mocks__/MessageTrackerHooks";
+import { RSMessageDetail } from "../../config/endpoints/messageTracker";
+
 import { MessageDetails } from "./MessageDetails";
 
-const mockData = {
+const TEST_ID = "12-234567";
+const MOCK_MESSAGE_WARNINGS = [
+    {
+        class: "gov.cdc.prime.router.InvalidCodeMessage",
+        fieldMapping: "Specimen_type_code (specimen_type)",
+        scope: "item",
+        message:
+            "Invalid code: '' is not a display value in altValues set for Specimen_type_code (specimen_type).",
+    },
+    {
+        class: "gov.cdc.prime.router.InvalidEquipmentMessage",
+        fieldMapping: "Equipment_Model_ID (equipment_model_id)",
+        scope: "item",
+        message:
+            "Invalid field Equipment_Model_ID (equipment_model_id); please refer to the Department of Health and Human Services' (HHS) LOINC Mapping spreadsheet for acceptable values.",
+    },
+];
+const MOCK_MESSAGE_ERRORS = [
+    {
+        class: "first field",
+        fieldMapping: "Missing type",
+        message: "Missing required HL7 message type",
+        scope: "error",
+    },
+    {
+        class: "second field",
+        fieldMapping: "Invalid content type",
+        message: "Expecting content type of 'application/hl7 -v2",
+        scope: "error",
+    },
+];
+const MOCK_RECEIVER_DATA = [
+    {
+        reportId: "578eae4e-b24d-45aa-bc5c-4d96a0bfef96",
+        receivingOrg: "md-phd",
+        receivingOrgSvc: "elr",
+        transportResult: null,
+        fileName:
+            "fl-covid-19-45ee5710-08fd-4446-bb89-c106fb4c63ea-20221022025000.hl7",
+        fileUrl: null,
+        createdAt: "2022-09-28T19:55:12.46782",
+        qualityFilters: [],
+    },
+    {
+        reportId: "6d2d1ad0-1bdf-4d0b-804a-1e3494928f0f",
+        receivingOrg: "ak-phd",
+        receivingOrgSvc: "elr",
+        transportResult: "FAILED Sftp Upload blah blah blah",
+        fileName: null,
+        fileUrl:
+            "https://azurite:10000/devstoreaccount1/reports/batch%2Fak-phd.elr%2Fcovid-19-6d2d1ad0-1bdf-4d0b-804a-1e3494928f0f-20220928195512.internal.csv",
+        createdAt: "2022-09-28T19:55:12.46782",
+        qualityFilters: [
+            {
+                trackingId: "Alaska1",
+                detail: {
+                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
+                    receiverName: "ak-phd.elr",
+                    originalCount: 5,
+                    filterName: "hasValidDataFor",
+                    filterArgs: ["patient_dob"],
+                    filteredTrackingElement: "Alaska1",
+                    filterType: "QUALITY_FILTER",
+                    scope: "translation",
+                    message:
+                        "For ak-phd.elr, filter hasValidDataFor[patient_dob] filtered out item Alaska1",
+                },
+            },
+            {
+                trackingId: "Alaska1",
+                detail: {
+                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
+                    receiverName: "ak-phd.elr",
+                    originalCount: 5,
+                    filterName: "isValidCLIA",
+                    filterArgs: ["testing_lab_clia", "reporting_facility_clia"],
+                    filteredTrackingElement: "Alaska1",
+                    filterType: "QUALITY_FILTER",
+                    scope: "translation",
+                    message:
+                        "For ak-phd.elr, filter isValidCLIA[testing_lab_clia, reporting_facility_clia] filtered out item Alaska1",
+                },
+            },
+            {
+                trackingId: "Alaska2",
+                detail: {
+                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
+                    receiverName: "ak-phd.elr",
+                    originalCount: 5,
+                    filterName: "isValidCLIA",
+                    filterArgs: ["testing_lab_clia", "reporting_facility_clia"],
+                    filteredTrackingElement: "Alaska2",
+                    filterType: "QUALITY_FILTER",
+                    scope: "translation",
+                    message:
+                        "For ak-phd.elr, filter isValidCLIA[testing_lab_clia, reporting_facility_clia] filtered out item Alaska2",
+                },
+            },
+            {
+                trackingId: "Alaska4",
+                detail: {
+                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
+                    receiverName: "ak-phd.elr",
+                    originalCount: 5,
+                    filterName: "isValidCLIA",
+                    filterArgs: ["testing_lab_clia", "reporting_facility_clia"],
+                    filteredTrackingElement: "Alaska4",
+                    filterType: "QUALITY_FILTER",
+                    scope: "translation",
+                    message:
+                        "For ak-phd.elr, filter isValidCLIA[testing_lab_clia, reporting_facility_clia] filtered out item Alaska4",
+                },
+            },
+        ],
+    },
+];
+const MOCK_MESSAGE_DETAIL = {
     id: 1,
-    messageId: "12-234567",
+    messageId: TEST_ID,
     sender: "somebody 1",
-    submittedDate: "2022-10-03T18:09:45.129997",
+    submittedDate: "09/28/2022",
     reportId: "29038fca-e521-4af8-82ac-6b9fafd0fd58",
     fileName: "simple_report_example.csv",
     fileUrl: "https://someurl",
-    warnings: [],
-    errors: [],
-    receiverData: [],
+    warnings: MOCK_MESSAGE_WARNINGS,
+    errors: MOCK_MESSAGE_ERRORS,
+    receiverData: MOCK_RECEIVER_DATA,
 };
 
 jest.mock("react-router-dom", () => ({
-    useResource: () => {
-        return mockData;
-    },
+    ...jest.requireActual("react-router-dom"), // use actual for all non-hook parts
     useNavigate: () => {
         return jest.fn();
     },
-    useParams: () => {
-        return {
-            messageId: "12-234567",
-        };
-    },
+    useParams: () => ({
+        messageId: TEST_ID,
+    }),
 }));
 
-describe("MessageDetails component", () => {
+describe("RSMessageDetail component", () => {
+    test("url param (messageId) feeds into network hook", () => {
+        mockUseMessageDetails.mockReturnValueOnce({
+            messageDetails: {} as RSMessageDetail,
+        });
+        render(<MessageDetails />);
+        expect(mockUseMessageDetails).toHaveBeenCalledWith(TEST_ID);
+    });
+
     test("renders expected content", async () => {
+        mockUseMessageDetails.mockReturnValueOnce({
+            messageDetails: MOCK_MESSAGE_DETAIL as RSMessageDetail,
+        });
         render(<MessageDetails />);
 
         expect(screen.getByText(/Message ID/)).toBeInTheDocument();

--- a/frontend-react/src/components/MessageTracker/MessageDetails.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageDetails.tsx
@@ -4,7 +4,9 @@ import { Button } from "@trussworks/react-uswds";
 
 import { AuthElement } from "../AuthElement";
 import { DetailItem } from "../DetailItem/DetailItem";
+import { withCatchAndSuspense } from "../RSErrorBoundary";
 import { MemberType } from "../../hooks/UseOktaMemberships";
+import { useMessageDetails } from "../../hooks/network/MessageTracker/MessageTrackerHooks";
 
 import { WarningsErrors } from "./WarningsErrors";
 import { MessageReceivers } from "./MessageReceivers";
@@ -13,139 +15,10 @@ type MessageDetailsProps = {
     messageId: string | undefined;
 };
 
-const MOCK_MESSAGE_WARNINGS = [
-    {
-        class: "gov.cdc.prime.router.InvalidCodeMessage",
-        fieldMapping: "Specimen_type_code (specimen_type)",
-        scope: "item",
-        message:
-            "Invalid code: '' is not a display value in altValues set for Specimen_type_code (specimen_type).",
-    },
-    {
-        class: "gov.cdc.prime.router.InvalidEquipmentMessage",
-        fieldMapping: "Equipment_Model_ID (equipment_model_id)",
-        scope: "item",
-        message:
-            "Invalid field Equipment_Model_ID (equipment_model_id); please refer to the Department of Health and Human Services' (HHS) LOINC Mapping spreadsheet for acceptable values.",
-    },
-];
-const MOCK_MESSAGE_ERRORS = [
-    {
-        class: "first field",
-        fieldMapping: "Missing type",
-        message: "Missing required HL7 message type",
-        scope: "error",
-    },
-    {
-        class: "second field",
-        fieldMapping: "Invalid content type",
-        message: "Expecting content type of 'application/hl7 -v2",
-        scope: "error",
-    },
-];
-const MOCK_RECEIVER_DATA = [
-    {
-        reportId: "578eae4e-b24d-45aa-bc5c-4d96a0bfef96",
-        receivingOrg: "md-phd",
-        receivingOrgSvc: "elr",
-        transportResult: null,
-        fileName:
-            "fl-covid-19-45ee5710-08fd-4446-bb89-c106fb4c63ea-20221022025000.hl7",
-        fileUrl: null,
-        createdAt: "2022-09-28T19:55:12.46782",
-        qualityFilters: [],
-    },
-    {
-        reportId: "6d2d1ad0-1bdf-4d0b-804a-1e3494928f0f",
-        receivingOrg: "ak-phd",
-        receivingOrgSvc: "elr",
-        transportResult: "FAILED Sftp Upload blah blah blah",
-        fileName: null,
-        fileUrl:
-            "https://azurite:10000/devstoreaccount1/reports/batch%2Fak-phd.elr%2Fcovid-19-6d2d1ad0-1bdf-4d0b-804a-1e3494928f0f-20220928195512.internal.csv",
-        createdAt: "2022-09-28T19:55:12.46782",
-        qualityFilters: [
-            {
-                trackingId: "Alaska1",
-                detail: {
-                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
-                    receiverName: "ak-phd.elr",
-                    originalCount: 5,
-                    filterName: "hasValidDataFor",
-                    filterArgs: ["patient_dob"],
-                    filteredTrackingElement: "Alaska1",
-                    filterType: "QUALITY_FILTER",
-                    scope: "translation",
-                    message:
-                        "For ak-phd.elr, filter hasValidDataFor[patient_dob] filtered out item Alaska1",
-                },
-            },
-            {
-                trackingId: "Alaska1",
-                detail: {
-                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
-                    receiverName: "ak-phd.elr",
-                    originalCount: 5,
-                    filterName: "isValidCLIA",
-                    filterArgs: ["testing_lab_clia", "reporting_facility_clia"],
-                    filteredTrackingElement: "Alaska1",
-                    filterType: "QUALITY_FILTER",
-                    scope: "translation",
-                    message:
-                        "For ak-phd.elr, filter isValidCLIA[testing_lab_clia, reporting_facility_clia] filtered out item Alaska1",
-                },
-            },
-            {
-                trackingId: "Alaska2",
-                detail: {
-                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
-                    receiverName: "ak-phd.elr",
-                    originalCount: 5,
-                    filterName: "isValidCLIA",
-                    filterArgs: ["testing_lab_clia", "reporting_facility_clia"],
-                    filteredTrackingElement: "Alaska2",
-                    filterType: "QUALITY_FILTER",
-                    scope: "translation",
-                    message:
-                        "For ak-phd.elr, filter isValidCLIA[testing_lab_clia, reporting_facility_clia] filtered out item Alaska2",
-                },
-            },
-            {
-                trackingId: "Alaska4",
-                detail: {
-                    class: "gov.cdc.prime.router.ReportStreamFilterResult",
-                    receiverName: "ak-phd.elr",
-                    originalCount: 5,
-                    filterName: "isValidCLIA",
-                    filterArgs: ["testing_lab_clia", "reporting_facility_clia"],
-                    filteredTrackingElement: "Alaska4",
-                    filterType: "QUALITY_FILTER",
-                    scope: "translation",
-                    message:
-                        "For ak-phd.elr, filter isValidCLIA[testing_lab_clia, reporting_facility_clia] filtered out item Alaska4",
-                },
-            },
-        ],
-    },
-];
-const MOCK_MESSAGE_SENDER_DETAILS = {
-    id: 1,
-    messageId: "12-234567",
-    sender: "somebody 1",
-    submittedDate: "09/28/2022",
-    reportId: "29038fca-e521-4af8-82ac-6b9fafd0fd58",
-    fileName: "simple_report_example.csv",
-    fileUrl: "https://someurl",
-    warnings: MOCK_MESSAGE_WARNINGS,
-    errors: MOCK_MESSAGE_ERRORS,
-    receiverData: MOCK_RECEIVER_DATA,
-};
-
-const messageDetails = MOCK_MESSAGE_SENDER_DETAILS;
-
 export function MessageDetails() {
     const navigate = useNavigate();
     const { messageId } = useParams<MessageDetailsProps>();
+    const { messageDetails } = useMessageDetails(messageId!!);
 
     return (
         <>
@@ -161,37 +34,37 @@ export function MessageDetails() {
                 </div>
                 <DetailItem
                     item={"Message ID"}
-                    content={messageId}
+                    content={messageDetails!.messageId}
                 ></DetailItem>
                 <div className="display-flex flex-column margin-bottom-5">
                     <h3>Sender:</h3>
                     <DetailItem
                         item={"Sender Name"}
-                        content={messageDetails.sender}
+                        content={messageDetails!.sender}
                     ></DetailItem>
                     <DetailItem
                         item={"Incoming Report ID"}
-                        content={messageDetails.reportId}
+                        content={messageDetails!.reportId}
                     ></DetailItem>
                     <DetailItem
                         item={"Incoming File Name"}
-                        content={messageDetails.fileName}
+                        content={messageDetails!.fileName}
                     ></DetailItem>
                     <DetailItem
                         item={"Incoming File URL"}
-                        content={messageDetails.fileUrl}
+                        content={messageDetails!.fileUrl}
                     ></DetailItem>
                 </div>
                 <MessageReceivers
-                    receiverDetails={messageDetails.receiverData}
+                    receiverDetails={messageDetails!.receiverData}
                 />
                 <WarningsErrors
-                    title={"Warnings:"}
-                    data={messageDetails.warnings}
+                    title={"WarningError:"}
+                    data={messageDetails!.warnings}
                 />
                 <WarningsErrors
                     title={"Errors:"}
-                    data={messageDetails.errors}
+                    data={messageDetails!.errors}
                 />
             </div>
         </>
@@ -200,7 +73,7 @@ export function MessageDetails() {
 
 export const MessageDetailsWithAuth = () => (
     <AuthElement
-        element={<MessageDetails />}
+        element={withCatchAndSuspense(<MessageDetails />)}
         requiredUserType={MemberType.PRIME_ADMIN}
     />
 );

--- a/frontend-react/src/components/MessageTracker/MessageReceivers.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageReceivers.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
 import { DetailItem } from "../DetailItem/DetailItem";
-import { ResponseReceiver } from "../../config/endpoints/messageTracker";
+import { ReceiverData } from "../../config/endpoints/messageTracker";
 import { formattedDateFromTimestamp } from "../../utils/DateTimeUtils";
 
 import { QualityFilters } from "./QualityFilters";
 
 type MessageReceiverProps = {
-    receiverDetails: ResponseReceiver[] | undefined;
+    receiverDetails: ReceiverData[] | undefined;
 };
 
 export const MessageReceivers = ({ receiverDetails }: MessageReceiverProps) => {

--- a/frontend-react/src/components/MessageTracker/WarningsErrors.tsx
+++ b/frontend-react/src/components/MessageTracker/WarningsErrors.tsx
@@ -1,15 +1,14 @@
 import React from "react";
 
-import { Warnings } from "../../config/endpoints/messageTracker";
+import { WarningError } from "../../config/endpoints/messageTracker";
 import Table, { TableConfig } from "../Table/Table";
 
 type WarningsErrorsDisplayProps = {
     title: string;
-    data: Warnings[];
+    data: WarningError[];
 };
 
 export const WarningsErrors = ({ title, data }: WarningsErrorsDisplayProps) => {
-    debugger;
     const tableConfig: TableConfig = {
         columns: [
             {

--- a/frontend-react/src/config/endpoints/messageTracker.ts
+++ b/frontend-react/src/config/endpoints/messageTracker.ts
@@ -1,9 +1,11 @@
+import { HTTPMethods, RSApiEndpoints, RSEndpoint } from "./index";
+
 export interface QualityFilter {
     trackingId: string | null;
     detail: any;
 }
 
-export interface ResponseReceiver {
+export interface ReceiverData {
     reportId: string;
     receivingOrg: string;
     receivingOrgSvc: string;
@@ -14,9 +16,30 @@ export interface ResponseReceiver {
     qualityFilters: QualityFilter[];
 }
 
-export interface Warnings {
+export interface WarningError {
     class: string | null;
     fieldMapping: string | null;
     scope: string | null;
     message: string | null;
 }
+
+export interface RSMessageDetail {
+    id: number;
+    messageId: string;
+    sender: string | null;
+    submittedDate: string | null;
+    reportId: string;
+    fileName: string | null;
+    fileUrl: string | null;
+    warnings: WarningError[];
+    errors: WarningError[];
+    receiverData: ReceiverData[];
+}
+
+export const messageTrackerEndpoints: RSApiEndpoints = {
+    getMessageDetails: new RSEndpoint({
+        path: "/message/:id",
+        method: HTTPMethods.GET,
+        queryKey: "messageDetails",
+    }),
+};

--- a/frontend-react/src/hooks/network/MessageTracker/MessageTrackerHooks.test.ts
+++ b/frontend-react/src/hooks/network/MessageTracker/MessageTrackerHooks.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import { messageTrackerServer } from "../../../__mocks__/MessageTrackerMockServer";
+import { mockSessionContext } from "../../../contexts/__mocks__/SessionContext";
+import { MemberType } from "../../UseOktaMemberships";
+import { QueryWrapper } from "../../../utils/CustomRenderUtils";
+
+import { useMessageDetails } from "./MessageTrackerHooks";
+
+describe("MessageTrackerHooks", () => {
+    beforeAll(() => messageTrackerServer.listen());
+    afterEach(() => messageTrackerServer.resetHandlers());
+    afterAll(() => messageTrackerServer.close());
+
+    test("useMessageDetail", async () => {
+        mockSessionContext.mockReturnValue({
+            oktaToken: {
+                accessToken: "TOKEN",
+            },
+            activeMembership: {
+                memberType: MemberType.RECEIVER,
+                parsedName: "testOrg",
+            },
+            dispatch: () => {},
+            initialized: true,
+        });
+
+        const { result, waitForNextUpdate } = renderHook(
+            () => useMessageDetails("11"),
+            { wrapper: QueryWrapper() }
+        );
+        await waitForNextUpdate();
+        expect(result.current.messageDetails?.id).toEqual(11);
+    });
+});

--- a/frontend-react/src/hooks/network/MessageTracker/MessageTrackerHooks.ts
+++ b/frontend-react/src/hooks/network/MessageTracker/MessageTrackerHooks.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+
+import {
+    RSMessageDetail,
+    messageTrackerEndpoints,
+} from "../../../config/endpoints/messageTracker";
+import { useAuthorizedFetch } from "../../../contexts/AuthorizedFetchContext";
+
+const { getMessageDetails } = messageTrackerEndpoints;
+
+/** Hook consumes the MessagesApi "detail" endpoint and delivers the response
+ *
+ * @param id {string} Pass in the covid_results_metadata_id to query a single message
+ * */
+const useMessageDetails = (id: string) => {
+    const { authorizedFetch, rsUseQuery } =
+        useAuthorizedFetch<RSMessageDetail>();
+    const memoizedDataFetch = useCallback(
+        () =>
+            authorizedFetch(getMessageDetails, {
+                segments: {
+                    id: id,
+                },
+            }),
+        [authorizedFetch, id]
+    );
+    const { data } = rsUseQuery(
+        [getMessageDetails.queryKey, id],
+        memoizedDataFetch,
+        { enabled: !!id }
+    );
+    return { messageDetails: data };
+};
+
+export { useMessageDetails };


### PR DESCRIPTION
This PR hooks up the Message Details UI with the MessageDetail API endpoint

Test Steps:

1. rebuild RS
2. login as an admin to the front-end
3. place in the feature flag "message-tracker" if not there already
4. navigate to the Message id Search page
5. search for a message id that you think is in the database, case insensitive (i.e. Ohio11)
6. Select a message Id from the list
7. View Message Details

## Changes

![Screenshot 2022-11-03 at 9 59 04 AM](https://user-images.githubusercontent.com/102491809/199786081-161c9cd0-f1cf-47d9-8bfc-69836ec5a66a.png)


## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Linked Issues
- Fixes #7190 

