### PR TITLE
adding ability to manually trigger the production branch creation action

### DIFF
--- a/.github/workflows/prepare_deployment_branch.yaml
+++ b/.github/workflows/prepare_deployment_branch.yaml
@@ -1,6 +1,7 @@
 name: "Prepare Deployment Branch"
 
 on:
+  workflow_dispatch:
   schedule:
     # At 23:00 on Monday and Wednesday (https://crontab.guru/#0_16_*_*_1,3)
     # GitHub actions run in UTC (and EDT is UTC-4)


### PR DESCRIPTION
So we can click a button to cut 'production' from 'master', not just rely on the cron jobs.