### PR TITLE
replace vpn lib

### DIFF
--- a/.github/actions/vpn-azure/action.yml
+++ b/.github/actions/vpn-azure/action.yml
@@ -69,7 +69,7 @@ runs:
         sudo apt install openvpn-systemd-resolved
       shell: bash
 
-    - uses: golfzaptw/action-connect-ovpn@9dba43b36861c6c2520045898bb709e8f11443dc
+    - uses: josiahsiegel/action-connect-ovpn@018b873a1f8f48af68984b31b42f219e4f3c9aa7
       if: env.VPN_ENV
       id: connect_vpn
       with:


### PR DESCRIPTION
This PR replaces the ovpn action that was removed from GitHub with a clone

## Changes
- Replaces ovpn lib with new clone

## Checklist

## Linked Issues
- Fixes #7387

