### PR TITLE
Experience/7190 Patch

### DIFF
--- a/frontend-react/src/components/MessageTracker/MessageDetails.test.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageDetails.test.tsx
@@ -5,7 +5,7 @@ import { RSMessageDetail } from "../../config/endpoints/messageTracker";
 
 import { MessageDetails } from "./MessageDetails";
 
-const TEST_ID = "12-234567";
+const TEST_ID = 1;
 const MOCK_MESSAGE_WARNINGS = [
     {
         class: "gov.cdc.prime.router.InvalidCodeMessage",
@@ -122,8 +122,8 @@ const MOCK_RECEIVER_DATA = [
     },
 ];
 const MOCK_MESSAGE_DETAIL = {
-    id: 1,
-    messageId: TEST_ID,
+    id: TEST_ID,
+    messageId: "12-234567",
     sender: "somebody 1",
     submittedDate: "09/28/2022",
     reportId: "29038fca-e521-4af8-82ac-6b9fafd0fd58",
@@ -140,7 +140,7 @@ jest.mock("react-router-dom", () => ({
         return jest.fn();
     },
     useParams: () => ({
-        messageId: TEST_ID,
+        id: TEST_ID,
     }),
 }));
 

--- a/frontend-react/src/components/MessageTracker/MessageDetails.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageDetails.tsx
@@ -12,13 +12,13 @@ import { WarningsErrors } from "./WarningsErrors";
 import { MessageReceivers } from "./MessageReceivers";
 
 type MessageDetailsProps = {
-    messageId: string | undefined;
+    id: string | undefined;
 };
 
 export function MessageDetails() {
     const navigate = useNavigate();
-    const { messageId } = useParams<MessageDetailsProps>();
-    const { messageDetails } = useMessageDetails(messageId!!);
+    const { id } = useParams<MessageDetailsProps>();
+    const { messageDetails } = useMessageDetails(id!!);
 
     return (
         <>

--- a/frontend-react/src/components/MessageTracker/MessageTracker.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageTracker.tsx
@@ -89,7 +89,7 @@ export function MessageTracker() {
             <h1>Message ID Search</h1>
 
             <Label className="font-sans-xs usa-label" htmlFor="input_filter">
-                Message ID (format as xx-xxxxxx)
+                Message ID
             </Label>
             <div className="grid-gap-lg display-flex">
                 <TextInput


### PR DESCRIPTION
This PR 
Changed messageId to id
Removed inaccurate text

Test Steps:
1. rebuild RS
2. login as an admin to the front-end
3. place in the feature flag "message-tracker" if not there already
4. navigate to the Message id Search page
5. search for a message id that you think is in the database, case insensitive (i.e. Ohio11)
6. Select a message Id from the list
7. View Message Details

## Changes
![Screenshot 2022-11-03 at 9 59 04 AM](https://user-images.githubusercontent.com/102491809/199805638-6189c924-b2eb-49f9-8f55-b6dcb96e1cf2.png)


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?