### PR TITLE
Experience-7607: Capture FE exceptions in Azure

### DIFF
--- a/frontend-react/src/TelemetryService.test.ts
+++ b/frontend-react/src/TelemetryService.test.ts
@@ -1,0 +1,90 @@
+import { SeverityLevel } from "@microsoft/applicationinsights-web";
+
+import { ai, getAppInsights, withInsights } from "./TelemetryService";
+
+jest.mock("@microsoft/applicationinsights-web", () => {
+    return {
+        ...jest.requireActual("@microsoft/applicationinsights-web"),
+        ApplicationInsights: function () {
+            return {
+                loadAppInsights() {},
+                trackEvent: jest.fn(),
+                trackException: jest.fn(),
+                addTelemetryInitializer: jest.fn(),
+            };
+        },
+    };
+});
+
+const oldEnv = process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING;
+
+describe("TelemetryService", () => {
+    beforeEach(() => {
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        jest.spyOn(console, "log").mockImplementation(() => {});
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        jest.spyOn(ai, "initialize");
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+        process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING = oldEnv;
+    });
+
+    it("initializes the appInsights service", () => {
+        process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+            "fake-connection-string";
+        ai.initialize();
+        expect(getAppInsights()).not.toBe(null);
+    });
+
+    it("calls app insights on console methods", () => {
+        process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+            "fake-connection-string";
+        const appInsights = getAppInsights();
+        withInsights(console);
+        const message = "hello there";
+        console.log(message);
+        expect(appInsights?.trackEvent).toBeCalledWith({
+            name: "LOG - hello there",
+            properties: {
+                severityLevel: SeverityLevel.Information,
+                message,
+                additionalInformation: undefined,
+            },
+        });
+
+        const warning = "some warning";
+        const data = { oh: "no" };
+        console.warn(warning, data);
+        expect(appInsights?.trackException).toBeCalledWith({
+            id: "some warning",
+            severityLevel: SeverityLevel.Warning,
+            properties: {
+                additionalInformation: JSON.stringify([data]),
+            },
+        });
+
+        const error = new Error("bad news");
+        console.error(error);
+        expect(appInsights?.trackException).toBeCalledWith({
+            exception: error,
+            id: error.message,
+            severityLevel: SeverityLevel.Error,
+            properties: {
+                additionalInformation: undefined,
+            },
+        });
+
+        const nonErrorError = "something bad happened";
+        console.error(nonErrorError);
+        expect(appInsights?.trackException).toBeCalledWith({
+            exception: undefined,
+            id: nonErrorError,
+            severityLevel: SeverityLevel.Error,
+            properties: {
+                additionalInformation: undefined,
+            },
+        });
+    });
+});

--- a/frontend-react/src/TelemetryService.test.ts
+++ b/frontend-react/src/TelemetryService.test.ts
@@ -1,6 +1,7 @@
-import { SeverityLevel } from "@microsoft/applicationinsights-web";
-
-import { ai, getAppInsights, withInsights } from "./TelemetryService";
+import {
+    ApplicationInsights,
+    SeverityLevel,
+} from "@microsoft/applicationinsights-web";
 
 jest.mock("@microsoft/applicationinsights-web", () => {
     return {
@@ -11,80 +12,321 @@ jest.mock("@microsoft/applicationinsights-web", () => {
                 trackEvent: jest.fn(),
                 trackException: jest.fn(),
                 addTelemetryInitializer: jest.fn(),
+                context: {
+                    getSessionId() {
+                        return "test-session-id";
+                    },
+                },
             };
         },
     };
 });
 
-const oldEnv = process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING;
-
 describe("TelemetryService", () => {
+    const oldConnectionString =
+        process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING;
+
+    let ai: { initialize: () => void };
+    let getAppInsights: () => ApplicationInsights;
+    let getAppInsightsHeaders: () => object;
+    let withInsights: (console: Console) => void;
+
     beforeEach(() => {
-        jest.spyOn(console, "warn").mockImplementation(() => {});
-        jest.spyOn(console, "log").mockImplementation(() => {});
-        jest.spyOn(console, "error").mockImplementation(() => {});
-        jest.spyOn(ai, "initialize");
+        // Isolating modules to "reset" previously initialized appInsights, reactPlugin, etc.
+        jest.isolateModules(() => {
+            ({
+                ai,
+                getAppInsights,
+                getAppInsightsHeaders,
+                withInsights,
+            } = require("./TelemetryService"));
+        });
+
+        delete process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING;
     });
 
-    afterEach(() => {
-        jest.resetAllMocks();
-        process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING = oldEnv;
-    });
-
-    it("initializes the appInsights service", () => {
+    afterAll(() => {
         process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
-            "fake-connection-string";
-        ai.initialize();
-        expect(getAppInsights()).not.toBe(null);
+            oldConnectionString;
     });
 
-    it("calls app insights on console methods", () => {
-        process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
-            "fake-connection-string";
-        const appInsights = getAppInsights();
-        withInsights(console);
-        const message = "hello there";
-        console.log(message);
-        expect(appInsights?.trackEvent).toBeCalledWith({
-            name: "LOG - hello there",
-            properties: {
-                severityLevel: SeverityLevel.Information,
-                message,
-                additionalInformation: undefined,
-            },
+    describe("#initialize", () => {
+        beforeEach(() => {
+            jest.spyOn(console, "warn").mockImplementation(jest.fn);
         });
 
-        const warning = "some warning";
-        const data = { oh: "no" };
-        console.warn(warning, data);
-        expect(appInsights?.trackException).toBeCalledWith({
-            id: "some warning",
-            severityLevel: SeverityLevel.Warning,
-            properties: {
-                additionalInformation: JSON.stringify([data]),
-            },
+        describe("when the connection string is falsy", () => {
+            test("warns that the string is not provided and returns undefined", () => {
+                ai.initialize();
+
+                expect(console.warn).toHaveBeenCalledWith(
+                    "App Insights connection string not provided"
+                );
+            });
         });
 
-        const error = new Error("bad news");
-        console.error(error);
-        expect(appInsights?.trackException).toBeCalledWith({
-            exception: error,
-            id: error.message,
-            severityLevel: SeverityLevel.Error,
-            properties: {
-                additionalInformation: undefined,
-            },
+        describe("when the connection string is provided", () => {
+            beforeEach(() => {
+                process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                    "test-connection-string";
+            });
+
+            afterEach(() => {
+                process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                    oldConnectionString;
+            });
+
+            test("does not warn", () => {
+                ai.initialize();
+
+                expect(console.warn).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe("#getAppInsights", () => {
+        describe("when AppInsights has not been initialized", () => {
+            test("returns null", () => {
+                expect(getAppInsights()).toBeNull();
+            });
         });
 
-        const nonErrorError = "something bad happened";
-        console.error(nonErrorError);
-        expect(appInsights?.trackException).toBeCalledWith({
-            exception: undefined,
-            id: nonErrorError,
-            severityLevel: SeverityLevel.Error,
-            properties: {
-                additionalInformation: undefined,
-            },
+        describe("when AppInsights has been initialized", () => {
+            beforeEach(() => {
+                process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                    "test";
+
+                ai.initialize();
+            });
+
+            afterEach(() => {
+                process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                    oldConnectionString;
+            });
+
+            test("returns the AppInsights instance", () => {
+                expect(getAppInsights()).not.toBeNull();
+            });
+        });
+    });
+
+    describe("#getAppInsightsHeaders", () => {
+        describe("when AppInsights has not been initialized", () => {
+            test("returns an object with an empty string for the session header", () => {
+                expect(getAppInsightsHeaders()).toEqual({
+                    "x-ms-session-id": "",
+                });
+            });
+        });
+
+        describe("when AppInsights has been initialized", () => {
+            beforeEach(() => {
+                process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                    "test-connection-string";
+
+                ai.initialize();
+            });
+
+            afterEach(() => {
+                process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                    oldConnectionString;
+            });
+
+            test("returns an object with the correct value for the session header", () => {
+                expect(getAppInsightsHeaders()).toEqual({
+                    "x-ms-session-id": "test-session-id",
+                });
+            });
+        });
+    });
+
+    describe("#withInsights", () => {
+        let appInsights: ApplicationInsights | null;
+
+        beforeAll(() => {
+            process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                "test-connection-string";
+
+            jest.spyOn(console, "log").mockImplementation(jest.fn);
+            jest.spyOn(console, "info").mockImplementation(jest.fn);
+            jest.spyOn(console, "warn").mockImplementation(jest.fn);
+            jest.spyOn(console, "error").mockImplementation(jest.fn);
+
+            ai.initialize();
+            appInsights = getAppInsights();
+            withInsights(console);
+        });
+
+        afterAll(() => {
+            jest.resetAllMocks();
+
+            process.env.REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING =
+                oldConnectionString;
+        });
+
+        describe("when calling console.info", () => {
+            describe("when not passing in more arguments", () => {
+                test("calls trackEvent with the correct message and severity level", () => {
+                    const message = "hello there";
+
+                    console.info(message);
+
+                    expect(appInsights?.trackEvent).toBeCalledWith({
+                        name: `INFO - ${message}`,
+                        properties: {
+                            severityLevel: SeverityLevel.Information,
+                            message,
+                            additionalInformation: undefined,
+                        },
+                    });
+                });
+            });
+
+            describe("when passing in more arguments", () => {
+                test("calls trackException with the correct message, severity level, and stringified additional details", () => {
+                    const message = "hello there";
+                    const data = { a: 1 };
+
+                    console.info(message, data);
+
+                    expect(appInsights?.trackEvent).toBeCalledWith({
+                        name: `INFO - ${message}`,
+                        properties: {
+                            severityLevel: SeverityLevel.Information,
+                            message,
+                            additionalInformation: JSON.stringify([data]),
+                        },
+                    });
+                });
+            });
+        });
+
+        describe("when calling console.log", () => {
+            describe("when not passing in more arguments", () => {
+                test("calls trackEvent with the correct message and severity level", () => {
+                    const message = "hello there";
+
+                    console.log(message);
+
+                    expect(appInsights?.trackEvent).toBeCalledWith({
+                        name: `LOG - ${message}`,
+                        properties: {
+                            severityLevel: SeverityLevel.Information,
+                            message,
+                            additionalInformation: undefined,
+                        },
+                    });
+                });
+            });
+
+            describe("when passing in more arguments", () => {
+                test("calls trackException with the correct message, severity level, and stringified additional details", () => {
+                    const message = "hello there";
+                    const data = { a: 1 };
+
+                    console.log(message, data);
+
+                    expect(appInsights?.trackEvent).toBeCalledWith({
+                        name: `LOG - ${message}`,
+                        properties: {
+                            severityLevel: SeverityLevel.Information,
+                            message,
+                            additionalInformation: JSON.stringify([data]),
+                        },
+                    });
+                });
+            });
+        });
+
+        describe("when calling console.warn", () => {
+            describe("when not passing in more arguments", () => {
+                test("calls trackEvent with the correct message and severity level", () => {
+                    const message = "hello there";
+
+                    console.warn(message);
+
+                    expect(appInsights?.trackEvent).toBeCalledWith({
+                        name: `WARN - ${message}`,
+                        properties: {
+                            severityLevel: SeverityLevel.Warning,
+                            message,
+                            additionalInformation: undefined,
+                        },
+                    });
+                });
+            });
+
+            describe("when passing in more arguments", () => {
+                test("calls trackException with the correct message, severity level, and stringified additional details", () => {
+                    const message = "hello there";
+                    const data = { a: 1 };
+
+                    console.warn(message, data);
+
+                    expect(appInsights?.trackEvent).toBeCalledWith({
+                        name: `WARN - ${message}`,
+                        properties: {
+                            severityLevel: SeverityLevel.Warning,
+                            message,
+                            additionalInformation: JSON.stringify([data]),
+                        },
+                    });
+                });
+            });
+        });
+
+        describe("when calling console.error", () => {
+            describe("when passing in an Error as the first parameter", () => {
+                test("calls trackException with the correct Error and severity level", () => {
+                    const error = new Error("test error");
+
+                    console.error(error);
+
+                    expect(appInsights?.trackException).toBeCalledWith({
+                        exception: error,
+                        id: error.message,
+                        severityLevel: SeverityLevel.Error,
+                        properties: {
+                            additionalInformation: undefined,
+                        },
+                    });
+                });
+            });
+
+            describe("when passing in a String as the first parameter", () => {
+                test("calls trackException with the correct Error and severity level", () => {
+                    const error = "test error";
+
+                    console.error(error);
+
+                    expect(appInsights?.trackException).toBeCalledWith({
+                        exception: new Error(error),
+                        id: error,
+                        severityLevel: SeverityLevel.Error,
+                        properties: {
+                            additionalInformation: undefined,
+                        },
+                    });
+                });
+            });
+
+            describe("when passing in more arguments", () => {
+                test("calls trackException with the correct Error, severity level, and stringified additional details", () => {
+                    const error = new Error("test error");
+                    const data = { a: 1 };
+
+                    console.error(error, data);
+
+                    expect(appInsights?.trackException).toBeCalledWith({
+                        exception: error,
+                        id: error.message,
+                        severityLevel: SeverityLevel.Error,
+                        properties: {
+                            additionalInformation: JSON.stringify([data]),
+                        },
+                    });
+                });
+            });
         });
     });
 });

--- a/frontend-react/src/TelemetryService.ts
+++ b/frontend-react/src/TelemetryService.ts
@@ -1,4 +1,7 @@
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import {
+    ApplicationInsights,
+    SeverityLevel,
+} from "@microsoft/applicationinsights-web";
 import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
 
 import { getSessionMembershipState } from "./utils/SessionStorageTools";
@@ -54,6 +57,10 @@ const createTelemetryService = () => {
 
 export const ai = createTelemetryService();
 
+export function getAppInsights() {
+    return appInsights;
+}
+
 export function getAppInsightsHeaders(): { [key: string]: string } {
     return {
         "x-ms-session-id": getAppInsightsSessionId(),
@@ -62,4 +69,69 @@ export function getAppInsightsHeaders(): { [key: string]: string } {
 
 function getAppInsightsSessionId(): string {
     return appInsights?.context.getSessionId() || "";
+}
+
+const logSeverityMap = {
+    log: SeverityLevel.Information,
+    warn: SeverityLevel.Warning,
+    error: SeverityLevel.Error,
+    info: SeverityLevel.Information,
+} as const;
+
+export function withInsights(console: Console) {
+    const originalConsole = { ...console };
+
+    Object.entries(logSeverityMap).forEach((el) => {
+        const [method, severityLevel] = el as [
+            keyof typeof logSeverityMap,
+            SeverityLevel
+        ];
+
+        console[method] = (...data: any[]) => {
+            originalConsole[method](...data);
+
+            if (method === "error" || method === "warn") {
+                const exception =
+                    data[0] instanceof Error ? data[0] : undefined;
+                const id = (() => {
+                    if (exception) {
+                        return exception.message;
+                    }
+                    if (typeof data[0] === "string") {
+                        return data[0];
+                    }
+                    return JSON.stringify(data[0]);
+                })();
+
+                appInsights?.trackException({
+                    exception,
+                    id,
+                    severityLevel,
+                    properties: {
+                        additionalInformation:
+                            data.length === 1
+                                ? undefined
+                                : JSON.stringify(data.slice(1)),
+                    },
+                });
+
+                return;
+            }
+
+            const message =
+                typeof data[0] === "string" ? data[0] : JSON.stringify(data[0]);
+
+            appInsights?.trackEvent({
+                name: `${method.toUpperCase()} - ${message}`,
+                properties: {
+                    severityLevel,
+                    message,
+                    additionalInformation:
+                        data.length === 1
+                            ? undefined
+                            : JSON.stringify(data.slice(1)),
+                },
+            });
+        };
+    });
 }

--- a/frontend-react/src/index.tsx
+++ b/frontend-react/src/index.tsx
@@ -6,11 +6,12 @@ import { BrowserRouter as Router } from "react-router-dom";
 import App from "./App";
 // compiled css so the resources process for the static site by the compiler
 import "./content/generated/global.out.css";
-import { ai } from "./TelemetryService";
+import { ai, withInsights } from "./TelemetryService";
 
 // Initialize the App Insights connection and React app plugin from Microsoft
 // The plugin is provided in the AppInsightsProvider in AppWrapper.tsx
 ai.initialize();
+withInsights(console);
 
 ReactDOM.render(
     <CacheProvider>


### PR DESCRIPTION
This PR ...

This changeset reverts the revert in https://github.com/CDCgov/prime-reportstream/pull/7740.  There are two main changes from that revert:

1) Always pass an instance of Error to `trackException`
Originally, we were passing in either an Error or a string depending on the arguments `console.error` was called with.  However, `exception` should be an instance of [Error or IAutoExceptionTelemetry](https://github.com/microsoft/ApplicationInsights-JS/blob/master/shared/AppInsightsCommon/src/Interfaces/IExceptionTelemetry.ts#L31) or we'll end up with a `not_specified` for the exception message.

2) Only tracking error-level messages
This is a deviation from SimpleReport so I'm happy to discuss and update if needed, but my feeling is that we don't have to track warnings just yet until we have a proper funnel or response to unexpected behaviors.  Errors are much more significant to track, and while they -- like warnings -- can be triggered from anywhere (by third-party scripts, by browsers themselves, et cetera), they're generally more actionable or intentional than warnings.

Also included:
- Some minor cleanup
- Rewritten tests + new ones to check for the changes

Test Steps:
1. (before starting local Webpack server) Populate `REACT_APP_APPINSIGHTS_KEY`, `REACT_APP_APPLICATIONINSIGHTS_CONNECTION_STRING` env vars
2. Open up the console
3. Trigger info, log, and warning and verify they're getting tracked as **events** with the proper data
<img width="1325" alt="Screenshot 2022-12-28 at 10 29 17 AM" src="https://user-images.githubusercontent.com/2421042/209835509-2f891511-fcd5-4ea7-95bd-abe3bd517f78.png">
<img width="1325" alt="Screenshot 2022-12-28 at 10 29 29 AM" src="https://user-images.githubusercontent.com/2421042/209835510-1bfa794f-4941-476f-97e7-4f435d530a3d.png">
<img width="1325" alt="Screenshot 2022-12-28 at 10 30 42 AM" src="https://user-images.githubusercontent.com/2421042/209835526-31606a1a-c94a-4d9a-b230-6448531e3104.png">

4. Trigger error and verify it's getting tracked as an **exception** with the proper data
<img width="1325" alt="Screenshot 2022-12-28 at 10 28 36 AM" src="https://user-images.githubusercontent.com/2421042/209835506-b1cd39c7-5c31-45de-ba63-0120ebcf6a3e.png">
<img width="1325" alt="Screenshot 2022-12-28 at 10 29 07 AM" src="https://user-images.githubusercontent.com/2421042/209835508-57a49abb-48d8-4e12-97c3-709246ac62c1.png">
<img width="1325" alt="Screenshot 2022-12-28 at 10 29 51 AM" src="https://user-images.githubusercontent.com/2421042/209835559-fe69c36a-d7e4-41dc-8f69-e9bb8270c87f.png">

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

## Linked Issues
- Fixes #7607 