### PR TITLE
Revert "Experience/7358"

### DIFF
--- a/frontend-react/src/hooks/network/History/DeliveryHooks.ts
+++ b/frontend-react/src/hooks/network/History/DeliveryHooks.ts
@@ -66,18 +66,17 @@ const useOrgDeliveries = (service?: string) => {
     const fetchResults = useCallback(
         (currentCursor: string, numResults: number) => {
             const fetcher = generateFetcher();
-            // The `cursor` parameter is always the "high" value of the range
-            const cursor = sortOrder === "DESC" ? rangeTo : rangeFrom;
+            const cursor = sortOrder === "DESC" ? currentCursor : rangeTo;
+            const endCursor = sortOrder === "DESC" ? rangeFrom : currentCursor;
 
             return fetcher(getOrgDeliveries, {
                 segments: {
                     orgAndService,
                 },
                 params: {
-                    sortdir: sortOrder,
-                    cursor: cursor,
-                    since: rangeFrom,
-                    until: rangeTo,
+                    sortDir: sortOrder,
+                    since: endCursor,
+                    until: cursor,
                     pageSize: numResults,
                 },
             }) as unknown as Promise<RSDelivery[]>;

--- a/frontend-react/src/pages/submissions/SubmissionTable.test.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionTable.test.tsx
@@ -43,10 +43,9 @@ describe("SubmissionTable", () => {
                     {
                         organization: "testOrg",
                         cursor: "3000-01-01T00:00:00.000Z",
-                        since: "2000-01-01T00:00:00.000Z",
-                        until: "3000-01-01T00:00:00.000Z",
+                        endCursor: "2000-01-01T00:00:00.000Z",
                         pageSize: 61,
-                        sortdir: "DESC",
+                        sort: "DESC",
                         showFailed: false,
                     },
                 ],

--- a/frontend-react/src/pages/submissions/SubmissionTable.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionTable.tsx
@@ -91,15 +91,19 @@ function SubmissionTableWithNumberedPagination() {
     const { fetch: controllerFetch } = useController();
     const fetchResults = useCallback(
         (currentCursor: string, numResults: number) => {
-            // The `cursor` parameter is always the "high" value of the range
-            const cursor = sortOrder === "DESC" ? rangeTo : rangeFrom;
+            // The `cursor` and `endCursor` parameters are always the high and
+            // low values of the range, respectively. When the results are in
+            // descending order we move the high value and keep the low value
+            // constant; in ascending order we keep the high value constant and
+            // move the low value.
+            const cursor = sortOrder === "DESC" ? currentCursor : rangeTo;
+            const endCursor = sortOrder === "DESC" ? rangeFrom : currentCursor;
             return controllerFetch(SubmissionsResource.list(), {
                 organization: activeMembership?.parsedName,
-                cursor: cursor,
-                since: rangeFrom,
-                until: rangeTo,
+                cursor,
+                endCursor,
                 pageSize: numResults,
-                sortdir: sortOrder,
+                sort: sortOrder,
                 showFailed: false,
             }) as unknown as Promise<SubmissionsResource[]>;
         },

--- a/frontend-react/src/resources/SubmissionsResource.ts
+++ b/frontend-react/src/resources/SubmissionsResource.ts
@@ -6,12 +6,10 @@ const { RS_API_URL } = config;
 
 type SubmissionsResourceParams = {
     organization: string;
-    sortdir: string;
-    sortcol: string;
-    cursor: string;
-    since: string;
-    until: string;
     pageSize: number;
+    cursor: string;
+    endCursor: string;
+    sort: string;
     showFailed: boolean;
 };
 
@@ -40,16 +38,8 @@ export default class SubmissionsResource extends AuthResource {
     }
 
     static listUrl(searchParams: SubmissionsResourceParams): string {
-        const url = new URL(`
-            ${RS_API_URL}/api/waters/org/${searchParams.organization}/submissions`);
-        url.searchParams.append("pageSize", searchParams.pageSize.toString());
-        url.searchParams.append("cursor", searchParams.cursor);
-        url.searchParams.append("since", searchParams.since);
-        url.searchParams.append("until", searchParams.until);
-        url.searchParams.append("sortcol", searchParams.sortcol);
-        url.searchParams.append("sortdir", searchParams.sortdir);
-        url.searchParams.append("showfailed", String(searchParams.showFailed));
-        return url.href;
+        return `
+        ${RS_API_URL}/api/waters/org/${searchParams.organization}/submissions?pageSize=${searchParams.pageSize}&cursor=${searchParams.cursor}&endcursor=${searchParams.endCursor}&sort=${searchParams.sort}&showfailed=${searchParams.showFailed}`;
     }
 
     isSuccessSubmitted(): boolean {


### PR DESCRIPTION
Reverts CDCgov/prime-reportstream#7635

Currently this sorting fix causes a new issue: The if a user navigates past the 5th page the pages stop updating with values. This is because I messed up the calculation of the "cursor" value. Will revert this PR so we don't introduce this issue to production and will work on a fix.