### PR TITLE
Experience 7541: Remove CSV upload from Contact/Support page on RS Website

### DIFF
--- a/frontend-react/src/pages/support/legacy-page-content/Contact.tsx
+++ b/frontend-react/src/pages/support/legacy-page-content/Contact.tsx
@@ -49,14 +49,11 @@ export const Contact = () => {
                 <p>
                     Read our guides for sending data via{" "}
                     <a className="usa-link" href="/resources/elr-checklist">
-                        ELR,
+                        ELR
                     </a>{" "}
+                    or{" "}
                     <a className="usa-link" href="/resources/programmers-guide">
                         API
-                    </a>
-                    , or{" "}
-                    <a className="usa-link" href="/resources/csv-upload-guide">
-                        CSV upload
                     </a>
                     .
                 </p>


### PR DESCRIPTION
This changeset is a simple removal of the 'CSV upload' link on the ReportStream support page.  Pretty simple, but let me know if I'm missing something!

Test Steps:
1. Navigate to /support/contact
2. Verify that the "Read our guides for sending data" no longer includes the "CSV upload upload" link

## Changes
Before:
<img width="1273" alt="Screenshot 2022-12-05 at 12 59 45 PM" src="https://user-images.githubusercontent.com/2421042/205710273-7ba2aec4-c69a-4842-8f1a-f9a9fb20872b.png">

After:
<img width="1273" alt="Screenshot 2022-12-05 at 12 59 58 PM" src="https://user-images.githubusercontent.com/2421042/205710289-907b8179-3e03-4f65-8a60-18a69124cfbc.png">

## Checklist

### Testing
- [x] Tested locally?
- <strike>[ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- <strike>[ ] Added tests?</strike>

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #7541 