### PR TITLE
Jessica/7355 record hl7 batch files

### DIFF
--- a/prime-router/src/main/kotlin/Sender.kt
+++ b/prime-router/src/main/kotlin/Sender.kt
@@ -124,7 +124,8 @@ abstract class Sender(
     enum class Format(val mimeType: String) {
         CSV("text/csv"),
         HL7("application/hl7-v2"),
-        FHIR("application/fhir+json")
+        FHIR("application/fhir+json"),
+        HL7_BATCH("application/hl7-v2"), // todo: figure out what to put as value
     }
 
     /**

--- a/prime-router/src/main/kotlin/Sender.kt
+++ b/prime-router/src/main/kotlin/Sender.kt
@@ -125,7 +125,7 @@ abstract class Sender(
         CSV("text/csv"),
         HL7("application/hl7-v2"),
         FHIR("application/fhir+json"),
-        HL7_BATCH("application/hl7-v2"), // todo: figure out what to put as value
+        HL7_BATCH("application/hl7-v2"),
     }
 
     /**

--- a/prime-router/src/main/kotlin/SubmissionReceiver.kt
+++ b/prime-router/src/main/kotlin/SubmissionReceiver.kt
@@ -114,7 +114,7 @@ abstract class SubmissionReceiver(
 
         /**
          * Determines what type of submission receiver to use based on [sender]
-         * Creates a new SubmissionReceiver using the given the [workflowEngine] and [actionHistory]
+         * Creates a new SubmissionReceiver using the given [workflowEngine] and [actionHistory]
          * @return Returns either a TopicReceiver or ELRReceiver based on the sender
          */
         internal fun getSubmissionReceiver(
@@ -261,15 +261,16 @@ class ELRReceiver : SubmissionReceiver {
         val sources = listOf(ClientSource(organization = sender.organizationName, client = sender.name))
         // check that our input is valid HL7. Additional validation will happen at a later step
 
-        var report: Report
+        val report: Report
 
         when (sender.format) {
             Sender.Format.HL7 -> {
-                var messages = HL7Reader(actionLogs).getMessages(content)
+                val messages = HL7Reader(actionLogs).getMessages(content)
+                val isBatch = HL7Reader(actionLogs).isBatch(content, messages.size)
                 // create a Report for this incoming HL7 message to use for tracking in the database
 
                 report = Report(
-                    Format.HL7,
+                    if (isBatch) Format.HL7_BATCH else Format.HL7,
                     sources,
                     messages.size,
                     metadata = metadata,

--- a/prime-router/src/main/kotlin/SubmissionReceiver.kt
+++ b/prime-router/src/main/kotlin/SubmissionReceiver.kt
@@ -67,7 +67,7 @@ abstract class SubmissionReceiver(
             val generatedHashes = mutableListOf<String>()
             val duplicateIndexes = mutableListOf<Int>()
             for (rowNum in 0 until report.itemCount) {
-                var itemHash = report.getItemHashForRow(rowNum)
+                val itemHash = report.getItemHashForRow(rowNum)
                 // check for duplicate item
                 val isDuplicate = generatedHashes.contains(itemHash) ||
                     workflowEngine.isDuplicateItem(itemHash)

--- a/prime-router/src/main/kotlin/azure/HttpUtilities.kt
+++ b/prime-router/src/main/kotlin/azure/HttpUtilities.kt
@@ -295,7 +295,7 @@ class HttpUtilities {
         ): Pair<Int, String> {
             val headers = mutableListOf<Pair<String, String>>()
             when (sendingOrgClient.format) {
-                Sender.Format.HL7 -> headers.add("Content-Type" to Report.Format.HL7.mimeType)
+                Sender.Format.HL7, Sender.Format.HL7_BATCH -> headers.add("Content-Type" to Report.Format.HL7.mimeType)
                 else -> headers.add("Content-Type" to Report.Format.CSV.mimeType)
             }
             val clientStr = sendingOrgClient.organizationName +
@@ -327,7 +327,7 @@ class HttpUtilities {
         ): Pair<Int, String> {
             val headers = mutableListOf<Pair<String, String>>()
             when (sendingOrgClient.format) {
-                Sender.Format.HL7 -> headers.add("Content-Type" to Report.Format.HL7.mimeType)
+                Sender.Format.HL7, Sender.Format.HL7_BATCH -> headers.add("Content-Type" to Report.Format.HL7.mimeType)
                 else -> headers.add("Content-Type" to Report.Format.CSV.mimeType)
             }
             val clientStr = sendingOrgClient.organizationName +

--- a/prime-router/src/main/kotlin/azure/SenderFilesFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SenderFilesFunction.kt
@@ -236,7 +236,7 @@ class SenderFilesFunction(
     private fun cutContent(reportBlob: String, senderFormat: Sender.Format, itemIndices: List<Int>): String {
         return when (senderFormat) {
             Sender.Format.CSV -> CsvUtilities.cut(reportBlob, itemIndices)
-            Sender.Format.HL7 -> Hl7Utilities.cut(reportBlob, itemIndices)
+            Sender.Format.HL7, Sender.Format.HL7_BATCH -> Hl7Utilities.cut(reportBlob, itemIndices)
             else -> throw IllegalStateException("Sender format $senderFormat is not supported")
         }
     }

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -871,7 +871,7 @@ class WorkflowEngine(
                     )
                 }
             }
-            Sender.Format.HL7 -> {
+            Sender.Format.HL7, Sender.Format.HL7_BATCH -> {
                 try {
                     this.hl7Serializer.readExternal(
                         schemaName = sender.schemaName,

--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -172,10 +172,10 @@ class WorkflowEngine(
         payloadName: String? = null
     ): BlobAccess.BlobInfo {
         // Save a copy of the original report
-        val senderReportFormat = Report.Format.safeValueOf(sender.format.toString())
-        val blobFilename = report.name.replace(report.bodyFormat.ext, senderReportFormat.ext)
+        val reportFormat = Report.Format.safeValueOf(report.bodyFormat.toString())
+        val blobFilename = report.name.replace(report.bodyFormat.ext, reportFormat.ext)
         val blobInfo = BlobAccess.uploadBody(
-            senderReportFormat,
+            reportFormat,
             rawBody,
             blobFilename,
             sender.fullName,

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -45,9 +45,9 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
     }
 
     /**
-     * Takes a rawMessage and the number of messages in the rawMessage and determines if it is a batch or singular HL7
-     * message. It will qualify as a batch message if it follows the HL7 standards and have the Hl7 batch headers which
-     * start with "FHS" or if they left off the batch headers and just sent multiple messages
+     * Takes a [rawMessage] and the number of messages [numMessages] in the rawMessage and determines if it is a batch
+     * or singular HL7 message. It will qualify as a batch message if it follows the HL7 standards and have the Hl7
+     * batch headers which start with "FHS" or if they left off the batch headers and just sent multiple messages
      */
     fun isBatch(rawMessage: String, numMessages: Int): Boolean {
         return rawMessage.startsWith("FHS") || numMessages > 1

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -44,6 +44,10 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
         return messages
     }
 
+    fun isBatch(rawMessage: String, numMessages: Int): Boolean {
+        return rawMessage.startsWith("FHS") || numMessages > 1
+    }
+
     /**
      * Takes an [exception] thrown by the HL7 HAPI library, gets the root cause and logs the error into [actionLogger].
      * Sample error messages returned by the HAPI library are:

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -44,6 +44,11 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
         return messages
     }
 
+    /**
+     * Takes a rawMessage and the number of messages in the rawMessage and determines if it is a batch or singular HL7
+     * message. It will qualify as a batch message if it follows the HL7 standards and have the Hl7 batch headers which
+     * start with "FHS" or if they left off the batch headers and just sent multiple messages
+     */
     fun isBatch(rawMessage: String, numMessages: Int): Boolean {
         return rawMessage.startsWith("FHS") || numMessages > 1
     }

--- a/prime-router/src/test/kotlin/SubmissionReceiverTests.kt
+++ b/prime-router/src/test/kotlin/SubmissionReceiverTests.kt
@@ -108,6 +108,161 @@ class SubmissionReceiverTests {
         "SPM|1|1234d1d1-95fe-462c-8ac6-46728dba581c&&05D2222542&ISO^1234d1d1-95fe-462c-8ac6-46728dba581c&&05D22225" +
         "42&ISO||445297001^Swab of internal nose^SCT^^^^2.67||||53342003^Internal nose structure (body structure)^" +
         "SCT^^^^2020-09-01|||||||||202108020000-0500|20210802000006.0000-0500"
+    val hl7_record_batch_headers = "FHS|^~\\&|||0.0.0.0.1|0.0.0.0.1|202106221314-0400\n" +
+        "BHS|^~\\&|||0.0.0.0.1|0.0.0.0.1|202106221314-0400\n" +
+        "MSH|^~\\&||Any facility USA^00D1063590^CLIA|0.0.0.0.1|0.0.0.0.1|20210622131413.8343-0400||ORU^R01^ORU_R01|" +
+        "858625|P|2.5.1|||NE|NE|USA|UNICODE UTF-8\n" +
+        "SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME Data Hub|0.1-SNAPSHOT||20210622\n" +
+        "PID|1||ty6vmz^^^Any lab USA&00D1063590&CLIA^sk6yx07d^&00D1063590&CLIA||Walker^Caleb^Elida^V^^^w9tdt9||" +
+        "19280828|A||2106-3^White^HL70005^^^^2.5.1|1663 Simonis Loaf^^^IG^^2ljq2bmyq|" +
+        "|^NET^Internet^gaylord.schumm@email.com~(235)8597464^PRN^PH^^1^235^8597464|||||||470-08-1020|" +
+        "|N^Non Hispanic or Latino^HL70189^^^^2.9|||||||20210619|UNK|||||||||83\n" +
+        "ORC|RE|094127^Any lab USA^91D6499987^CLIA|790928^Any lab USA^91D6499987^CLIA|" +
+        "429385^zpa15khbo^23D3640684^CLIA||||||||9761354546^Hane^Merrill^Winston^^^^^0.0.0.0.1^^^^uyheq064u||" +
+        "(203)9088367^WPN^PH^^1^203^9088367|20210613||||||Any facility USA|52005 Jaime Courts^^^IG^^^^CSV|" +
+        "(226)4923361^WPN^PH^^1^226^4923361|495 Li Orchard^^^IG\n" +
+        "OBR|1|094127^Any lab USA^91D6499987^CLIA|790928^Any lab USA^91D6499987^CLIA|" +
+        "94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^e3lcoj^^^^2.68|||" +
+        "202106130143-0400|202106130143-0400||||||||9761354546^Hane^Merrill^Winston^^^^^0.0.0.0.1^^^^uyheq064u|" +
+        "(203)9088367^WPN^PH^^1^203^9088367|||||202106151804-0400|||F^Final results^HL70123||||||khi2a\n" +
+        "OBX|1|CWE^^HL70125|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid" +
+        " immunoassay^5380sz^^^^2.68|752053|260373001^Detected^SCT|eq1bvbvr|Normal|L^Below low normal^HL70078^^^^2.7|" +
+        "||F^Final results; Can only be changed with a corrected result^HL70085|||202106130143-0400|91D6499987^CLIA||" +
+        "^^^^^^2.68|BD Veritor Plus System_Becton Dickinson^^MNI|202106140503-0400|||202106192007-0400|" +
+        "Any lab USA^^^^^0.0.0.0.1^XX^^^91D6499987^CLIA|84684 Hans River^^^IG\n" +
+        "NTE||L^Ancillary (filler) department is source of comment^HL70105|0aswk4cws|" +
+        "AI^Ancillary Instructions^HL70364^^^^2.5.1\n" +
+        "OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||UNK^Unknown^HL70136|" +
+        "|||||F|||202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||UNK^Unknown^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|4|CWE|77974-4^Patient was hospitalized because of this condition^LN||Y^Yes^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|5|CWE|95420-6^Admitted to intensive care unit for condition of interest^LN^^^^2.69||" +
+        "UNK^Unknown^HL70136||||||F|||202106130143-0400|91D6499987||||202106140503-0400||||" +
+        "Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|6|DT|65222-2^Date and time of symptom onset^LN^^^^2.68||20210614||||||F|||202106130143-0400|" +
+        "91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|7|CWE|30525-0^Age^LN^^^^2.68||3|mo^months^UCUM|||||F|||202106130143-0400|91D6499987||||" +
+        "202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|8|CWE|82810-3^Pregnancy status^LN^^^^2.68||77386006^Pregnant^SCT||||||F|||202106130143-0400|" +
+        "91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|9|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|10|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "SPM|1|428303&&00D1063590&CLIA^790928&&00D1063590&CLIA||258580003^Whole blood sample^SCT^^^^2.67|||" +
+        "TMSC^Transport Media, Stool Culture^HL70048|71836000^Nasopharyngeal structure" +
+        " (body structure)^SCT^^^^2020-09-01||i0rqgdf|R|||8lls9tlx|||202106130143-0400|202106132135-0400\n" +
+        "BTS|25\n" +
+        "FTS|1\n"
+    val hl7_multiple_records_no_headers = "MSH|^~\\&||Any facility USA^00D1063590^CLIA|0.0.0.0.1|0.0.0.0.1|" +
+        "20210622131413.8343-0400||ORU^R01^ORU_R01|858625|P|2.5.1|||NE|NE|USA|UNICODE UTF-8\n" +
+        "SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME Data Hub|0.1-SNAPSHOT||20210622\n" +
+        "PID|1||ty6vmz^^^Any lab USA&00D1063590&CLIA^sk6yx07d^&00D1063590&CLIA||Walker^Caleb^Elida^V^^^w9tdt9||" +
+        "19280828|A||2106-3^White^HL70005^^^^2.5.1|1663 Simonis Loaf^^^IG^^2ljq2bmyq||" +
+        "^NET^Internet^gaylord.schumm@email.com~(235)8597464^PRN^PH^^1^235^8597464|||||||470-08-1020||" +
+        "N^Non Hispanic or Latino^HL70189^^^^2.9|||||||20210619|UNK|||||||||83\n" +
+        "ORC|RE|094127^Any lab USA^91D6499987^CLIA|790928^Any lab USA^91D6499987^CLIA|" +
+        "429385^zpa15khbo^23D3640684^CLIA||||||||9761354546^Hane^Merrill^Winston^^^^^0.0.0.0.1^^^^uyheq064u||" +
+        "(203)9088367^WPN^PH^^1^203^9088367|20210613||||||Any facility USA|52005 Jaime Courts^^^IG^^^^CSV|" +
+        "(226)4923361^WPN^PH^^1^226^4923361|495 Li Orchard^^^IG\n" +
+        "OBR|1|094127^Any lab USA^91D6499987^CLIA|790928^Any lab USA^91D6499987^CLIA|" +
+        "94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^e3lcoj^^^^2.68|" +
+        "||202106130143-0400|202106130143-0400||||||||9761354546^Hane^Merrill^Winston^^^^^0.0.0.0.1^^^^uyheq064u|" +
+        "(203)9088367^WPN^PH^^1^203^9088367|||||202106151804-0400|||F^Final results^HL70123||||||khi2a\n" +
+        "OBX|1|CWE^^HL70125|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid " +
+        "immunoassay^5380sz^^^^2.68|752053|260373001^Detected^SCT|eq1bvbvr|Normal|L^Below low normal^HL70078^^^^2.7|" +
+        "||F^Final results; Can only be changed with a corrected result^HL70085|||202106130143-0400|91D6499987^CLIA|" +
+        "|^^^^^^2.68|BD Veritor Plus System_Becton Dickinson^^MNI|202106140503-0400|||202106192007-0400|" +
+        "Any lab USA^^^^^0.0.0.0.1^XX^^^91D6499987^CLIA|84684 Hans River^^^IG\n" +
+        "NTE||L^Ancillary (filler) department is source of comment^HL70105|0aswk4cws|" +
+        "AI^Ancillary Instructions^HL70364^^^^2.5.1\n" +
+        "OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||UNK^Unknown^HL70136|" +
+        "|||||F|||202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||UNK^Unknown^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|4|CWE|77974-4^Patient was hospitalized because of this condition^LN||Y^Yes^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|5|CWE|95420-6^Admitted to intensive care unit for condition of interest^LN^^^^2.69||" +
+        "UNK^Unknown^HL70136||||||F|||202106130143-0400|91D6499987||||202106140503-0400||||" +
+        "Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|6|DT|65222-2^Date and time of symptom onset^LN^^^^2.68||20210614||||||F|||202106130143-0400|91D6499987|" +
+        "|||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|7|CWE|30525-0^Age^LN^^^^2.68||3|mo^months^UCUM|||||F|||202106130143-0400|91D6499987||||" +
+        "202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|8|CWE|82810-3^Pregnancy status^LN^^^^2.68||77386006^Pregnant^SCT||||||F|||202106130143-0400|" +
+        "91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|9|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "OBX|10|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||" +
+        "202106130143-0400|91D6499987||||202106140503-0400||||Any lab USA^^^^^^XX^^^91D6499987|" +
+        "84684 Hans River^^^IG^^^^^CSV|||||QST\n" +
+        "SPM|1|428303&&00D1063590&CLIA^790928&&00D1063590&CLIA||258580003^Whole blood sample^SCT^^^^2.67|||" +
+        "TMSC^Transport Media, Stool Culture^HL70048|71836000^Nasopharyngeal structure (body structure)^SCT^^^^" +
+        "2020-09-01||i0rqgdf|R|||8lls9tlx|||202106130143-0400|202106132135-0400\n" +
+        "MSH|^~\\&||Any facility USA^89D0179727^CLIA|0.0.0.0.1|0.0.0.0.1|20210622131413.8343-0400||ORU^R01^ORU_R01|" +
+        "444647|P|2.5.1|||NE|NE|USA|UNICODE UTF-8\n" +
+        "SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME Data Hub|0.1-SNAPSHOT||20210622\n" +
+        "PID|1||pym78h^^^Any lab USA&89D0179727&CLIA^7iwz8b7^&89D0179727&CLIA||Boyle^Milagro^America^^^^r8qat6||" +
+        "19530809|U||2028-9^Asian^HL70005^^^^2.5.1|13833 Gerlach Pine^^^IG^^9zylw94i||" +
+        "^NET^Internet^amparo.donnelly@email.com~(218)2671915^PRN^PH^^1^218^2671915|||||||612-20-4749||" +
+        "U^Unknown^NULLFL^^^^2.9|||||||20210616|Y|||||||||73\n" +
+        "ORC|RE|343803^Any lab USA^52D3802033^CLIA|801572^Any lab USA^52D3802033^CLIA|143237^fn9qu^36D3186071^CLIA|" +
+        "|||||||6295335628^Kutch^Deidre^Gilbert^^^^^0.0.0.0.1^^^^73bjs5f||(210)2187892^WPN^PH^^1^210^2187892|" +
+        "20210620||||||Any facility USA|858 Lowe Roads^^^IG^^^^HL7|(215)4870805^WPN^PH^^1^215^4870805|" +
+        "8339 Fahey Isle^^^IG\n" +
+        "OBR|1|343803^Any lab USA^52D3802033^CLIA|801572^Any lab USA^52D3802033^CLIA|" +
+        "95209-3^SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid " +
+        "immunoassay^rofbw^^^^2.68|||202106191723-0400|202106191723-0400||||||||" +
+        "6295335628^Kutch^Deidre^Gilbert^^^^^0.0.0.0.1^^^^73bjs5f|(210)2187892^WPN^PH^^1^210^2187892|||||" +
+        "202106161517-0400|||F^Order received; specimen not yet received^HL70123||||||airqhmcn\n" +
+        "OBX|1|CWE^^HL70125|95209-3^SARS-CoV+SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid " +
+        "immunoassay^og3lqsx6l^^^^2.68|321016|419984006^Inconclusive^SCT|o74lqd5po|Normal|>^Above absolute high-off" +
+        " instrument scale^HL70078^^^^2.7|||F^Not asked; used to affirmatively document that the observation" +
+        " identified in the OBX was not sought when the universal service ID in OBR-4 implies that it would be" +
+        " sought.^HL70085|||202106191723-0400|52D3802033^CLIA||^^^^^^2.68|LumiraDx Platform_LumiraDx^^MNI|" +
+        "202106210113-0400|||202106140838-0400|Any lab USA^^^^^0.0.0.0.1^XX^^^52D3802033^CLIA|" +
+        "39111 Zemlak Route^^^IG\n" +
+        "NTE||P^Orderer (placer) is source of comment^HL70105|x3fmq|RE^Remark^HL70364^^^^2.5.1\n" +
+        "OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||UNK^Unknown^HL70136|" +
+        "|||||F|||202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||UNK^Unknown^HL70136||||||F|||" +
+        "202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|4|CWE|77974-4^Patient was hospitalized because of this condition^LN||Y^Yes^HL70136||||||F|||" +
+        "202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|5|CWE|95420-6^Admitted to intensive care unit for condition of interest^LN^^^^2.69||Y^Yes^HL70136|" +
+        "|||||F|||202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|6|DT|65222-2^Date and time of symptom onset^LN^^^^2.68||20210614||||||F|||202106191723-0400|" +
+        "52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|7|CWE|30525-0^Age^LN^^^^2.68||9|wk^weeks^UCUM|||||F|||202106191723-0400|52D3802033||||" +
+        "202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|8|CWE|82810-3^Pregnancy status^LN^^^^2.68||261665006^Unknown^SCT||||||F|||" +
+        "202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|9|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||" +
+        "202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "OBX|10|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||Y^Yes^HL70136|" +
+        "|||||F|||202106191723-0400|52D3802033||||202106210113-0400||||Any lab USA^^^^^^XX^^^52D3802033|" +
+        "39111 Zemlak Route^^^IG^^^^^HL7|||||QST\n" +
+        "SPM|1|716531&&89D0179727&CLIA^801572&&89D0179727&CLIA||258500001^Nasopharyngeal swab^SCT^^^^2.67|" +
+        "||TMVI^Transport Media, Viral^HL70048|71836000^Nasopharyngeal structure " +
+        "(body structure)^SCT^^^^2020-09-01||m074nakh|B|||pvnlh|||202106191723-0400|202106212137-0400"
     val hl7_record_bad_type = "MSH|^~\\&|CDC PRIME - Atlanta,^2.16.840.1.114222.4.1.237821^ISO|" +
         "Winchester House^05D2222542^" +
         "ISO|CDPH FL REDIE^2.16.840.1.114222.4.3.3.10.1.1^ISO|CDPH_CID^2.16.840.1.114222.4.1.214104^ISO|202108031315" +
@@ -662,6 +817,19 @@ class SubmissionReceiverTests {
 
     @Test
     fun `test ELR receiver validateAndMoveToProcessing, inactive sender`() {
+        callELRReceiverValidateAndMoveToProcessing(Report.Format.HL7, hl7_record)
+    }
+    @Test
+    fun `test ELR receiver validateAndMoveToProcessing, HL7_BATCH format with header`() {
+        callELRReceiverValidateAndMoveToProcessing(Report.Format.HL7_BATCH, hl7_record_batch_headers)
+    }
+
+    @Test
+    fun `test ELR receiver validateAndMoveToProcessing, HL7_BATCH format no header, multiple records`() {
+        callELRReceiverValidateAndMoveToProcessing(Report.Format.HL7_BATCH, hl7_multiple_records_no_headers)
+    }
+
+    private fun callELRReceiverValidateAndMoveToProcessing(format: Report.Format, content: String) {
         // setup
         mockkObject(SubmissionReceiver.Companion)
         val one = Schema(name = "one", topic = Topic.TEST, elements = listOf(Element("a"), Element("b")))
@@ -706,7 +874,7 @@ class SubmissionReceiverTests {
         // act
         receiver.validateAndMoveToProcessing(
             sender,
-            hl7_record,
+            content,
             emptyMap(),
             Options.None,
             emptyList(),
@@ -722,7 +890,7 @@ class SubmissionReceiverTests {
             engine.recordReceivedReport(any(), any(), any(), any(), any())
             SubmissionReceiver.doDuplicateDetection(any(), any(), any())
             actionHistory.trackLogs(emptyList())
-            engine.insertProcessTask(any(), any(), any(), any())
+            engine.insertProcessTask(any(), format.toString(), any(), any())
         }
         verify(exactly = 0) {
             queueMock.sendMessage(elrConvertQueueName, any())

--- a/prime-router/src/test/kotlin/SubmissionReceiverTests.kt
+++ b/prime-router/src/test/kotlin/SubmissionReceiverTests.kt
@@ -817,19 +817,19 @@ class SubmissionReceiverTests {
 
     @Test
     fun `test ELR receiver validateAndMoveToProcessing, inactive sender`() {
-        callELRReceiverValidateAndMoveToProcessing(Report.Format.HL7, hl7_record)
+        testELRReceiverValidateAndMoveToProcessing(Report.Format.HL7, hl7_record)
     }
     @Test
     fun `test ELR receiver validateAndMoveToProcessing, HL7_BATCH format with header`() {
-        callELRReceiverValidateAndMoveToProcessing(Report.Format.HL7_BATCH, hl7_record_batch_headers)
+        testELRReceiverValidateAndMoveToProcessing(Report.Format.HL7_BATCH, hl7_record_batch_headers)
     }
 
     @Test
     fun `test ELR receiver validateAndMoveToProcessing, HL7_BATCH format no header, multiple records`() {
-        callELRReceiverValidateAndMoveToProcessing(Report.Format.HL7_BATCH, hl7_multiple_records_no_headers)
+        testELRReceiverValidateAndMoveToProcessing(Report.Format.HL7_BATCH, hl7_multiple_records_no_headers)
     }
 
-    private fun callELRReceiverValidateAndMoveToProcessing(format: Report.Format, content: String) {
+    private fun testELRReceiverValidateAndMoveToProcessing(format: Report.Format, content: String) {
         // setup
         mockkObject(SubmissionReceiver.Companion)
         val one = Schema(name = "one", topic = Topic.TEST, elements = listOf(Element("a"), Element("b")))

--- a/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
+++ b/prime-router/src/test/kotlin/azure/WorkflowEngineTests.kt
@@ -202,13 +202,19 @@ class WorkflowEngineTests {
         val one = Schema(name = "one", topic = Topic.TEST, elements = listOf(Element("a"), Element("b")))
         val metadata = Metadata(schema = one)
         val settings = FileSettings()
-        val report1 = Report(one, listOf(listOf("1", "2"), listOf("3", "4")), source = TestSource, metadata = metadata)
+        val report1 = Report(
+            one,
+            listOf(listOf("1", "2"), listOf("3", "4")),
+            source = TestSource,
+            metadata = metadata,
+            bodyFormat = Report.Format.CSV
+        )
         val actionHistory = mockk<ActionHistory>()
         val sender = CovidSender("senderName", "org", Sender.Format.CSV, CustomerStatus.INACTIVE, one.name)
 
         every {
             BlobAccess.Companion.uploadBody(
-                Report.Format.CSV,
+                report1.bodyFormat,
                 any(),
                 any(),
                 sender.fullName,

--- a/prime-router/src/test/kotlin/fhirengine/utils/HL7ReaderTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/utils/HL7ReaderTests.kt
@@ -160,4 +160,96 @@ OBX|1|test|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen b
         assertThat(actionLogger.logs[0].detail.message).contains("Data type error")
         actionLogger.logs.clear()
     }
+
+    @Test
+    fun `test isBatch with FSH Header`() {
+        val actionLogger = ActionLogger()
+        val hl7Reader = HL7Reader(actionLogger)
+
+        val goodData1 = """
+            FHS|^~\&|||0.0.0.0.1|0.0.0.0.1|202106221314-0400
+            BHS|^~\&|||0.0.0.0.1|0.0.0.0.1|202106221314-0400
+            MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|PRIME_DOH|Prime ReportStream|20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO
+            SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME ReportStream|0.1-SNAPSHOT||20210210
+            PID|1||2a14112c-ece1-4f82-915c-7b3a8d152eda^^^Avante at Ormond Beach^PI||Buckridge^Kareem^Millie^^^^L||19580810|F||2106-3^White^HL70005^^^^2.5.1|688 Leighann Inlet^^South Rodneychester^TX^67071^^^^48077||7275555555:1:^PRN^^roscoe.wilkinson@email.com^1^211^2240784|||||||||U^Unknown^HL70189||||||||N
+            ORC|RE|73a6e9bd-aaec-418e-813a-0ad33366ca85|73a6e9bd-aaec-418e-813a-0ad33366ca85|||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI||^WPN^^^1^386^6825220|20210209||||||Avante at Ormond Beach|170 North King Road^^Ormond Beach^FL^32174^^^^12127|^WPN^^jbrush@avantecenters.com^1^407^7397506|^^^^32174
+            OBR|1|73a6e9bd-aaec-418e-813a-0ad33366ca85|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN|||202102090000-0600|202102090000-0600||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI|^WPN^^^1^386^6825220|||||202102090000-0600|||F
+            OBX|1|CWE|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN||260415000^Not detected^SCT|||N^Normal (applies to non-numeric results)^HL70078|||F|||202102090000-0600|||CareStart COVID-19 Antigen test_Access Bio, Inc._EUA^^99ELR||202102090000-0600||||Avante at Ormond Beach^^^^^CLIA&2.16.840.1.113883.4.7&ISO^^^^10D0876999^CLIA|170 North King Road^^Ormond Beach^FL^32174^^^^12127
+            OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|4|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|5|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|6|CWE|82810-3^Pregnant^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            NTE|1|L|This is a note|RE
+            SPM|1|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b||258500001^Nasopharyngeal swab^SCT||||71836000^Nasopharyngeal structure (body structure)^SCT^^^^2020-09-01|||||||||202102090000-0600|202102090000-0600
+            BTS|2
+            FTS|1
+        """.trimIndent()
+        val messages = hl7Reader.getMessages(goodData1)
+        val isBatch = hl7Reader.isBatch(goodData1, messages.size)
+        assertThat(isBatch).isTrue()
+    }
+
+    @Test
+    fun `test isBatch without FSH Header`() {
+        val actionLogger = ActionLogger()
+        val hl7Reader = HL7Reader(actionLogger)
+
+        val goodData1 = """          
+            MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|PRIME_DOH|Prime ReportStream|20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO
+            SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME ReportStream|0.1-SNAPSHOT||20210210
+            PID|1||2a14112c-ece1-4f82-915c-7b3a8d152eda^^^Avante at Ormond Beach^PI||Buckridge^Kareem^Millie^^^^L||19580810|F||2106-3^White^HL70005^^^^2.5.1|688 Leighann Inlet^^South Rodneychester^TX^67071^^^^48077||7275555555:1:^PRN^^roscoe.wilkinson@email.com^1^211^2240784|||||||||U^Unknown^HL70189||||||||N
+            ORC|RE|73a6e9bd-aaec-418e-813a-0ad33366ca85|73a6e9bd-aaec-418e-813a-0ad33366ca85|||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI||^WPN^^^1^386^6825220|20210209||||||Avante at Ormond Beach|170 North King Road^^Ormond Beach^FL^32174^^^^12127|^WPN^^jbrush@avantecenters.com^1^407^7397506|^^^^32174
+            OBR|1|73a6e9bd-aaec-418e-813a-0ad33366ca85|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN|||202102090000-0600|202102090000-0600||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI|^WPN^^^1^386^6825220|||||202102090000-0600|||F
+            OBX|1|CWE|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN||260415000^Not detected^SCT|||N^Normal (applies to non-numeric results)^HL70078|||F|||202102090000-0600|||CareStart COVID-19 Antigen test_Access Bio, Inc._EUA^^99ELR||202102090000-0600||||Avante at Ormond Beach^^^^^CLIA&2.16.840.1.113883.4.7&ISO^^^^10D0876999^CLIA|170 North King Road^^Ormond Beach^FL^32174^^^^12127
+            OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|4|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|5|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|6|CWE|82810-3^Pregnant^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            NTE|1|L|This is a note|RE
+            SPM|1|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b||258500001^Nasopharyngeal swab^SCT||||71836000^Nasopharyngeal structure (body structure)^SCT^^^^2020-09-01|||||||||202102090000-0600|202102090000-0600
+            MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|PRIME_DOH|Prime ReportStream|20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO
+            SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME ReportStream|0.1-SNAPSHOT||20210210
+            PID|1||2a14112c-ece1-4f82-915c-7b3a8d152eda^^^Avante at Ormond Beach^PI||Buckridge^Kareem^Millie^^^^L||19580810|F||2106-3^White^HL70005^^^^2.5.1|688 Leighann Inlet^^South Rodneychester^TX^67071^^^^48077||7275555555:1:^PRN^^roscoe.wilkinson@email.com^1^211^2240784|||||||||U^Unknown^HL70189||||||||N
+            ORC|RE|73a6e9bd-aaec-418e-813a-0ad33366ca85|73a6e9bd-aaec-418e-813a-0ad33366ca85|||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI||^WPN^^^1^386^6825220|20210209||||||Avante at Ormond Beach|170 North King Road^^Ormond Beach^FL^32174^^^^12127|^WPN^^jbrush@avantecenters.com^1^407^7397506|^^^^32174
+            OBR|1|73a6e9bd-aaec-418e-813a-0ad33366ca85|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN|||202102090000-0600|202102090000-0600||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI|^WPN^^^1^386^6825220|||||202102090000-0600|||F
+            OBX|1|CWE|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN||260415000^Not detected^SCT|||N^Normal (applies to non-numeric results)^HL70078|||F|||202102090000-0600|||CareStart COVID-19 Antigen test_Access Bio, Inc._EUA^^99ELR||202102090000-0600||||Avante at Ormond Beach^^^^^CLIA&2.16.840.1.113883.4.7&ISO^^^^10D0876999^CLIA|170 North King Road^^Ormond Beach^FL^32174^^^^12127
+            OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|4|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|5|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|6|CWE|82810-3^Pregnant^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            NTE|1|L|This is a note|RE
+            SPM|1|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b||258500001^Nasopharyngeal swab^SCT||||71836000^Nasopharyngeal structure (body structure)^SCT^^^^2020-09-01|||||||||202102090000-0600|202102090000-0600      
+        """.trimIndent()
+        val messages = hl7Reader.getMessages(goodData1)
+        val isBatch = hl7Reader.isBatch(goodData1, messages.size)
+        assertThat(isBatch).isTrue()
+    }
+
+    @Test
+    fun `test isBatch singular message`() {
+        val actionLogger = ActionLogger()
+        val hl7Reader = HL7Reader(actionLogger)
+
+        val goodData1 = """           
+            MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|PRIME_DOH|Prime ReportStream|20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO
+            SFT|Centers for Disease Control and Prevention|0.1-SNAPSHOT|PRIME ReportStream|0.1-SNAPSHOT||20210210
+            PID|1||2a14112c-ece1-4f82-915c-7b3a8d152eda^^^Avante at Ormond Beach^PI||Buckridge^Kareem^Millie^^^^L||19580810|F||2106-3^White^HL70005^^^^2.5.1|688 Leighann Inlet^^South Rodneychester^TX^67071^^^^48077||7275555555:1:^PRN^^roscoe.wilkinson@email.com^1^211^2240784|||||||||U^Unknown^HL70189||||||||N
+            ORC|RE|73a6e9bd-aaec-418e-813a-0ad33366ca85|73a6e9bd-aaec-418e-813a-0ad33366ca85|||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI||^WPN^^^1^386^6825220|20210209||||||Avante at Ormond Beach|170 North King Road^^Ormond Beach^FL^32174^^^^12127|^WPN^^jbrush@avantecenters.com^1^407^7397506|^^^^32174
+            OBR|1|73a6e9bd-aaec-418e-813a-0ad33366ca85|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN|||202102090000-0600|202102090000-0600||||||||1629082607^Eddin^Husam^^^^^^CMS&2.16.840.1.113883.3.249&ISO^^^^NPI|^WPN^^^1^386^6825220|||||202102090000-0600|||F
+            OBX|1|CWE|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay^LN||260415000^Not detected^SCT|||N^Normal (applies to non-numeric results)^HL70078|||F|||202102090000-0600|||CareStart COVID-19 Antigen test_Access Bio, Inc._EUA^^99ELR||202102090000-0600||||Avante at Ormond Beach^^^^^CLIA&2.16.840.1.113883.4.7&ISO^^^^10D0876999^CLIA|170 North King Road^^Ormond Beach^FL^32174^^^^12127
+            OBX|2|CWE|95418-0^Whether patient is employed in a healthcare setting^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|3|CWE|95417-2^First test for condition of interest^LN^^^^2.69||Y^Yes^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|4|CWE|95421-4^Resides in a congregate care setting^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|5|CWE|95419-8^Has symptoms related to condition of interest^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            OBX|6|CWE|82810-3^Pregnant^LN^^^^2.69||N^No^HL70136||||||F|||202102090000-0600|||||||||||||||QST
+            NTE|1|L|This is a note|RE
+            SPM|1|b518ef23-1d9a-40c1-ac4b-ed7b438dfc4b||258500001^Nasopharyngeal swab^SCT||||71836000^Nasopharyngeal structure (body structure)^SCT^^^^2020-09-01|||||||||202102090000-0600|202102090000-0600           
+        """.trimIndent()
+        val messages = hl7Reader.getMessages(goodData1)
+        val isBatch = hl7Reader.isBatch(goodData1, messages.size)
+        assertThat(isBatch).isFalse()
+    }
 }


### PR DESCRIPTION
This PR ...

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
Using the Postman collection, send three different tests via the Send HCA HL7 Full ELR endpoint found in the full-ELR folder.

Send a singular message without headers and check that it gets marked as HL7 in the body_format field in the report_file table in the db
Add the headers to the message and make sure it gets marked as HL7_BATCH
Remove the headers and add a second message to make sure it gets marked as HL7_BATCH


## Changes
- Detecting HL7 Batch vs HL7
- Saving the report bodyFormat rather than the sender format to the report_file body_format field

## Checklist

### Testing
- [ Y] Tested locally?
- [ Y] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ N/A] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ Y] Added tests?

### Process
- [ N] Are there licensing issues with any new dependencies introduced?
- [ Y] Includes a summary of what a code reviewer should test/verify?
- [ N] Updated the release notes?
- [ N/A] Database changes are submitted as a separate PR?
- [ N/A] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue 7355

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints? No
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints? No
- Does this change introduce new dependencies that need vetting?No 
- Does this change require changes to our infrastructure? No
- Does logging contain sensitive data? No
- Does this PR include or remove any sensitive information itself? No