### PR TITLE
increase db restore timeout

### DIFF
--- a/.github/actions/db-restore/action.yml
+++ b/.github/actions/db-restore/action.yml
@@ -39,7 +39,7 @@ runs:
         shell: bash
     - uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
       with:
-        timeout_minutes: 240
+        timeout_minutes: 480
         max_attempts: 3
         retry_wait_seconds: 10
         command: |


### PR DESCRIPTION
This PR increases the timeout threshold for database restores

Test Steps:
1. Restore database

## Changes
- Set timeout threshold from 4 hours to 8 hours

