### PR TITLE
Experience 7448: Fix highlighting UX

### DIFF
--- a/frontend-react/src/components/Admin/CompareJsonModal.test.tsx
+++ b/frontend-react/src/components/Admin/CompareJsonModal.test.tsx
@@ -1,0 +1,237 @@
+import React, { useRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import {
+    ConfirmSaveSettingModal,
+    ConfirmSaveSettingModalRef,
+    CompareSettingsModalProps,
+} from "./CompareJsonModal";
+
+describe("ConfirmSaveSettingModal", () => {
+    const VALID_JSON = JSON.stringify({ a: 1 });
+    const VALID_JSON_UPDATED = JSON.stringify({ a: 1, b: 2 });
+    const INVALID_JSON = "{ nope }";
+    let errorDiffNode: HTMLElement | null;
+    let textareaNode: HTMLElement;
+    let saveButtonNode: HTMLElement;
+    let checkSyntaxButtonNode: HTMLElement;
+
+    function TestWrapper(props?: Partial<CompareSettingsModalProps>) {
+        const confirmModalRef = useRef<ConfirmSaveSettingModalRef>(null);
+
+        return (
+            <ConfirmSaveSettingModal
+                uniquid={new Date().getTime().toString()}
+                onConfirm={jest.fn()}
+                ref={confirmModalRef}
+                oldjson={VALID_JSON}
+                newjson={VALID_JSON}
+                {...props}
+            />
+        );
+    }
+
+    function renderComponent(props: Partial<CompareSettingsModalProps> = {}) {
+        render(<TestWrapper {...props} />);
+
+        textareaNode = screen.getByTestId("EditableCompare__textarea");
+        saveButtonNode = screen.getByText("Save");
+        checkSyntaxButtonNode = screen.getByText("Check syntax");
+    }
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("on initial mount", () => {
+        describe("when the updated JSON is valid", () => {
+            beforeEach(() => {
+                renderComponent();
+            });
+
+            test("enables the save button", () => {
+                expect(saveButtonNode).toBeEnabled();
+            });
+        });
+
+        describe("when the updated JSON is invalid", () => {
+            beforeEach(() => {
+                renderComponent({
+                    newjson: INVALID_JSON,
+                });
+            });
+
+            test("disables the save button", () => {
+                expect(saveButtonNode).toBeDisabled();
+            });
+        });
+    });
+
+    describe("on change", () => {
+        describe("when the updated JSON is valid", () => {
+            beforeEach(() => {
+                renderComponent();
+
+                fireEvent.change(textareaNode, {
+                    target: { value: VALID_JSON_UPDATED },
+                });
+            });
+
+            test("enables the save button", () => {
+                expect(saveButtonNode).toBeEnabled();
+            });
+        });
+
+        describe("when the updated JSON is invalid", () => {
+            beforeEach(() => {
+                renderComponent();
+
+                fireEvent.change(textareaNode, {
+                    target: { value: INVALID_JSON },
+                });
+            });
+
+            test("disables the save button", () => {
+                expect(saveButtonNode).toBeDisabled();
+            });
+        });
+    });
+
+    describe("on blur", () => {
+        describe("when the updated JSON is valid", () => {
+            beforeEach(() => {
+                renderComponent();
+
+                fireEvent.change(textareaNode, {
+                    target: { value: VALID_JSON_UPDATED },
+                });
+                fireEvent.blur(textareaNode);
+
+                errorDiffNode = screen.queryByTestId(
+                    "EditableCompare__errorDiff"
+                );
+            });
+
+            test("does not render an error diff", () => {
+                expect(errorDiffNode).toBeNull();
+            });
+
+            test("does not render an error toast", () => {
+                expect(
+                    screen.queryByText(/JSON data generated/)
+                ).not.toBeInTheDocument();
+            });
+        });
+
+        describe("when the updated JSON is invalid", () => {
+            const consoleTraceSpy = jest.fn();
+
+            beforeEach(() => {
+                renderComponent();
+
+                jest.spyOn(console, "trace").mockImplementationOnce(
+                    consoleTraceSpy
+                );
+
+                fireEvent.change(textareaNode, {
+                    target: { value: INVALID_JSON },
+                });
+                fireEvent.blur(textareaNode);
+
+                errorDiffNode = screen.getByTestId(
+                    "EditableCompare__errorDiff"
+                );
+            });
+
+            afterEach(() => {
+                jest.resetAllMocks();
+            });
+
+            test("renders an error diff highlighting the error", () => {
+                expect(errorDiffNode).toBeVisible();
+                expect(errorDiffNode?.innerHTML).toContain("{ nope");
+            });
+
+            test("renders an error toast", () => {
+                expect(consoleTraceSpy).toHaveBeenCalled();
+                expect(
+                    screen.queryByText(/JSON data generated/)
+                ).not.toBeInTheDocument();
+            });
+
+            describe("when the user starts typing again", () => {
+                test("it removes the highlighting", () => {
+                    expect(errorDiffNode).toBeVisible();
+
+                    fireEvent.change(textareaNode, {
+                        target: { value: "lalalalala" },
+                    });
+
+                    errorDiffNode = screen.queryByTestId(
+                        "EditableCompare__errorDiff"
+                    );
+                    expect(errorDiffNode).toBeNull();
+                });
+            });
+
+            test("when the user starts typing again", () => {});
+        });
+    });
+
+    describe("on clicking the 'Check syntax' button", () => {
+        describe("when the updated JSON is valid", () => {
+            describe("when there are no changes", () => {
+                beforeEach(() => {
+                    renderComponent();
+
+                    fireEvent.click(checkSyntaxButtonNode);
+                });
+
+                test("pretty-prints the JSON in the textarea", () => {
+                    expect(textareaNode.innerHTML).toEqual('{\n  "a": 1\n}');
+                });
+            });
+
+            describe("when there are changes", () => {
+                beforeEach(() => {
+                    renderComponent();
+
+                    fireEvent.change(textareaNode, {
+                        target: {
+                            value: VALID_JSON_UPDATED,
+                        },
+                    });
+                    fireEvent.click(checkSyntaxButtonNode);
+                });
+
+                test("pretty-prints the JSON in the textarea", () => {
+                    expect(textareaNode.innerHTML).toEqual(
+                        '{\n  "a": 1,\n  "b": 2\n}'
+                    );
+                });
+            });
+        });
+
+        describe("when the updated JSON is invalid", () => {
+            beforeEach(() => {
+                renderComponent();
+
+                fireEvent.change(textareaNode, {
+                    target: {
+                        value: INVALID_JSON,
+                    },
+                });
+                fireEvent.click(checkSyntaxButtonNode);
+
+                errorDiffNode = screen.getByTestId(
+                    "EditableCompare__errorDiff"
+                );
+            });
+
+            test("renders an error diff highlighting the error", () => {
+                expect(errorDiffNode).toBeVisible();
+                expect(errorDiffNode?.innerHTML).toContain("{ nope");
+            });
+        });
+    });
+});

--- a/frontend-react/src/components/Admin/CompareJsonModal.test.tsx
+++ b/frontend-react/src/components/Admin/CompareJsonModal.test.tsx
@@ -49,8 +49,8 @@ describe("ConfirmSaveSettingModal", () => {
                 renderComponent();
             });
 
-            test("enables the save button", () => {
-                expect(saveButtonNode).toBeEnabled();
+            test("disables the save button", () => {
+                expect(saveButtonNode).toBeDisabled();
             });
         });
 
@@ -77,8 +77,8 @@ describe("ConfirmSaveSettingModal", () => {
                 });
             });
 
-            test("enables the save button", () => {
-                expect(saveButtonNode).toBeEnabled();
+            test("disables the save button", () => {
+                expect(saveButtonNode).toBeDisabled();
             });
         });
 
@@ -97,29 +97,63 @@ describe("ConfirmSaveSettingModal", () => {
         });
     });
 
-    describe("on blur", () => {
+    describe("on clicking the 'Check syntax' button", () => {
         describe("when the updated JSON is valid", () => {
-            beforeEach(() => {
-                renderComponent();
+            describe("when there are no changes", () => {
+                beforeEach(() => {
+                    renderComponent();
 
-                fireEvent.change(textareaNode, {
-                    target: { value: VALID_JSON_UPDATED },
+                    fireEvent.click(checkSyntaxButtonNode);
+
+                    errorDiffNode = screen.queryByTestId(
+                        "EditableCompare__errorDiff"
+                    );
                 });
-                fireEvent.blur(textareaNode);
 
-                errorDiffNode = screen.queryByTestId(
-                    "EditableCompare__errorDiff"
-                );
+                test("does not render an error diff", () => {
+                    expect(errorDiffNode).toBeNull();
+                });
+
+                test("does not render an error toast", () => {
+                    expect(
+                        screen.queryByText(/JSON data generated/)
+                    ).not.toBeInTheDocument();
+                });
+
+                test("pretty-prints the JSON in the textarea", () => {
+                    expect(textareaNode.innerHTML).toEqual('{\n  "a": 1\n}');
+                });
             });
 
-            test("does not render an error diff", () => {
-                expect(errorDiffNode).toBeNull();
-            });
+            describe("when there are changes", () => {
+                beforeEach(() => {
+                    renderComponent();
 
-            test("does not render an error toast", () => {
-                expect(
-                    screen.queryByText(/JSON data generated/)
-                ).not.toBeInTheDocument();
+                    fireEvent.change(textareaNode, {
+                        target: { value: VALID_JSON_UPDATED },
+                    });
+                    fireEvent.click(checkSyntaxButtonNode);
+
+                    errorDiffNode = screen.queryByTestId(
+                        "EditableCompare__errorDiff"
+                    );
+                });
+
+                test("does not render an error diff", () => {
+                    expect(errorDiffNode).toBeNull();
+                });
+
+                test("does not render an error toast", () => {
+                    expect(
+                        screen.queryByText(/JSON data generated/)
+                    ).not.toBeInTheDocument();
+                });
+
+                test("pretty-prints the JSON in the textarea", () => {
+                    expect(textareaNode.innerHTML).toEqual(
+                        '{\n  "a": 1,\n  "b": 2\n}'
+                    );
+                });
             });
         });
 
@@ -136,7 +170,7 @@ describe("ConfirmSaveSettingModal", () => {
                 fireEvent.change(textareaNode, {
                     target: { value: INVALID_JSON },
                 });
-                fireEvent.blur(textareaNode);
+                fireEvent.click(checkSyntaxButtonNode);
 
                 errorDiffNode = screen.getByTestId(
                     "EditableCompare__errorDiff"
@@ -172,65 +206,6 @@ describe("ConfirmSaveSettingModal", () => {
                     );
                     expect(errorDiffNode).toBeNull();
                 });
-            });
-
-            test("when the user starts typing again", () => {});
-        });
-    });
-
-    describe("on clicking the 'Check syntax' button", () => {
-        describe("when the updated JSON is valid", () => {
-            describe("when there are no changes", () => {
-                beforeEach(() => {
-                    renderComponent();
-
-                    fireEvent.click(checkSyntaxButtonNode);
-                });
-
-                test("pretty-prints the JSON in the textarea", () => {
-                    expect(textareaNode.innerHTML).toEqual('{\n  "a": 1\n}');
-                });
-            });
-
-            describe("when there are changes", () => {
-                beforeEach(() => {
-                    renderComponent();
-
-                    fireEvent.change(textareaNode, {
-                        target: {
-                            value: VALID_JSON_UPDATED,
-                        },
-                    });
-                    fireEvent.click(checkSyntaxButtonNode);
-                });
-
-                test("pretty-prints the JSON in the textarea", () => {
-                    expect(textareaNode.innerHTML).toEqual(
-                        '{\n  "a": 1,\n  "b": 2\n}'
-                    );
-                });
-            });
-        });
-
-        describe("when the updated JSON is invalid", () => {
-            beforeEach(() => {
-                renderComponent();
-
-                fireEvent.change(textareaNode, {
-                    target: {
-                        value: INVALID_JSON,
-                    },
-                });
-                fireEvent.click(checkSyntaxButtonNode);
-
-                errorDiffNode = screen.getByTestId(
-                    "EditableCompare__errorDiff"
-                );
-            });
-
-            test("renders an error diff highlighting the error", () => {
-                expect(errorDiffNode).toBeVisible();
-                expect(errorDiffNode?.innerHTML).toContain("{ nope");
             });
         });
     });

--- a/frontend-react/src/components/Admin/CompareJsonModal.tsx
+++ b/frontend-react/src/components/Admin/CompareJsonModal.tsx
@@ -56,7 +56,7 @@ export interface ConfirmSaveSettingModalRef extends ModalRef {
     disableSave: () => void;
 }
 
-interface CompareSettingsModalProps {
+export interface CompareSettingsModalProps {
     uniquid: string;
     onConfirm: () => void;
     oldjson: string;
@@ -75,6 +75,10 @@ export const ConfirmSaveSettingModal = forwardRef(
         const scopedConfirm = () => {
             onConfirm();
         };
+
+        function onChange(_text: string, isValid: boolean) {
+            setSaveDisabled(!isValid);
+        }
 
         useImperativeHandle(
             ref,
@@ -136,6 +140,7 @@ export const ConfirmSaveSettingModal = forwardRef(
                             original={oldjson}
                             modified={newjson}
                             jsonDiffMode={true}
+                            onChange={onChange}
                         />
                     </div>
                     <ModalFooter>
@@ -157,6 +162,17 @@ export const ConfirmSaveSettingModal = forwardRef(
                             >
                                 Save
                             </ModalConfirmSaveButton>
+                            <Button
+                                aria-label="Check the settings JSON syntax"
+                                key={`${uniquid}-validate-button`}
+                                data-uniquid={uniquid}
+                                onClick={() =>
+                                    diffEditorRef?.current?.refreshEditedText()
+                                }
+                                type="button"
+                            >
+                                Check syntax
+                            </Button>
                         </ButtonGroup>
                     </ModalFooter>
                 </Modal>

--- a/frontend-react/src/components/Admin/CompareJsonModal.tsx
+++ b/frontend-react/src/components/Admin/CompareJsonModal.tsx
@@ -76,9 +76,15 @@ export const ConfirmSaveSettingModal = forwardRef(
             onConfirm();
         };
 
-        function onChange(_text: string, isValid: boolean) {
-            setSaveDisabled(!isValid);
-        }
+        // Disable the 'Save' button whenever the user updates the textarea
+        // It'll only be enabled when they click the 'Check syntax' button,
+        // and it passes validation
+        const onChange = () => setSaveDisabled(true);
+        const onCheckSyntaxClick = () => {
+            if (diffEditorRef?.current?.refreshEditedText()) {
+                setSaveDisabled(false);
+            }
+        };
 
         useImperativeHandle(
             ref,
@@ -166,9 +172,7 @@ export const ConfirmSaveSettingModal = forwardRef(
                                 aria-label="Check the settings JSON syntax"
                                 key={`${uniquid}-validate-button`}
                                 data-uniquid={uniquid}
-                                onClick={() =>
-                                    diffEditorRef?.current?.refreshEditedText()
-                                }
+                                onClick={onCheckSyntaxClick}
                                 type="button"
                             >
                                 Check syntax

--- a/frontend-react/src/components/EditableCompare.tsx
+++ b/frontend-react/src/components/EditableCompare.tsx
@@ -21,7 +21,7 @@ import { showError } from "./AlertNotifications";
 export type EditableCompareRef = {
     getEditedText: () => string;
     getOriginalText: () => string;
-    refreshEditedText: (updatedjson: string) => void;
+    refreshEditedText: (updatedjson?: string) => void;
     isValidSyntax: () => boolean;
 };
 
@@ -29,6 +29,7 @@ interface EditableCompareProps {
     original: string;
     modified: string;
     jsonDiffMode: boolean; // true is json aware compare, false is a text compare
+    onChange: (text: string, isValid: boolean) => void;
 }
 
 /**
@@ -48,7 +49,7 @@ interface EditableCompareProps {
 export const EditableCompare = forwardRef(
     // allows for functions on components (useImperativeHandle)
     (
-        props: EditableCompareProps,
+        { jsonDiffMode, modified, onChange, original }: EditableCompareProps,
         ref: Ref<EditableCompareRef>
     ): ReactElement => {
         // useRefs are used to access html elements directly (instead of document.getElementById)
@@ -66,42 +67,11 @@ export const EditableCompare = forwardRef(
         // the API call into this forwardRef well say if json is valid (to enable save button)
         const [isValidSyntax, setIsValidSyntax] = useState(true);
 
-        useImperativeHandle(
-            ref,
-            () => ({
-                getEditedText() {
-                    return textAreaContent;
-                },
-                getOriginalText() {
-                    return props.original;
-                },
-                // when showing/hiding json, force am update of the content
-                refreshEditedText(updatedjson) {
-                    setTextAreaContent(updatedjson);
-                    onChangeHandler(updatedjson);
-                },
-                isValidSyntax() {
-                    return isValidSyntax;
-                },
-            }),
-            // onChangeHandler appears below, remove from deps
-            // eslint-disable-next-line
-            [textAreaContent]
-        );
-
-        const turnOffSpellCheckSwigglies = () => {
-            if (editDiffRef?.current?.spellcheck) {
-                editDiffRef.current.spellcheck = false;
-            }
-        };
-
         const refreshDiffCallback = useCallback(
             (originalText: string, modifiedText: string) => {
                 if (originalText.length === 0 || modifiedText.length === 0) {
                     return;
                 }
-
-                turnOffSpellCheckSwigglies();
 
                 // jsonDiffMode requires json be valid. If it's not then don't run it.
                 const { valid, offset } = checkJson(modifiedText);
@@ -115,12 +85,13 @@ export const EditableCompare = forwardRef(
 
                     const threeParts = splitOn(modifiedText, start, end);
                     // we're using HTML5's <s> tag to show error, style sets background to red.
-                    const errorHtml = `${threeParts[0]}<s>${threeParts[1]}</s>${threeParts[2]}`;
+                    const errorHtml = `${threeParts[0]}<s data-testid="EditableCompare__errorDiff">${threeParts[1]}</s>${threeParts[2]}`;
                     setRightHandSideHighlightHtml(errorHtml);
+
                     return;
                 }
 
-                const result = props.jsonDiffMode
+                const result = jsonDiffMode
                     ? jsonDifferMarkup(
                           JSON.parse(originalText),
                           JSON.parse(modifiedText)
@@ -132,7 +103,7 @@ export const EditableCompare = forwardRef(
                     setLeftHandSideHighlightHtml(result.left.markupText);
                 }
 
-                // we only change the hightlighting on the BACKGROUND div so we don't mess up typing/cursor
+                // we only change the highlighting on the BACKGROUND div so we don't mess up typing/cursor
                 if (result.right.markupText !== rightHandSideHighlightHtml) {
                     setRightHandSideHighlightHtml(result.right.markupText);
                 }
@@ -140,33 +111,74 @@ export const EditableCompare = forwardRef(
             [
                 leftHandSideHighlightHtml,
                 rightHandSideHighlightHtml,
-                props.jsonDiffMode,
+                jsonDiffMode,
             ]
         );
 
-        // on change, we highlight the errors
+        // force an update of the content
+        // will update with the provided content or infer from previous content
+        const refreshEditedText = useCallback(
+            (updatedJson: string | undefined) => {
+                let formattedText = updatedJson || textAreaContent;
+
+                if (checkJson(formattedText).valid) {
+                    formattedText = JSON.stringify(
+                        JSON.parse(formattedText),
+                        null,
+                        2
+                    );
+                    setTextAreaContent(formattedText);
+                }
+
+                refreshDiffCallback(original, formattedText);
+            },
+            [original, textAreaContent, refreshDiffCallback]
+        );
+
         const onChangeHandler = useCallback(
             (newText: string) => {
                 setTextAreaContent(newText);
-                refreshDiffCallback(props.original, newText);
+                setRightHandSideHighlightHtml("");
+                onChange(newText, checkJson(newText).valid);
             },
-            [setTextAreaContent, refreshDiffCallback, props]
+            [setTextAreaContent, onChange]
         );
 
-        const onBlurHandler = useCallback((newText: string) => {
-            const { valid, errorMsg } = checkJson(newText);
-            setIsValidSyntax(valid);
-            if (!valid) {
-                showError(`JSon data generated an error "${errorMsg}"`);
-            }
-        }, []);
+        useImperativeHandle(
+            ref,
+            () => ({
+                getEditedText() {
+                    return textAreaContent;
+                },
+                getOriginalText() {
+                    return original;
+                },
+                refreshEditedText,
+                isValidSyntax() {
+                    return isValidSyntax;
+                },
+            }),
+            [textAreaContent, original, isValidSyntax, refreshEditedText]
+        );
+
+        const onBlurHandler = useCallback(
+            (newText: string) => {
+                const { valid, errorMsg } = checkJson(newText);
+                setIsValidSyntax(valid);
+                refreshEditedText(newText);
+                if (!valid) {
+                    showError(`JSON data generated an error "${errorMsg}"`);
+                }
+            },
+            [refreshEditedText]
+        );
 
         useEffect(() => {
-            if (props.modified?.length > 0 && textAreaContent.length === 0) {
+            if (modified?.length > 0 && textAreaContent.length === 0) {
                 // initialization only
-                onChangeHandler(props.modified);
+                onChangeHandler(modified);
             }
-        }, [textAreaContent, props, onChangeHandler]);
+        }, [textAreaContent, modified, onChangeHandler]);
 
         return (
             <ScrollSync>
@@ -178,7 +190,7 @@ export const EditableCompare = forwardRef(
                                 className="rs-editable-compare-base rs-editable-compare-static"
                                 contentEditable={false}
                                 dangerouslySetInnerHTML={{
-                                    __html: DOMPurify.sanitize(props.original),
+                                    __html: DOMPurify.sanitize(original),
                                 }}
                             />
                         </ScrollSyncPane>
@@ -207,6 +219,8 @@ export const EditableCompare = forwardRef(
                                 onBlur={(e) => {
                                     onBlurHandler(e?.target?.value || "");
                                 }}
+                                spellCheck="false"
+                                data-testid="EditableCompare__textarea"
                             />
                         </ScrollSyncPane>
 


### PR DESCRIPTION
This changeset updates the Organization settings highlighting UX flow to:
- Disable highlighting while the user is updating the textarea
- Add a 'Check syntax' button to reformat + highlight errors/changes
- Update the blur listener to reformat + highlight

It also includes a few minor/refactory updates to the code, which I'll point out in comments.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. Log in as a PrimeAdmin
2. Start the flow to edit an Organization's settings
3. Ensure that the 'Save' button is enabled by default (since settings should be valid from the first fetch)
4. Update the textarea with changes
  a. When the textarea has valid JSON:
    i. Ensure the 'Save' button is enabled
    ii. On blurring OR clicking the 'Check syntax' button, ensure that the JSON is properly formatted and changes are highlighted in yellow
  b. When the textarea has invalid JSON:
    i.  Ensure the 'Save' button is disabled
    ii. On blurring OR clicking the 'Check syntax' button, ensure that the errors are highlighted in red
5. Ensure that submissions are persisted (for valid fields)

![2022-12-19 09 46 44](https://user-images.githubusercontent.com/2421042/208452302-478ed525-2b4c-4f1c-b9d9-ea9c8aa6b729.gif)

## Checklist

### Testing
- [x] Tested locally?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

## Linked Issues
- Fixes #7448 