### PR TITLE
Experience-7857: Add ReactQueryDevtools for query/mutation debugging

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -12,6 +12,7 @@
         "@okta/okta-signin-widget": "^6.0.1",
         "@rest-hooks/rest": "^3.0.3",
         "@tanstack/react-query": "^4.20.9",
+        "@tanstack/react-query-devtools": "^4.20.9",
         "@testing-library/user-event": "^13.5.0",
         "@trussworks/react-uswds": "<3.0.0",
         "@types/downloadjs": "^1.4.2",

--- a/frontend-react/src/components/AppWrapper.tsx
+++ b/frontend-react/src/components/AppWrapper.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from "react";
 import { Security } from "@okta/okta-react";
 import { OktaAuth } from "@okta/okta-auth-js";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { AppInsightsContext } from "@microsoft/applicationinsights-react-js";
 
 import SessionProvider, { OktaHook } from "../contexts/SessionContext";
@@ -38,6 +39,7 @@ export const AppWrapper = ({
                                 {children}
                             </FeatureFlagProvider>
                         </AuthorizedFetchProvider>
+                        <ReactQueryDevtools initialIsOpen={false} />
                     </QueryClientProvider>
                 </SessionProvider>
             </AppInsightsProvider>

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -2048,10 +2048,26 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tanstack/match-sorter-utils@^8.7.0":
+  version "8.7.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.2.tgz#6308c250308e103ab476928cc4ee26cf328716f5"
+  integrity sha512-bptNeoexeDB947fWoCPwUchPSx5FA9gwzU0bkXz0du5pT8Ud2+1ob+xOgHj6EF3VN0kdXtLhwjPyhY7/dJglkg==
+  dependencies:
+    remove-accents "0.4.2"
+
 "@tanstack/query-core@4.20.9":
   version "4.20.9"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.20.9.tgz#62eb14c2fd6688eaa507452881c96a2c8b6d2544"
   integrity sha512-XTEEvOGy7wlABPTYfmg7U287WYcf2PV8lH15oKWD2I09okqMOHrB23WxyikEVRwJCjYNKcCW0BuYaAY4S2g/jg==
+
+"@tanstack/react-query-devtools@^4.20.9":
+  version "4.20.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.20.9.tgz#d1645e910213d9c5f23c06ba93fd1f511532c014"
+  integrity sha512-Bim/6nzxb5ZdFR+du4MvyAGPsOlMXiJiIiU8XcDIrgJzdRzHdw6dkkMpWXENKmjn9nTE5Ns0Mj+r11yBZcnMYA==
+  dependencies:
+    "@tanstack/match-sorter-utils" "^8.7.0"
+    superjson "^1.10.0"
+    use-sync-external-store "^1.2.0"
 
 "@tanstack/react-query@^4.20.9":
   version "4.20.9"
@@ -4111,6 +4127,13 @@ cookie@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+copy-anything@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.3.tgz#206767156f08da0e02efd392f71abcdf79643559"
+  integrity sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==
+  dependencies:
+    is-what "^4.1.8"
 
 core-js-compat@^3.21.0, core-js-compat@^3.22.1:
   version "3.23.3"
@@ -6604,6 +6627,11 @@ is-weakref@^1.0.2:
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-what@^4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.8.tgz#0e2a8807fda30980ddb2571c79db3d209b14cbe4"
+  integrity sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==
 
 is-wsl@^2.2.0:
   version "2.2.0"
@@ -10034,6 +10062,11 @@ remark-toc@^8.0.1:
     mdast-util-toc "^6.0.0"
     unified "^10.0.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -10815,6 +10848,13 @@ stylehacks@^5.1.0:
   dependencies:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
+
+superjson@^1.10.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.12.1.tgz#35e8c08e5a4c2bb65b1c63a6ff00414f3c364fca"
+  integrity sha512-HMTj43zvwW5bD+JCZCvFf4DkZQCmiLTen4C+W1Xogj0SPOpnhxsriogM04QmBVGH5b3kcIIOr6FqQ/aoIDx7TQ==
+  dependencies:
+    copy-anything "^3.0.2"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
This PR ...

This changeset adds the ReactQueryDevtools utility to our codebase to let us more easily debug query/mutation statuses in development mode.  When the devtools are open, you can see the statuses of queries and mutations ("mountedness" and staleness), and you can retrigger them or even delete them from the cache entirely.

There's also a possibility of lazy-loading the devtools in production mode if we need that, but I think we can just include it in development for now.


Test Steps:
1. Start up the local Webpack dev server: `yarn run start:localdev`
2. Load up any page
3. Look for the devtools icon on the lower-left corner
<img width="1169" alt="Screenshot 2023-01-05 at 10 29 12" src="https://user-images.githubusercontent.com/2421042/210819245-3d42b1cf-b2c7-4466-8bd5-c1c357bd2d3c.png">
4. Start making requests through react-query and see the devtools populate
<img width="1169" alt="Screenshot 2023-01-05 at 10 29 03" src="https://user-images.githubusercontent.com/2421042/210819397-729d7e4e-9754-4e4d-b331-950363f88781.png">

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
<strike>- [ ] Added tests?</strike>

## Linked Issues
- Fixes #7857 