### PR TITLE
demo provision no longer first destroys the env

### DIFF
--- a/.github/workflows/release_to_azure.yml
+++ b/.github/workflows/release_to_azure.yml
@@ -100,12 +100,6 @@ jobs:
           sp-creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
           tf-auth: true
 
-      - name: Destroy demo environment
-        uses: ./.github/actions/demo-env
-        with:
-          env-name: ${{ needs.pre_job.outputs.env_name }}
-          destroy: true
-
       - name: Provision demo environment
         uses: ./.github/actions/demo-env
         with:


### PR DESCRIPTION
This PR updates demo env provisioning to no longer first destroy the environment before every provision. Demo destroy is exclusively a separate process.

Test Steps:
1. Push to any demo branch

## Changes
- Demo env provisioning no longer first destroys env
