### PR TITLE
Experience-7891: Disable organization-specific fetches as admin

### DIFF
--- a/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
@@ -5,10 +5,10 @@ import {
     formattedDateFromTimestamp,
     timeZoneAbbreviated,
 } from "../../utils/DateTimeUtils";
-import { StaticAlert } from "../StaticAlert";
+import { StaticAlert, StaticAlertType } from "../StaticAlert";
 import {
-    ResponseError,
     ErrorCodeTranslation,
+    ResponseError,
 } from "../../config/endpoints/waters";
 import { Destination } from "../../resources/ActionDetailsResource";
 import { USExtLink, USLink } from "../USLink";
@@ -38,7 +38,7 @@ export const FileSuccessDisplay = ({
     return (
         <>
             <StaticAlert
-                type={"success slim"}
+                type={[StaticAlertType.Success, StaticAlertType.Slim]}
                 heading={heading}
                 message={message}
             />
@@ -129,7 +129,10 @@ export const RequestedChangesDisplay = ({
     handlerType,
 }: RequestedChangesDisplayProps) => {
     const alertType = useMemo(
-        () => (title === RequestLevel.WARNING ? "warning" : "error"),
+        () =>
+            title === RequestLevel.WARNING
+                ? StaticAlertType.Warning
+                : StaticAlertType.Error,
         [title]
     );
     const showTable =
@@ -208,7 +211,13 @@ interface FileWarningBannerProps {
 }
 
 export const FileWarningBanner = ({ message }: FileWarningBannerProps) => {
-    return <StaticAlert type={"warning"} heading="Warning" message={message} />;
+    return (
+        <StaticAlert
+            type={StaticAlertType.Warning}
+            heading="Warning"
+            message={message}
+        />
+    );
 };
 
 interface ErrorRowProps {
@@ -251,7 +260,7 @@ export const FileQualityFilterDisplay = ({
     return (
         <>
             <StaticAlert
-                type={"error slim"}
+                type={[StaticAlertType.Error, StaticAlertType.Slim]}
                 heading={heading}
                 message={message}
             />

--- a/frontend-react/src/components/StaticAlert.test.tsx
+++ b/frontend-react/src/components/StaticAlert.test.tsx
@@ -1,17 +1,17 @@
 import { screen, render } from "@testing-library/react";
 
-import { StaticAlert } from "./StaticAlert";
+import { StaticAlert, StaticAlertType } from "./StaticAlert";
 
 describe("StaticAlert", () => {
     test("renders correct class for success", async () => {
-        render(<StaticAlert type={"success"} heading={"any"} />);
+        render(<StaticAlert type={StaticAlertType.Success} heading={"any"} />);
 
         const wrapper = await screen.findByRole("alert");
         expect(wrapper).toHaveClass("usa-alert--success");
     });
 
     test("renders correct class for success", async () => {
-        render(<StaticAlert type={"error"} heading={"any"} />);
+        render(<StaticAlert type={StaticAlertType.Error} heading={"any"} />);
 
         const wrapper = await screen.findByRole("alert");
         expect(wrapper).toHaveClass("usa-alert--error");

--- a/frontend-react/src/components/StaticAlert.tsx
+++ b/frontend-react/src/components/StaticAlert.tsx
@@ -1,8 +1,15 @@
 import React, { ReactNode } from "react";
 import classNames from "classnames";
 
+export enum StaticAlertType {
+    Success = "success",
+    Error = "error",
+    Warning = "warning",
+    Slim = "slim",
+}
+
 interface StaticAlertProps {
-    type: string;
+    type: StaticAlertType | StaticAlertType[];
     heading: string;
     message?: string;
     children?: ReactNode;
@@ -14,12 +21,14 @@ export const StaticAlert = ({
     message,
     children,
 }: StaticAlertProps) => {
+    type = Array.isArray(type) ? type : [type];
+
     const alertClasses = classNames({
         "usa-alert": true,
-        "usa-alert--success": type.indexOf("success") > -1,
-        "usa-alert--error": type.indexOf("error") > -1,
-        "usa-alert--warning": type.indexOf("warning") > -1,
-        "usa-alert--slim": type.indexOf("slim") > -1,
+        "usa-alert--success": type.includes(StaticAlertType.Success),
+        "usa-alert--error": type.includes(StaticAlertType.Error),
+        "usa-alert--warning": type.includes(StaticAlertType.Warning),
+        "usa-alert--slim": type.includes(StaticAlertType.Slim),
     });
     return (
         <div className={alertClasses} role="alert">

--- a/frontend-react/src/components/alerts/AdminFetchAlert.tsx
+++ b/frontend-react/src/components/alerts/AdminFetchAlert.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import { StaticAlert, StaticAlertType } from "../StaticAlert";
+
+export default function AdminFetchAlert() {
+    return (
+        <StaticAlert
+            type={StaticAlertType.Error}
+            heading="Cannot fetch Organization data as admin"
+            message="Please try again as an Organization"
+        />
+    );
+}

--- a/frontend-react/src/components/alerts/NoServicesAlert.tsx
+++ b/frontend-react/src/components/alerts/NoServicesAlert.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { StaticAlert } from "../StaticAlert";
+import { StaticAlert, StaticAlertType } from "../StaticAlert";
 import { capitalizeFirst } from "../../utils/misc";
 
 interface NoServicesBannerProps {
@@ -16,7 +16,7 @@ export const NoServicesBanner = ({
 }: NoServicesBannerProps) => {
     return (
         <StaticAlert
-            type={"error"}
+            type={StaticAlertType.Error}
             heading={`${capitalizeFirst(featureName || "feature")} unavailable`}
             message={`No valid ${serviceType || "service"} found for ${
                 organization || "your organization"

--- a/frontend-react/src/hooks/UseOrganizationReceivers.ts
+++ b/frontend-react/src/hooks/UseOrganizationReceivers.ts
@@ -4,25 +4,30 @@ import { RSReceiver, servicesEndpoints } from "../config/endpoints/settings";
 import { useAuthorizedFetch } from "../contexts/AuthorizedFetchContext";
 import { useSessionContext } from "../contexts/SessionContext";
 
+import { Organizations } from "./UseAdminSafeOrganizationName";
+
 const { receivers } = servicesEndpoints;
 
 export const useOrganizationReceivers = () => {
     const { activeMembership } = useSessionContext();
+    const parsedName = activeMembership?.parsedName;
+
     const { authorizedFetch, rsUseQuery } = useAuthorizedFetch<RSReceiver[]>();
     const memoizedDataFetch = useCallback(
         () =>
             authorizedFetch(receivers, {
                 segments: {
-                    orgName: activeMembership?.parsedName!!,
+                    orgName: parsedName!!,
                 },
             }),
-        [activeMembership?.parsedName, authorizedFetch]
+        [parsedName, authorizedFetch]
     );
     return rsUseQuery(
         [receivers.queryKey, activeMembership],
         memoizedDataFetch,
         {
-            enabled: !!activeMembership?.parsedName,
+            enabled:
+                Boolean(parsedName) && parsedName !== Organizations.PRIMEADMINS,
         }
     );
 };

--- a/frontend-react/src/hooks/UseOrganizationReceiversFeed.ts
+++ b/frontend-react/src/hooks/UseOrganizationReceiversFeed.ts
@@ -10,11 +10,16 @@ interface ReceiverFeeds {
     services: RSReceiver[];
     activeService: RSReceiver | undefined;
     setActiveService: Dispatch<SetStateAction<RSReceiver | undefined>>;
+    isDisabled: boolean;
 }
 /** Fetches a list of receivers for your active organization, and provides a controller to switch
  * between them */
 export const useOrganizationReceiversFeed = (): ReceiverFeeds => {
-    const { data: receivers, isLoading } = useOrganizationReceivers();
+    const {
+        data: receivers,
+        isLoading,
+        fetchStatus,
+    } = useOrganizationReceivers();
     const [active, setActive] = useState<RSReceiver | undefined>();
 
     useEffect(() => {
@@ -29,9 +34,10 @@ export const useOrganizationReceiversFeed = (): ReceiverFeeds => {
     }, [receivers]);
 
     return {
-        loadingServices: isLoading,
+        loadingServices: isLoading && fetchStatus !== "idle",
         services: receivers || [],
         activeService: active,
         setActiveService: setActive,
+        isDisabled: isLoading && fetchStatus === "idle",
     };
 };

--- a/frontend-react/src/hooks/UseOrganizationSettings.test.ts
+++ b/frontend-react/src/hooks/UseOrganizationSettings.test.ts
@@ -6,6 +6,7 @@ import { mockSessionContext } from "../contexts/__mocks__/SessionContext";
 
 import { MemberType } from "./UseOktaMemberships";
 import { useOrganizationSettings } from "./UseOrganizationSettings";
+import { Organizations } from "./UseAdminSafeOrganizationName";
 
 describe("useOrganizationSettings", () => {
     beforeAll(() => {
@@ -13,40 +14,76 @@ describe("useOrganizationSettings", () => {
     });
     afterEach(() => orgServer.resetHandlers());
     afterAll(() => orgServer.close());
-    test("returns undefined if no active membership parsed name", () => {
-        mockSessionContext.mockReturnValue({
-            oktaToken: {
-                accessToken: "TOKEN",
-            },
-            activeMembership: undefined,
-            dispatch: () => {},
-            initialized: true,
+    describe("with no Organization name", () => {
+        beforeEach(() => {
+            mockSessionContext.mockReturnValue({
+                oktaToken: {
+                    accessToken: "TOKEN",
+                },
+                activeMembership: undefined,
+                dispatch: () => {},
+                initialized: true,
+            });
         });
-        const { result } = renderHook(() => useOrganizationSettings(), {
-            wrapper: QueryWrapper(),
+
+        test("returns undefined", () => {
+            const { result } = renderHook(() => useOrganizationSettings(), {
+                wrapper: QueryWrapper(),
+            });
+            expect(result.current.data).toEqual(undefined);
+            expect(result.current.isLoading).toEqual(true);
         });
-        expect(result.current.data).toEqual(undefined);
-        expect(result.current.isLoading).toEqual(true);
     });
-    test("returns correct organization settings", async () => {
-        mockSessionContext.mockReturnValue({
-            oktaToken: {
-                accessToken: "TOKEN",
-            },
-            activeMembership: {
-                memberType: MemberType.SENDER,
-                parsedName: "testOrg",
-                service: "testSender",
-            },
-            dispatch: () => {},
-            initialized: true,
+
+    describe("with a non-admin Organization name", () => {
+        beforeEach(() => {
+            mockSessionContext.mockReturnValue({
+                oktaToken: {
+                    accessToken: "TOKEN",
+                },
+                activeMembership: {
+                    memberType: MemberType.SENDER,
+                    parsedName: "testOrg",
+                    service: "testSender",
+                },
+                dispatch: () => {},
+                initialized: true,
+            });
         });
-        const { result, waitForNextUpdate } = renderHook(
-            () => useOrganizationSettings(),
-            { wrapper: QueryWrapper() }
-        );
-        await waitForNextUpdate();
-        expect(result.current.data).toEqual(fakeOrg);
-        expect(result.current.isLoading).toEqual(false);
+
+        test("returns correct organization settings", async () => {
+            const { result, waitForNextUpdate } = renderHook(
+                () => useOrganizationSettings(),
+                { wrapper: QueryWrapper() }
+            );
+            await waitForNextUpdate();
+            expect(result.current.data).toEqual(fakeOrg);
+            expect(result.current.isLoading).toEqual(false);
+        });
+    });
+
+    describe("with an admin Organization name", () => {
+        beforeEach(() => {
+            mockSessionContext.mockReturnValue({
+                oktaToken: {
+                    accessToken: "TOKEN",
+                },
+                activeMembership: {
+                    memberType: MemberType.PRIME_ADMIN,
+                    parsedName: Organizations.PRIMEADMINS,
+                },
+                dispatch: () => {},
+                initialized: true,
+            });
+        });
+
+        test("is disabled", async () => {
+            const { result } = renderHook(() => useOrganizationSettings(), {
+                wrapper: QueryWrapper(),
+            });
+            expect(result.current.fetchStatus).toEqual("idle");
+            expect(result.current.status).toEqual("loading");
+            expect(result.current.isInitialLoading).toEqual(false);
+        });
     });
 });

--- a/frontend-react/src/hooks/UseOrganizationSettings.ts
+++ b/frontend-react/src/hooks/UseOrganizationSettings.ts
@@ -7,26 +7,31 @@ import {
 import { useAuthorizedFetch } from "../contexts/AuthorizedFetchContext";
 import { useSessionContext } from "../contexts/SessionContext";
 
+import { Organizations } from "./UseAdminSafeOrganizationName";
+
 const { settings } = servicesEndpoints;
 
 export const useOrganizationSettings = () => {
     const { activeMembership } = useSessionContext();
+    const parsedName = activeMembership?.parsedName;
+
     const { authorizedFetch, rsUseQuery } =
         useAuthorizedFetch<RSOrganizationSettings>();
     const memoizedDataFetch = useCallback(
         () =>
             authorizedFetch(settings, {
                 segments: {
-                    orgName: activeMembership?.parsedName!!,
+                    orgName: parsedName!!,
                 },
             }),
-        [activeMembership?.parsedName, authorizedFetch]
+        [parsedName, authorizedFetch]
     );
     return rsUseQuery(
         [settings.queryKey, activeMembership],
         memoizedDataFetch,
         {
-            enabled: !!activeMembership?.parsedName,
+            enabled:
+                Boolean(parsedName) && parsedName !== Organizations.PRIMEADMINS,
         }
     );
 };

--- a/frontend-react/src/hooks/network/History/DeliveryHooks.test.ts
+++ b/frontend-react/src/hooks/network/History/DeliveryHooks.test.ts
@@ -4,6 +4,7 @@ import { mockSessionContext } from "../../../contexts/__mocks__/SessionContext";
 import { MemberType } from "../../UseOktaMemberships";
 import { deliveryServer } from "../../../__mocks__/DeliveriesMockServer";
 import { QueryWrapper } from "../../../utils/CustomRenderUtils";
+import { Organizations } from "../../UseAdminSafeOrganizationName";
 
 import {
     useReportsDetail,
@@ -80,5 +81,57 @@ describe("DeliveryHooks", () => {
         );
         await waitForNextUpdate();
         expect(result.current.reportFacilities?.length).toEqual(2);
+    });
+
+    describe("useOrgDeliveries", () => {
+        describe("when requesting as a receiver", () => {
+            beforeEach(() => {
+                mockSessionContext.mockReturnValue({
+                    oktaToken: {
+                        accessToken: "TOKEN",
+                    },
+                    activeMembership: {
+                        memberType: MemberType.RECEIVER,
+                        parsedName: "testOrg",
+                    },
+                    dispatch: () => {},
+                    initialized: true,
+                });
+            });
+
+            test("fetchResults returns an array of deliveries", async () => {
+                const { result } = renderHook(() =>
+                    useOrgDeliveries("testService")
+                );
+                const results = await result.current.fetchResults(" ", 10);
+
+                expect(results).toHaveLength(3);
+            });
+        });
+
+        describe("when requesting as an admin", () => {
+            beforeEach(() => {
+                mockSessionContext.mockReturnValue({
+                    oktaToken: {
+                        accessToken: "TOKEN",
+                    },
+                    activeMembership: {
+                        memberType: MemberType.PRIME_ADMIN,
+                        parsedName: Organizations.PRIMEADMINS,
+                    },
+                    dispatch: () => {},
+                    initialized: true,
+                });
+            });
+
+            test("fetchResults returns an empty array", async () => {
+                const { result } = renderHook(() =>
+                    useOrgDeliveries("testService")
+                );
+                const results = await result.current.fetchResults(" ", 10);
+
+                expect(results).toHaveLength(0);
+            });
+        });
     });
 });

--- a/frontend-react/src/hooks/network/History/DeliveryHooks.ts
+++ b/frontend-react/src/hooks/network/History/DeliveryHooks.ts
@@ -1,7 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { AccessToken } from "@okta/okta-auth-js";
 
-import { useAdminSafeOrganizationName } from "../../UseAdminSafeOrganizationName";
+import {
+    Organizations,
+    useAdminSafeOrganizationName,
+} from "../../UseAdminSafeOrganizationName";
 import { useAuthorizedFetch } from "../../../contexts/AuthorizedFetchContext";
 import {
     deliveriesEndpoints,
@@ -65,6 +68,11 @@ const useOrgDeliveries = (service?: string) => {
 
     const fetchResults = useCallback(
         (currentCursor: string, numResults: number) => {
+            // HACK: return empty results if requesting as an admin
+            if (activeMembership?.parsedName === Organizations.PRIMEADMINS) {
+                return Promise.resolve<RSDelivery[]>([]);
+            }
+
             const fetcher = generateFetcher();
             return fetcher(getOrgDeliveries, {
                 segments: {
@@ -79,7 +87,14 @@ const useOrgDeliveries = (service?: string) => {
                 },
             }) as unknown as Promise<RSDelivery[]>;
         },
-        [orgAndService, sortOrder, generateFetcher, rangeFrom, rangeTo]
+        [
+            orgAndService,
+            sortOrder,
+            generateFetcher,
+            rangeFrom,
+            rangeTo,
+            activeMembership?.parsedName,
+        ]
     );
 
     return { fetchResults, filterManager };

--- a/frontend-react/src/network/QueryClients.ts
+++ b/frontend-react/src/network/QueryClients.ts
@@ -2,7 +2,14 @@ import { QueryClient } from "@tanstack/react-query";
 
 export const appQueryClient = new QueryClient({
     defaultOptions: {
-        queries: { suspense: true, useErrorBoundary: true },
+        queries: {
+            suspense: true,
+            useErrorBoundary: true,
+            retry: false,
+            staleTime: Infinity,
+            cacheTime: Infinity,
+            refetchOnWindowFocus: false,
+        },
     },
 });
 export const testQueryClient = new QueryClient({

--- a/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
+++ b/frontend-react/src/pages/admin/value-set-editor/ValueSetsDetail.tsx
@@ -24,7 +24,7 @@ import {
     LookupTable,
     ValueSetRow,
 } from "../../../config/endpoints/lookupTables";
-import { StaticAlert } from "../../../components/StaticAlert";
+import { StaticAlert, StaticAlertType } from "../../../components/StaticAlert";
 import {
     handleErrorWithAlert,
     ReportStreamAlert,
@@ -234,7 +234,7 @@ const ValueSetsDetailContent = () => {
                 {/* ONLY handles success messaging now */}
                 {alert && (
                     <StaticAlert
-                        type={alert.type}
+                        type={alert.type as StaticAlertType}
                         heading={alert.type.toUpperCase()}
                         message={alert.message}
                     />

--- a/frontend-react/src/pages/deliveries/Table/DeliveriesTable.tsx
+++ b/frontend-react/src/pages/deliveries/Table/DeliveriesTable.tsx
@@ -20,6 +20,7 @@ import { RSReceiver } from "../../../config/endpoints/settings";
 import { useOrganizationReceiversFeed } from "../../../hooks/UseOrganizationReceiversFeed";
 import { EventName, trackAppInsightEvent } from "../../../utils/Analytics";
 import { FeatureName } from "../../../AppRouter";
+import AdminFetchAlert from "../../../components/alerts/AdminFetchAlert";
 
 import { getReportAndDownload } from "./ReportsUtils";
 import ServicesDropdown from "./ServicesDropdown";
@@ -204,10 +205,23 @@ const DeliveriesTableWithNumberedPagination = ({
 };
 
 export const DeliveriesTable = () => {
-    const { loadingServices, services, activeService, setActiveService } =
-        useOrganizationReceiversFeed();
+    const {
+        loadingServices,
+        services,
+        activeService,
+        setActiveService,
+        isDisabled,
+    } = useOrganizationReceiversFeed();
 
     if (loadingServices) return <Spinner />;
+
+    if (isDisabled) {
+        return (
+            <div className="grid-container">
+                <AdminFetchAlert />
+            </div>
+        );
+    }
 
     if (!loadingServices && !activeService)
         return (

--- a/frontend-react/src/pages/submissions/SubmissionTable.test.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionTable.test.tsx
@@ -7,6 +7,7 @@ import SubmissionsResource from "../../resources/SubmissionsResource";
 import { renderWithRouter } from "../../utils/CustomRenderUtils";
 import { mockSessionContext } from "../../contexts/__mocks__/SessionContext";
 import { MemberType } from "../../hooks/UseOktaMemberships";
+import { Organizations } from "../../hooks/UseAdminSafeOrganizationName";
 
 import SubmissionTable from "./SubmissionTable";
 
@@ -72,5 +73,32 @@ describe("SubmissionTable", () => {
         const tBody = rowGroups[1];
         const rows = within(tBody).getAllByRole("row");
         expect(rows).toHaveLength(2);
+    });
+
+    describe("when rendering as an admin", () => {
+        beforeEach(() => {
+            mockSessionContext.mockReturnValue({
+                activeMembership: {
+                    memberType: MemberType.PRIME_ADMIN,
+                    parsedName: Organizations.PRIMEADMINS,
+                    service: "",
+                },
+                dispatch: () => {},
+                initialized: true,
+            });
+
+            renderWithResolver(<SubmissionTable />, []);
+        });
+
+        test("renders a warning about not being able to request submission history", async () => {
+            expect(
+                await screen.findByText(
+                    "Cannot fetch Organization data as admin"
+                )
+            ).toBeVisible();
+            expect(
+                await screen.findByText("Please try again as an Organization")
+            ).toBeVisible();
+        });
     });
 });


### PR DESCRIPTION
This changeset disables a few Organization-specific requests to mitigate the number of 404s we're getting as admins try to fetch Organization resources:
- Organization settings
- Deliveries
- Submissions

There's not a one-size-fits-all solution here given the different fetch mechanisms we already have and how the data is rendered, so I tried to add minimal changes to prevent disrupting anything down the line.  I think going forward, we can make a generic `useOrganizationQuery` hook (or whatever) that'll automatically be disabled if the user is logged in as an admin without impersonating an Organization.  There are a lot of layers with our fetching that in my opinion should be untangled, but that's out of the scope of this pull request.

Test Steps:
1. Log in as an admin
2. Open the network tab
3. Without impersonating an organization:
  a. Navigate to `/submissions` --> ensure no GET request is made for PrimeAdmins Organization settings or submissions 
  b. Navigate to `/daily-data` --> ensure no GET request is made for for PrimeAdmins Organization settings or deliveries
4. While impersonating an organization:
  a. Navigate to `/submissions` --> ensure GET requests are made for selected Organization settings and submissions
  b. Navigate to `/daily-data` --> ensure GET requests are made for selected Organization settings and deliveries

## Changes

Added a small visual change for the pages to account for this case:

<img width="1480" alt="Screenshot 2023-01-18 at 17 09 47" src="https://user-images.githubusercontent.com/2421042/213306617-aa3e006a-f51a-4c2f-8828-8699b55ffcc7.png">
<img width="1480" alt="Screenshot 2023-01-18 at 17 09 49" src="https://user-images.githubusercontent.com/2421042/213306620-bdcb9f33-6b0a-4b3e-9f63-3db5c1f28897.png">

Valid user behavior is unaffected:
<img width="1480" alt="Screenshot 2023-01-18 at 17 09 54" src="https://user-images.githubusercontent.com/2421042/213306622-85fe9db9-7dfd-4f8f-9f00-c83908b33c01.png">
<img width="1480" alt="Screenshot 2023-01-18 at 17 09 59" src="https://user-images.githubusercontent.com/2421042/213306624-8cbed1a4-2f64-42fd-a376-28e2ff4aca49.png">


## Checklist

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

## Linked Issues
- Fixes #7891 
- Fixes #7890 
