### PR TITLE
Move the project over to Java 17 and Azure 4

### DIFF
--- a/.github/workflows/build_hub.yml
+++ b/.github/workflows/build_hub.yml
@@ -41,10 +41,10 @@ jobs:
       # Appears not to be needed on GitHub (but needed when running act [https://github.com/nektos/act] locally)
       # - name: Install docker-compose
       #   run: apt-get update && apt-get --yes install docker-compose
-      - name: Set up JDK 11
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+      - name: Set up JDK 17
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
 
@@ -201,10 +201,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+      - name: Set up JDK 17
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
 

--- a/prime-router/Dockerfile
+++ b/prime-router/Dockerfile
@@ -1,10 +1,10 @@
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 # This Docker file was generated from a `mvn archetype:generate -Ddocker` command. It creates 
 # a container that is deployable to the Azure cloud
 #
 # This image additionally contains function core tools – useful when using custom extensions
-#FROM mcr.microsoft.com/azure-functions/java:3.0-java$JAVA_VERSION-core-tools AS installer-env
-FROM mcr.microsoft.com/azure-functions/java:3.0-java$JAVA_VERSION-build AS installer-env
+#FROM mcr.microsoft.com/azure-functions/java:4.0-java$JAVA_VERSION-core-tools AS installer-env
+FROM mcr.microsoft.com/azure-functions/java:4-java$JAVA_VERSION-build AS installer-env
 
 COPY . /src/java-function-app
 RUN cd /src/java-function-app && \
@@ -14,7 +14,7 @@ RUN cd /src/java-function-app && \
     cp -a . /home/site/wwwroot
 
 # This image is ssh enabled
-FROM mcr.microsoft.com/azure-functions/java:3.0-java$JAVA_VERSION-appservice
+FROM mcr.microsoft.com/azure-functions/java:4-java$JAVA_VERSION-appservice
 # This image isn't ssh enabled
 #FROM mcr.microsoft.com/azure-functions/java:3.0-java$JAVA_VERSION
 

--- a/prime-router/Dockerfile.build
+++ b/prime-router/Dockerfile.build
@@ -5,7 +5,7 @@
 #
 # --build-arg GRADLE_VERSION=7.1        - The version of Gradle you want to build with
 # --build-arg AFCT_VERSION=3.0.3568     - The version of the Azure Functions Core Tools
-# --build-arg JAVA_VERSION=11           - The version of the JDK (and thus JRE) you want to build against/with
+# --build-arg JAVA_VERSION=17           - The version of the JDK (and thus JRE) you want to build against/with
 #
 
 #
@@ -41,7 +41,7 @@ RUN rm Azure.Functions.Cli.linux-x64.${AFCT_VERSION}.zip
 # STAGE 2: Build the actual container that does the build
 #
 FROM debian:bullseye AS builder
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 
 # Get the unpacked gradle binaries from the downloader stage
 RUN mkdir -p /opt/gradle

--- a/prime-router/Dockerfile.dev
+++ b/prime-router/Dockerfile.dev
@@ -6,10 +6,10 @@
 # The intent is for the prime-router to be mounted into this container,
 # allowing the content of this container to be stable
 #
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 
 # This Debian image additionally contains function core tools – useful when using custom extensions
-FROM mcr.microsoft.com/azure-functions/java:3.0-java$JAVA_VERSION-core-tools
+FROM mcr.microsoft.com/azure-functions/java:4-java$JAVA_VERSION-core-tools
 
 # Disable SSL verification for agencies that re-sign SSL connections
 ARG INSECURE_SSL=false

--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -51,6 +51,12 @@ val azureFunctionsDir = "azure-functions"
 val primeMainClass = "gov.cdc.prime.router.cli.MainKt"
 val defaultDuplicateStrategy = DuplicatesStrategy.WARN
 azurefunctions.appName = azureAppName
+val appJvmTarget = "17"
+val javaVersion = if (appJvmTarget == "17") {
+    JavaVersion.VERSION_17
+} else {
+    JavaVersion.VERSION_11
+}
 
 // Local database information, first one wins:
 // 1. Project properties (-P<VAR>=<VALUE> flag)
@@ -110,17 +116,17 @@ jacoco.toolVersion = "0.8.9"
 
 // Set the compiler JVM target
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
 }
 
 val compileKotlin: KotlinCompile by tasks
 val compileTestKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions.jvmTarget = "11"
+compileKotlin.kotlinOptions.jvmTarget = appJvmTarget
 compileKotlin.kotlinOptions.allWarningsAsErrors = true
 // if you set this to true, you will get a warning, which then gets treated as an error
 compileKotlin.kotlinOptions.useK2 = false
-compileTestKotlin.kotlinOptions.jvmTarget = "11"
+compileTestKotlin.kotlinOptions.jvmTarget = appJvmTarget
 compileTestKotlin.kotlinOptions.allWarningsAsErrors = true
 
 tasks.clean {
@@ -243,7 +249,7 @@ sourceSets.create("testIntegration") {
 }
 
 val compileTestIntegrationKotlin: KotlinCompile by tasks
-compileTestIntegrationKotlin.kotlinOptions.jvmTarget = "11"
+compileTestIntegrationKotlin.kotlinOptions.jvmTarget = appJvmTarget
 
 val testIntegrationImplementation: Configuration by configurations.getting {
     extendsFrom(configurations["testImplementation"])


### PR DESCRIPTION
This PR moves us to Java 17 and upgrades the Azure functions image and libraries to version 4.

This is a draft PR so we can test it and make any other updates that we want along the way. There's going to be a lot more work involved with this, though it passes initial local testing.