### PR TITLE
Abort ProcessFunction if the TASK table and queue entry don't match

### DIFF
--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -549,9 +549,7 @@ class WorkflowEngine(
         db.transact { txn ->
             val task = db.fetchAndLockTask(messageEvent.reportId, txn)
 
-            val blobContent = BlobAccess.downloadBlob(task.bodyUrl)
             val currentAction = Event.EventAction.parseQueueMessage(task.nextAction.literal)
-
             if (currentAction != Event.EventAction.PROCESS) {
                 // As of this writing we are not sure why this bug occurs.  However, this at least prevents it from
                 // causing trouble.
@@ -565,6 +563,8 @@ class WorkflowEngine(
                 // Also, no reason to update the TASK table:  its already marked as done.
                 return@transact
             }
+
+            val blobContent = BlobAccess.downloadBlob(task.bodyUrl)
 
             val report = csvSerializer.readInternal(
                 task.schemaName,

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -552,6 +552,20 @@ class WorkflowEngine(
             val blobContent = BlobAccess.downloadBlob(task.bodyUrl)
             val currentAction = Event.EventAction.parseQueueMessage(task.nextAction.literal)
 
+            if (currentAction != Event.EventAction.PROCESS) {
+                // As of this writing we are not sure why this bug occurs.  However, this at least prevents it from
+                // causing trouble.
+                logger.error(
+                    "ProcessQueueFailure: The 'process' queue wants to " +
+                        "process report ${messageEvent.reportId}, " +
+                        "but the TASK table shows its next_action is $currentAction. " +
+                        "Its likely this report was processed earlier, but not removed from the 'process' queue."
+                )
+                // don't throw an exception, as that'll just make this erroneous process action run again.
+                // Also, no reason to update the TASK table:  its already marked as done.
+                return@transact
+            }
+
             val report = csvSerializer.readInternal(
                 task.schemaName,
                 ByteArrayInputStream(blobContent),

--- a/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
+++ b/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
@@ -8,6 +8,7 @@ import gov.cdc.prime.router.DeepOrganization
 import gov.cdc.prime.router.Element
 import gov.cdc.prime.router.FileSettings
 import gov.cdc.prime.router.Metadata
+import gov.cdc.prime.router.Options
 import gov.cdc.prime.router.Organization
 import gov.cdc.prime.router.Receiver
 import gov.cdc.prime.router.Report
@@ -280,6 +281,44 @@ class WorkflowEngineTests {
             accessSpy.fetchAndLockTask(reportId = any(), any())
             accessSpy.fetchItemLineagesForReport(reportId = any(), any(), any())
             accessSpy.fetchReportFile(reportId = any(), any(), any())
+        }
+        confirmVerified(accessSpy, blobMock, queueMock)
+    }
+
+    @Test
+    fun `test handleProcessEvent queue vs task table mismatch error`() {
+        // This only tests an error case in handleProcessEvent, not the 'happy path'.
+        val one = Schema(name = "one", topic = "test", elements = listOf(Element("a"), Element("b")))
+        val metadata = Metadata(schema = one)
+        val settings = FileSettings().loadOrganizations(oneOrganization)
+        val report1 = Report(
+            one,
+            listOf(listOf("1", "2"), listOf("3", "4")),
+            source = TestSource,
+            destination = oneOrganization.receivers[0],
+            metadata = metadata
+        )
+        val bodyFormat = "CSV"
+        val bodyUrl = "http://anyblob.com"
+        // The event in the queue is a Process event.
+        val processEvent = ProcessEvent(Event.EventAction.PROCESS, report1.id, Options.None, emptyMap(), emptyList())
+        // Mismatch:  The event in the TASK table is a NONE event.
+        val mismatchedNotProcessEvent = ReportEvent(Event.EventAction.NONE, report1.id, false)
+        val mismatchedNotProcessTask = DatabaseAccess.createTask(
+            report1, bodyFormat, bodyUrl, mismatchedNotProcessEvent
+        )
+        val actionHistoryMock = mockk<ActionHistory>()
+        mockkObject(ActionHistory.Companion)
+        val engine = makeEngine(metadata, settings)
+
+        every { accessSpy.fetchAndLockTask(reportId = eq(report1.id), any()) }.returns(mismatchedNotProcessTask)
+        // Run the test:
+        engine.handleProcessEvent(processEvent, actionHistoryMock)
+
+        // The code should just run these two methods, then log an error and return.
+        verify(exactly = 1) {
+            accessSpy.transact(block = any())
+            accessSpy.fetchAndLockTask(reportId = any(), any())
         }
         confirmVerified(accessSpy, blobMock, queueMock)
     }


### PR DESCRIPTION
We track work-waiting-to-be-done in two places:    It gets queued in an Azure queue, and it gets a row in the TASK table in the database.

There appears to be an issue wherein in rare cases queued items are picked up and processed twice.    Examples of this are documented in #7404.  

The first successful run will update the TASK table, and change the "next_action" to NONE.    So, this double-procesing can be prevented by having the ProcessFunction check that the TASK table next_action value is PROCESS -- that is, the expected next_action in the TASK table matches the expected action found in the queue.   It was probably just an oversight that we were not checking this already - its just a basic assertion / sanity check.

This PR adds a check in ProcessFunction that the next_action in the TASK table is indeed 'process'.

Test Steps:
1. A test has been added to the unit tests.    Further manual testing is not needed.

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [N/A] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [X] Added tests?

### Process
- [N] Are there licensing issues with any new dependencies introduced?
- [X] Includes a summary of what a code reviewer should test/verify?
- [N/A] Updated the release notes?
- [N/A] Database changes are submitted as a separate PR?
- [N/A] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #7404 

## To Be Done
- We should check that the other functions do this sanity check!   See #7409


