### PR TITLE
Added a check that the uuid generated for a report is unique

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -314,7 +314,7 @@ class Report : Logging {
         metadata: Metadata,
         itemCountBeforeQualFilter: Int? = null
     ) {
-        this.id = id ?: generateRandomReportId()
+        this.id = generateRandomReportId(id)
         this.schema = schema
         this.sources = sources
         this.createdDateTime = OffsetDateTime.now()
@@ -430,11 +430,10 @@ class Report : Logging {
         this.itemCountBeforeQualFilter = itemCountBeforeQualFilter
     }
 
-    private fun generateRandomReportId(): UUID {
+    private fun generateRandomReportId(uuid: UUID? = UUID.randomUUID()): UUID {
         val database = WorkflowEngine().db
-        var uuid = UUID.randomUUID()
-        while (database.reportIdExists(uuid)) {
-            uuid = UUID.randomUUID()
+        while (database.reportIdExists(uuid!!)) {
+            return generateRandomReportId(UUID.randomUUID())
         }
         return uuid
     }

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -432,10 +432,11 @@ class Report : Logging {
 
     private fun generateRandomReportId(uuid: UUID? = UUID.randomUUID()): UUID {
         val database = WorkflowEngine().db
-        while (database.reportIdExists(uuid!!)) {
+        val proposedUuid = uuid ?: UUID.randomUUID()
+        while (database.reportIdExists(proposedUuid)) {
             return generateRandomReportId(UUID.randomUUID())
         }
-        return uuid
+        return proposedUuid
     }
 
     @Suppress("Destructure")

--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -314,7 +314,7 @@ class Report : Logging {
         metadata: Metadata,
         itemCountBeforeQualFilter: Int? = null
     ) {
-        this.id = id ?: UUID.randomUUID()
+        this.id = id ?: generateRandomReportId()
         this.schema = schema
         this.sources = sources
         this.createdDateTime = OffsetDateTime.now()
@@ -338,7 +338,7 @@ class Report : Logging {
         metadata: Metadata? = null,
         itemCountBeforeQualFilter: Int? = null
     ) {
-        this.id = UUID.randomUUID()
+        this.id = generateRandomReportId()
         this.schema = schema
         this.sources = listOf(source)
         this.destination = destination
@@ -361,7 +361,7 @@ class Report : Logging {
         metadata: Metadata,
         itemCountBeforeQualFilter: Int? = null
     ) {
-        this.id = UUID.randomUUID()
+        this.id = generateRandomReportId()
         this.schema = schema
         this.sources = listOf(source)
         this.bodyFormat = bodyFormat ?: destination?.format ?: Format.INTERNAL
@@ -391,7 +391,7 @@ class Report : Logging {
         destination: Receiver? = null,
         nextAction: TaskAction = TaskAction.process
     ) {
-        this.id = UUID.randomUUID()
+        this.id = generateRandomReportId()
         // ELR submissions do not need a schema, but it is required by the database to maintain legacy functionality
         this.schema = Schema("None", Topic.FULL_ELR)
         this.sources = sources
@@ -417,7 +417,7 @@ class Report : Logging {
         metadata: Metadata? = null,
         itemCountBeforeQualFilter: Int? = null
     ) {
-        this.id = UUID.randomUUID()
+        this.id = generateRandomReportId()
         this.schema = schema
         this.table = table
         this.itemCount = this.table.rowCount()
@@ -428,6 +428,15 @@ class Report : Logging {
         this.createdDateTime = OffsetDateTime.now()
         this.metadata = metadata ?: Metadata.getInstance()
         this.itemCountBeforeQualFilter = itemCountBeforeQualFilter
+    }
+
+    private fun generateRandomReportId(): UUID {
+        val database = WorkflowEngine().db
+        var uuid = UUID.randomUUID()
+        while (database.reportIdExists(uuid)) {
+            uuid = UUID.randomUUID()
+        }
+        return uuid
     }
 
     @Suppress("Destructure")

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -180,6 +180,9 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             )
     }
 
+    /**
+     * Checks if the report id already exists in the db
+     */
     fun reportIdExists(proposedUuid: UUID): Boolean {
         return create.fetchExists(REPORT_FILE, REPORT_FILE.REPORT_ID.eq(proposedUuid))
     }

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -180,6 +180,10 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             )
     }
 
+    fun reportIdExists(proposedUuid: UUID): Boolean {
+        return create.fetchExists(REPORT_FILE, REPORT_FILE.REPORT_ID.eq(proposedUuid))
+    }
+
     /**
      * Get the number of outstanding actions to batch for a specific receiver
      */

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -385,7 +385,8 @@ class WorkflowEngine(
             destination = receiver,
             bodyFormat = receiver.format,
             metadata = Metadata.getInstance(),
-            itemLineage = emptyList()
+            itemLineage = emptyList(),
+            workflowEngine = this
         )
 
         // set the empty report to be sent to the receiver
@@ -483,7 +484,8 @@ class WorkflowEngine(
                         emptyList(),
                         destination = report.destination,
                         bodyFormat = report.bodyFormat,
-                        metadata = Metadata.getInstance()
+                        metadata = Metadata.getInstance(),
+                        workflowEngine = this
                     )
                     emptyReport.filteringResults.add(it)
                     actionHistory.trackFilteredReport(report, emptyReport, receiver)

--- a/prime-router/src/test/kotlin/ReportTests.kt
+++ b/prime-router/src/test/kotlin/ReportTests.kt
@@ -66,19 +66,23 @@ class ReportTests {
     @Test
     fun `test merge`() {
         val one = Schema(name = "one", topic = Topic.TEST, elements = listOf(Element("a"), Element("b")))
+        val settings = FileSettings().loadOrganizations(oneOrganization)
+        val engine = makeEngine(settings)
         val report1 = Report(
             one,
             listOf(listOf("1", "2"), listOf("3", "4")),
             source = TestSource,
-            metadata = metadata
+            metadata = metadata,
+            workflowEngine = engine
         )
         val report2 = Report(
             one,
             listOf(listOf("5", "6"), listOf("7", "8")),
             source = TestSource,
-            metadata = metadata
+            metadata = metadata,
+            workflowEngine = engine
         )
-        val mergedReport = Report.merge(listOf(report1, report2))
+        val mergedReport = Report.merge(listOf(report1, report2), engine)
         assertThat(mergedReport.itemCount).isEqualTo(4)
         assertThat(report1.itemCount).isEqualTo(2)
         assertThat(mergedReport.getString(3, "b")).isEqualTo("8")
@@ -91,7 +95,16 @@ class ReportTests {
         val one = Schema(name = "one", topic = Topic.TEST, elements = listOf(Element("a"), Element("b")))
         val metadata = Metadata(schema = one)
         val jurisdictionalFilter = metadata.findReportStreamFilterDefinitions("matches") ?: fail("cannot find filter")
-        val report1 = Report(one, listOf(listOf("1", "2"), listOf("3", "4")), source = TestSource, metadata = metadata)
+        val settings = FileSettings().loadOrganizations(oneOrganization)
+        val engine = makeEngine(settings)
+        val report1 = Report(
+            one,
+            listOf(listOf("1", "2"),
+                listOf("3", "4")),
+            source = TestSource,
+            metadata = metadata,
+            workflowEngine = engine
+        )
         assertThat(report1.itemCount).isEqualTo(2)
         val filteredReport = report1.filter(
             listOf(
@@ -117,12 +130,15 @@ class ReportTests {
         val one = Schema(name = "one", topic = Topic.TEST, elements = listOf(Element("a"), Element("b")))
         val metadata = Metadata(schema = one)
         val jurisdictionalFilter = metadata.findReportStreamFilterDefinitions("matches") ?: fail("cannot find filter")
+        val settings = FileSettings().loadOrganizations(oneOrganization)
+        val engine = makeEngine(settings)
         // each sublist is a row.
         val report1 = Report(
             one,
             listOf(listOf("row1_a", "row1_b"), listOf("row2_a", "row2_b")),
             source = TestSource,
-            metadata = metadata
+            metadata = metadata,
+            workflowEngine = engine
         )
         assertThat(2).isEqualTo(report1.itemCount)
         val filteredReportA = report1.filter(

--- a/prime-router/src/test/kotlin/ReportTests.kt
+++ b/prime-router/src/test/kotlin/ReportTests.kt
@@ -744,7 +744,8 @@ class ReportTests {
             schema = schema,
             values = listOf(listOf("smith", "sarah"), listOf("jones", "mary"), listOf("white", "roberta")),
             source = TestSource,
-            metadata = metadata
+            metadata = metadata,
+            workflowEngine = engine
         )
         // act
         val synthesizedReport = report.synthesizeData(metadata = metadata)


### PR DESCRIPTION
This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
Use the Postman collection, ex Send CE HL7 Copy to send a report so that the system needs to generate a new id. It returns with an id. 

## Changes
- Added a method in DatabaseAccess to check if there is a report with the provided report id
- Added a method in Report.kt that uses the above method to check if a proposed id already is assigned to a record and repeats this process until it finds one that does not. 

## Checklist

### Testing
- [Y ] Tested locally?
- [ Y] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ N/A] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ N] Added tests? - I am not sure how to create a test that will actually test this functionality since DatabaseAccess does not currently have a test time. Very open to suggestions

### Process
- [N ] Are there licensing issues with any new dependencies introduced?
- [ Y] Includes a summary of what a code reviewer should test/verify?
- [ N] Updated the release notes?
- [ N/A] Database changes are submitted as a separate PR?
- [ N/A] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue 5493

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints? No
- Does this PR include changes in authentication and/or authorization of existing endpoints? No
- Does this change introduce new dependencies that need vetting? No
- Does this change require changes to our infrastructure? No
- Does logging contain sensitive data? No
- Does this PR include or remove any sensitive information itself? No