### PR TITLE
Experience/7359

### DIFF
--- a/frontend-react/src/components/Table/Table.tsx
+++ b/frontend-react/src/components/Table/Table.tsx
@@ -174,10 +174,9 @@ const Table = ({
                             rowToEdit={rowToEdit}
                             setRowToEdit={setRowToEdit}
                         />
-                    ) : (
-                        <span>No data to show</span>
-                    )}
+                    ) : undefined}
                 </table>
+                {!memoizedRows ? <span>No data to show</span> : undefined}
                 {paginationProps && <Pagination {...paginationProps} />}
             </div>
         </div>


### PR DESCRIPTION
This PR fixes a bug with a span element not being properly wrapped inside the table by moving it outside and after it.

Test Steps:
1. Log into reportstream
2. Set abbott from organization table
3. Go to Submissions page
4. Open javascript console
5. Verify that the following warning is not emitted: Warning: validateDOMNesting(...): <span> cannot appear as a child of <table>.

## Changes
- span message moved to outside & after table

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #7359 
