### PR TITLE
OBR hl7v2 to fhir mapping updates

### DIFF
--- a/prime-router/metadata/fhir_mapping/hl7/resource/DiagnosticReport.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/resource/DiagnosticReport.yml
@@ -103,7 +103,6 @@ identifier_5:
     system: OBR.26.1.2
 
 status:
-  condition: OBR.25 NOT_NULL
   type: DIAGNOSTIC_REPORT_STATUS
   valueOf: OBR.25
   expressionType: HL7Spec

--- a/prime-router/metadata/fhir_mapping/hl7/resource/DiagnosticReport.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/resource/DiagnosticReport.yml
@@ -14,35 +14,68 @@ identifier_1:
   constants:
     sys: "urn:id:extID"
 
-identifier_2:
+identifier_2a:
   condition: $valueIn NOT_NULL
   valueOf: datatype/Identifier_var
   generateList: true
+  useGroup: true
   expressionType: resource
   vars:
-    valueIn: ORC.3.1 | OBR.3.1
-    systemCX: ORC.3.2 | OBR.3.2
-    universalId: ORC.3.3 | OBR.3.3
-    universalIdType: ORC.3.4 | OBR.3.4
+    valueIn: ORC.3.1
+    systemCX: ORC.3.2
+    universalId: ORC.3.3
+    universalIdType: ORC.3.4
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "FILL"
     display: "Filler Identifier"
 
-identifier_3:
+identifier_2b:
+  condition: $valueInORC NULL && $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  useGroup: true
+  expressionType: resource
+  vars:
+    valueIn: OBR.3.1
+    systemCX: OBR.3.2
+    universalId: OBR.3.3
+    universalIdType: OBR.3.4
+    valueInORC: ORC.3.1
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "FILL"
+
+identifier_3a:
   condition: $valueIn NOT_NULL
   valueOf: datatype/Identifier_var
   generateList: true
+  useGroup: true
   expressionType: resource
   vars:
-    valueIn: ORC.2.1 | OBR.2.1
-    systemCX: ORC.2.2 | OBR.2.2
-    universalId: ORC.2.3 | OBR.2.3
-    universalIdType: ORC.2.4 | OBR.2.4
+    valueIn: ORC.2.1
+    systemCX: ORC.2.2
+    universalId: ORC.2.3
+    universalIdType: ORC.2.4
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "PLAC"
-    display: "Placer Identifier"
+
+identifier_3b:
+  condition: $valueInORC NULL && $valueIn NOT_NULL
+  valueOf: datatype/Identifier_var
+  generateList: true
+  useGroup: true
+  expressionType: resource
+  vars:
+    valueIn: OBR.2.1
+    systemCX: OBR.2.2
+    universalId: OBR.2.3
+    universalIdType: OBR.2.4
+    valueInORC: ORC.2.1
+  constants:
+    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+    code: "PLAC"
 
 identifier_4:
   condition: $valueIn NOT_NULL
@@ -87,7 +120,7 @@ category:
 code:
   valueOf: datatype/CodeableConcept
   expressionType: resource
-  specs: OBR.4.4 | OBR.4.5 | OBR.4.6
+  specs: OBR.4
   required: true
   vars:
     code: OBR.4
@@ -124,8 +157,8 @@ issued:
   type: STRING
   valueOf: 'GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)'
   expressionType: JEXL
-  vars: 
-    dateTimeIn: OBR.22  
+  vars:
+    dateTimeIn: OBR.22
 
 resultsInterpreter:
   condition: $interpreter NOT_NULL

--- a/prime-router/metadata/fhir_mapping/hl7/resource/DiagnosticReport.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/resource/DiagnosticReport.yml
@@ -70,6 +70,7 @@ identifier_5:
     system: OBR.26.1.2
 
 status:
+  condition: OBR.25 NOT_NULL
   type: DIAGNOSTIC_REPORT_STATUS
   valueOf: OBR.25
   expressionType: HL7Spec
@@ -86,7 +87,7 @@ category:
 code:
   valueOf: datatype/CodeableConcept
   expressionType: resource
-  specs: OBR.4
+  specs: OBR.4.4 | OBR.4.5 | OBR.4.6
   required: true
   vars:
     code: OBR.4

--- a/prime-router/metadata/fhir_mapping/hl7/resource/ServiceRequest.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/resource/ServiceRequest.yml
@@ -50,11 +50,12 @@ identifier_2b:
   vars:
     valueIn: OBR.3.1
     systemCX: OBR.3.2
+    universalId: OBR.3.3
+    universalIdType: OBR.3.4
     valueInORC: ORC.3.1
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "FILL"
-    display: "Filler Identifier"
 
 identifier_3a:
   condition: $valueIn NOT_NULL
@@ -81,13 +82,12 @@ identifier_3b:
   vars:
     valueIn: OBR.2.1
     systemCX: OBR.2.2
+    universalId: OBR.2.3
+    universalIdType: OBR.2.4
     valueInORC: ORC.2.1
-    universalId: ORC.2.3
-    universalIdType: ORC.2.4
   constants:
     system: "http://terminology.hl7.org/CodeSystem/v2-0203"
     code: "PLAC"
-    display: "Placer Identifier"
 
 identifier_4:
   condition: $valueIn NOT_NULL

--- a/prime-router/metadata/fhir_mapping/hl7/secondary/Collection.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/secondary/Collection.yml
@@ -4,24 +4,24 @@ collectedDateTime:
   valueOf: "GeneralUtils.dateTimeWithZoneId(dateTimeIn,ZONEID)"
   expressionType: JEXL
   vars:
-    dateTimeIn: SPM.17.1
-    end: SPM.17.2
+    dateTimeIn: SPM.17.1 | OBR.7
+    end: SPM.17.2 | OBR.8
 
 collectedPeriod:
   condition: $end NOT_NULL
   valueOf: datatype/Period
   expressionType: resource
   vars:
-    start: SPM.17.1
-    end: SPM.17.2
+    start: SPM.17.1 | OBR.7
+    end: SPM.17.2 | OBR.8
 
 quantity:
   condition: $value NOT_NULL || $unit NOT_NULL
   valueOf: datatype/Quantity
   expressionType: resource
   vars:
-    value: String, SPM.12.1
-    unit: SPM.12.2
+    value: String, SPM.12.1 | OBR.9.1
+    unit: SPM.12.2 | OBR.9.2
 
 method:
   condition: $spm7 NOT_NULL
@@ -38,3 +38,12 @@ bodySite:
   specs: SPM.8
   vars:
     valueIn: SPM.8
+
+collector:
+  condition: $practitionerVal NOT_NULL
+  valueOf: resource/Practitioner
+  generateList: true
+  expressionType: reference
+  specs: OBR.10
+  vars:
+    practitionerVal: OBR.10

--- a/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0001.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1674153054109185000.9fae9996-785b-428d-a4f8-5d6d0de32cc6",
+  "id" : "1674521440825036000.40737ea0-7664-4043-ad07-2ef8ecabd90e",
   "meta" : {
-    "lastUpdated" : "2023-01-19T13:30:54.124-05:00"
+    "lastUpdated" : "2023-01-23T17:50:40.833-07:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "MT_COCAA_ORU_AAPHELR.1.6214638"
   },
   "type" : "message",
-  "timestamp" : "2028-08-08T11:28:05.000-04:00",
+  "timestamp" : "2028-08-08T08:28:05.000-07:00",
   "entry" : [ {
     "fullUrl" : "MessageHeader/88a50cd6-72bf-34a1-9025-708e7c29cc32",
     "resource" : {
@@ -32,7 +32,7 @@
       },
       "destination" : [ {
         "target" : {
-          "reference" : "Device/1674153054186080000.fc3e88de-9ad6-4956-bfe7-49ac430febd8"
+          "reference" : "Device/1674521440904594000.bff9ee84-ede8-44f3-8503-ef2c2a54edb1"
         },
         "endpoint" : "urn:oid:2.16.840.1.114222.4.1.144.2.5",
         "receiver" : {
@@ -40,13 +40,13 @@
         }
       } ],
       "sender" : {
-        "reference" : "Organization/1674153054181948000.196165f3-87b4-4196-be05-b91c63cb02e8"
+        "reference" : "Organization/1674521440899521000.87974627-6c57-4903-9ff8-5e902e3345f3"
       },
       "source" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
           "valueReference" : {
-            "reference" : "Organization/1674153054199986000.c1acb9c2-fea5-4b99-8042-db821804c8a2"
+            "reference" : "Organization/1674521440915753000.4d437a82-e7eb-46bb-b3ff-eea30e3ade5d"
           }
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
@@ -62,10 +62,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1674153054181948000.196165f3-87b4-4196-be05-b91c63cb02e8",
+    "fullUrl" : "Organization/1674521440899521000.87974627-6c57-4903-9ff8-5e902e3345f3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153054181948000.196165f3-87b4-4196-be05-b91c63cb02e8",
+      "id" : "1674521440899521000.87974627-6c57-4903-9ff8-5e902e3345f3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -81,10 +81,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1674153054186080000.fc3e88de-9ad6-4956-bfe7-49ac430febd8",
+    "fullUrl" : "Device/1674521440904594000.bff9ee84-ede8-44f3-8503-ef2c2a54edb1",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1674153054186080000.fc3e88de-9ad6-4956-bfe7-49ac430febd8",
+      "id" : "1674521440904594000.bff9ee84-ede8-44f3-8503-ef2c2a54edb1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -131,10 +131,10 @@
       "name" : "CDPHE"
     }
   }, {
-    "fullUrl" : "Organization/1674153054199986000.c1acb9c2-fea5-4b99-8042-db821804c8a2",
+    "fullUrl" : "Organization/1674521440915753000.4d437a82-e7eb-46bb-b3ff-eea30e3ade5d",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153054199986000.c1acb9c2-fea5-4b99-8042-db821804c8a2",
+      "id" : "1674521440915753000.4d437a82-e7eb-46bb-b3ff-eea30e3ade5d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -172,10 +172,10 @@
       "name" : "MEDITECH, Inc."
     }
   }, {
-    "fullUrl" : "Provenance/1674153055292827000.9d04b7ca-6b0a-49eb-a1b4-f47f646be4ef",
+    "fullUrl" : "Provenance/1674521442179849000.08561341-5b0f-47e3-ad3e-bead37876f2f",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1674153055292827000.9d04b7ca-6b0a-49eb-a1b4-f47f646be4ef",
+      "id" : "1674521442179849000.08561341-5b0f-47e3-ad3e-bead37876f2f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -202,21 +202,21 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1674153055292173000.22ac2353-7ed6-423d-b2c8-c171f84fe189"
+          "reference" : "Organization/1674521442179003000.c3f9e0f8-b1c8-4024-b36d-4fce8bb96e3c"
         }
       } ],
       "entity" : [ {
         "role" : "source",
         "what" : {
-          "reference" : "Device/1674153055293791000.894d93c3-f84d-4ccd-bcde-2d525ab206ec"
+          "reference" : "Device/1674521442181184000.7f6d29fa-f6f3-49c2-9192-d8dfc861188e"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055292173000.22ac2353-7ed6-423d-b2c8-c171f84fe189",
+    "fullUrl" : "Organization/1674521442179003000.c3f9e0f8-b1c8-4024-b36d-4fce8bb96e3c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055292173000.22ac2353-7ed6-423d-b2c8-c171f84fe189",
+      "id" : "1674521442179003000.c3f9e0f8-b1c8-4024-b36d-4fce8bb96e3c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -243,10 +243,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1674153055293791000.894d93c3-f84d-4ccd-bcde-2d525ab206ec",
+    "fullUrl" : "Device/1674521442181184000.7f6d29fa-f6f3-49c2-9192-d8dfc861188e",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1674153055293791000.894d93c3-f84d-4ccd-bcde-2d525ab206ec",
+      "id" : "1674521442181184000.7f6d29fa-f6f3-49c2-9192-d8dfc861188e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -273,10 +273,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Observation/1674153055380463000.0c944001-dfb9-4667-81ec-d74aac12589e",
+    "fullUrl" : "Observation/1674521442287530000.da049d02-4207-4186-aa99-8ea491b5c854",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055380463000.0c944001-dfb9-4667-81ec-d74aac12589e",
+      "id" : "1674521442287530000.da049d02-4207-4186-aa99-8ea491b5c854",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -293,7 +293,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055380336000.0fb36972-cd72-488d-b948-53d6e13f9da1"
+          "reference" : "Organization/1674521442287356000.1d70cd62-c74d-4a7e-b672-536de8e74b64"
         }
       } ],
       "identifier" : [ {
@@ -327,22 +327,22 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055378849000.5afa4f2d-5d61-4186-8ec2-91b98618adfe"
+        "reference" : "PractitionerRole/1674521442284962000.e7517327-6d68-4681-99b6-7f3e1c129306"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055375864000.6f98faaa-012a-47fe-baa8-705f07f718db",
+    "fullUrl" : "Location/1674521442280740000.98b49c9e-1d17-4a9a-b7de-18d9ff990ea0",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055375864000.6f98faaa-012a-47fe-baa8-705f07f718db",
+      "id" : "1674521442280740000.98b49c9e-1d17-4a9a-b7de-18d9ff990ea0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -356,10 +356,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055376347000.887179fa-93b5-46a8-b6a8-0d83f784efb7",
+    "fullUrl" : "Practitioner/1674521442281456000.68c2c330-edee-48dc-886e-43ddb7025a65",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055376347000.887179fa-93b5-46a8-b6a8-0d83f784efb7",
+      "id" : "1674521442281456000.68c2c330-edee-48dc-886e-43ddb7025a65",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -381,7 +381,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055375864000.6f98faaa-012a-47fe-baa8-705f07f718db"
+          "reference" : "Location/1674521442280740000.98b49c9e-1d17-4a9a-b7de-18d9ff990ea0"
         }
       } ],
       "identifier" : [ {
@@ -408,10 +408,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055378735000.c9e53b3e-81fa-4381-8ae4-055f49a0d0a0",
+    "fullUrl" : "Organization/1674521442284848000.b6d8c8e4-4caa-43b9-ad88-706152c6dda0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055378735000.c9e53b3e-81fa-4381-8ae4-055f49a0d0a0",
+      "id" : "1674521442284848000.b6d8c8e4-4caa-43b9-ad88-706152c6dda0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -443,10 +443,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055378849000.5afa4f2d-5d61-4186-8ec2-91b98618adfe",
+    "fullUrl" : "PractitionerRole/1674521442284962000.e7517327-6d68-4681-99b6-7f3e1c129306",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055378849000.5afa4f2d-5d61-4186-8ec2-91b98618adfe",
+      "id" : "1674521442284962000.e7517327-6d68-4681-99b6-7f3e1c129306",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -458,10 +458,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055376347000.887179fa-93b5-46a8-b6a8-0d83f784efb7"
+        "reference" : "Practitioner/1674521442281456000.68c2c330-edee-48dc-886e-43ddb7025a65"
       },
       "organization" : {
-        "reference" : "Organization/1674153055378735000.c9e53b3e-81fa-4381-8ae4-055f49a0d0a0"
+        "reference" : "Organization/1674521442284848000.b6d8c8e4-4caa-43b9-ad88-706152c6dda0"
       },
       "code" : [ {
         "coding" : [ {
@@ -471,10 +471,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055380336000.0fb36972-cd72-488d-b948-53d6e13f9da1",
+    "fullUrl" : "Organization/1674521442287356000.1d70cd62-c74d-4a7e-b672-536de8e74b64",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055380336000.0fb36972-cd72-488d-b948-53d6e13f9da1",
+      "id" : "1674521442287356000.1d70cd62-c74d-4a7e-b672-536de8e74b64",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -500,10 +500,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055386567000.f17e8fd6-85f8-4fb4-ae3b-85d2ff39a3b0",
+    "fullUrl" : "Observation/1674521442295325000.7ca42a93-a037-43cd-9886-f37b64ad84dd",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055386567000.f17e8fd6-85f8-4fb4-ae3b-85d2ff39a3b0",
+      "id" : "1674521442295325000.7ca42a93-a037-43cd-9886-f37b64ad84dd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -520,7 +520,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055386456000.aeb41aa5-f28f-4055-993f-47d7a613777a"
+          "reference" : "Organization/1674521442295204000.24337a05-6cd5-43d0-a972-a8afccaae07f"
         }
       } ],
       "identifier" : [ {
@@ -554,15 +554,15 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055384987000.a42a6a9f-3226-4d06-9478-9116250ba203"
+        "reference" : "PractitionerRole/1674521442293135000.a506c9e8-25e9-42c7-97c1-12c57516c5e9"
       } ],
       "valueCodeableConcept" : {
         "extension" : [ {
@@ -591,10 +591,10 @@
       }
     }
   }, {
-    "fullUrl" : "Location/1674153055382622000.2b4e6252-6d5b-4db6-8cf0-3d512eecf05a",
+    "fullUrl" : "Location/1674521442290158000.2adfa0fb-f7e3-4422-bcaa-63aa76d552fe",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055382622000.2b4e6252-6d5b-4db6-8cf0-3d512eecf05a",
+      "id" : "1674521442290158000.2adfa0fb-f7e3-4422-bcaa-63aa76d552fe",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -608,10 +608,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055383043000.5a6bbb33-6962-4c4c-8024-a59db187c70f",
+    "fullUrl" : "Practitioner/1674521442290813000.0405b2b2-f9e7-4039-949b-a4e9cfc1bf70",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055383043000.5a6bbb33-6962-4c4c-8024-a59db187c70f",
+      "id" : "1674521442290813000.0405b2b2-f9e7-4039-949b-a4e9cfc1bf70",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -633,7 +633,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055382622000.2b4e6252-6d5b-4db6-8cf0-3d512eecf05a"
+          "reference" : "Location/1674521442290158000.2adfa0fb-f7e3-4422-bcaa-63aa76d552fe"
         }
       } ],
       "identifier" : [ {
@@ -660,10 +660,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055384873000.5981f1fc-d0fa-43e4-b294-eb6dac74747c",
+    "fullUrl" : "Organization/1674521442293029000.0c90a9ac-d651-4145-8a2b-f0cad5957ebe",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055384873000.5981f1fc-d0fa-43e4-b294-eb6dac74747c",
+      "id" : "1674521442293029000.0c90a9ac-d651-4145-8a2b-f0cad5957ebe",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -695,10 +695,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055384987000.a42a6a9f-3226-4d06-9478-9116250ba203",
+    "fullUrl" : "PractitionerRole/1674521442293135000.a506c9e8-25e9-42c7-97c1-12c57516c5e9",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055384987000.a42a6a9f-3226-4d06-9478-9116250ba203",
+      "id" : "1674521442293135000.a506c9e8-25e9-42c7-97c1-12c57516c5e9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -710,10 +710,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055383043000.5a6bbb33-6962-4c4c-8024-a59db187c70f"
+        "reference" : "Practitioner/1674521442290813000.0405b2b2-f9e7-4039-949b-a4e9cfc1bf70"
       },
       "organization" : {
-        "reference" : "Organization/1674153055384873000.5981f1fc-d0fa-43e4-b294-eb6dac74747c"
+        "reference" : "Organization/1674521442293029000.0c90a9ac-d651-4145-8a2b-f0cad5957ebe"
       },
       "code" : [ {
         "coding" : [ {
@@ -723,10 +723,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055386456000.aeb41aa5-f28f-4055-993f-47d7a613777a",
+    "fullUrl" : "Organization/1674521442295204000.24337a05-6cd5-43d0-a972-a8afccaae07f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055386456000.aeb41aa5-f28f-4055-993f-47d7a613777a",
+      "id" : "1674521442295204000.24337a05-6cd5-43d0-a972-a8afccaae07f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -752,10 +752,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055392839000.1d8e5c37-996c-4c2f-b57d-cfcb64fa5158",
+    "fullUrl" : "Observation/1674521442301575000.1f3a85d4-90b4-4cee-b10f-50ddf39d9bc4",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055392839000.1d8e5c37-996c-4c2f-b57d-cfcb64fa5158",
+      "id" : "1674521442301575000.1f3a85d4-90b4-4cee-b10f-50ddf39d9bc4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -772,7 +772,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055392689000.73ffaaaf-70ef-4117-a449-7185475a9637"
+          "reference" : "Organization/1674521442301445000.f967b4f8-abbe-473d-8470-354cf87d5d57"
         }
       } ],
       "identifier" : [ {
@@ -806,15 +806,15 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055390410000.85972be8-e442-4642-a5f1-743d42ae9e9a"
+        "reference" : "PractitionerRole/1674521442299872000.98daf95b-62db-445a-ab61-cd55e302a945"
       } ],
       "valueCodeableConcept" : {
         "extension" : [ {
@@ -875,10 +875,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055388152000.e5fe7818-3d1e-47b4-bea7-499c1e90b839",
+    "fullUrl" : "Location/1674521442297034000.1446bb65-4780-4aeb-9bf7-0445882ffebd",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055388152000.e5fe7818-3d1e-47b4-bea7-499c1e90b839",
+      "id" : "1674521442297034000.1446bb65-4780-4aeb-9bf7-0445882ffebd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -892,10 +892,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055388552000.c819f9f7-0cab-40bf-8f8c-aad6121e563c",
+    "fullUrl" : "Practitioner/1674521442297475000.997552d1-2342-43e4-9d68-7dd8f51d4969",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055388552000.c819f9f7-0cab-40bf-8f8c-aad6121e563c",
+      "id" : "1674521442297475000.997552d1-2342-43e4-9d68-7dd8f51d4969",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -917,7 +917,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055388152000.e5fe7818-3d1e-47b4-bea7-499c1e90b839"
+          "reference" : "Location/1674521442297034000.1446bb65-4780-4aeb-9bf7-0445882ffebd"
         }
       } ],
       "identifier" : [ {
@@ -944,10 +944,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055390320000.317bddc1-632f-41f6-9e68-428039534c1f",
+    "fullUrl" : "Organization/1674521442299752000.ddb8be59-4d4f-4365-be1d-017c295ea383",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055390320000.317bddc1-632f-41f6-9e68-428039534c1f",
+      "id" : "1674521442299752000.ddb8be59-4d4f-4365-be1d-017c295ea383",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -979,10 +979,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055390410000.85972be8-e442-4642-a5f1-743d42ae9e9a",
+    "fullUrl" : "PractitionerRole/1674521442299872000.98daf95b-62db-445a-ab61-cd55e302a945",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055390410000.85972be8-e442-4642-a5f1-743d42ae9e9a",
+      "id" : "1674521442299872000.98daf95b-62db-445a-ab61-cd55e302a945",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -994,10 +994,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055388552000.c819f9f7-0cab-40bf-8f8c-aad6121e563c"
+        "reference" : "Practitioner/1674521442297475000.997552d1-2342-43e4-9d68-7dd8f51d4969"
       },
       "organization" : {
-        "reference" : "Organization/1674153055390320000.317bddc1-632f-41f6-9e68-428039534c1f"
+        "reference" : "Organization/1674521442299752000.ddb8be59-4d4f-4365-be1d-017c295ea383"
       },
       "code" : [ {
         "coding" : [ {
@@ -1007,10 +1007,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055392689000.73ffaaaf-70ef-4117-a449-7185475a9637",
+    "fullUrl" : "Organization/1674521442301445000.f967b4f8-abbe-473d-8470-354cf87d5d57",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055392689000.73ffaaaf-70ef-4117-a449-7185475a9637",
+      "id" : "1674521442301445000.f967b4f8-abbe-473d-8470-354cf87d5d57",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1036,10 +1036,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055401005000.be0453a6-fbfe-46a0-9013-079c9b424892",
+    "fullUrl" : "Observation/1674521442310851000.300fc468-ff44-435e-9bca-31d391e794d6",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055401005000.be0453a6-fbfe-46a0-9013-079c9b424892",
+      "id" : "1674521442310851000.300fc468-ff44-435e-9bca-31d391e794d6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1056,7 +1056,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055400890000.5969e1c2-b0f6-4710-b251-45d5b7a1dfe3"
+          "reference" : "Organization/1674521442310765000.abf6e7cd-f02b-44e2-9080-cde70e077042"
         }
       } ],
       "identifier" : [ {
@@ -1090,22 +1090,22 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055399112000.c4ab7b5f-3362-45f0-85a1-ff2ab3a9349f"
+        "reference" : "PractitionerRole/1674521442309541000.d86d4254-0a44-4f92-a46d-2fd950072696"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055395551000.56c243f2-d431-46ce-b7b5-5724143a4478",
+    "fullUrl" : "Location/1674521442306940000.53a04528-0f29-408e-b56f-160c3328bd30",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055395551000.56c243f2-d431-46ce-b7b5-5724143a4478",
+      "id" : "1674521442306940000.53a04528-0f29-408e-b56f-160c3328bd30",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1119,10 +1119,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055396140000.8a18a857-e26e-4308-96b7-3ee4d5a138b1",
+    "fullUrl" : "Practitioner/1674521442307383000.748204a1-84aa-4f53-b952-f4abe916a2cc",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055396140000.8a18a857-e26e-4308-96b7-3ee4d5a138b1",
+      "id" : "1674521442307383000.748204a1-84aa-4f53-b952-f4abe916a2cc",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1144,7 +1144,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055395551000.56c243f2-d431-46ce-b7b5-5724143a4478"
+          "reference" : "Location/1674521442306940000.53a04528-0f29-408e-b56f-160c3328bd30"
         }
       } ],
       "identifier" : [ {
@@ -1171,10 +1171,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055398987000.a45a67ec-f5df-4551-af9f-17569f931042",
+    "fullUrl" : "Organization/1674521442309431000.fc4f10b7-c688-4e4d-8e56-9a9b53ddad81",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055398987000.a45a67ec-f5df-4551-af9f-17569f931042",
+      "id" : "1674521442309431000.fc4f10b7-c688-4e4d-8e56-9a9b53ddad81",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1221,10 +1221,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055399112000.c4ab7b5f-3362-45f0-85a1-ff2ab3a9349f",
+    "fullUrl" : "PractitionerRole/1674521442309541000.d86d4254-0a44-4f92-a46d-2fd950072696",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055399112000.c4ab7b5f-3362-45f0-85a1-ff2ab3a9349f",
+      "id" : "1674521442309541000.d86d4254-0a44-4f92-a46d-2fd950072696",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1236,10 +1236,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055396140000.8a18a857-e26e-4308-96b7-3ee4d5a138b1"
+        "reference" : "Practitioner/1674521442307383000.748204a1-84aa-4f53-b952-f4abe916a2cc"
       },
       "organization" : {
-        "reference" : "Organization/1674153055398987000.a45a67ec-f5df-4551-af9f-17569f931042"
+        "reference" : "Organization/1674521442309431000.fc4f10b7-c688-4e4d-8e56-9a9b53ddad81"
       },
       "code" : [ {
         "coding" : [ {
@@ -1249,10 +1249,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055400890000.5969e1c2-b0f6-4710-b251-45d5b7a1dfe3",
+    "fullUrl" : "Organization/1674521442310765000.abf6e7cd-f02b-44e2-9080-cde70e077042",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055400890000.5969e1c2-b0f6-4710-b251-45d5b7a1dfe3",
+      "id" : "1674521442310765000.abf6e7cd-f02b-44e2-9080-cde70e077042",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1278,10 +1278,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055405832000.c5de99e4-70a5-4bd7-9b19-cf2fdd80b278",
+    "fullUrl" : "Observation/1674521442316070000.4f8d486d-0e40-49e1-9832-054d826948cd",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055405832000.c5de99e4-70a5-4bd7-9b19-cf2fdd80b278",
+      "id" : "1674521442316070000.4f8d486d-0e40-49e1-9832-054d826948cd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1298,7 +1298,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055405736000.252af891-16ef-4749-9f13-e5f013668fb7"
+          "reference" : "Organization/1674521442315971000.79d55e28-36dd-43d5-83bb-754a04123b58"
         }
       } ],
       "identifier" : [ {
@@ -1321,23 +1321,23 @@
         "text" : "BLOOD CULTURE PCR"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055404692000.ebb608be-0f7c-4596-96e7-896eb0bb7fb9"
+        "reference" : "PractitionerRole/1674521442314688000.c0e63ead-17ee-4d12-82e6-90159e57931e"
       } ],
       "valueString" : "GRAM POSITIVE PCR; NO TARGETS DETECTED (SEE COMMENT)"
     }
   }, {
-    "fullUrl" : "Location/1674153055402557000.093163d3-61f0-482b-9b67-0661eaa3eef8",
+    "fullUrl" : "Location/1674521442312314000.05cd3697-a517-4712-810a-15a56fea7d5a",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055402557000.093163d3-61f0-482b-9b67-0661eaa3eef8",
+      "id" : "1674521442312314000.05cd3697-a517-4712-810a-15a56fea7d5a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1351,10 +1351,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055402890000.ad44f135-9909-4cd1-a831-5ddd57940f40",
+    "fullUrl" : "Practitioner/1674521442312704000.a106a51c-02e2-44ed-a190-b98201facaa9",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055402890000.ad44f135-9909-4cd1-a831-5ddd57940f40",
+      "id" : "1674521442312704000.a106a51c-02e2-44ed-a190-b98201facaa9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1376,7 +1376,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055402557000.093163d3-61f0-482b-9b67-0661eaa3eef8"
+          "reference" : "Location/1674521442312314000.05cd3697-a517-4712-810a-15a56fea7d5a"
         }
       } ],
       "identifier" : [ {
@@ -1403,10 +1403,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055404588000.c6d81883-18b9-4a28-acc5-9aeb4acdea5c",
+    "fullUrl" : "Organization/1674521442314597000.3d52cc9f-cce2-426b-ba21-0c9b1df7a9f0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055404588000.c6d81883-18b9-4a28-acc5-9aeb4acdea5c",
+      "id" : "1674521442314597000.3d52cc9f-cce2-426b-ba21-0c9b1df7a9f0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1452,10 +1452,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055404692000.ebb608be-0f7c-4596-96e7-896eb0bb7fb9",
+    "fullUrl" : "PractitionerRole/1674521442314688000.c0e63ead-17ee-4d12-82e6-90159e57931e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055404692000.ebb608be-0f7c-4596-96e7-896eb0bb7fb9",
+      "id" : "1674521442314688000.c0e63ead-17ee-4d12-82e6-90159e57931e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1467,10 +1467,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055402890000.ad44f135-9909-4cd1-a831-5ddd57940f40"
+        "reference" : "Practitioner/1674521442312704000.a106a51c-02e2-44ed-a190-b98201facaa9"
       },
       "organization" : {
-        "reference" : "Organization/1674153055404588000.c6d81883-18b9-4a28-acc5-9aeb4acdea5c"
+        "reference" : "Organization/1674521442314597000.3d52cc9f-cce2-426b-ba21-0c9b1df7a9f0"
       },
       "code" : [ {
         "coding" : [ {
@@ -1480,10 +1480,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055405736000.252af891-16ef-4749-9f13-e5f013668fb7",
+    "fullUrl" : "Organization/1674521442315971000.79d55e28-36dd-43d5-83bb-754a04123b58",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055405736000.252af891-16ef-4749-9f13-e5f013668fb7",
+      "id" : "1674521442315971000.79d55e28-36dd-43d5-83bb-754a04123b58",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1509,10 +1509,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055410379000.289654e4-0d4c-4a6e-b2d8-c2ac615075ba",
+    "fullUrl" : "Observation/1674521442321201000.62fd01d4-2b3e-4825-8302-472ba7bf73c9",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055410379000.289654e4-0d4c-4a6e-b2d8-c2ac615075ba",
+      "id" : "1674521442321201000.62fd01d4-2b3e-4825-8302-472ba7bf73c9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1529,7 +1529,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055410283000.ca5ad829-fc78-4a4e-a761-88b2774d8db9"
+          "reference" : "Organization/1674521442321102000.7b884ec2-4568-43c1-a940-2c26466900fe"
         }
       } ],
       "identifier" : [ {
@@ -1552,15 +1552,15 @@
         "text" : "BLOOD CULTURE GRAM STAIN"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055409271000.38c4d102-21b1-4000-b2ec-21fdb355def6"
+        "reference" : "PractitionerRole/1674521442319916000.39b76734-b4f7-4308-bebc-733ac99ef7aa"
       } ],
       "valueString" : "GRAM POSITIVE COCCI IN PAIRS",
       "interpretation" : [ {
@@ -1572,10 +1572,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055407131000.d9f68f2c-6334-4542-8ccc-70c08d438425",
+    "fullUrl" : "Location/1674521442317547000.21541922-a89e-4a5d-9b69-08eb17cf4a0f",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055407131000.d9f68f2c-6334-4542-8ccc-70c08d438425",
+      "id" : "1674521442317547000.21541922-a89e-4a5d-9b69-08eb17cf4a0f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1589,10 +1589,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055407485000.616d09ff-e3a2-4f00-b59b-9b60f49891ac",
+    "fullUrl" : "Practitioner/1674521442318028000.ca3a2271-abef-43ca-b248-dbea3be3cb24",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055407485000.616d09ff-e3a2-4f00-b59b-9b60f49891ac",
+      "id" : "1674521442318028000.ca3a2271-abef-43ca-b248-dbea3be3cb24",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1614,7 +1614,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055407131000.d9f68f2c-6334-4542-8ccc-70c08d438425"
+          "reference" : "Location/1674521442317547000.21541922-a89e-4a5d-9b69-08eb17cf4a0f"
         }
       } ],
       "identifier" : [ {
@@ -1641,10 +1641,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055409205000.6d2f0c03-0001-480d-a210-294ba413f592",
+    "fullUrl" : "Organization/1674521442319830000.c2ef1b7b-06ae-4ae8-b226-73e8639365f1",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055409205000.6d2f0c03-0001-480d-a210-294ba413f592",
+      "id" : "1674521442319830000.c2ef1b7b-06ae-4ae8-b226-73e8639365f1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1691,10 +1691,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055409271000.38c4d102-21b1-4000-b2ec-21fdb355def6",
+    "fullUrl" : "PractitionerRole/1674521442319916000.39b76734-b4f7-4308-bebc-733ac99ef7aa",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055409271000.38c4d102-21b1-4000-b2ec-21fdb355def6",
+      "id" : "1674521442319916000.39b76734-b4f7-4308-bebc-733ac99ef7aa",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1706,10 +1706,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055407485000.616d09ff-e3a2-4f00-b59b-9b60f49891ac"
+        "reference" : "Practitioner/1674521442318028000.ca3a2271-abef-43ca-b248-dbea3be3cb24"
       },
       "organization" : {
-        "reference" : "Organization/1674153055409205000.6d2f0c03-0001-480d-a210-294ba413f592"
+        "reference" : "Organization/1674521442319830000.c2ef1b7b-06ae-4ae8-b226-73e8639365f1"
       },
       "code" : [ {
         "coding" : [ {
@@ -1719,10 +1719,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055410283000.ca5ad829-fc78-4a4e-a761-88b2774d8db9",
+    "fullUrl" : "Organization/1674521442321102000.7b884ec2-4568-43c1-a940-2c26466900fe",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055410283000.ca5ad829-fc78-4a4e-a761-88b2774d8db9",
+      "id" : "1674521442321102000.7b884ec2-4568-43c1-a940-2c26466900fe",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1748,10 +1748,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055424013000.dd032d26-06af-4208-af8d-1dde34ffd0cb",
+    "fullUrl" : "Observation/1674521442334602000.31f281b0-a252-45e4-9fa4-0ec6ef5b8d59",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055424013000.dd032d26-06af-4208-af8d-1dde34ffd0cb",
+      "id" : "1674521442334602000.31f281b0-a252-45e4-9fa4-0ec6ef5b8d59",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1768,7 +1768,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055423918000.e16a12bc-0b49-46b2-8141-eedd6b379831"
+          "reference" : "Organization/1674521442334505000.9ba0d378-9923-4988-ab55-fddbb2e74c95"
         }
       } ],
       "identifier" : [ {
@@ -1791,23 +1791,23 @@
         "text" : "BLOOD CULTURE GRAM STAIN"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055422871000.e0f8d6d6-b3de-4992-aa37-b2d008453f32"
+        "reference" : "PractitionerRole/1674521442333289000.80264a0a-aff2-4c84-9a5f-d110fa588b06"
       } ],
       "valueString" : "ANAEROBIC BOTTLE"
     }
   }, {
-    "fullUrl" : "Location/1674153055419405000.fc6f4d66-d5bb-4c16-a76b-bb71f38ed7ae",
+    "fullUrl" : "Location/1674521442330822000.91599557-5357-49f7-9203-44c6e141c170",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055419405000.fc6f4d66-d5bb-4c16-a76b-bb71f38ed7ae",
+      "id" : "1674521442330822000.91599557-5357-49f7-9203-44c6e141c170",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1821,10 +1821,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055419780000.a5740fb8-e9ef-4daf-a339-3f06d654e0d7",
+    "fullUrl" : "Practitioner/1674521442331234000.ddd38872-7fdc-4616-8dbc-1107580d8e2e",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055419780000.a5740fb8-e9ef-4daf-a339-3f06d654e0d7",
+      "id" : "1674521442331234000.ddd38872-7fdc-4616-8dbc-1107580d8e2e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1846,7 +1846,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055419405000.fc6f4d66-d5bb-4c16-a76b-bb71f38ed7ae"
+          "reference" : "Location/1674521442330822000.91599557-5357-49f7-9203-44c6e141c170"
         }
       } ],
       "identifier" : [ {
@@ -1873,10 +1873,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055422785000.b5d28c26-daea-4b3d-8588-3af216ad3ec0",
+    "fullUrl" : "Organization/1674521442333178000.a560daa0-6912-4faa-b7a2-6fe1333409e6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055422785000.b5d28c26-daea-4b3d-8588-3af216ad3ec0",
+      "id" : "1674521442333178000.a560daa0-6912-4faa-b7a2-6fe1333409e6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1922,10 +1922,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055422871000.e0f8d6d6-b3de-4992-aa37-b2d008453f32",
+    "fullUrl" : "PractitionerRole/1674521442333289000.80264a0a-aff2-4c84-9a5f-d110fa588b06",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055422871000.e0f8d6d6-b3de-4992-aa37-b2d008453f32",
+      "id" : "1674521442333289000.80264a0a-aff2-4c84-9a5f-d110fa588b06",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1937,10 +1937,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055419780000.a5740fb8-e9ef-4daf-a339-3f06d654e0d7"
+        "reference" : "Practitioner/1674521442331234000.ddd38872-7fdc-4616-8dbc-1107580d8e2e"
       },
       "organization" : {
-        "reference" : "Organization/1674153055422785000.b5d28c26-daea-4b3d-8588-3af216ad3ec0"
+        "reference" : "Organization/1674521442333178000.a560daa0-6912-4faa-b7a2-6fe1333409e6"
       },
       "code" : [ {
         "coding" : [ {
@@ -1950,10 +1950,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055423918000.e16a12bc-0b49-46b2-8141-eedd6b379831",
+    "fullUrl" : "Organization/1674521442334505000.9ba0d378-9923-4988-ab55-fddbb2e74c95",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055423918000.e16a12bc-0b49-46b2-8141-eedd6b379831",
+      "id" : "1674521442334505000.9ba0d378-9923-4988-ab55-fddbb2e74c95",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1979,10 +1979,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055428606000.e7a95a1c-d5db-4881-b933-35f9b3d50f14",
+    "fullUrl" : "Observation/1674521442339746000.7f7f2e53-3ba4-4479-97da-43662b525531",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055428606000.e7a95a1c-d5db-4881-b933-35f9b3d50f14",
+      "id" : "1674521442339746000.7f7f2e53-3ba4-4479-97da-43662b525531",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1999,7 +1999,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055428486000.16015377-16e0-4583-960b-17b0702d1688"
+          "reference" : "Organization/1674521442339646000.3a62325a-0e70-41fd-a3f1-94eaad7636a8"
         }
       } ],
       "identifier" : [ {
@@ -2022,15 +2022,15 @@
         "text" : "BLOOD CULTURE GRAM STAIN"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055427291000.633749a8-ebcb-4517-9ec1-99cafe927bdb"
+        "reference" : "PractitionerRole/1674521442338576000.8385f3dc-dc4f-47c0-814a-9603ba3e58dd"
       } ],
       "valueString" : "YEAST",
       "interpretation" : [ {
@@ -2042,10 +2042,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055425278000.c08330cb-17ee-46e3-a824-1ec325593497",
+    "fullUrl" : "Location/1674521442335982000.7ccd959a-7f0e-4576-82a1-19364a4a7ece",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055425278000.c08330cb-17ee-46e3-a824-1ec325593497",
+      "id" : "1674521442335982000.7ccd959a-7f0e-4576-82a1-19364a4a7ece",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2059,10 +2059,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055425598000.7e436fb7-b64d-4f93-a998-dc10c0062ed0",
+    "fullUrl" : "Practitioner/1674521442336323000.04c7e02c-78ab-4dea-9347-ad926d2dd8eb",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055425598000.7e436fb7-b64d-4f93-a998-dc10c0062ed0",
+      "id" : "1674521442336323000.04c7e02c-78ab-4dea-9347-ad926d2dd8eb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2084,7 +2084,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055425278000.c08330cb-17ee-46e3-a824-1ec325593497"
+          "reference" : "Location/1674521442335982000.7ccd959a-7f0e-4576-82a1-19364a4a7ece"
         }
       } ],
       "identifier" : [ {
@@ -2111,10 +2111,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055427207000.065951bc-be00-4d46-950a-ab17ed779b1d",
+    "fullUrl" : "Organization/1674521442338482000.577975c9-4ca0-4747-a990-3ecc0d503b94",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055427207000.065951bc-be00-4d46-950a-ab17ed779b1d",
+      "id" : "1674521442338482000.577975c9-4ca0-4747-a990-3ecc0d503b94",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2161,10 +2161,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055427291000.633749a8-ebcb-4517-9ec1-99cafe927bdb",
+    "fullUrl" : "PractitionerRole/1674521442338576000.8385f3dc-dc4f-47c0-814a-9603ba3e58dd",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055427291000.633749a8-ebcb-4517-9ec1-99cafe927bdb",
+      "id" : "1674521442338576000.8385f3dc-dc4f-47c0-814a-9603ba3e58dd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2176,10 +2176,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055425598000.7e436fb7-b64d-4f93-a998-dc10c0062ed0"
+        "reference" : "Practitioner/1674521442336323000.04c7e02c-78ab-4dea-9347-ad926d2dd8eb"
       },
       "organization" : {
-        "reference" : "Organization/1674153055427207000.065951bc-be00-4d46-950a-ab17ed779b1d"
+        "reference" : "Organization/1674521442338482000.577975c9-4ca0-4747-a990-3ecc0d503b94"
       },
       "code" : [ {
         "coding" : [ {
@@ -2189,10 +2189,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055428486000.16015377-16e0-4583-960b-17b0702d1688",
+    "fullUrl" : "Organization/1674521442339646000.3a62325a-0e70-41fd-a3f1-94eaad7636a8",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055428486000.16015377-16e0-4583-960b-17b0702d1688",
+      "id" : "1674521442339646000.3a62325a-0e70-41fd-a3f1-94eaad7636a8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2218,10 +2218,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055433142000.664e6dd7-53f4-4299-86fa-efd9d62e5c6f",
+    "fullUrl" : "Observation/1674521442344213000.ed2980fc-7e56-4e73-a8ad-4bb9be363d27",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055433142000.664e6dd7-53f4-4299-86fa-efd9d62e5c6f",
+      "id" : "1674521442344213000.ed2980fc-7e56-4e73-a8ad-4bb9be363d27",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2238,7 +2238,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055433069000.5df6de91-ff6c-477a-8e0f-996fa871346b"
+          "reference" : "Organization/1674521442344141000.b7ba23db-2765-47b0-b006-b0170b072ae3"
         }
       } ],
       "identifier" : [ {
@@ -2261,23 +2261,23 @@
         "text" : "BLOOD CULTURE GRAM STAIN"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055432081000.dcc81a8f-302f-4341-8e5a-f9dd769e5bca"
+        "reference" : "PractitionerRole/1674521442343120000.e3f16700-0436-46a4-9447-fad4261060a4"
       } ],
       "valueString" : "AEROBIC BOTTLE"
     }
   }, {
-    "fullUrl" : "Location/1674153055430026000.c190d5d5-0533-4f38-ac1d-6737d9328209",
+    "fullUrl" : "Location/1674521442341077000.ff4e8954-cf4a-4c45-9d33-a4211d07d890",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055430026000.c190d5d5-0533-4f38-ac1d-6737d9328209",
+      "id" : "1674521442341077000.ff4e8954-cf4a-4c45-9d33-a4211d07d890",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2291,10 +2291,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055430382000.f2317d29-dc51-4b72-98d9-a44bbce5aa51",
+    "fullUrl" : "Practitioner/1674521442341454000.265bdbbf-af79-4f8e-8330-f030341f9791",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055430382000.f2317d29-dc51-4b72-98d9-a44bbce5aa51",
+      "id" : "1674521442341454000.265bdbbf-af79-4f8e-8330-f030341f9791",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2316,7 +2316,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055430026000.c190d5d5-0533-4f38-ac1d-6737d9328209"
+          "reference" : "Location/1674521442341077000.ff4e8954-cf4a-4c45-9d33-a4211d07d890"
         }
       } ],
       "identifier" : [ {
@@ -2343,10 +2343,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055431995000.38fa49b2-20d4-4f88-a058-7021fb4537b8",
+    "fullUrl" : "Organization/1674521442343044000.6673641e-dbcb-4325-9362-debe26de160a",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055431995000.38fa49b2-20d4-4f88-a058-7021fb4537b8",
+      "id" : "1674521442343044000.6673641e-dbcb-4325-9362-debe26de160a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2392,10 +2392,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055432081000.dcc81a8f-302f-4341-8e5a-f9dd769e5bca",
+    "fullUrl" : "PractitionerRole/1674521442343120000.e3f16700-0436-46a4-9447-fad4261060a4",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055432081000.dcc81a8f-302f-4341-8e5a-f9dd769e5bca",
+      "id" : "1674521442343120000.e3f16700-0436-46a4-9447-fad4261060a4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2407,10 +2407,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055430382000.f2317d29-dc51-4b72-98d9-a44bbce5aa51"
+        "reference" : "Practitioner/1674521442341454000.265bdbbf-af79-4f8e-8330-f030341f9791"
       },
       "organization" : {
-        "reference" : "Organization/1674153055431995000.38fa49b2-20d4-4f88-a058-7021fb4537b8"
+        "reference" : "Organization/1674521442343044000.6673641e-dbcb-4325-9362-debe26de160a"
       },
       "code" : [ {
         "coding" : [ {
@@ -2420,10 +2420,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055433069000.5df6de91-ff6c-477a-8e0f-996fa871346b",
+    "fullUrl" : "Organization/1674521442344141000.b7ba23db-2765-47b0-b006-b0170b072ae3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055433069000.5df6de91-ff6c-477a-8e0f-996fa871346b",
+      "id" : "1674521442344141000.b7ba23db-2765-47b0-b006-b0170b072ae3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2449,10 +2449,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055437434000.6259904d-d13a-4616-8f85-590f9c5fdc34",
+    "fullUrl" : "Observation/1674521442348731000.2c23112a-4b03-4e0a-b2d6-142e137691f6",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055437434000.6259904d-d13a-4616-8f85-590f9c5fdc34",
+      "id" : "1674521442348731000.2c23112a-4b03-4e0a-b2d6-142e137691f6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2466,7 +2466,7 @@
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055437339000.3c5465eb-f981-485a-92ce-03bfc57fcd08"
+          "reference" : "Organization/1674521442348636000.8f9c4261-830a-4455-9e33-58dce159fc21"
         }
       } ],
       "identifier" : [ {
@@ -2500,15 +2500,15 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-10T06:25:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055436258000.652e82d5-51e8-4b60-9b38-abda3334d831"
+        "reference" : "PractitionerRole/1674521442347415000.a4eacdf6-84c4-4878-bb9f-ac6c72020c31"
       } ],
       "valueCodeableConcept" : {
         "coding" : [ {
@@ -2551,10 +2551,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055434393000.266ea13c-ecd2-40be-9510-40ff9460fbfb",
+    "fullUrl" : "Location/1674521442345432000.f27c65ed-5fd9-43ea-877c-1c06ab41ce12",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055434393000.266ea13c-ecd2-40be-9510-40ff9460fbfb",
+      "id" : "1674521442345432000.f27c65ed-5fd9-43ea-877c-1c06ab41ce12",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2568,10 +2568,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055434716000.2d853e6b-ca5c-45d7-afca-f53a3ab1b987",
+    "fullUrl" : "Practitioner/1674521442345772000.641d2097-84ff-4fe6-9e01-709731894fa1",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055434716000.2d853e6b-ca5c-45d7-afca-f53a3ab1b987",
+      "id" : "1674521442345772000.641d2097-84ff-4fe6-9e01-709731894fa1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2593,7 +2593,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055434393000.266ea13c-ecd2-40be-9510-40ff9460fbfb"
+          "reference" : "Location/1674521442345432000.f27c65ed-5fd9-43ea-877c-1c06ab41ce12"
         }
       } ],
       "identifier" : [ {
@@ -2620,10 +2620,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055436182000.1d19054d-3790-49bf-b430-1893a02bedd7",
+    "fullUrl" : "Organization/1674521442347328000.00fd1cd3-5672-4913-b06f-2a608722b4d8",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055436182000.1d19054d-3790-49bf-b430-1893a02bedd7",
+      "id" : "1674521442347328000.00fd1cd3-5672-4913-b06f-2a608722b4d8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2670,10 +2670,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055436258000.652e82d5-51e8-4b60-9b38-abda3334d831",
+    "fullUrl" : "PractitionerRole/1674521442347415000.a4eacdf6-84c4-4878-bb9f-ac6c72020c31",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055436258000.652e82d5-51e8-4b60-9b38-abda3334d831",
+      "id" : "1674521442347415000.a4eacdf6-84c4-4878-bb9f-ac6c72020c31",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2685,10 +2685,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055434716000.2d853e6b-ca5c-45d7-afca-f53a3ab1b987"
+        "reference" : "Practitioner/1674521442345772000.641d2097-84ff-4fe6-9e01-709731894fa1"
       },
       "organization" : {
-        "reference" : "Organization/1674153055436182000.1d19054d-3790-49bf-b430-1893a02bedd7"
+        "reference" : "Organization/1674521442347328000.00fd1cd3-5672-4913-b06f-2a608722b4d8"
       },
       "code" : [ {
         "coding" : [ {
@@ -2698,10 +2698,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055437339000.3c5465eb-f981-485a-92ce-03bfc57fcd08",
+    "fullUrl" : "Organization/1674521442348636000.8f9c4261-830a-4455-9e33-58dce159fc21",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055437339000.3c5465eb-f981-485a-92ce-03bfc57fcd08",
+      "id" : "1674521442348636000.8f9c4261-830a-4455-9e33-58dce159fc21",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2727,10 +2727,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055442152000.fece5601-966d-4d09-9117-a1d227513017",
+    "fullUrl" : "Observation/1674521442354051000.ceb88f47-6c16-47cc-98e9-55242d14fcf2",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055442152000.fece5601-966d-4d09-9117-a1d227513017",
+      "id" : "1674521442354051000.ceb88f47-6c16-47cc-98e9-55242d14fcf2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2747,7 +2747,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055442065000.14f26645-f6f3-4d00-b5ef-0ef825b03271"
+          "reference" : "Organization/1674521442353939000.035737d5-6d23-4668-ae8e-c0454abec148"
         }
       } ],
       "identifier" : [ {
@@ -2781,15 +2781,15 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-02T02:52:01-06:00",
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055440954000.f3020d1c-e4b0-457e-94c7-80837241f038"
+        "reference" : "PractitionerRole/1674521442352636000.de9cdcc4-0353-470d-816b-4665e25cd90d"
       } ],
       "valueCodeableConcept" : {
         "coding" : [ {
@@ -2799,10 +2799,10 @@
       }
     }
   }, {
-    "fullUrl" : "Location/1674153055438841000.19b72c27-ea97-4187-b408-a2d7cb9b6fa8",
+    "fullUrl" : "Location/1674521442350386000.72d6a97e-4fba-46bc-ab91-f982e9d7c6a5",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055438841000.19b72c27-ea97-4187-b408-a2d7cb9b6fa8",
+      "id" : "1674521442350386000.72d6a97e-4fba-46bc-ab91-f982e9d7c6a5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2816,10 +2816,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055439147000.5d3b3a8d-d279-438d-bd10-52f029801fc1",
+    "fullUrl" : "Practitioner/1674521442350715000.ed9583c8-82d7-42cd-8699-e3577d5c5626",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055439147000.5d3b3a8d-d279-438d-bd10-52f029801fc1",
+      "id" : "1674521442350715000.ed9583c8-82d7-42cd-8699-e3577d5c5626",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2841,7 +2841,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055438841000.19b72c27-ea97-4187-b408-a2d7cb9b6fa8"
+          "reference" : "Location/1674521442350386000.72d6a97e-4fba-46bc-ab91-f982e9d7c6a5"
         }
       } ],
       "identifier" : [ {
@@ -2868,10 +2868,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055440884000.44b98ddb-877f-4034-88aa-c80fa760f63a",
+    "fullUrl" : "Organization/1674521442352544000.b4fc27c5-4129-4603-9d08-175716a08bf0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055440884000.44b98ddb-877f-4034-88aa-c80fa760f63a",
+      "id" : "1674521442352544000.b4fc27c5-4129-4603-9d08-175716a08bf0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2918,10 +2918,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055440954000.f3020d1c-e4b0-457e-94c7-80837241f038",
+    "fullUrl" : "PractitionerRole/1674521442352636000.de9cdcc4-0353-470d-816b-4665e25cd90d",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055440954000.f3020d1c-e4b0-457e-94c7-80837241f038",
+      "id" : "1674521442352636000.de9cdcc4-0353-470d-816b-4665e25cd90d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2933,10 +2933,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055439147000.5d3b3a8d-d279-438d-bd10-52f029801fc1"
+        "reference" : "Practitioner/1674521442350715000.ed9583c8-82d7-42cd-8699-e3577d5c5626"
       },
       "organization" : {
-        "reference" : "Organization/1674153055440884000.44b98ddb-877f-4034-88aa-c80fa760f63a"
+        "reference" : "Organization/1674521442352544000.b4fc27c5-4129-4603-9d08-175716a08bf0"
       },
       "code" : [ {
         "coding" : [ {
@@ -2946,10 +2946,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055442065000.14f26645-f6f3-4d00-b5ef-0ef825b03271",
+    "fullUrl" : "Organization/1674521442353939000.035737d5-6d23-4668-ae8e-c0454abec148",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055442065000.14f26645-f6f3-4d00-b5ef-0ef825b03271",
+      "id" : "1674521442353939000.035737d5-6d23-4668-ae8e-c0454abec148",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2975,10 +2975,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055446120000.7857bf13-d550-4b07-b14b-80573a1ca1c6",
+    "fullUrl" : "Observation/1674521442358726000.729783aa-a66a-4bec-b668-c10b32187427",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055446120000.7857bf13-d550-4b07-b14b-80573a1ca1c6",
+      "id" : "1674521442358726000.729783aa-a66a-4bec-b668-c10b32187427",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2995,7 +2995,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055446038000.b114e27e-d3c9-4b92-9496-8aed341221cd"
+          "reference" : "Organization/1674521442358624000.3dbcd6bb-e339-4cae-967f-20039635fff6"
         }
       } ],
       "identifier" : [ {
@@ -3029,22 +3029,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055445138000.338e6e34-7ebd-4a35-8ed7-02d444181e9d"
+        "reference" : "PractitionerRole/1674521442357570000.6a817433-d3cb-4824-925f-17ec39e11198"
       } ],
       "valueString" : "This is a rapid molecular assay that simultaneously detects"
     }
   }, {
-    "fullUrl" : "Location/1674153055443315000.c074fe32-0701-47b6-912c-ba2f24372c92",
+    "fullUrl" : "Location/1674521442355434000.6d9718de-e942-4cf8-846f-2c2fa6065356",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055443315000.c074fe32-0701-47b6-912c-ba2f24372c92",
+      "id" : "1674521442355434000.6d9718de-e942-4cf8-846f-2c2fa6065356",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3058,10 +3058,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055443611000.9acd3535-4950-43e2-95a3-5207ff2d5529",
+    "fullUrl" : "Practitioner/1674521442355789000.f9d7d970-5cd8-4ce4-a808-254c6ebae16a",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055443611000.9acd3535-4950-43e2-95a3-5207ff2d5529",
+      "id" : "1674521442355789000.f9d7d970-5cd8-4ce4-a808-254c6ebae16a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3083,7 +3083,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055443315000.c074fe32-0701-47b6-912c-ba2f24372c92"
+          "reference" : "Location/1674521442355434000.6d9718de-e942-4cf8-846f-2c2fa6065356"
         }
       } ],
       "identifier" : [ {
@@ -3110,10 +3110,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055445064000.5f01c099-197e-4ec9-8931-7559d63ce6aa",
+    "fullUrl" : "Organization/1674521442357479000.20c71ee1-47ab-460a-987b-941940c2b5ee",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055445064000.5f01c099-197e-4ec9-8931-7559d63ce6aa",
+      "id" : "1674521442357479000.20c71ee1-47ab-460a-987b-941940c2b5ee",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3160,10 +3160,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055445138000.338e6e34-7ebd-4a35-8ed7-02d444181e9d",
+    "fullUrl" : "PractitionerRole/1674521442357570000.6a817433-d3cb-4824-925f-17ec39e11198",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055445138000.338e6e34-7ebd-4a35-8ed7-02d444181e9d",
+      "id" : "1674521442357570000.6a817433-d3cb-4824-925f-17ec39e11198",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3175,10 +3175,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055443611000.9acd3535-4950-43e2-95a3-5207ff2d5529"
+        "reference" : "Practitioner/1674521442355789000.f9d7d970-5cd8-4ce4-a808-254c6ebae16a"
       },
       "organization" : {
-        "reference" : "Organization/1674153055445064000.5f01c099-197e-4ec9-8931-7559d63ce6aa"
+        "reference" : "Organization/1674521442357479000.20c71ee1-47ab-460a-987b-941940c2b5ee"
       },
       "code" : [ {
         "coding" : [ {
@@ -3188,10 +3188,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055446038000.b114e27e-d3c9-4b92-9496-8aed341221cd",
+    "fullUrl" : "Organization/1674521442358624000.3dbcd6bb-e339-4cae-967f-20039635fff6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055446038000.b114e27e-d3c9-4b92-9496-8aed341221cd",
+      "id" : "1674521442358624000.3dbcd6bb-e339-4cae-967f-20039635fff6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3217,10 +3217,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055450337000.ec93c53b-6cca-403c-b9b0-b96b5e82a6ca",
+    "fullUrl" : "Observation/1674521442363389000.cf384af6-a589-40ad-a25e-b443db1da19a",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055450337000.ec93c53b-6cca-403c-b9b0-b96b5e82a6ca",
+      "id" : "1674521442363389000.cf384af6-a589-40ad-a25e-b443db1da19a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3237,7 +3237,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055450243000.c9975b73-9e5d-4de4-8bcd-f92c15a0df63"
+          "reference" : "Organization/1674521442363288000.e53e4150-0e5f-4b05-b197-8ad21d57f314"
         }
       } ],
       "identifier" : [ {
@@ -3271,22 +3271,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055449261000.c5bacfe4-6295-4bac-aea1-2f2a4ed7e000"
+        "reference" : "PractitionerRole/1674521442362233000.b109f376-aa39-4884-b612-dd56ae29c3b7"
       } ],
       "valueString" : "and identifies the following gram-positive organisms:"
     }
   }, {
-    "fullUrl" : "Location/1674153055447165000.430e32f9-57a5-4f54-ac08-c263ee9ce27d",
+    "fullUrl" : "Location/1674521442360032000.dfb78b7d-2ee3-443c-aa43-0e0453c8bfa2",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055447165000.430e32f9-57a5-4f54-ac08-c263ee9ce27d",
+      "id" : "1674521442360032000.dfb78b7d-2ee3-443c-aa43-0e0453c8bfa2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3300,10 +3300,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055447441000.2f08bd47-e07f-4cbc-9ba9-4a8f1e815db8",
+    "fullUrl" : "Practitioner/1674521442360354000.00c968ed-4f6b-4631-aef5-c4e4e0204373",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055447441000.2f08bd47-e07f-4cbc-9ba9-4a8f1e815db8",
+      "id" : "1674521442360354000.00c968ed-4f6b-4631-aef5-c4e4e0204373",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3325,7 +3325,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055447165000.430e32f9-57a5-4f54-ac08-c263ee9ce27d"
+          "reference" : "Location/1674521442360032000.dfb78b7d-2ee3-443c-aa43-0e0453c8bfa2"
         }
       } ],
       "identifier" : [ {
@@ -3352,10 +3352,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055449170000.7f1a8618-2c33-4690-8b09-b2714d33013d",
+    "fullUrl" : "Organization/1674521442362124000.ef471ee5-64ff-46be-aefb-20ab6a34e3b3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055449170000.7f1a8618-2c33-4690-8b09-b2714d33013d",
+      "id" : "1674521442362124000.ef471ee5-64ff-46be-aefb-20ab6a34e3b3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3402,10 +3402,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055449261000.c5bacfe4-6295-4bac-aea1-2f2a4ed7e000",
+    "fullUrl" : "PractitionerRole/1674521442362233000.b109f376-aa39-4884-b612-dd56ae29c3b7",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055449261000.c5bacfe4-6295-4bac-aea1-2f2a4ed7e000",
+      "id" : "1674521442362233000.b109f376-aa39-4884-b612-dd56ae29c3b7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3417,10 +3417,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055447441000.2f08bd47-e07f-4cbc-9ba9-4a8f1e815db8"
+        "reference" : "Practitioner/1674521442360354000.00c968ed-4f6b-4631-aef5-c4e4e0204373"
       },
       "organization" : {
-        "reference" : "Organization/1674153055449170000.7f1a8618-2c33-4690-8b09-b2714d33013d"
+        "reference" : "Organization/1674521442362124000.ef471ee5-64ff-46be-aefb-20ab6a34e3b3"
       },
       "code" : [ {
         "coding" : [ {
@@ -3430,10 +3430,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055450243000.c9975b73-9e5d-4de4-8bcd-f92c15a0df63",
+    "fullUrl" : "Organization/1674521442363288000.e53e4150-0e5f-4b05-b197-8ad21d57f314",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055450243000.c9975b73-9e5d-4de4-8bcd-f92c15a0df63",
+      "id" : "1674521442363288000.e53e4150-0e5f-4b05-b197-8ad21d57f314",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3459,10 +3459,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055454207000.feec4b3c-4f51-4e9c-83c3-8594dac4b096",
+    "fullUrl" : "Observation/1674521442368213000.5e5977f0-5437-40e1-9edd-afc2b013b69c",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055454207000.feec4b3c-4f51-4e9c-83c3-8594dac4b096",
+      "id" : "1674521442368213000.5e5977f0-5437-40e1-9edd-afc2b013b69c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3479,7 +3479,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055454142000.e7854ff8-5c01-40c0-b350-7aa1b4b22526"
+          "reference" : "Organization/1674521442368138000.60f73aec-e938-4175-b60e-5826341a7bd0"
         }
       } ],
       "identifier" : [ {
@@ -3513,21 +3513,21 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055453265000.7a9d1209-f2fa-4fc5-8223-0669a67bb04f"
+        "reference" : "PractitionerRole/1674521442367073000.46417227-29b9-4453-9540-12b2cfed3326"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055451395000.e7658e52-779b-4868-8440-1fa0500a17cc",
+    "fullUrl" : "Location/1674521442364624000.e54b56ec-bbe9-4ddc-bd3c-529c9dbbfd8e",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055451395000.e7658e52-779b-4868-8440-1fa0500a17cc",
+      "id" : "1674521442364624000.e54b56ec-bbe9-4ddc-bd3c-529c9dbbfd8e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3541,10 +3541,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055451696000.d740dade-fc2a-4338-89c2-d6f7634f9236",
+    "fullUrl" : "Practitioner/1674521442365166000.b6116db4-4a36-483f-99b9-be486e06481f",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055451696000.d740dade-fc2a-4338-89c2-d6f7634f9236",
+      "id" : "1674521442365166000.b6116db4-4a36-483f-99b9-be486e06481f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3566,7 +3566,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055451395000.e7658e52-779b-4868-8440-1fa0500a17cc"
+          "reference" : "Location/1674521442364624000.e54b56ec-bbe9-4ddc-bd3c-529c9dbbfd8e"
         }
       } ],
       "identifier" : [ {
@@ -3593,10 +3593,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055453192000.41c157e6-1e67-4818-9909-d2472b0824fd",
+    "fullUrl" : "Organization/1674521442366965000.7bb74e7c-5137-42dd-a181-378c75c6076e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055453192000.41c157e6-1e67-4818-9909-d2472b0824fd",
+      "id" : "1674521442366965000.7bb74e7c-5137-42dd-a181-378c75c6076e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3643,10 +3643,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055453265000.7a9d1209-f2fa-4fc5-8223-0669a67bb04f",
+    "fullUrl" : "PractitionerRole/1674521442367073000.46417227-29b9-4453-9540-12b2cfed3326",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055453265000.7a9d1209-f2fa-4fc5-8223-0669a67bb04f",
+      "id" : "1674521442367073000.46417227-29b9-4453-9540-12b2cfed3326",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3658,10 +3658,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055451696000.d740dade-fc2a-4338-89c2-d6f7634f9236"
+        "reference" : "Practitioner/1674521442365166000.b6116db4-4a36-483f-99b9-be486e06481f"
       },
       "organization" : {
-        "reference" : "Organization/1674153055453192000.41c157e6-1e67-4818-9909-d2472b0824fd"
+        "reference" : "Organization/1674521442366965000.7bb74e7c-5137-42dd-a181-378c75c6076e"
       },
       "code" : [ {
         "coding" : [ {
@@ -3671,10 +3671,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055454142000.e7854ff8-5c01-40c0-b350-7aa1b4b22526",
+    "fullUrl" : "Organization/1674521442368138000.60f73aec-e938-4175-b60e-5826341a7bd0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055454142000.e7854ff8-5c01-40c0-b350-7aa1b4b22526",
+      "id" : "1674521442368138000.60f73aec-e938-4175-b60e-5826341a7bd0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3700,10 +3700,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055462767000.6666e633-161c-4f4d-b665-776db8238419",
+    "fullUrl" : "Observation/1674521442372476000.dfe5e47b-b49e-4e05-a2bb-fcc7ff6776e9",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055462767000.6666e633-161c-4f4d-b665-776db8238419",
+      "id" : "1674521442372476000.dfe5e47b-b49e-4e05-a2bb-fcc7ff6776e9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3720,7 +3720,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055462662000.195ac5f1-ae2a-4ce7-a904-ad009f2e3b4c"
+          "reference" : "Organization/1674521442372393000.320cae2b-b7dc-41d2-a88b-ba25c20d0042"
         }
       } ],
       "identifier" : [ {
@@ -3754,22 +3754,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055456918000.f7b4c566-7913-46ac-a08c-8ff09b7b111a"
+        "reference" : "PractitionerRole/1674521442371413000.d154bedf-31a1-4790-8bcc-981885873e26"
       } ],
       "valueString" : "Staphylococcus spp.          Streptococcus pyogenes"
     }
   }, {
-    "fullUrl" : "Location/1674153055455225000.666fc2ba-2ce4-4954-b398-0f14e46083f6",
+    "fullUrl" : "Location/1674521442369404000.2e92ad95-3c12-4f90-a4fa-b978acecb9f0",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055455225000.666fc2ba-2ce4-4954-b398-0f14e46083f6",
+      "id" : "1674521442369404000.2e92ad95-3c12-4f90-a4fa-b978acecb9f0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3783,10 +3783,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055455512000.017d1a2d-1a30-47ae-beb8-c9d40c53c4c8",
+    "fullUrl" : "Practitioner/1674521442369745000.53e9511a-0f52-477f-a5b1-87b432dc2956",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055455512000.017d1a2d-1a30-47ae-beb8-c9d40c53c4c8",
+      "id" : "1674521442369745000.53e9511a-0f52-477f-a5b1-87b432dc2956",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3808,7 +3808,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055455225000.666fc2ba-2ce4-4954-b398-0f14e46083f6"
+          "reference" : "Location/1674521442369404000.2e92ad95-3c12-4f90-a4fa-b978acecb9f0"
         }
       } ],
       "identifier" : [ {
@@ -3835,10 +3835,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055456848000.fe770915-6357-4e04-b993-8781150f81a3",
+    "fullUrl" : "Organization/1674521442371333000.2409c581-dfca-4df4-8724-b953706311c2",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055456848000.fe770915-6357-4e04-b993-8781150f81a3",
+      "id" : "1674521442371333000.2409c581-dfca-4df4-8724-b953706311c2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3885,10 +3885,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055456918000.f7b4c566-7913-46ac-a08c-8ff09b7b111a",
+    "fullUrl" : "PractitionerRole/1674521442371413000.d154bedf-31a1-4790-8bcc-981885873e26",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055456918000.f7b4c566-7913-46ac-a08c-8ff09b7b111a",
+      "id" : "1674521442371413000.d154bedf-31a1-4790-8bcc-981885873e26",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3900,10 +3900,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055455512000.017d1a2d-1a30-47ae-beb8-c9d40c53c4c8"
+        "reference" : "Practitioner/1674521442369745000.53e9511a-0f52-477f-a5b1-87b432dc2956"
       },
       "organization" : {
-        "reference" : "Organization/1674153055456848000.fe770915-6357-4e04-b993-8781150f81a3"
+        "reference" : "Organization/1674521442371333000.2409c581-dfca-4df4-8724-b953706311c2"
       },
       "code" : [ {
         "coding" : [ {
@@ -3913,10 +3913,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055462662000.195ac5f1-ae2a-4ce7-a904-ad009f2e3b4c",
+    "fullUrl" : "Organization/1674521442372393000.320cae2b-b7dc-41d2-a88b-ba25c20d0042",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055462662000.195ac5f1-ae2a-4ce7-a904-ad009f2e3b4c",
+      "id" : "1674521442372393000.320cae2b-b7dc-41d2-a88b-ba25c20d0042",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3942,10 +3942,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055466570000.1aa299df-54c0-4a33-8a11-6296e0443246",
+    "fullUrl" : "Observation/1674521442377417000.0d02c53b-b905-4c3b-a6a1-440767395b22",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055466570000.1aa299df-54c0-4a33-8a11-6296e0443246",
+      "id" : "1674521442377417000.0d02c53b-b905-4c3b-a6a1-440767395b22",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3962,7 +3962,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055466489000.026df24d-fc0f-4275-b058-87f184cf4848"
+          "reference" : "Organization/1674521442377319000.c6fdf6db-723c-4070-9d47-4c5330a383be"
         }
       } ],
       "identifier" : [ {
@@ -3996,22 +3996,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055465628000.12daa67b-89ee-4d69-b7b4-b1ce453d8cbb"
+        "reference" : "PractitionerRole/1674521442376164000.188efb4c-0c6e-4f7a-a7b4-69db899402f1"
       } ],
       "valueString" : "Staphylococcus aureus        Streptococcus agalactiae"
     }
   }, {
-    "fullUrl" : "Location/1674153055463862000.82e3f797-478d-45a2-b9ec-24b9b2b1513a",
+    "fullUrl" : "Location/1674521442373783000.a2c15930-311e-4efd-b420-0b4fef2725f0",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055463862000.82e3f797-478d-45a2-b9ec-24b9b2b1513a",
+      "id" : "1674521442373783000.a2c15930-311e-4efd-b420-0b4fef2725f0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4025,10 +4025,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055464146000.b2827749-1a31-4ff3-ab7f-f5f674af2dd4",
+    "fullUrl" : "Practitioner/1674521442374123000.72a5d51d-122d-4f36-9154-d146daacdf00",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055464146000.b2827749-1a31-4ff3-ab7f-f5f674af2dd4",
+      "id" : "1674521442374123000.72a5d51d-122d-4f36-9154-d146daacdf00",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4050,7 +4050,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055463862000.82e3f797-478d-45a2-b9ec-24b9b2b1513a"
+          "reference" : "Location/1674521442373783000.a2c15930-311e-4efd-b420-0b4fef2725f0"
         }
       } ],
       "identifier" : [ {
@@ -4077,10 +4077,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055465571000.d2e2dabd-8bd0-4208-ab89-b300b04a480b",
+    "fullUrl" : "Organization/1674521442376082000.3ada7a2b-edb7-48a0-a2cc-b31dd4e78f47",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055465571000.d2e2dabd-8bd0-4208-ab89-b300b04a480b",
+      "id" : "1674521442376082000.3ada7a2b-edb7-48a0-a2cc-b31dd4e78f47",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4127,10 +4127,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055465628000.12daa67b-89ee-4d69-b7b4-b1ce453d8cbb",
+    "fullUrl" : "PractitionerRole/1674521442376164000.188efb4c-0c6e-4f7a-a7b4-69db899402f1",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055465628000.12daa67b-89ee-4d69-b7b4-b1ce453d8cbb",
+      "id" : "1674521442376164000.188efb4c-0c6e-4f7a-a7b4-69db899402f1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4142,10 +4142,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055464146000.b2827749-1a31-4ff3-ab7f-f5f674af2dd4"
+        "reference" : "Practitioner/1674521442374123000.72a5d51d-122d-4f36-9154-d146daacdf00"
       },
       "organization" : {
-        "reference" : "Organization/1674153055465571000.d2e2dabd-8bd0-4208-ab89-b300b04a480b"
+        "reference" : "Organization/1674521442376082000.3ada7a2b-edb7-48a0-a2cc-b31dd4e78f47"
       },
       "code" : [ {
         "coding" : [ {
@@ -4155,10 +4155,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055466489000.026df24d-fc0f-4275-b058-87f184cf4848",
+    "fullUrl" : "Organization/1674521442377319000.c6fdf6db-723c-4070-9d47-4c5330a383be",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055466489000.026df24d-fc0f-4275-b058-87f184cf4848",
+      "id" : "1674521442377319000.c6fdf6db-723c-4070-9d47-4c5330a383be",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4184,10 +4184,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055470141000.d1e9ed89-2bcb-42c7-a2c4-54d78e4c9bce",
+    "fullUrl" : "Observation/1674521442382406000.21caba7b-06d4-4bc8-ab1d-9d3137d34ea4",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055470141000.d1e9ed89-2bcb-42c7-a2c4-54d78e4c9bce",
+      "id" : "1674521442382406000.21caba7b-06d4-4bc8-ab1d-9d3137d34ea4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4204,7 +4204,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055470068000.87856a0e-d138-43a8-a871-61c0d2ebeb96"
+          "reference" : "Organization/1674521442382327000.52c44879-8038-4ce4-bfc6-53ff50f0c86b"
         }
       } ],
       "identifier" : [ {
@@ -4238,22 +4238,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055469220000.a3a9799a-feab-4808-9b19-71efdb463d8c"
+        "reference" : "PractitionerRole/1674521442381382000.d27ea574-f799-447d-8914-fd5ace94e7f1"
       } ],
       "valueString" : "Staphylococcus epidermidis   Streptococcus anginosus group"
     }
   }, {
-    "fullUrl" : "Location/1674153055467580000.bdec461b-27e7-4877-99df-e94d6b30616e",
+    "fullUrl" : "Location/1674521442379503000.31ed4715-d22b-47a5-9b4a-7e52f2778eb7",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055467580000.bdec461b-27e7-4877-99df-e94d6b30616e",
+      "id" : "1674521442379503000.31ed4715-d22b-47a5-9b4a-7e52f2778eb7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4267,10 +4267,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055467858000.a7f08fe4-d231-4411-b592-e881a0992b1e",
+    "fullUrl" : "Practitioner/1674521442379843000.748eafeb-ef54-46d3-a619-5e149f7bd8e3",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055467858000.a7f08fe4-d231-4411-b592-e881a0992b1e",
+      "id" : "1674521442379843000.748eafeb-ef54-46d3-a619-5e149f7bd8e3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4292,7 +4292,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055467580000.bdec461b-27e7-4877-99df-e94d6b30616e"
+          "reference" : "Location/1674521442379503000.31ed4715-d22b-47a5-9b4a-7e52f2778eb7"
         }
       } ],
       "identifier" : [ {
@@ -4319,10 +4319,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055469148000.dc7c5006-5974-4da5-b2f4-9db5fe39abd3",
+    "fullUrl" : "Organization/1674521442381310000.9668be80-92ad-4370-821a-e6c9203f4c1b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055469148000.dc7c5006-5974-4da5-b2f4-9db5fe39abd3",
+      "id" : "1674521442381310000.9668be80-92ad-4370-821a-e6c9203f4c1b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4369,10 +4369,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055469220000.a3a9799a-feab-4808-9b19-71efdb463d8c",
+    "fullUrl" : "PractitionerRole/1674521442381382000.d27ea574-f799-447d-8914-fd5ace94e7f1",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055469220000.a3a9799a-feab-4808-9b19-71efdb463d8c",
+      "id" : "1674521442381382000.d27ea574-f799-447d-8914-fd5ace94e7f1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4384,10 +4384,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055467858000.a7f08fe4-d231-4411-b592-e881a0992b1e"
+        "reference" : "Practitioner/1674521442379843000.748eafeb-ef54-46d3-a619-5e149f7bd8e3"
       },
       "organization" : {
-        "reference" : "Organization/1674153055469148000.dc7c5006-5974-4da5-b2f4-9db5fe39abd3"
+        "reference" : "Organization/1674521442381310000.9668be80-92ad-4370-821a-e6c9203f4c1b"
       },
       "code" : [ {
         "coding" : [ {
@@ -4397,10 +4397,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055470068000.87856a0e-d138-43a8-a871-61c0d2ebeb96",
+    "fullUrl" : "Organization/1674521442382327000.52c44879-8038-4ce4-bfc6-53ff50f0c86b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055470068000.87856a0e-d138-43a8-a871-61c0d2ebeb96",
+      "id" : "1674521442382327000.52c44879-8038-4ce4-bfc6-53ff50f0c86b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4426,10 +4426,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055473720000.65c6e4c3-3222-47d2-8ff7-df9adbba8cb4",
+    "fullUrl" : "Observation/1674521442386563000.e99e907b-0cb6-46b7-b21f-df4697d9fbf6",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055473720000.65c6e4c3-3222-47d2-8ff7-df9adbba8cb4",
+      "id" : "1674521442386563000.e99e907b-0cb6-46b7-b21f-df4697d9fbf6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4446,7 +4446,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055473649000.962b68d5-4624-4cdf-9f57-e35eb476ff72"
+          "reference" : "Organization/1674521442386478000.74b0da85-5110-44fc-af7c-d9dfa344b7be"
         }
       } ],
       "identifier" : [ {
@@ -4480,22 +4480,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055472815000.76818b97-7ba3-4c6f-a765-5424103a7483"
+        "reference" : "PractitionerRole/1674521442385461000.3b78cab9-df5a-4911-aba6-f21add8152af"
       } ],
       "valueString" : "Staphylococcus lugdunensis   Streptococcus faecalis"
     }
   }, {
-    "fullUrl" : "Location/1674153055471105000.eb5cb667-d028-4ee6-9e35-59b1742e4bc9",
+    "fullUrl" : "Location/1674521442383516000.3a555313-620e-4a2c-bd9f-1c6c9c28e6ea",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055471105000.eb5cb667-d028-4ee6-9e35-59b1742e4bc9",
+      "id" : "1674521442383516000.3a555313-620e-4a2c-bd9f-1c6c9c28e6ea",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4509,10 +4509,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055471373000.81e94c1a-f823-4506-8882-2ecb8495691b",
+    "fullUrl" : "Practitioner/1674521442383799000.7f90ad5c-6002-4ad1-81fa-926814e6dc48",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055471373000.81e94c1a-f823-4506-8882-2ecb8495691b",
+      "id" : "1674521442383799000.7f90ad5c-6002-4ad1-81fa-926814e6dc48",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4534,7 +4534,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055471105000.eb5cb667-d028-4ee6-9e35-59b1742e4bc9"
+          "reference" : "Location/1674521442383516000.3a555313-620e-4a2c-bd9f-1c6c9c28e6ea"
         }
       } ],
       "identifier" : [ {
@@ -4561,10 +4561,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055472724000.53dc846d-8588-4daa-865b-e5d16afdb731",
+    "fullUrl" : "Organization/1674521442385335000.0818ada4-9dba-4945-9520-0922b6e180aa",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055472724000.53dc846d-8588-4daa-865b-e5d16afdb731",
+      "id" : "1674521442385335000.0818ada4-9dba-4945-9520-0922b6e180aa",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4611,10 +4611,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055472815000.76818b97-7ba3-4c6f-a765-5424103a7483",
+    "fullUrl" : "PractitionerRole/1674521442385461000.3b78cab9-df5a-4911-aba6-f21add8152af",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055472815000.76818b97-7ba3-4c6f-a765-5424103a7483",
+      "id" : "1674521442385461000.3b78cab9-df5a-4911-aba6-f21add8152af",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4626,10 +4626,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055471373000.81e94c1a-f823-4506-8882-2ecb8495691b"
+        "reference" : "Practitioner/1674521442383799000.7f90ad5c-6002-4ad1-81fa-926814e6dc48"
       },
       "organization" : {
-        "reference" : "Organization/1674153055472724000.53dc846d-8588-4daa-865b-e5d16afdb731"
+        "reference" : "Organization/1674521442385335000.0818ada4-9dba-4945-9520-0922b6e180aa"
       },
       "code" : [ {
         "coding" : [ {
@@ -4639,10 +4639,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055473649000.962b68d5-4624-4cdf-9f57-e35eb476ff72",
+    "fullUrl" : "Organization/1674521442386478000.74b0da85-5110-44fc-af7c-d9dfa344b7be",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055473649000.962b68d5-4624-4cdf-9f57-e35eb476ff72",
+      "id" : "1674521442386478000.74b0da85-5110-44fc-af7c-d9dfa344b7be",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4668,10 +4668,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055477445000.9212d890-d2ff-44dc-b742-651809497e9c",
+    "fullUrl" : "Observation/1674521442391046000.4e2c6b59-6980-451d-a2a4-14bf19aaaf61",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055477445000.9212d890-d2ff-44dc-b742-651809497e9c",
+      "id" : "1674521442391046000.4e2c6b59-6980-451d-a2a4-14bf19aaaf61",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4688,7 +4688,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055477384000.9e7d66b6-1d37-480f-b241-8920af742563"
+          "reference" : "Organization/1674521442390971000.ab6f34c9-c09c-4552-8181-8000bc57c3dd"
         }
       } ],
       "identifier" : [ {
@@ -4722,22 +4722,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055476546000.7c74c04e-c266-40db-817b-71965fb3fef9"
+        "reference" : "PractitionerRole/1674521442390024000.02b43da0-9fa8-4c37-9e74-18b69cd731ee"
       } ],
       "valueString" : "Streptococcus spp.           Enterococcus faecium"
     }
   }, {
-    "fullUrl" : "Location/1674153055474663000.8ba8efda-7843-4c1b-9278-7175d282566c",
+    "fullUrl" : "Location/1674521442387749000.8e041fa1-817e-4880-9466-17e6a6aa16f2",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055474663000.8ba8efda-7843-4c1b-9278-7175d282566c",
+      "id" : "1674521442387749000.8e041fa1-817e-4880-9466-17e6a6aa16f2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4751,10 +4751,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055474955000.a0137c03-a024-4c40-be2f-996df36c8b65",
+    "fullUrl" : "Practitioner/1674521442388091000.db75edbd-8930-43a3-a34b-df561d082695",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055474955000.a0137c03-a024-4c40-be2f-996df36c8b65",
+      "id" : "1674521442388091000.db75edbd-8930-43a3-a34b-df561d082695",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4776,7 +4776,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055474663000.8ba8efda-7843-4c1b-9278-7175d282566c"
+          "reference" : "Location/1674521442387749000.8e041fa1-817e-4880-9466-17e6a6aa16f2"
         }
       } ],
       "identifier" : [ {
@@ -4803,10 +4803,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055476303000.89ffdaeb-c99d-4fdc-9e3c-1c241ea269e8",
+    "fullUrl" : "Organization/1674521442389938000.92ddce38-57d2-4f57-bcad-81fa0b05e7e8",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055476303000.89ffdaeb-c99d-4fdc-9e3c-1c241ea269e8",
+      "id" : "1674521442389938000.92ddce38-57d2-4f57-bcad-81fa0b05e7e8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4853,10 +4853,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055476546000.7c74c04e-c266-40db-817b-71965fb3fef9",
+    "fullUrl" : "PractitionerRole/1674521442390024000.02b43da0-9fa8-4c37-9e74-18b69cd731ee",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055476546000.7c74c04e-c266-40db-817b-71965fb3fef9",
+      "id" : "1674521442390024000.02b43da0-9fa8-4c37-9e74-18b69cd731ee",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4868,10 +4868,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055474955000.a0137c03-a024-4c40-be2f-996df36c8b65"
+        "reference" : "Practitioner/1674521442388091000.db75edbd-8930-43a3-a34b-df561d082695"
       },
       "organization" : {
-        "reference" : "Organization/1674153055476303000.89ffdaeb-c99d-4fdc-9e3c-1c241ea269e8"
+        "reference" : "Organization/1674521442389938000.92ddce38-57d2-4f57-bcad-81fa0b05e7e8"
       },
       "code" : [ {
         "coding" : [ {
@@ -4881,10 +4881,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055477384000.9e7d66b6-1d37-480f-b241-8920af742563",
+    "fullUrl" : "Organization/1674521442390971000.ab6f34c9-c09c-4552-8181-8000bc57c3dd",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055477384000.9e7d66b6-1d37-480f-b241-8920af742563",
+      "id" : "1674521442390971000.ab6f34c9-c09c-4552-8181-8000bc57c3dd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4910,10 +4910,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055480899000.5c5d1652-a4e3-4d60-98e7-765f5a8f6b77",
+    "fullUrl" : "Observation/1674521442395016000.1a1347a8-b27b-450a-9a6c-3293107cc222",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055480899000.5c5d1652-a4e3-4d60-98e7-765f5a8f6b77",
+      "id" : "1674521442395016000.1a1347a8-b27b-450a-9a6c-3293107cc222",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4930,7 +4930,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055480834000.958233bc-4822-4bd2-a9b8-c8f88ba6187b"
+          "reference" : "Organization/1674521442394943000.4963ad48-9840-47ce-a026-d5228a0a7d0a"
         }
       } ],
       "identifier" : [ {
@@ -4964,22 +4964,22 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "issued" : "2021-08-05T01:38:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055480033000.4633b3a1-3290-48ce-bb03-1a2a32782dd4"
+        "reference" : "PractitionerRole/1674521442394021000.33b45781-38b2-4c59-995b-892b7d792935"
       } ],
       "valueString" : "Streptococcus pneumoniae     "
     }
   }, {
-    "fullUrl" : "Location/1674153055478412000.63ef4b0c-f4c7-4957-b4cf-44704f6c747e",
+    "fullUrl" : "Location/1674521442392130000.212ebec4-d1de-47d4-bf7b-ad417b103f27",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055478412000.63ef4b0c-f4c7-4957-b4cf-44704f6c747e",
+      "id" : "1674521442392130000.212ebec4-d1de-47d4-bf7b-ad417b103f27",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4993,10 +4993,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055478678000.dcc770f7-bcf3-4594-b2b2-159c51d9e661",
+    "fullUrl" : "Practitioner/1674521442392440000.16369977-74f3-48cf-9aa3-72945cc68461",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055478678000.dcc770f7-bcf3-4594-b2b2-159c51d9e661",
+      "id" : "1674521442392440000.16369977-74f3-48cf-9aa3-72945cc68461",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5018,7 +5018,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055478412000.63ef4b0c-f4c7-4957-b4cf-44704f6c747e"
+          "reference" : "Location/1674521442392130000.212ebec4-d1de-47d4-bf7b-ad417b103f27"
         }
       } ],
       "identifier" : [ {
@@ -5045,10 +5045,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055479967000.dc3b7057-114f-40da-92e9-1fb4645ab64c",
+    "fullUrl" : "Organization/1674521442393952000.181d0871-fd82-4634-bcc7-3617f83d0aec",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055479967000.dc3b7057-114f-40da-92e9-1fb4645ab64c",
+      "id" : "1674521442393952000.181d0871-fd82-4634-bcc7-3617f83d0aec",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5095,10 +5095,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055480033000.4633b3a1-3290-48ce-bb03-1a2a32782dd4",
+    "fullUrl" : "PractitionerRole/1674521442394021000.33b45781-38b2-4c59-995b-892b7d792935",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055480033000.4633b3a1-3290-48ce-bb03-1a2a32782dd4",
+      "id" : "1674521442394021000.33b45781-38b2-4c59-995b-892b7d792935",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5110,10 +5110,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055478678000.dcc770f7-bcf3-4594-b2b2-159c51d9e661"
+        "reference" : "Practitioner/1674521442392440000.16369977-74f3-48cf-9aa3-72945cc68461"
       },
       "organization" : {
-        "reference" : "Organization/1674153055479967000.dc3b7057-114f-40da-92e9-1fb4645ab64c"
+        "reference" : "Organization/1674521442393952000.181d0871-fd82-4634-bcc7-3617f83d0aec"
       },
       "code" : [ {
         "coding" : [ {
@@ -5123,10 +5123,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055480834000.958233bc-4822-4bd2-a9b8-c8f88ba6187b",
+    "fullUrl" : "Organization/1674521442394943000.4963ad48-9840-47ce-a026-d5228a0a7d0a",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055480834000.958233bc-4822-4bd2-a9b8-c8f88ba6187b",
+      "id" : "1674521442394943000.4963ad48-9840-47ce-a026-d5228a0a7d0a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5152,10 +5152,10 @@
       "name" : "TMCA, SOUTH CAMPUS"
     }
   }, {
-    "fullUrl" : "Observation/1674153055484588000.35fc6369-b3ba-4f34-895e-5bd908d69de4",
+    "fullUrl" : "Observation/1674521442399329000.c2e5ac79-15aa-4118-80c7-196c6aa28bce",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055484588000.35fc6369-b3ba-4f34-895e-5bd908d69de4",
+      "id" : "1674521442399329000.c2e5ac79-15aa-4118-80c7-196c6aa28bce",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5192,7 +5192,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055484524000.354bcf06-590a-40d1-b180-851768672312"
+          "reference" : "Organization/1674521442399208000.92b2304d-7c92-437b-8f26-9cea2afccbe4"
         }
       } ],
       "identifier" : [ {
@@ -5219,15 +5219,15 @@
         "text" : "DAPTOmycin [Susceptibility] by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-07T16:36:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055483533000.89f56116-543e-416f-9a51-8c6cc04f4561"
+        "reference" : "PractitionerRole/1674521442397831000.23572540-728f-406d-99e1-93162fbd1d85"
       } ],
       "valueRatio" : {
         "numerator" : {
@@ -5298,10 +5298,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055481904000.18ded337-cd75-4b80-8fd0-e26a458d9dd7",
+    "fullUrl" : "Location/1674521442396077000.612288ca-2552-4fa8-815c-386a7c701ac9",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055481904000.18ded337-cd75-4b80-8fd0-e26a458d9dd7",
+      "id" : "1674521442396077000.612288ca-2552-4fa8-815c-386a7c701ac9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5315,10 +5315,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055482177000.de310959-702e-4a7d-acb0-ecbb7d63e01e",
+    "fullUrl" : "Practitioner/1674521442396379000.ab9d1f8e-ba2c-4349-a638-4aad27e0c488",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055482177000.de310959-702e-4a7d-acb0-ecbb7d63e01e",
+      "id" : "1674521442396379000.ab9d1f8e-ba2c-4349-a638-4aad27e0c488",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5340,7 +5340,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055481904000.18ded337-cd75-4b80-8fd0-e26a458d9dd7"
+          "reference" : "Location/1674521442396077000.612288ca-2552-4fa8-815c-386a7c701ac9"
         }
       } ],
       "identifier" : [ {
@@ -5367,10 +5367,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055483476000.c9d32ddb-5b67-43d3-acf7-0d61d6a42faf",
+    "fullUrl" : "Organization/1674521442397773000.4a41fb7b-3983-4ae5-9d58-8dc46d27f264",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055483476000.c9d32ddb-5b67-43d3-acf7-0d61d6a42faf",
+      "id" : "1674521442397773000.4a41fb7b-3983-4ae5-9d58-8dc46d27f264",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5402,10 +5402,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055483533000.89f56116-543e-416f-9a51-8c6cc04f4561",
+    "fullUrl" : "PractitionerRole/1674521442397831000.23572540-728f-406d-99e1-93162fbd1d85",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055483533000.89f56116-543e-416f-9a51-8c6cc04f4561",
+      "id" : "1674521442397831000.23572540-728f-406d-99e1-93162fbd1d85",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5417,10 +5417,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055482177000.de310959-702e-4a7d-acb0-ecbb7d63e01e"
+        "reference" : "Practitioner/1674521442396379000.ab9d1f8e-ba2c-4349-a638-4aad27e0c488"
       },
       "organization" : {
-        "reference" : "Organization/1674153055483476000.c9d32ddb-5b67-43d3-acf7-0d61d6a42faf"
+        "reference" : "Organization/1674521442397773000.4a41fb7b-3983-4ae5-9d58-8dc46d27f264"
       },
       "code" : [ {
         "coding" : [ {
@@ -5430,10 +5430,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055484524000.354bcf06-590a-40d1-b180-851768672312",
+    "fullUrl" : "Organization/1674521442399208000.92b2304d-7c92-437b-8f26-9cea2afccbe4",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055484524000.354bcf06-590a-40d1-b180-851768672312",
+      "id" : "1674521442399208000.92b2304d-7c92-437b-8f26-9cea2afccbe4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5459,10 +5459,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055488978000.32714a71-eb02-4505-830c-c18cf364d289",
+    "fullUrl" : "Observation/1674521442404979000.f3a759ee-408f-4471-a1af-0b1d4a551148",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055488978000.32714a71-eb02-4505-830c-c18cf364d289",
+      "id" : "1674521442404979000.f3a759ee-408f-4471-a1af-0b1d4a551148",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5499,7 +5499,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055488913000.601e0662-9732-450e-a3b7-0988731d5e01"
+          "reference" : "Organization/1674521442404898000.ff98669a-f89c-484a-8552-cb7db4d26857"
         }
       } ],
       "identifier" : [ {
@@ -5533,15 +5533,15 @@
         "text" : "Ampicillin [Susceptibility] by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-07T16:36:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055487966000.830a9239-afe1-487b-89c3-1b6f5899bced"
+        "reference" : "PractitionerRole/1674521442403753000.f67a076c-400a-483e-9279-c89cb9120b93"
       } ],
       "valueRatio" : {
         "numerator" : {
@@ -5612,10 +5612,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055486394000.6f5aaf6c-5474-4796-90a6-13a9bd98eff9",
+    "fullUrl" : "Location/1674521442401780000.c7cf01c4-b41c-48df-bc5c-f8ae51e92573",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055486394000.6f5aaf6c-5474-4796-90a6-13a9bd98eff9",
+      "id" : "1674521442401780000.c7cf01c4-b41c-48df-bc5c-f8ae51e92573",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5629,10 +5629,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055486669000.8ba18443-5fbc-412d-8d22-bb554ef28a56",
+    "fullUrl" : "Practitioner/1674521442402185000.f2ce3d2f-29d1-42dd-a1a4-0fae9c6be834",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055486669000.8ba18443-5fbc-412d-8d22-bb554ef28a56",
+      "id" : "1674521442402185000.f2ce3d2f-29d1-42dd-a1a4-0fae9c6be834",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5654,7 +5654,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055486394000.6f5aaf6c-5474-4796-90a6-13a9bd98eff9"
+          "reference" : "Location/1674521442401780000.c7cf01c4-b41c-48df-bc5c-f8ae51e92573"
         }
       } ],
       "identifier" : [ {
@@ -5681,10 +5681,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055487903000.33b50a58-a750-4c8b-94a6-b766deef662f",
+    "fullUrl" : "Organization/1674521442403659000.4f4f2475-eb10-4d7e-a216-25b171beeed0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055487903000.33b50a58-a750-4c8b-94a6-b766deef662f",
+      "id" : "1674521442403659000.4f4f2475-eb10-4d7e-a216-25b171beeed0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5716,10 +5716,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055487966000.830a9239-afe1-487b-89c3-1b6f5899bced",
+    "fullUrl" : "PractitionerRole/1674521442403753000.f67a076c-400a-483e-9279-c89cb9120b93",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055487966000.830a9239-afe1-487b-89c3-1b6f5899bced",
+      "id" : "1674521442403753000.f67a076c-400a-483e-9279-c89cb9120b93",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5731,10 +5731,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055486669000.8ba18443-5fbc-412d-8d22-bb554ef28a56"
+        "reference" : "Practitioner/1674521442402185000.f2ce3d2f-29d1-42dd-a1a4-0fae9c6be834"
       },
       "organization" : {
-        "reference" : "Organization/1674153055487903000.33b50a58-a750-4c8b-94a6-b766deef662f"
+        "reference" : "Organization/1674521442403659000.4f4f2475-eb10-4d7e-a216-25b171beeed0"
       },
       "code" : [ {
         "coding" : [ {
@@ -5744,10 +5744,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055488913000.601e0662-9732-450e-a3b7-0988731d5e01",
+    "fullUrl" : "Organization/1674521442404898000.ff98669a-f89c-484a-8552-cb7db4d26857",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055488913000.601e0662-9732-450e-a3b7-0988731d5e01",
+      "id" : "1674521442404898000.ff98669a-f89c-484a-8552-cb7db4d26857",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5773,10 +5773,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055493627000.88c8dcde-85d7-4e1f-8501-2c67d79a3b89",
+    "fullUrl" : "Observation/1674521442410297000.b7b5274b-bb26-451c-aa27-57107845bda0",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055493627000.88c8dcde-85d7-4e1f-8501-2c67d79a3b89",
+      "id" : "1674521442410297000.b7b5274b-bb26-451c-aa27-57107845bda0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5813,7 +5813,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055493559000.7b8c3cde-518e-42fc-a484-3f2d654f623d"
+          "reference" : "Organization/1674521442410212000.5a7a4491-3a5e-4b2d-92f3-dc44a20abb0e"
         }
       } ],
       "identifier" : [ {
@@ -5847,15 +5847,15 @@
         "text" : "Gentamicin.high potency [Susceptibility] by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-07T16:36:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055492610000.f72e3c8f-b377-429b-8c9b-fb5614a075f3"
+        "reference" : "PractitionerRole/1674521442408958000.466a32a9-211f-46de-91fa-e654522b5ebf"
       } ],
       "valueString" : "SYN-S",
       "interpretation" : [ {
@@ -5867,10 +5867,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055490989000.52a1af22-2625-4537-a998-4a48b05b7e77",
+    "fullUrl" : "Location/1674521442407057000.72e6614c-cab9-46dd-8d36-8e60fb9e3221",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055490989000.52a1af22-2625-4537-a998-4a48b05b7e77",
+      "id" : "1674521442407057000.72e6614c-cab9-46dd-8d36-8e60fb9e3221",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5884,10 +5884,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055491264000.1589e298-ce1a-4e63-b165-eeaf14e8bb19",
+    "fullUrl" : "Practitioner/1674521442407360000.507a5113-e10f-445f-abb3-35bae7681ee8",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055491264000.1589e298-ce1a-4e63-b165-eeaf14e8bb19",
+      "id" : "1674521442407360000.507a5113-e10f-445f-abb3-35bae7681ee8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5909,7 +5909,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055490989000.52a1af22-2625-4537-a998-4a48b05b7e77"
+          "reference" : "Location/1674521442407057000.72e6614c-cab9-46dd-8d36-8e60fb9e3221"
         }
       } ],
       "identifier" : [ {
@@ -5936,10 +5936,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055492539000.e95a76aa-f92f-4f38-8631-9d3a4ddc0cd2",
+    "fullUrl" : "Organization/1674521442408740000.58998400-82a3-4279-a2ba-94f1233d33da",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055492539000.e95a76aa-f92f-4f38-8631-9d3a4ddc0cd2",
+      "id" : "1674521442408740000.58998400-82a3-4279-a2ba-94f1233d33da",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5971,10 +5971,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055492610000.f72e3c8f-b377-429b-8c9b-fb5614a075f3",
+    "fullUrl" : "PractitionerRole/1674521442408958000.466a32a9-211f-46de-91fa-e654522b5ebf",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055492610000.f72e3c8f-b377-429b-8c9b-fb5614a075f3",
+      "id" : "1674521442408958000.466a32a9-211f-46de-91fa-e654522b5ebf",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5986,10 +5986,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055491264000.1589e298-ce1a-4e63-b165-eeaf14e8bb19"
+        "reference" : "Practitioner/1674521442407360000.507a5113-e10f-445f-abb3-35bae7681ee8"
       },
       "organization" : {
-        "reference" : "Organization/1674153055492539000.e95a76aa-f92f-4f38-8631-9d3a4ddc0cd2"
+        "reference" : "Organization/1674521442408740000.58998400-82a3-4279-a2ba-94f1233d33da"
       },
       "code" : [ {
         "coding" : [ {
@@ -5999,10 +5999,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055493559000.7b8c3cde-518e-42fc-a484-3f2d654f623d",
+    "fullUrl" : "Organization/1674521442410212000.5a7a4491-3a5e-4b2d-92f3-dc44a20abb0e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055493559000.7b8c3cde-518e-42fc-a484-3f2d654f623d",
+      "id" : "1674521442410212000.5a7a4491-3a5e-4b2d-92f3-dc44a20abb0e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6028,10 +6028,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055497516000.325f17d9-a0fe-468f-80f0-631289160df8",
+    "fullUrl" : "Observation/1674521442414710000.db5dda24-3d1b-485b-a078-b69a58535877",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055497516000.325f17d9-a0fe-468f-80f0-631289160df8",
+      "id" : "1674521442414710000.db5dda24-3d1b-485b-a078-b69a58535877",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6068,7 +6068,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055497456000.eb87a36c-c3c9-450f-92ef-3a58d58f6291"
+          "reference" : "Organization/1674521442414645000.dbdf07ff-dfbb-451b-829d-a14e57588cf1"
         }
       } ],
       "identifier" : [ {
@@ -6102,15 +6102,15 @@
         "text" : "Linezolid [Susceptibility] by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-07T16:36:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055496435000.bb2602ef-1645-4eb3-9579-13a1d7de5473"
+        "reference" : "PractitionerRole/1674521442413555000.82b2e3c1-9862-4c28-be29-bd9275fb88c6"
       } ],
       "valueRatio" : {
         "numerator" : {
@@ -6181,10 +6181,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055494806000.a43104ef-8d18-4dcc-b933-d804c4e61249",
+    "fullUrl" : "Location/1674521442411660000.be68526e-dd51-4c4d-8d4f-f45214c9221d",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055494806000.a43104ef-8d18-4dcc-b933-d804c4e61249",
+      "id" : "1674521442411660000.be68526e-dd51-4c4d-8d4f-f45214c9221d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6198,10 +6198,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055495089000.f25e81d8-d097-41e5-8107-cefac6e3d353",
+    "fullUrl" : "Practitioner/1674521442411970000.5cb1e728-6bdc-40d8-a396-61eb1c5e1e27",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055495089000.f25e81d8-d097-41e5-8107-cefac6e3d353",
+      "id" : "1674521442411970000.5cb1e728-6bdc-40d8-a396-61eb1c5e1e27",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6223,7 +6223,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055494806000.a43104ef-8d18-4dcc-b933-d804c4e61249"
+          "reference" : "Location/1674521442411660000.be68526e-dd51-4c4d-8d4f-f45214c9221d"
         }
       } ],
       "identifier" : [ {
@@ -6250,10 +6250,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055496360000.90cb700d-f066-4eef-95fe-dd3bfa6d7311",
+    "fullUrl" : "Organization/1674521442413459000.8c6299d5-6d2f-4f6a-ba0d-6936fb452c9f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055496360000.90cb700d-f066-4eef-95fe-dd3bfa6d7311",
+      "id" : "1674521442413459000.8c6299d5-6d2f-4f6a-ba0d-6936fb452c9f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6285,10 +6285,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055496435000.bb2602ef-1645-4eb3-9579-13a1d7de5473",
+    "fullUrl" : "PractitionerRole/1674521442413555000.82b2e3c1-9862-4c28-be29-bd9275fb88c6",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055496435000.bb2602ef-1645-4eb3-9579-13a1d7de5473",
+      "id" : "1674521442413555000.82b2e3c1-9862-4c28-be29-bd9275fb88c6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6300,10 +6300,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055495089000.f25e81d8-d097-41e5-8107-cefac6e3d353"
+        "reference" : "Practitioner/1674521442411970000.5cb1e728-6bdc-40d8-a396-61eb1c5e1e27"
       },
       "organization" : {
-        "reference" : "Organization/1674153055496360000.90cb700d-f066-4eef-95fe-dd3bfa6d7311"
+        "reference" : "Organization/1674521442413459000.8c6299d5-6d2f-4f6a-ba0d-6936fb452c9f"
       },
       "code" : [ {
         "coding" : [ {
@@ -6313,10 +6313,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055497456000.eb87a36c-c3c9-450f-92ef-3a58d58f6291",
+    "fullUrl" : "Organization/1674521442414645000.dbdf07ff-dfbb-451b-829d-a14e57588cf1",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055497456000.eb87a36c-c3c9-450f-92ef-3a58d58f6291",
+      "id" : "1674521442414645000.dbdf07ff-dfbb-451b-829d-a14e57588cf1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6342,10 +6342,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055502078000.8045f6b2-2e0f-4176-a169-0a59d74915b0",
+    "fullUrl" : "Observation/1674521442419465000.841a15fc-1179-4e9a-9c5a-73c0f71b93a0",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055502078000.8045f6b2-2e0f-4176-a169-0a59d74915b0",
+      "id" : "1674521442419465000.841a15fc-1179-4e9a-9c5a-73c0f71b93a0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6382,7 +6382,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055502017000.f7e8e791-b7a8-4428-9613-43228e5fd44e"
+          "reference" : "Organization/1674521442419398000.c79e629a-b8cb-48ac-aad8-00ea2cf1cfdb"
         }
       } ],
       "identifier" : [ {
@@ -6416,15 +6416,15 @@
         "text" : "Streptomycin.high potency [Susceptibility] by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-07T16:36:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055501063000.c5994ecc-6b51-4917-ae4a-664e537b3c09"
+        "reference" : "PractitionerRole/1674521442418374000.3f8bbbe7-51fb-4a1b-935d-1ddb9804db8e"
       } ],
       "valueString" : "SYN-S",
       "interpretation" : [ {
@@ -6436,10 +6436,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055499436000.47ccdbac-7a63-4a25-9a1a-fea0d49fbb49",
+    "fullUrl" : "Location/1674521442416570000.4f2e696a-814c-4481-9de1-ff9926acf4f4",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055499436000.47ccdbac-7a63-4a25-9a1a-fea0d49fbb49",
+      "id" : "1674521442416570000.4f2e696a-814c-4481-9de1-ff9926acf4f4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6453,10 +6453,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055499715000.ccbfd943-d043-497c-9ed0-5d195f0dc19e",
+    "fullUrl" : "Practitioner/1674521442416926000.b0d184e0-f568-4bae-833f-1f21952da0dd",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055499715000.ccbfd943-d043-497c-9ed0-5d195f0dc19e",
+      "id" : "1674521442416926000.b0d184e0-f568-4bae-833f-1f21952da0dd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6478,7 +6478,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055499436000.47ccdbac-7a63-4a25-9a1a-fea0d49fbb49"
+          "reference" : "Location/1674521442416570000.4f2e696a-814c-4481-9de1-ff9926acf4f4"
         }
       } ],
       "identifier" : [ {
@@ -6505,10 +6505,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055501002000.712ebae7-5225-409b-a273-2b5babe135eb",
+    "fullUrl" : "Organization/1674521442418311000.7c62afe4-9719-4362-9d1d-ce54e332915b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055501002000.712ebae7-5225-409b-a273-2b5babe135eb",
+      "id" : "1674521442418311000.7c62afe4-9719-4362-9d1d-ce54e332915b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6540,10 +6540,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055501063000.c5994ecc-6b51-4917-ae4a-664e537b3c09",
+    "fullUrl" : "PractitionerRole/1674521442418374000.3f8bbbe7-51fb-4a1b-935d-1ddb9804db8e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055501063000.c5994ecc-6b51-4917-ae4a-664e537b3c09",
+      "id" : "1674521442418374000.3f8bbbe7-51fb-4a1b-935d-1ddb9804db8e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6555,10 +6555,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055499715000.ccbfd943-d043-497c-9ed0-5d195f0dc19e"
+        "reference" : "Practitioner/1674521442416926000.b0d184e0-f568-4bae-833f-1f21952da0dd"
       },
       "organization" : {
-        "reference" : "Organization/1674153055501002000.712ebae7-5225-409b-a273-2b5babe135eb"
+        "reference" : "Organization/1674521442418311000.7c62afe4-9719-4362-9d1d-ce54e332915b"
       },
       "code" : [ {
         "coding" : [ {
@@ -6568,10 +6568,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055502017000.f7e8e791-b7a8-4428-9613-43228e5fd44e",
+    "fullUrl" : "Organization/1674521442419398000.c79e629a-b8cb-48ac-aad8-00ea2cf1cfdb",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055502017000.f7e8e791-b7a8-4428-9613-43228e5fd44e",
+      "id" : "1674521442419398000.c79e629a-b8cb-48ac-aad8-00ea2cf1cfdb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6597,10 +6597,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Observation/1674153055505713000.8561498c-a121-4d26-8eff-0d1a8d0d92c3",
+    "fullUrl" : "Observation/1674521442423941000.0473ed52-5e0a-40b3-9093-a76d48fa332c",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1674153055505713000.8561498c-a121-4d26-8eff-0d1a8d0d92c3",
+      "id" : "1674521442423941000.0473ed52-5e0a-40b3-9093-a76d48fa332c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6637,7 +6637,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1674153055505653000.e9252055-c875-4db7-86fd-9091e75727a8"
+          "reference" : "Organization/1674521442423876000.30e85b24-cd52-45dc-9ded-1b5798313940"
         }
       } ],
       "identifier" : [ {
@@ -6671,15 +6671,15 @@
         "text" : "Vancomycin [Susceptibility]"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectiveDateTime" : "2028-08-07T16:36:01-06:00",
       "issued" : "2028-08-07T16:36:01-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1674153055504740000.e502a51c-d001-4252-b1ce-120816c92292"
+        "reference" : "PractitionerRole/1674521442422851000.b3048158-c19e-4785-82fb-57f478bbdbad"
       } ],
       "valueRatio" : {
         "numerator" : {
@@ -6746,10 +6746,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055503235000.d1519efd-66a0-474c-aa88-90fc897e26f0",
+    "fullUrl" : "Location/1674521442420963000.69252bb6-fdab-494b-bbf1-5a304f155053",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055503235000.d1519efd-66a0-474c-aa88-90fc897e26f0",
+      "id" : "1674521442420963000.69252bb6-fdab-494b-bbf1-5a304f155053",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6763,10 +6763,10 @@
       "name" : "ROSE MEDICAL CENTER "
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055503497000.7ef6ecc6-1ed3-400f-a35e-267998a241a4",
+    "fullUrl" : "Practitioner/1674521442421289000.cec03eaf-1d8f-4583-b4a7-62b5b750e70a",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055503497000.7ef6ecc6-1ed3-400f-a35e-267998a241a4",
+      "id" : "1674521442421289000.cec03eaf-1d8f-4583-b4a7-62b5b750e70a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6788,7 +6788,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055503235000.d1519efd-66a0-474c-aa88-90fc897e26f0"
+          "reference" : "Location/1674521442420963000.69252bb6-fdab-494b-bbf1-5a304f155053"
         }
       } ],
       "identifier" : [ {
@@ -6815,10 +6815,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055504686000.32b69fd6-4ea5-4791-abfd-32ae4136b1bd",
+    "fullUrl" : "Organization/1674521442422791000.08474391-dd88-4f21-8249-a4f3dbfdf718",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055504686000.32b69fd6-4ea5-4791-abfd-32ae4136b1bd",
+      "id" : "1674521442422791000.08474391-dd88-4f21-8249-a4f3dbfdf718",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6850,10 +6850,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055504740000.e502a51c-d001-4252-b1ce-120816c92292",
+    "fullUrl" : "PractitionerRole/1674521442422851000.b3048158-c19e-4785-82fb-57f478bbdbad",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055504740000.e502a51c-d001-4252-b1ce-120816c92292",
+      "id" : "1674521442422851000.b3048158-c19e-4785-82fb-57f478bbdbad",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6865,10 +6865,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055503497000.7ef6ecc6-1ed3-400f-a35e-267998a241a4"
+        "reference" : "Practitioner/1674521442421289000.cec03eaf-1d8f-4583-b4a7-62b5b750e70a"
       },
       "organization" : {
-        "reference" : "Organization/1674153055504686000.32b69fd6-4ea5-4791-abfd-32ae4136b1bd"
+        "reference" : "Organization/1674521442422791000.08474391-dd88-4f21-8249-a4f3dbfdf718"
       },
       "code" : [ {
         "coding" : [ {
@@ -6878,10 +6878,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055505653000.e9252055-c875-4db7-86fd-9091e75727a8",
+    "fullUrl" : "Organization/1674521442423876000.30e85b24-cd52-45dc-9ded-1b5798313940",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055505653000.e9252055-c875-4db7-86fd-9091e75727a8",
+      "id" : "1674521442423876000.30e85b24-cd52-45dc-9ded-1b5798313940",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6907,10 +6907,10 @@
       "name" : "ROSE MEDICAL CENTER (MCOE)"
     }
   }, {
-    "fullUrl" : "Specimen/1674153055662922000.3ca7e5eb-32f8-4007-8e25-78e2df2ad79c",
+    "fullUrl" : "Specimen/1674521442617144000.b7f2ddf0-0cc8-49b4-9c27-c6c8a63aadfc",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1674153055662922000.3ca7e5eb-32f8-4007-8e25-78e2df2ad79c",
+      "id" : "1674521442617144000.b7f2ddf0-0cc8-49b4-9c27-c6c8a63aadfc",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6993,10 +6993,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Specimen/1674153055663922000.42374100-7426-4692-877a-f895abb17566",
+    "fullUrl" : "Specimen/1674521442618342000.bac5bec0-8dcb-44f2-8310-ccf5818b9bcc",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1674153055663922000.42374100-7426-4692-877a-f895abb17566",
+      "id" : "1674521442618342000.bac5bec0-8dcb-44f2-8310-ccf5818b9bcc",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7079,10 +7079,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Specimen/1674153055664644000.ef271804-37d5-4655-a9ac-dc5189d875e8",
+    "fullUrl" : "Specimen/1674521442619268000.981c1cca-c514-4c22-bd73-954db05e49f8",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1674153055664644000.ef271804-37d5-4655-a9ac-dc5189d875e8",
+      "id" : "1674521442619268000.981c1cca-c514-4c22-bd73-954db05e49f8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7153,10 +7153,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Specimen/1674153055665498000.8e690449-9274-4a59-a6d9-4c3a81a04edd",
+    "fullUrl" : "Specimen/1674521442620334000.07e81cfb-f13f-4bf9-9b75-a0b6ae1a5df5",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1674153055665498000.8e690449-9274-4a59-a6d9-4c3a81a04edd",
+      "id" : "1674521442620334000.07e81cfb-f13f-4bf9-9b75-a0b6ae1a5df5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7239,10 +7239,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1674153055668614000.c8d8cb2f-406d-4562-867e-a584d6c04647",
+    "fullUrl" : "DiagnosticReport/1674521442624203000.ba0bba97-c708-4dbb-aed3-a7ae60a89b68",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1674153055668614000.c8d8cb2f-406d-4562-867e-a584d6c04647",
+      "id" : "1674521442624203000.ba0bba97-c708-4dbb-aed3-a7ae60a89b68",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7278,30 +7278,6 @@
         "system" : "urn:id:extID",
         "value" : "20280808092805-0600"
       }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.1",
-        "value" : "21:AA:B0029251S.1"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.1",
-        "value" : "09339017"
-      }, {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
           "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
@@ -7315,9 +7291,32 @@
         },
         "system" : "urn:id:M12776123",
         "value" : "21:AA:B0029251S"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "PLAC"
+          } ]
+        },
+        "system" : "urn:id:M12776123.1",
+        "value" : "09339017"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "FILL",
+            "display" : "Filler Identifier"
+          } ]
+        },
+        "system" : "urn:id:M12776123.1",
+        "value" : "21:AA:B0029251S.1"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1674153055670514000.4d47469d-0e06-4088-8803-31f518fa26fe"
+        "reference" : "ServiceRequest/1674521442626305000.01a60f3f-59b2-4805-a380-a14c14797ab5"
       } ],
       "status" : "preliminary",
       "code" : {
@@ -7339,10 +7338,10 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectivePeriod" : {
         "start" : "2028-08-02T02:52:01-06:00",
@@ -7350,21 +7349,21 @@
       },
       "issued" : "2021-08-10T06:25:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1674153055662922000.3ca7e5eb-32f8-4007-8e25-78e2df2ad79c"
+        "reference" : "Specimen/1674521442617144000.b7f2ddf0-0cc8-49b4-9c27-c6c8a63aadfc"
       } ],
       "result" : [ {
-        "reference" : "Observation/1674153055380463000.0c944001-dfb9-4667-81ec-d74aac12589e"
+        "reference" : "Observation/1674521442287530000.da049d02-4207-4186-aa99-8ea491b5c854"
       }, {
-        "reference" : "Observation/1674153055386567000.f17e8fd6-85f8-4fb4-ae3b-85d2ff39a3b0"
+        "reference" : "Observation/1674521442295325000.7ca42a93-a037-43cd-9886-f37b64ad84dd"
       }, {
-        "reference" : "Observation/1674153055392839000.1d8e5c37-996c-4c2f-b57d-cfcb64fa5158"
+        "reference" : "Observation/1674521442301575000.1f3a85d4-90b4-4cee-b10f-50ddf39d9bc4"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055670253000.7e0d7dfa-9b3a-4b3b-8e54-1a04b8745e09",
+    "fullUrl" : "Practitioner/1674521442626021000.776415f5-b3cf-43ab-89c5-2f3d864f557f",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055670253000.7e0d7dfa-9b3a-4b3b-8e54-1a04b8745e09",
+      "id" : "1674521442626021000.776415f5-b3cf-43ab-89c5-2f3d864f557f",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7384,10 +7383,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055671620000.4c49804c-b685-48d3-93b2-f45eef2d5809",
+    "fullUrl" : "Location/1674521442627416000.9469951e-5b66-4e30-9f10-1f51433976b9",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055671620000.4c49804c-b685-48d3-93b2-f45eef2d5809",
+      "id" : "1674521442627416000.9469951e-5b66-4e30-9f10-1f51433976b9",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7405,10 +7404,10 @@
       "name" : "RML"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055671986000.a52332dc-8c9a-4b3b-98ad-856c744d3ee1",
+    "fullUrl" : "Practitioner/1674521442627858000.d8692ad2-26e4-41d2-be88-4a97d05a2e19",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055671986000.a52332dc-8c9a-4b3b-98ad-856c744d3ee1",
+      "id" : "1674521442627858000.d8692ad2-26e4-41d2-be88-4a97d05a2e19",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7434,7 +7433,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055671620000.4c49804c-b685-48d3-93b2-f45eef2d5809"
+          "reference" : "Location/1674521442627416000.9469951e-5b66-4e30-9f10-1f51433976b9"
         }
       } ],
       "identifier" : [ {
@@ -7482,10 +7481,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055673923000.6717fc42-7701-4be3-9c08-3a4682c03cf9",
+    "fullUrl" : "Organization/1674521442629837000.a20235aa-9c0c-490d-896f-e725b1994bc5",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055673923000.6717fc42-7701-4be3-9c08-3a4682c03cf9",
+      "id" : "1674521442629837000.a20235aa-9c0c-490d-896f-e725b1994bc5",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7543,10 +7542,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055673997000.2d09a224-a3de-4c61-b97c-3f176d72c037",
+    "fullUrl" : "PractitionerRole/1674521442629914000.07c3c61c-87e5-4373-801a-546e47be2f21",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055673997000.2d09a224-a3de-4c61-b97c-3f176d72c037",
+      "id" : "1674521442629914000.07c3c61c-87e5-4373-801a-546e47be2f21",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7562,17 +7561,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055671986000.a52332dc-8c9a-4b3b-98ad-856c744d3ee1"
+        "reference" : "Practitioner/1674521442627858000.d8692ad2-26e4-41d2-be88-4a97d05a2e19"
       },
       "organization" : {
-        "reference" : "Organization/1674153055673923000.6717fc42-7701-4be3-9c08-3a4682c03cf9"
+        "reference" : "Organization/1674521442629837000.a20235aa-9c0c-490d-896f-e725b1994bc5"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1674153055670514000.4d47469d-0e06-4088-8803-31f518fa26fe",
+    "fullUrl" : "ServiceRequest/1674521442626305000.01a60f3f-59b2-4805-a380-a14c14797ab5",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1674153055670514000.4d47469d-0e06-4088-8803-31f518fa26fe",
+      "id" : "1674521442626305000.01a60f3f-59b2-4805-a380-a14c14797ab5",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7599,7 +7598,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1674153055670253000.7e0d7dfa-9b3a-4b3b-8e54-1a04b8745e09"
+          "reference" : "Practitioner/1674521442626021000.776415f5-b3cf-43ab-89c5-2f3d864f557f"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -7697,7 +7696,7 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "occurrenceTiming" : {
         "repeat" : {
@@ -7709,7 +7708,7 @@
       },
       "authoredOn" : "2028-08-08T09:28:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1674153055673997000.2d09a224-a3de-4c61-b97c-3f176d72c037"
+        "reference" : "PractitionerRole/1674521442629914000.07c3c61c-87e5-4373-801a-546e47be2f21"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -7763,10 +7762,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1674153055675861000.48b82d1b-1ce5-420b-acce-a488a0732408",
+    "fullUrl" : "DiagnosticReport/1674521442632550000.5c4cbda5-2ad0-4304-8bf8-bdfd7641c7d2",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1674153055675861000.48b82d1b-1ce5-420b-acce-a488a0732408",
+      "id" : "1674521442632550000.5c4cbda5-2ad0-4304-8bf8-bdfd7641c7d2",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7802,30 +7801,6 @@
         "system" : "urn:id:extID",
         "value" : "20280808092805-0600"
       }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.2",
-        "value" : "21:AA:B0029251S.2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.2",
-        "value" : "09339017"
-      }, {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
           "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
@@ -7839,9 +7814,32 @@
         },
         "system" : "urn:id:M12776123",
         "value" : "21:AA:B0029251S"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "PLAC"
+          } ]
+        },
+        "system" : "urn:id:M12776123.2",
+        "value" : "09339017"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "FILL",
+            "display" : "Filler Identifier"
+          } ]
+        },
+        "system" : "urn:id:M12776123.2",
+        "value" : "21:AA:B0029251S.2"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1674153055677673000.481ec701-82cd-41c7-a1a9-59d60f0c3ad0"
+        "reference" : "ServiceRequest/1674521442634831000.1c22535f-94c6-4ba9-8056-476c8a7f82fb"
       } ],
       "status" : "preliminary",
       "code" : {
@@ -7863,10 +7861,10 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectivePeriod" : {
         "start" : "2028-08-02T02:52:01-06:00",
@@ -7874,29 +7872,29 @@
       },
       "issued" : "2021-08-10T06:25:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1674153055663922000.42374100-7426-4692-877a-f895abb17566"
+        "reference" : "Specimen/1674521442618342000.bac5bec0-8dcb-44f2-8310-ccf5818b9bcc"
       } ],
       "result" : [ {
-        "reference" : "Observation/1674153055401005000.be0453a6-fbfe-46a0-9013-079c9b424892"
+        "reference" : "Observation/1674521442310851000.300fc468-ff44-435e-9bca-31d391e794d6"
       }, {
-        "reference" : "Observation/1674153055405832000.c5de99e4-70a5-4bd7-9b19-cf2fdd80b278"
+        "reference" : "Observation/1674521442316070000.4f8d486d-0e40-49e1-9832-054d826948cd"
       }, {
-        "reference" : "Observation/1674153055410379000.289654e4-0d4c-4a6e-b2d8-c2ac615075ba"
+        "reference" : "Observation/1674521442321201000.62fd01d4-2b3e-4825-8302-472ba7bf73c9"
       }, {
-        "reference" : "Observation/1674153055424013000.dd032d26-06af-4208-af8d-1dde34ffd0cb"
+        "reference" : "Observation/1674521442334602000.31f281b0-a252-45e4-9fa4-0ec6ef5b8d59"
       }, {
-        "reference" : "Observation/1674153055428606000.e7a95a1c-d5db-4881-b933-35f9b3d50f14"
+        "reference" : "Observation/1674521442339746000.7f7f2e53-3ba4-4479-97da-43662b525531"
       }, {
-        "reference" : "Observation/1674153055433142000.664e6dd7-53f4-4299-86fa-efd9d62e5c6f"
+        "reference" : "Observation/1674521442344213000.ed2980fc-7e56-4e73-a8ad-4bb9be363d27"
       }, {
-        "reference" : "Observation/1674153055437434000.6259904d-d13a-4616-8f85-590f9c5fdc34"
+        "reference" : "Observation/1674521442348731000.2c23112a-4b03-4e0a-b2d6-142e137691f6"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055677415000.a1a260d6-026b-4dc7-9d6a-6909908a2d74",
+    "fullUrl" : "Practitioner/1674521442634543000.14ee3fce-e131-4f1e-9fde-f200b7dded41",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055677415000.a1a260d6-026b-4dc7-9d6a-6909908a2d74",
+      "id" : "1674521442634543000.14ee3fce-e131-4f1e-9fde-f200b7dded41",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7916,10 +7914,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055678760000.10a665e8-033a-4d9c-9f0e-51dbe10d2e6c",
+    "fullUrl" : "Location/1674521442635986000.87be8f27-6359-4d24-9a30-847753425dad",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055678760000.10a665e8-033a-4d9c-9f0e-51dbe10d2e6c",
+      "id" : "1674521442635986000.87be8f27-6359-4d24-9a30-847753425dad",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7937,10 +7935,10 @@
       "name" : "RML"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055679137000.ff423276-789d-49c7-afcf-652adb5dced3",
+    "fullUrl" : "Practitioner/1674521442636433000.828e9363-aa8d-4362-9af8-1776215c3bf0",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055679137000.ff423276-789d-49c7-afcf-652adb5dced3",
+      "id" : "1674521442636433000.828e9363-aa8d-4362-9af8-1776215c3bf0",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -7966,7 +7964,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055678760000.10a665e8-033a-4d9c-9f0e-51dbe10d2e6c"
+          "reference" : "Location/1674521442635986000.87be8f27-6359-4d24-9a30-847753425dad"
         }
       } ],
       "identifier" : [ {
@@ -8014,10 +8012,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055681208000.a283f811-9897-4309-86ea-4f02cc19c929",
+    "fullUrl" : "Organization/1674521442638637000.634fc4d7-dceb-4a33-b154-1f3fec32969c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055681208000.a283f811-9897-4309-86ea-4f02cc19c929",
+      "id" : "1674521442638637000.634fc4d7-dceb-4a33-b154-1f3fec32969c",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8075,10 +8073,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055681303000.38d57996-340f-48f8-a78d-12d13cb5a2b2",
+    "fullUrl" : "PractitionerRole/1674521442638735000.361349aa-2f09-4bab-a2a3-60d7f6a8b213",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055681303000.38d57996-340f-48f8-a78d-12d13cb5a2b2",
+      "id" : "1674521442638735000.361349aa-2f09-4bab-a2a3-60d7f6a8b213",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8094,17 +8092,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055679137000.ff423276-789d-49c7-afcf-652adb5dced3"
+        "reference" : "Practitioner/1674521442636433000.828e9363-aa8d-4362-9af8-1776215c3bf0"
       },
       "organization" : {
-        "reference" : "Organization/1674153055681208000.a283f811-9897-4309-86ea-4f02cc19c929"
+        "reference" : "Organization/1674521442638637000.634fc4d7-dceb-4a33-b154-1f3fec32969c"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1674153055677673000.481ec701-82cd-41c7-a1a9-59d60f0c3ad0",
+    "fullUrl" : "ServiceRequest/1674521442634831000.1c22535f-94c6-4ba9-8056-476c8a7f82fb",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1674153055677673000.481ec701-82cd-41c7-a1a9-59d60f0c3ad0",
+      "id" : "1674521442634831000.1c22535f-94c6-4ba9-8056-476c8a7f82fb",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8131,7 +8129,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1674153055677415000.a1a260d6-026b-4dc7-9d6a-6909908a2d74"
+          "reference" : "Practitioner/1674521442634543000.14ee3fce-e131-4f1e-9fde-f200b7dded41"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -8229,7 +8227,7 @@
         "text" : "Bacteria identified in Blood by Culture"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "occurrenceTiming" : {
         "repeat" : {
@@ -8241,7 +8239,7 @@
       },
       "authoredOn" : "2028-08-08T09:28:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1674153055681303000.38d57996-340f-48f8-a78d-12d13cb5a2b2"
+        "reference" : "PractitionerRole/1674521442638735000.361349aa-2f09-4bab-a2a3-60d7f6a8b213"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -8295,10 +8293,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1674153055683406000.6bdd75dd-8dc2-4ea1-bd28-6faf42557b48",
+    "fullUrl" : "DiagnosticReport/1674521442640766000.20001c15-1091-46fb-8e0d-156e0242fd78",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1674153055683406000.6bdd75dd-8dc2-4ea1-bd28-6faf42557b48",
+      "id" : "1674521442640766000.20001c15-1091-46fb-8e0d-156e0242fd78",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8334,30 +8332,6 @@
         "system" : "urn:id:extID",
         "value" : "20280808092805-0600"
       }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.3",
-        "value" : "21:AA:B0029251S.3"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.3",
-        "value" : "09339017"
-      }, {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
           "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
@@ -8371,9 +8345,32 @@
         },
         "system" : "urn:id:M12776123",
         "value" : "21:AA:B0029251S"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueOid" : "urn:oid:2.16.840.1.114222.4.1.144"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "PLAC"
+          } ]
+        },
+        "system" : "urn:id:M12776123.3",
+        "value" : "09339017"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "FILL",
+            "display" : "Filler Identifier"
+          } ]
+        },
+        "system" : "urn:id:M12776123.3",
+        "value" : "21:AA:B0029251S.3"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1674153055685414000.5020d1a7-0a90-4380-9534-cbf547eac287"
+        "reference" : "ServiceRequest/1674521442643014000.dd9bfc14-c927-4254-b8df-9f728c765866"
       } ],
       "status" : "preliminary",
       "code" : {
@@ -8395,10 +8392,10 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectivePeriod" : {
         "start" : "2028-08-02T02:52:01-06:00",
@@ -8406,35 +8403,35 @@
       },
       "issued" : "2021-08-10T06:25:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1674153055664644000.ef271804-37d5-4655-a9ac-dc5189d875e8"
+        "reference" : "Specimen/1674521442619268000.981c1cca-c514-4c22-bd73-954db05e49f8"
       } ],
       "result" : [ {
-        "reference" : "Observation/1674153055442152000.fece5601-966d-4d09-9117-a1d227513017"
+        "reference" : "Observation/1674521442354051000.ceb88f47-6c16-47cc-98e9-55242d14fcf2"
       }, {
-        "reference" : "Observation/1674153055446120000.7857bf13-d550-4b07-b14b-80573a1ca1c6"
+        "reference" : "Observation/1674521442358726000.729783aa-a66a-4bec-b668-c10b32187427"
       }, {
-        "reference" : "Observation/1674153055450337000.ec93c53b-6cca-403c-b9b0-b96b5e82a6ca"
+        "reference" : "Observation/1674521442363389000.cf384af6-a589-40ad-a25e-b443db1da19a"
       }, {
-        "reference" : "Observation/1674153055454207000.feec4b3c-4f51-4e9c-83c3-8594dac4b096"
+        "reference" : "Observation/1674521442368213000.5e5977f0-5437-40e1-9edd-afc2b013b69c"
       }, {
-        "reference" : "Observation/1674153055462767000.6666e633-161c-4f4d-b665-776db8238419"
+        "reference" : "Observation/1674521442372476000.dfe5e47b-b49e-4e05-a2bb-fcc7ff6776e9"
       }, {
-        "reference" : "Observation/1674153055466570000.1aa299df-54c0-4a33-8a11-6296e0443246"
+        "reference" : "Observation/1674521442377417000.0d02c53b-b905-4c3b-a6a1-440767395b22"
       }, {
-        "reference" : "Observation/1674153055470141000.d1e9ed89-2bcb-42c7-a2c4-54d78e4c9bce"
+        "reference" : "Observation/1674521442382406000.21caba7b-06d4-4bc8-ab1d-9d3137d34ea4"
       }, {
-        "reference" : "Observation/1674153055473720000.65c6e4c3-3222-47d2-8ff7-df9adbba8cb4"
+        "reference" : "Observation/1674521442386563000.e99e907b-0cb6-46b7-b21f-df4697d9fbf6"
       }, {
-        "reference" : "Observation/1674153055477445000.9212d890-d2ff-44dc-b742-651809497e9c"
+        "reference" : "Observation/1674521442391046000.4e2c6b59-6980-451d-a2a4-14bf19aaaf61"
       }, {
-        "reference" : "Observation/1674153055480899000.5c5d1652-a4e3-4d60-98e7-765f5a8f6b77"
+        "reference" : "Observation/1674521442395016000.1a1347a8-b27b-450a-9a6c-3293107cc222"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055685130000.a4bb95b4-5e66-4452-ac8e-832dd7e49a43",
+    "fullUrl" : "Practitioner/1674521442642729000.bf2c339d-1f7d-415c-84a0-58a8c2b2a767",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055685130000.a4bb95b4-5e66-4452-ac8e-832dd7e49a43",
+      "id" : "1674521442642729000.bf2c339d-1f7d-415c-84a0-58a8c2b2a767",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8454,10 +8451,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055686483000.c3961053-3006-44cf-9052-8856f3fc7d3d",
+    "fullUrl" : "Location/1674521442644078000.f47179a9-289d-4f1f-a9fd-e58770a15f34",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055686483000.c3961053-3006-44cf-9052-8856f3fc7d3d",
+      "id" : "1674521442644078000.f47179a9-289d-4f1f-a9fd-e58770a15f34",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8475,10 +8472,10 @@
       "name" : "RML"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055686840000.45aaf9d2-4722-40d6-8ded-81775e63aae2",
+    "fullUrl" : "Practitioner/1674521442644438000.ead50097-0e9c-442d-a254-cf3dd6aafc17",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055686840000.45aaf9d2-4722-40d6-8ded-81775e63aae2",
+      "id" : "1674521442644438000.ead50097-0e9c-442d-a254-cf3dd6aafc17",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8504,7 +8501,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055686483000.c3961053-3006-44cf-9052-8856f3fc7d3d"
+          "reference" : "Location/1674521442644078000.f47179a9-289d-4f1f-a9fd-e58770a15f34"
         }
       } ],
       "identifier" : [ {
@@ -8552,10 +8549,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055688757000.ce8bdf36-cdfa-4f42-8d88-357371b08860",
+    "fullUrl" : "Organization/1674521442646451000.e768499a-693b-4886-a932-7740df12eeb8",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055688757000.ce8bdf36-cdfa-4f42-8d88-357371b08860",
+      "id" : "1674521442646451000.e768499a-693b-4886-a932-7740df12eeb8",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8613,10 +8610,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055688832000.bcf066c5-563a-41b1-b12e-efaa943755e1",
+    "fullUrl" : "PractitionerRole/1674521442646527000.734274ad-ff78-44f6-9353-f92637709e2a",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055688832000.bcf066c5-563a-41b1-b12e-efaa943755e1",
+      "id" : "1674521442646527000.734274ad-ff78-44f6-9353-f92637709e2a",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8632,17 +8629,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055686840000.45aaf9d2-4722-40d6-8ded-81775e63aae2"
+        "reference" : "Practitioner/1674521442644438000.ead50097-0e9c-442d-a254-cf3dd6aafc17"
       },
       "organization" : {
-        "reference" : "Organization/1674153055688757000.ce8bdf36-cdfa-4f42-8d88-357371b08860"
+        "reference" : "Organization/1674521442646451000.e768499a-693b-4886-a932-7740df12eeb8"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1674153055685414000.5020d1a7-0a90-4380-9534-cbf547eac287",
+    "fullUrl" : "ServiceRequest/1674521442643014000.dd9bfc14-c927-4254-b8df-9f728c765866",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1674153055685414000.5020d1a7-0a90-4380-9534-cbf547eac287",
+      "id" : "1674521442643014000.dd9bfc14-c927-4254-b8df-9f728c765866",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8669,7 +8666,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1674153055685130000.a4bb95b4-5e66-4452-ac8e-832dd7e49a43"
+          "reference" : "Practitioner/1674521442642729000.bf2c339d-1f7d-415c-84a0-58a8c2b2a767"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -8767,7 +8764,7 @@
         "text" : "Laboratory comment [Text] in Report Narrative"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "occurrenceTiming" : {
         "repeat" : {
@@ -8779,7 +8776,7 @@
       },
       "authoredOn" : "2028-08-08T09:28:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1674153055688832000.bcf066c5-563a-41b1-b12e-efaa943755e1"
+        "reference" : "PractitionerRole/1674521442646527000.734274ad-ff78-44f6-9353-f92637709e2a"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -8833,10 +8830,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1674153055690946000.b354c716-2a01-42ae-aa55-2117924f2d04",
+    "fullUrl" : "DiagnosticReport/1674521442648597000.f4956ad2-bc69-4f6c-b8dc-daa3069d0a60",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1674153055690946000.b354c716-2a01-42ae-aa55-2117924f2d04",
+      "id" : "1674521442648597000.f4956ad2-bc69-4f6c-b8dc-daa3069d0a60",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8884,16 +8881,6 @@
         "value" : "20280808092805-0600"
       }, {
         "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.4",
-        "value" : "21:AA:B0029251S.4"
-      }, {
-        "type" : {
           "extension" : [ {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/alternate-identifier",
             "valueCodeableConcept" : {
@@ -8912,9 +8899,18 @@
         },
         "system" : "600-7",
         "value" : "600-7"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "FILL"
+          } ]
+        },
+        "system" : "urn:id:M12776123.4",
+        "value" : "21:AA:B0029251S.4"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1674153055692336000.cfe85ff9-5937-4377-96e5-a7fa759f94be"
+        "reference" : "ServiceRequest/1674521442649902000.c8b6c555-41a0-4dc5-ba19-0b0d0a48d298"
       } ],
       "status" : "preliminary",
       "code" : {
@@ -8936,10 +8932,10 @@
         "text" : "Bacterial susceptibility panel by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectivePeriod" : {
         "start" : "2028-08-07T16:36:01-06:00",
@@ -8947,14 +8943,14 @@
       },
       "issued" : "2021-08-10T06:25:00-06:00",
       "result" : [ {
-        "reference" : "Observation/1674153055484588000.35fc6369-b3ba-4f34-895e-5bd908d69de4"
+        "reference" : "Observation/1674521442399329000.c2e5ac79-15aa-4118-80c7-196c6aa28bce"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055692097000.ce1be084-2a9e-4578-8cd2-264b3ab293aa",
+    "fullUrl" : "Practitioner/1674521442649685000.174e3c0d-f277-4e5f-bca9-5d4ef12783d4",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055692097000.ce1be084-2a9e-4578-8cd2-264b3ab293aa",
+      "id" : "1674521442649685000.174e3c0d-f277-4e5f-bca9-5d4ef12783d4",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8974,10 +8970,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055693371000.9bb2b0aa-a64b-445b-859e-2d0c86d45a83",
+    "fullUrl" : "Location/1674521442650899000.775d6aba-c0e6-4f21-a32c-2c23667ecc47",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055693371000.9bb2b0aa-a64b-445b-859e-2d0c86d45a83",
+      "id" : "1674521442650899000.775d6aba-c0e6-4f21-a32c-2c23667ecc47",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -8995,10 +8991,10 @@
       "name" : "RML"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055693720000.b28668cb-ac0a-444e-8696-28b53c2a0f80",
+    "fullUrl" : "Practitioner/1674521442651259000.19424b32-e648-41a1-8d8a-84623d91378d",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055693720000.b28668cb-ac0a-444e-8696-28b53c2a0f80",
+      "id" : "1674521442651259000.19424b32-e648-41a1-8d8a-84623d91378d",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9024,7 +9020,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055693371000.9bb2b0aa-a64b-445b-859e-2d0c86d45a83"
+          "reference" : "Location/1674521442650899000.775d6aba-c0e6-4f21-a32c-2c23667ecc47"
         }
       } ],
       "identifier" : [ {
@@ -9063,10 +9059,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055695304000.b9a2dbc2-9774-4ac6-920f-9b52dc791e53",
+    "fullUrl" : "Organization/1674521442652775000.f2067a47-439a-415c-be0b-5d6f72376320",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055695304000.b9a2dbc2-9774-4ac6-920f-9b52dc791e53",
+      "id" : "1674521442652775000.f2067a47-439a-415c-be0b-5d6f72376320",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9083,10 +9079,10 @@
       }
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055695372000.9fbca006-4095-4e9f-bd3d-34278908e52e",
+    "fullUrl" : "PractitionerRole/1674521442652846000.00989455-067b-495d-8929-e3cc81d03b6e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055695372000.9fbca006-4095-4e9f-bd3d-34278908e52e",
+      "id" : "1674521442652846000.00989455-067b-495d-8929-e3cc81d03b6e",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9102,17 +9098,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055693720000.b28668cb-ac0a-444e-8696-28b53c2a0f80"
+        "reference" : "Practitioner/1674521442651259000.19424b32-e648-41a1-8d8a-84623d91378d"
       },
       "organization" : {
-        "reference" : "Organization/1674153055695304000.b9a2dbc2-9774-4ac6-920f-9b52dc791e53"
+        "reference" : "Organization/1674521442652775000.f2067a47-439a-415c-be0b-5d6f72376320"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1674153055692336000.cfe85ff9-5937-4377-96e5-a7fa759f94be",
+    "fullUrl" : "ServiceRequest/1674521442649902000.c8b6c555-41a0-4dc5-ba19-0b0d0a48d298",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1674153055692336000.cfe85ff9-5937-4377-96e5-a7fa759f94be",
+      "id" : "1674521442649902000.c8b6c555-41a0-4dc5-ba19-0b0d0a48d298",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9139,7 +9135,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1674153055692097000.ce1be084-2a9e-4578-8cd2-264b3ab293aa"
+          "reference" : "Practitioner/1674521442649685000.174e3c0d-f277-4e5f-bca9-5d4ef12783d4"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/result-status",
@@ -9166,8 +9162,7 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "FILL"
           } ]
         },
         "system" : "urn:id:M12776123.4",
@@ -9194,10 +9189,10 @@
         "text" : "Bacterial susceptibility panel by Minimum inhibitory concentration (MIC)"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "requester" : {
-        "reference" : "PractitionerRole/1674153055695372000.9fbca006-4095-4e9f-bd3d-34278908e52e"
+        "reference" : "PractitionerRole/1674521442652846000.00989455-067b-495d-8929-e3cc81d03b6e"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -9219,10 +9214,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1674153055705411000.1cb6daeb-3616-4fa9-840c-ba6a9bf3cbb3",
+    "fullUrl" : "DiagnosticReport/1674521442654544000.16bde447-c82d-41ff-ab48-ed1e4c716409",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1674153055705411000.1cb6daeb-3616-4fa9-840c-ba6a9bf3cbb3",
+      "id" : "1674521442654544000.16bde447-c82d-41ff-ab48-ed1e4c716409",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9270,16 +9265,6 @@
         "value" : "20280808092805-0600"
       }, {
         "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
-          } ]
-        },
-        "system" : "urn:id:M12776123.5",
-        "value" : "21:AA:B0029251S.5"
-      }, {
-        "type" : {
           "extension" : [ {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/alternate-identifier",
             "valueCodeableConcept" : {
@@ -9298,9 +9283,18 @@
         },
         "system" : "600-7",
         "value" : "600-7"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "FILL"
+          } ]
+        },
+        "system" : "urn:id:M12776123.5",
+        "value" : "21:AA:B0029251S.5"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1674153055706816000.2145bebc-2239-42ea-bdb2-0cced640b485"
+        "reference" : "ServiceRequest/1674521442655835000.74388fcf-45d4-442a-955d-fee1351157ba"
       } ],
       "status" : "preliminary",
       "code" : {
@@ -9311,10 +9305,10 @@
         "text" : "VITEK2 AST-GP75"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "encounter" : {
-        "reference" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462"
+        "reference" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb"
       },
       "effectivePeriod" : {
         "start" : "2028-08-07T16:36:01-06:00",
@@ -9322,25 +9316,25 @@
       },
       "issued" : "2021-08-10T06:25:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1674153055665498000.8e690449-9274-4a59-a6d9-4c3a81a04edd"
+        "reference" : "Specimen/1674521442620334000.07e81cfb-f13f-4bf9-9b75-a0b6ae1a5df5"
       } ],
       "result" : [ {
-        "reference" : "Observation/1674153055488978000.32714a71-eb02-4505-830c-c18cf364d289"
+        "reference" : "Observation/1674521442404979000.f3a759ee-408f-4471-a1af-0b1d4a551148"
       }, {
-        "reference" : "Observation/1674153055493627000.88c8dcde-85d7-4e1f-8501-2c67d79a3b89"
+        "reference" : "Observation/1674521442410297000.b7b5274b-bb26-451c-aa27-57107845bda0"
       }, {
-        "reference" : "Observation/1674153055497516000.325f17d9-a0fe-468f-80f0-631289160df8"
+        "reference" : "Observation/1674521442414710000.db5dda24-3d1b-485b-a078-b69a58535877"
       }, {
-        "reference" : "Observation/1674153055502078000.8045f6b2-2e0f-4176-a169-0a59d74915b0"
+        "reference" : "Observation/1674521442419465000.841a15fc-1179-4e9a-9c5a-73c0f71b93a0"
       }, {
-        "reference" : "Observation/1674153055505713000.8561498c-a121-4d26-8eff-0d1a8d0d92c3"
+        "reference" : "Observation/1674521442423941000.0473ed52-5e0a-40b3-9093-a76d48fa332c"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055706588000.e790925d-9742-4994-9470-c139d925121e",
+    "fullUrl" : "Practitioner/1674521442655526000.df09ebb8-6142-4855-8416-4d3e1eb111d9",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055706588000.e790925d-9742-4994-9470-c139d925121e",
+      "id" : "1674521442655526000.df09ebb8-6142-4855-8416-4d3e1eb111d9",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9360,10 +9354,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055707847000.07c3d2f6-1243-43c3-ab3d-5aa4697827ae",
+    "fullUrl" : "Location/1674521442656812000.92408862-f6fe-4b40-8c88-927c5eec71de",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055707847000.07c3d2f6-1243-43c3-ab3d-5aa4697827ae",
+      "id" : "1674521442656812000.92408862-f6fe-4b40-8c88-927c5eec71de",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9381,10 +9375,10 @@
       "name" : "RML"
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055708190000.2ef96039-6003-4664-9ac6-dcb0b7721551",
+    "fullUrl" : "Practitioner/1674521442657138000.2741798a-a5d2-47d5-adc8-bd082b9b469e",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055708190000.2ef96039-6003-4664-9ac6-dcb0b7721551",
+      "id" : "1674521442657138000.2741798a-a5d2-47d5-adc8-bd082b9b469e",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9410,7 +9404,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1674153055707847000.07c3d2f6-1243-43c3-ab3d-5aa4697827ae"
+          "reference" : "Location/1674521442656812000.92408862-f6fe-4b40-8c88-927c5eec71de"
         }
       } ],
       "identifier" : [ {
@@ -9449,10 +9443,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055709709000.6a49c6a7-65b0-4c65-936c-b80a9815f357",
+    "fullUrl" : "Organization/1674521442658524000.515eff93-5b5a-42a4-a8a5-2084e66af767",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055709709000.6a49c6a7-65b0-4c65-936c-b80a9815f357",
+      "id" : "1674521442658524000.515eff93-5b5a-42a4-a8a5-2084e66af767",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9469,10 +9463,10 @@
       }
     }
   }, {
-    "fullUrl" : "PractitionerRole/1674153055709775000.1f412974-39b0-4d98-a512-8eec9bb7c0f3",
+    "fullUrl" : "PractitionerRole/1674521442658589000.bc7bae7d-0c8a-4c11-b4ed-014cc803f1fc",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1674153055709775000.1f412974-39b0-4d98-a512-8eec9bb7c0f3",
+      "id" : "1674521442658589000.bc7bae7d-0c8a-4c11-b4ed-014cc803f1fc",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9488,17 +9482,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1674153055708190000.2ef96039-6003-4664-9ac6-dcb0b7721551"
+        "reference" : "Practitioner/1674521442657138000.2741798a-a5d2-47d5-adc8-bd082b9b469e"
       },
       "organization" : {
-        "reference" : "Organization/1674153055709709000.6a49c6a7-65b0-4c65-936c-b80a9815f357"
+        "reference" : "Organization/1674521442658524000.515eff93-5b5a-42a4-a8a5-2084e66af767"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1674153055706816000.2145bebc-2239-42ea-bdb2-0cced640b485",
+    "fullUrl" : "ServiceRequest/1674521442655835000.74388fcf-45d4-442a-955d-fee1351157ba",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1674153055706816000.2145bebc-2239-42ea-bdb2-0cced640b485",
+      "id" : "1674521442655835000.74388fcf-45d4-442a-955d-fee1351157ba",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9525,7 +9519,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1674153055706588000.e790925d-9742-4994-9470-c139d925121e"
+          "reference" : "Practitioner/1674521442655526000.df09ebb8-6142-4855-8416-4d3e1eb111d9"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/result-status",
@@ -9552,8 +9546,7 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "FILL"
           } ]
         },
         "system" : "urn:id:M12776123.5",
@@ -9569,10 +9562,10 @@
         "text" : "VITEK2 AST-GP75"
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "requester" : {
-        "reference" : "PractitionerRole/1674153055709775000.1f412974-39b0-4d98-a512-8eec9bb7c0f3"
+        "reference" : "PractitionerRole/1674521442658589000.bc7bae7d-0c8a-4c11-b4ed-014cc803f1fc"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -9594,10 +9587,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c",
+    "fullUrl" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793",
     "resource" : {
       "resourceType" : "Patient",
-      "id" : "1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c",
+      "id" : "1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9881,15 +9874,15 @@
           "country" : "USA"
         },
         "organization" : {
-          "reference" : "Organization/1674153055328749000.59c45ca4-1b52-48c5-9db1-32cd6d35ec26"
+          "reference" : "Organization/1674521442226765000.9172dd54-17af-4ed5-996c-f406125bf949"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1674153055328749000.59c45ca4-1b52-48c5-9db1-32cd6d35ec26",
+    "fullUrl" : "Organization/1674521442226765000.9172dd54-17af-4ed5-996c-f406125bf949",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1674153055328749000.59c45ca4-1b52-48c5-9db1-32cd6d35ec26",
+      "id" : "1674521442226765000.9172dd54-17af-4ed5-996c-f406125bf949",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -9921,10 +9914,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Encounter/1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462",
+    "fullUrl" : "Encounter/1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb",
     "resource" : {
       "resourceType" : "Encounter",
-      "id" : "1674153055343780000.cfa981d2-0eac-44d8-a060-7640e7e12462",
+      "id" : "1674521442243615000.3fe42329-d3e4-460b-9ff7-f87e8dba5cbb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9977,7 +9970,7 @@
         } ]
       },
       "subject" : {
-        "reference" : "Patient/1674153055329809000.6d61b1d4-be5e-4ac9-b1d1-3c8541f3f00c"
+        "reference" : "Patient/1674521442228130000.c87c46a6-43b7-4288-aa23-b3489f23a793"
       },
       "participant" : [ {
         "type" : [ {
@@ -9988,7 +9981,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1674153055337438000.ea87e39e-eb48-4254-8c3b-a066afd1fae7"
+          "reference" : "Practitioner/1674521442235732000.521230ba-32d6-4968-af86-b4c5cd2911e5"
         }
       }, {
         "type" : [ {
@@ -9999,7 +9992,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1674153055339052000.ea62bedd-078d-4692-a4c8-f34967775630"
+          "reference" : "Practitioner/1674521442237910000.8dd16c59-8faa-4304-a2c0-b02cfc8f6260"
         }
       }, {
         "type" : [ {
@@ -10010,7 +10003,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1674153055340428000.2c6e6247-ea9a-4670-b351-2bd38441368a"
+          "reference" : "Practitioner/1674521442239644000.62f7dc1c-7137-468c-84b6-6a79f5afba03"
         }
       }, {
         "type" : [ {
@@ -10021,7 +10014,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1674153055341981000.13cde552-91ae-4e36-be2c-8c699ec5cf59"
+          "reference" : "Practitioner/1674521442241374000.80d195da-3a90-4bf3-ad99-386e04452060"
         }
       }, {
         "type" : [ {
@@ -10032,7 +10025,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1674153055343217000.77aa306c-608e-4157-8d7c-1b4a1644f5c5"
+          "reference" : "Practitioner/1674521442243071000.6b88e931-2abf-494f-8602-99ed74f0d89a"
         }
       }, {
         "type" : [ {
@@ -10043,7 +10036,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1674153055344670000.3e8e4592-3b45-45bd-9bfa-888250ef9742"
+          "reference" : "Practitioner/1674521442244541000.c2312735-b150-4a85-ab34-5e46b4cd596a"
         }
       } ],
       "period" : {
@@ -10063,16 +10056,16 @@
       },
       "location" : [ {
         "location" : {
-          "reference" : "Location/1674153055372493000.782f97cd-0939-4392-8335-1b079453564e"
+          "reference" : "Location/1674521442276925000.a82ce4e5-ebd6-44d9-b9af-30895c33682c"
         },
         "status" : "active"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055337438000.ea87e39e-eb48-4254-8c3b-a066afd1fae7",
+    "fullUrl" : "Practitioner/1674521442235732000.521230ba-32d6-4968-af86-b4c5cd2911e5",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055337438000.ea87e39e-eb48-4254-8c3b-a066afd1fae7",
+      "id" : "1674521442235732000.521230ba-32d6-4968-af86-b4c5cd2911e5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10118,10 +10111,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055339052000.ea62bedd-078d-4692-a4c8-f34967775630",
+    "fullUrl" : "Practitioner/1674521442237910000.8dd16c59-8faa-4304-a2c0-b02cfc8f6260",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055339052000.ea62bedd-078d-4692-a4c8-f34967775630",
+      "id" : "1674521442237910000.8dd16c59-8faa-4304-a2c0-b02cfc8f6260",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10167,10 +10160,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055340428000.2c6e6247-ea9a-4670-b351-2bd38441368a",
+    "fullUrl" : "Practitioner/1674521442239644000.62f7dc1c-7137-468c-84b6-6a79f5afba03",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055340428000.2c6e6247-ea9a-4670-b351-2bd38441368a",
+      "id" : "1674521442239644000.62f7dc1c-7137-468c-84b6-6a79f5afba03",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10216,10 +10209,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055341981000.13cde552-91ae-4e36-be2c-8c699ec5cf59",
+    "fullUrl" : "Practitioner/1674521442241374000.80d195da-3a90-4bf3-ad99-386e04452060",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055341981000.13cde552-91ae-4e36-be2c-8c699ec5cf59",
+      "id" : "1674521442241374000.80d195da-3a90-4bf3-ad99-386e04452060",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10262,10 +10255,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055343217000.77aa306c-608e-4157-8d7c-1b4a1644f5c5",
+    "fullUrl" : "Practitioner/1674521442243071000.6b88e931-2abf-494f-8602-99ed74f0d89a",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055343217000.77aa306c-608e-4157-8d7c-1b4a1644f5c5",
+      "id" : "1674521442243071000.6b88e931-2abf-494f-8602-99ed74f0d89a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10308,10 +10301,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1674153055344670000.3e8e4592-3b45-45bd-9bfa-888250ef9742",
+    "fullUrl" : "Practitioner/1674521442244541000.c2312735-b150-4a85-ab34-5e46b4cd596a",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1674153055344670000.3e8e4592-3b45-45bd-9bfa-888250ef9742",
+      "id" : "1674521442244541000.c2312735-b150-4a85-ab34-5e46b4cd596a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10357,10 +10350,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1674153055372493000.782f97cd-0939-4392-8335-1b079453564e",
+    "fullUrl" : "Location/1674521442276925000.a82ce4e5-ebd6-44d9-b9af-30895c33682c",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1674153055372493000.782f97cd-0939-4392-8335-1b079453564e",
+      "id" : "1674521442276925000.a82ce4e5-ebd6-44d9-b9af-30895c33682c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",

--- a/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0006.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0006.fhir
@@ -1,14 +1,14 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1673381819538984000.4a062f8e-c5cc-49bd-a224-3d44752297e2",
+  "id" : "1674157637470916000.2cc27992-5c2b-4953-a0bf-22f9d76e2ee5",
   "meta" : {
-    "lastUpdated" : "2023-01-10T14:16:59.547-06:00"
+    "lastUpdated" : "2023-01-19T12:47:17.479-07:00"
   },
   "identifier" : {
     "value" : "MT_COCSR_ORU_SRPHELR.1.4978157"
   },
   "type" : "message",
-  "timestamp" : "2028-08-02T08:34:21.000-05:00",
+  "timestamp" : "2028-08-02T06:34:21.000-07:00",
   "entry" : [ {
     "fullUrl" : "MessageHeader/0a13c720-6cf6-346e-9432-b45f95182407",
     "resource" : {
@@ -31,17 +31,17 @@
       },
       "destination" : [ {
         "target" : {
-          "reference" : "Device/1673381819613963000.8a09c870-55a0-4436-98e5-15e3dfed712c"
+          "reference" : "Device/1674157637552664000.bbba0c6e-48f4-4177-8fb0-de6d4a134fac"
         }
       } ],
       "sender" : {
-        "reference" : "Organization/1673381819611048000.99d22bd7-1bd4-4932-af92-43105d3b735e"
+        "reference" : "Organization/1674157637549801000.f9cd7ed0-66a8-443e-ac28-4e3c624c6e85"
       },
       "source" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
           "valueReference" : {
-            "reference" : "Organization/1673381819624197000.ed9c4cd0-7cb1-4381-8f65-229ee6c10b2f"
+            "reference" : "Organization/1674157637562380000.f0f520a1-31a9-4dee-b5c1-480828773d43"
           }
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
@@ -56,10 +56,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1673381819611048000.99d22bd7-1bd4-4932-af92-43105d3b735e",
+    "fullUrl" : "Organization/1674157637549801000.f9cd7ed0-66a8-443e-ac28-4e3c624c6e85",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381819611048000.99d22bd7-1bd4-4932-af92-43105d3b735e",
+      "id" : "1674157637549801000.f9cd7ed0-66a8-443e-ac28-4e3c624c6e85",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -75,10 +75,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1673381819613963000.8a09c870-55a0-4436-98e5-15e3dfed712c",
+    "fullUrl" : "Device/1674157637552664000.bbba0c6e-48f4-4177-8fb0-de6d4a134fac",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1673381819613963000.8a09c870-55a0-4436-98e5-15e3dfed712c",
+      "id" : "1674157637552664000.bbba0c6e-48f4-4177-8fb0-de6d4a134fac",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -91,10 +91,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1673381819624197000.ed9c4cd0-7cb1-4381-8f65-229ee6c10b2f",
+    "fullUrl" : "Organization/1674157637562380000.f0f520a1-31a9-4dee-b5c1-480828773d43",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381819624197000.ed9c4cd0-7cb1-4381-8f65-229ee6c10b2f",
+      "id" : "1674157637562380000.f0f520a1-31a9-4dee-b5c1-480828773d43",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -132,10 +132,10 @@
       "name" : "MEDITECH, Inc."
     }
   }, {
-    "fullUrl" : "Provenance/1673381821052757000.6aaec211-4da8-427f-8815-da34b2b2382a",
+    "fullUrl" : "Provenance/1674157638889575000.336c54e7-f29b-4f4f-8851-2c6df4bd577b",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1673381821052757000.6aaec211-4da8-427f-8815-da34b2b2382a",
+      "id" : "1674157638889575000.336c54e7-f29b-4f4f-8851-2c6df4bd577b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -162,21 +162,21 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1673381821051895000.ebeee6ba-bede-4591-ae53-78955e0352bc"
+          "reference" : "Organization/1674157638888841000.c2617c76-38b3-4e7f-9fd7-5ff9b9eb8811"
         }
       } ],
       "entity" : [ {
         "role" : "source",
         "what" : {
-          "reference" : "Device/1673381821054193000.3d7fb0da-1359-45f5-a3a9-3341010ed397"
+          "reference" : "Device/1674157638890916000.74660e76-cd07-4b83-b185-7557e3ee8f48"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821051895000.ebeee6ba-bede-4591-ae53-78955e0352bc",
+    "fullUrl" : "Organization/1674157638888841000.c2617c76-38b3-4e7f-9fd7-5ff9b9eb8811",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821051895000.ebeee6ba-bede-4591-ae53-78955e0352bc",
+      "id" : "1674157638888841000.c2617c76-38b3-4e7f-9fd7-5ff9b9eb8811",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -203,10 +203,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1673381821054193000.3d7fb0da-1359-45f5-a3a9-3341010ed397",
+    "fullUrl" : "Device/1674157638890916000.74660e76-cd07-4b83-b185-7557e3ee8f48",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1673381821054193000.3d7fb0da-1359-45f5-a3a9-3341010ed397",
+      "id" : "1674157638890916000.74660e76-cd07-4b83-b185-7557e3ee8f48",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -224,10 +224,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Observation/1673381821161542000.52150245-0a0c-45f3-9408-6b0bfb7deb57",
+    "fullUrl" : "Observation/1674157638997099000.885713a2-3430-4176-8213-92e25ec50b67",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821161542000.52150245-0a0c-45f3-9408-6b0bfb7deb57",
+      "id" : "1674157638997099000.885713a2-3430-4176-8213-92e25ec50b67",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -244,7 +244,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821161418000.94f935cc-80d3-4f4c-a94f-adfb5222a063"
+          "reference" : "Organization/1674157638996979000.b98351d1-1566-4e73-b1a0-3487017bf235"
         }
       } ],
       "identifier" : [ {
@@ -278,23 +278,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821159745000.fd8424fd-966c-46ae-80bd-dccb12069b54"
+        "reference" : "PractitionerRole/1674157638995203000.0c20a393-7d4a-471e-9286-105bc749099d"
       } ],
       "valueString" : "The test methodology for this assay is RT-PCR.  Negative"
     }
   }, {
-    "fullUrl" : "Location/1673381821155870000.6fffbb7b-90d4-4145-bc55-ea0bf68edf58",
+    "fullUrl" : "Location/1674157638989174000.3adb0ac4-65fe-44ac-88ee-0014e58f8bea",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821155870000.6fffbb7b-90d4-4145-bc55-ea0bf68edf58",
+      "id" : "1674157638989174000.3adb0ac4-65fe-44ac-88ee-0014e58f8bea",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -308,10 +308,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821156624000.79b9bcd9-71fd-4faa-8e14-ab8f8b5d5156",
+    "fullUrl" : "Practitioner/1674157638990013000.e917ed16-a0d9-40d6-b44b-351e1d4bf3f4",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821156624000.79b9bcd9-71fd-4faa-8e14-ab8f8b5d5156",
+      "id" : "1674157638990013000.e917ed16-a0d9-40d6-b44b-351e1d4bf3f4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -333,7 +333,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821155870000.6fffbb7b-90d4-4145-bc55-ea0bf68edf58"
+          "reference" : "Location/1674157638989174000.3adb0ac4-65fe-44ac-88ee-0014e58f8bea"
         }
       } ],
       "identifier" : [ {
@@ -359,10 +359,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821159634000.7a04244a-e0ba-4495-a014-f56514f62ad1",
+    "fullUrl" : "Organization/1674157638995073000.ce0aea89-1ab9-4c55-a5a5-0984ccca588e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821159634000.7a04244a-e0ba-4495-a014-f56514f62ad1",
+      "id" : "1674157638995073000.ce0aea89-1ab9-4c55-a5a5-0984ccca588e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -406,10 +406,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821159745000.fd8424fd-966c-46ae-80bd-dccb12069b54",
+    "fullUrl" : "PractitionerRole/1674157638995203000.0c20a393-7d4a-471e-9286-105bc749099d",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821159745000.fd8424fd-966c-46ae-80bd-dccb12069b54",
+      "id" : "1674157638995203000.0c20a393-7d4a-471e-9286-105bc749099d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -421,10 +421,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821156624000.79b9bcd9-71fd-4faa-8e14-ab8f8b5d5156"
+        "reference" : "Practitioner/1674157638990013000.e917ed16-a0d9-40d6-b44b-351e1d4bf3f4"
       },
       "organization" : {
-        "reference" : "Organization/1673381821159634000.7a04244a-e0ba-4495-a014-f56514f62ad1"
+        "reference" : "Organization/1674157638995073000.ce0aea89-1ab9-4c55-a5a5-0984ccca588e"
       },
       "code" : [ {
         "coding" : [ {
@@ -434,10 +434,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821161418000.94f935cc-80d3-4f4c-a94f-adfb5222a063",
+    "fullUrl" : "Organization/1674157638996979000.b98351d1-1566-4e73-b1a0-3487017bf235",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821161418000.94f935cc-80d3-4f4c-a94f-adfb5222a063",
+      "id" : "1674157638996979000.b98351d1-1566-4e73-b1a0-3487017bf235",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -463,10 +463,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821168614000.6d2bdc0c-1f6b-48a8-a752-ec898bf709c2",
+    "fullUrl" : "Observation/1674157639003971000.f595cb9e-c700-43c4-95cc-1aad9fa7bb7b",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821168614000.6d2bdc0c-1f6b-48a8-a752-ec898bf709c2",
+      "id" : "1674157639003971000.f595cb9e-c700-43c4-95cc-1aad9fa7bb7b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -483,7 +483,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821168497000.a8f12d82-25f1-4ef5-8206-b5c19d6440e0"
+          "reference" : "Organization/1674157639003857000.d630562f-b99b-41e0-99a7-aeb675efee9b"
         }
       } ],
       "identifier" : [ {
@@ -517,23 +517,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821166998000.08547246-c291-46ec-82fb-8129a1c91dd3"
+        "reference" : "PractitionerRole/1674157639002630000.360c00d9-5f35-4bdd-9adb-20da164df9e2"
       } ],
       "valueString" : "results do not preclude SARS-CoV-2, influenza A, and/or"
     }
   }, {
-    "fullUrl" : "Location/1673381821164105000.d58a3289-bdc5-4a58-95c1-06e73059159a",
+    "fullUrl" : "Location/1674157638999718000.7dcaf1a3-460a-456f-855f-b043d977ba41",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821164105000.d58a3289-bdc5-4a58-95c1-06e73059159a",
+      "id" : "1674157638999718000.7dcaf1a3-460a-456f-855f-b043d977ba41",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -547,10 +547,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821164577000.c9330a54-cd29-4aff-bf52-b2ea72e59b45",
+    "fullUrl" : "Practitioner/1674157639000275000.87956741-aa1d-4d71-b12d-7ac5f20cd2ac",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821164577000.c9330a54-cd29-4aff-bf52-b2ea72e59b45",
+      "id" : "1674157639000275000.87956741-aa1d-4d71-b12d-7ac5f20cd2ac",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -572,7 +572,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821164105000.d58a3289-bdc5-4a58-95c1-06e73059159a"
+          "reference" : "Location/1674157638999718000.7dcaf1a3-460a-456f-855f-b043d977ba41"
         }
       } ],
       "identifier" : [ {
@@ -598,10 +598,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821166895000.7e20f182-493c-445d-b09b-ff125271e485",
+    "fullUrl" : "Organization/1674157639002540000.917b4684-e4b9-46e8-ac8d-f13f9335f55d",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821166895000.7e20f182-493c-445d-b09b-ff125271e485",
+      "id" : "1674157639002540000.917b4684-e4b9-46e8-ac8d-f13f9335f55d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -645,10 +645,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821166998000.08547246-c291-46ec-82fb-8129a1c91dd3",
+    "fullUrl" : "PractitionerRole/1674157639002630000.360c00d9-5f35-4bdd-9adb-20da164df9e2",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821166998000.08547246-c291-46ec-82fb-8129a1c91dd3",
+      "id" : "1674157639002630000.360c00d9-5f35-4bdd-9adb-20da164df9e2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -660,10 +660,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821164577000.c9330a54-cd29-4aff-bf52-b2ea72e59b45"
+        "reference" : "Practitioner/1674157639000275000.87956741-aa1d-4d71-b12d-7ac5f20cd2ac"
       },
       "organization" : {
-        "reference" : "Organization/1673381821166895000.7e20f182-493c-445d-b09b-ff125271e485"
+        "reference" : "Organization/1674157639002540000.917b4684-e4b9-46e8-ac8d-f13f9335f55d"
       },
       "code" : [ {
         "coding" : [ {
@@ -673,10 +673,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821168497000.a8f12d82-25f1-4ef5-8206-b5c19d6440e0",
+    "fullUrl" : "Organization/1674157639003857000.d630562f-b99b-41e0-99a7-aeb675efee9b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821168497000.a8f12d82-25f1-4ef5-8206-b5c19d6440e0",
+      "id" : "1674157639003857000.d630562f-b99b-41e0-99a7-aeb675efee9b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -702,10 +702,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821175670000.730f6692-5ffa-48b5-a484-c10a27151ce3",
+    "fullUrl" : "Observation/1674157639009999000.8a9a57f4-cd2d-42b9-828c-27dbceb22ca1",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821175670000.730f6692-5ffa-48b5-a484-c10a27151ce3",
+      "id" : "1674157639009999000.8a9a57f4-cd2d-42b9-828c-27dbceb22ca1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -722,7 +722,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821175548000.64bd1961-85f7-4743-bfed-49783b69076d"
+          "reference" : "Organization/1674157639009872000.37f9f527-2cda-4690-b424-e8de1697312c"
         }
       } ],
       "identifier" : [ {
@@ -756,23 +756,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821174023000.1181fe01-d500-4e44-b716-577bd7248f50"
+        "reference" : "PractitionerRole/1674157639008455000.9187e974-ce56-4d5a-bc98-5e7af3578f97"
       } ],
       "valueString" : "influenza B infection and should not be used as the sole"
     }
   }, {
-    "fullUrl" : "Location/1673381821170813000.c2870169-abbe-48ec-9d18-1092e635a880",
+    "fullUrl" : "Location/1674157639005599000.e50a300f-e0c2-4465-b9f7-5adb40d45477",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821170813000.c2870169-abbe-48ec-9d18-1092e635a880",
+      "id" : "1674157639005599000.e50a300f-e0c2-4465-b9f7-5adb40d45477",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -786,10 +786,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821171532000.602e28fb-b6ed-4bb1-ad62-de25544573fd",
+    "fullUrl" : "Practitioner/1674157639006236000.74cb1835-5adc-49a7-b016-941c9299ad21",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821171532000.602e28fb-b6ed-4bb1-ad62-de25544573fd",
+      "id" : "1674157639006236000.74cb1835-5adc-49a7-b016-941c9299ad21",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -811,7 +811,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821170813000.c2870169-abbe-48ec-9d18-1092e635a880"
+          "reference" : "Location/1674157639005599000.e50a300f-e0c2-4465-b9f7-5adb40d45477"
         }
       } ],
       "identifier" : [ {
@@ -837,10 +837,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821173927000.67728fe2-6545-476b-83d4-d04da06bdaca",
+    "fullUrl" : "Organization/1674157639008330000.03e2de30-2bff-4b0a-9dca-18a3a3150f3d",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821173927000.67728fe2-6545-476b-83d4-d04da06bdaca",
+      "id" : "1674157639008330000.03e2de30-2bff-4b0a-9dca-18a3a3150f3d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -884,10 +884,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821174023000.1181fe01-d500-4e44-b716-577bd7248f50",
+    "fullUrl" : "PractitionerRole/1674157639008455000.9187e974-ce56-4d5a-bc98-5e7af3578f97",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821174023000.1181fe01-d500-4e44-b716-577bd7248f50",
+      "id" : "1674157639008455000.9187e974-ce56-4d5a-bc98-5e7af3578f97",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -899,10 +899,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821171532000.602e28fb-b6ed-4bb1-ad62-de25544573fd"
+        "reference" : "Practitioner/1674157639006236000.74cb1835-5adc-49a7-b016-941c9299ad21"
       },
       "organization" : {
-        "reference" : "Organization/1673381821173927000.67728fe2-6545-476b-83d4-d04da06bdaca"
+        "reference" : "Organization/1674157639008330000.03e2de30-2bff-4b0a-9dca-18a3a3150f3d"
       },
       "code" : [ {
         "coding" : [ {
@@ -912,10 +912,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821175548000.64bd1961-85f7-4743-bfed-49783b69076d",
+    "fullUrl" : "Organization/1674157639009872000.37f9f527-2cda-4690-b424-e8de1697312c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821175548000.64bd1961-85f7-4743-bfed-49783b69076d",
+      "id" : "1674157639009872000.37f9f527-2cda-4690-b424-e8de1697312c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -941,10 +941,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821185637000.ed514958-0dcc-4d12-ba9d-d499205dbc89",
+    "fullUrl" : "Observation/1674157639019385000.1fb07a22-e689-4c69-80e3-9b0b0f02e4d0",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821185637000.ed514958-0dcc-4d12-ba9d-d499205dbc89",
+      "id" : "1674157639019385000.1fb07a22-e689-4c69-80e3-9b0b0f02e4d0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -961,7 +961,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821185526000.b95b2d48-d4af-4fee-b801-e2768109ddd7"
+          "reference" : "Organization/1674157639019226000.cd6371a1-d8f6-45db-b098-142d236b9fe8"
         }
       } ],
       "identifier" : [ {
@@ -995,23 +995,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821184046000.7a4f6b0e-7f5b-4700-922e-6cfa9684670f"
+        "reference" : "PractitionerRole/1674157639017098000.49aaaf75-013b-4629-a68e-36ad14fd79d9"
       } ],
       "valueString" : "basis for treatment or other patient management decisions."
     }
   }, {
-    "fullUrl" : "Location/1673381821181055000.1a793e74-0342-47eb-91bb-1527ef3eb11a",
+    "fullUrl" : "Location/1674157639011989000.bfe44025-ada2-49ed-8137-087160b5d61c",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821181055000.1a793e74-0342-47eb-91bb-1527ef3eb11a",
+      "id" : "1674157639011989000.bfe44025-ada2-49ed-8137-087160b5d61c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1025,10 +1025,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821181590000.0d511a18-176f-45ec-9fbf-b0c6eec88b7b",
+    "fullUrl" : "Practitioner/1674157639012735000.5da80a41-82cd-4f89-bfb8-0f96fa0ba27a",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821181590000.0d511a18-176f-45ec-9fbf-b0c6eec88b7b",
+      "id" : "1674157639012735000.5da80a41-82cd-4f89-bfb8-0f96fa0ba27a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1050,7 +1050,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821181055000.1a793e74-0342-47eb-91bb-1527ef3eb11a"
+          "reference" : "Location/1674157639011989000.bfe44025-ada2-49ed-8137-087160b5d61c"
         }
       } ],
       "identifier" : [ {
@@ -1076,10 +1076,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821183931000.66a384b4-78ed-4f24-a445-c81f96294227",
+    "fullUrl" : "Organization/1674157639016867000.7308801c-65f8-4a26-883d-4d2f633872fe",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821183931000.66a384b4-78ed-4f24-a445-c81f96294227",
+      "id" : "1674157639016867000.7308801c-65f8-4a26-883d-4d2f633872fe",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1123,10 +1123,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821184046000.7a4f6b0e-7f5b-4700-922e-6cfa9684670f",
+    "fullUrl" : "PractitionerRole/1674157639017098000.49aaaf75-013b-4629-a68e-36ad14fd79d9",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821184046000.7a4f6b0e-7f5b-4700-922e-6cfa9684670f",
+      "id" : "1674157639017098000.49aaaf75-013b-4629-a68e-36ad14fd79d9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1138,10 +1138,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821181590000.0d511a18-176f-45ec-9fbf-b0c6eec88b7b"
+        "reference" : "Practitioner/1674157639012735000.5da80a41-82cd-4f89-bfb8-0f96fa0ba27a"
       },
       "organization" : {
-        "reference" : "Organization/1673381821183931000.66a384b4-78ed-4f24-a445-c81f96294227"
+        "reference" : "Organization/1674157639016867000.7308801c-65f8-4a26-883d-4d2f633872fe"
       },
       "code" : [ {
         "coding" : [ {
@@ -1151,10 +1151,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821185526000.b95b2d48-d4af-4fee-b801-e2768109ddd7",
+    "fullUrl" : "Organization/1674157639019226000.cd6371a1-d8f6-45db-b098-142d236b9fe8",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821185526000.b95b2d48-d4af-4fee-b801-e2768109ddd7",
+      "id" : "1674157639019226000.cd6371a1-d8f6-45db-b098-142d236b9fe8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1180,10 +1180,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821191996000.2ec903f1-48f3-475b-adba-8348bc92e1f1",
+    "fullUrl" : "Observation/1674157639028243000.95fc1546-4336-4c48-9aac-870962f62a60",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821191996000.2ec903f1-48f3-475b-adba-8348bc92e1f1",
+      "id" : "1674157639028243000.95fc1546-4336-4c48-9aac-870962f62a60",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1200,7 +1200,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821191890000.0579ec72-adde-4f4d-8b33-498274b8c3f7"
+          "reference" : "Organization/1674157639028132000.95d88df0-5361-4cd8-a1ee-132c43d5ba49"
         }
       } ],
       "identifier" : [ {
@@ -1234,23 +1234,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821190509000.5551ba59-c216-4f1e-8960-e3e2fa868e3e"
+        "reference" : "PractitionerRole/1674157639026528000.1b9a6495-ad7f-4d14-ac06-cda1d0e67abd"
       } ],
       "valueString" : "Negative results must be combined with clinical"
     }
   }, {
-    "fullUrl" : "Location/1673381821187387000.3808a6d0-74e3-4e98-98a8-f21247871f25",
+    "fullUrl" : "Location/1674157639023015000.60d30906-86c8-49de-ab0e-35c5e664f761",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821187387000.3808a6d0-74e3-4e98-98a8-f21247871f25",
+      "id" : "1674157639023015000.60d30906-86c8-49de-ab0e-35c5e664f761",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1264,10 +1264,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821187876000.4883473f-6156-4924-a0b2-1c6aeba10843",
+    "fullUrl" : "Practitioner/1674157639023628000.a95bb006-2640-4820-b989-e2d5aa466891",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821187876000.4883473f-6156-4924-a0b2-1c6aeba10843",
+      "id" : "1674157639023628000.a95bb006-2640-4820-b989-e2d5aa466891",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1289,7 +1289,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821187387000.3808a6d0-74e3-4e98-98a8-f21247871f25"
+          "reference" : "Location/1674157639023015000.60d30906-86c8-49de-ab0e-35c5e664f761"
         }
       } ],
       "identifier" : [ {
@@ -1315,10 +1315,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821190383000.8815eebb-d7d6-42e1-85e6-ad97807dacb2",
+    "fullUrl" : "Organization/1674157639026406000.886657b3-6030-4593-b903-9fc1b8e1126e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821190383000.8815eebb-d7d6-42e1-85e6-ad97807dacb2",
+      "id" : "1674157639026406000.886657b3-6030-4593-b903-9fc1b8e1126e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1362,10 +1362,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821190509000.5551ba59-c216-4f1e-8960-e3e2fa868e3e",
+    "fullUrl" : "PractitionerRole/1674157639026528000.1b9a6495-ad7f-4d14-ac06-cda1d0e67abd",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821190509000.5551ba59-c216-4f1e-8960-e3e2fa868e3e",
+      "id" : "1674157639026528000.1b9a6495-ad7f-4d14-ac06-cda1d0e67abd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1377,10 +1377,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821187876000.4883473f-6156-4924-a0b2-1c6aeba10843"
+        "reference" : "Practitioner/1674157639023628000.a95bb006-2640-4820-b989-e2d5aa466891"
       },
       "organization" : {
-        "reference" : "Organization/1673381821190383000.8815eebb-d7d6-42e1-85e6-ad97807dacb2"
+        "reference" : "Organization/1674157639026406000.886657b3-6030-4593-b903-9fc1b8e1126e"
       },
       "code" : [ {
         "coding" : [ {
@@ -1390,10 +1390,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821191890000.0579ec72-adde-4f4d-8b33-498274b8c3f7",
+    "fullUrl" : "Organization/1674157639028132000.95d88df0-5361-4cd8-a1ee-132c43d5ba49",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821191890000.0579ec72-adde-4f4d-8b33-498274b8c3f7",
+      "id" : "1674157639028132000.95d88df0-5361-4cd8-a1ee-132c43d5ba49",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1419,10 +1419,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821198144000.60cdcd0a-c8c0-4f08-b1dc-015641df1277",
+    "fullUrl" : "Observation/1674157639035908000.d36a5168-7fa8-4d61-8703-c44fe9ea6ccb",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821198144000.60cdcd0a-c8c0-4f08-b1dc-015641df1277",
+      "id" : "1674157639035908000.d36a5168-7fa8-4d61-8703-c44fe9ea6ccb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1439,7 +1439,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821198037000.fe43a0af-a619-400f-96f3-3baf130bfd82"
+          "reference" : "Organization/1674157639035806000.78ebd22d-8a62-42a5-bb9d-94d61cdac107"
         }
       } ],
       "identifier" : [ {
@@ -1473,23 +1473,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821196553000.db68310c-1ddc-45ad-bc5e-910565b7e2ff"
+        "reference" : "PractitionerRole/1674157639034136000.5472f513-d90c-42c1-bf58-4274137bdc1f"
       } ],
       "valueString" : "observations, patient history, and/or epidemiological"
     }
   }, {
-    "fullUrl" : "Location/1673381821193754000.0aa7443a-cd82-4d06-89ae-bba3eb4e2100",
+    "fullUrl" : "Location/1674157639030262000.295fd4fa-2593-40b8-804b-5e054be27765",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821193754000.0aa7443a-cd82-4d06-89ae-bba3eb4e2100",
+      "id" : "1674157639030262000.295fd4fa-2593-40b8-804b-5e054be27765",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1503,10 +1503,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821194196000.a84b7413-f34d-4017-b614-bba3338cbc19",
+    "fullUrl" : "Practitioner/1674157639031018000.63ed77fa-40aa-4491-b1f2-a4b1244e573b",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821194196000.a84b7413-f34d-4017-b614-bba3338cbc19",
+      "id" : "1674157639031018000.63ed77fa-40aa-4491-b1f2-a4b1244e573b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1528,7 +1528,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821193754000.0aa7443a-cd82-4d06-89ae-bba3eb4e2100"
+          "reference" : "Location/1674157639030262000.295fd4fa-2593-40b8-804b-5e054be27765"
         }
       } ],
       "identifier" : [ {
@@ -1554,10 +1554,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821196454000.d49a1bc9-e84a-47bf-8f52-33b5904f5ee1",
+    "fullUrl" : "Organization/1674157639034000000.e5f965f3-d57e-4cdf-ace4-735860a7e6cc",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821196454000.d49a1bc9-e84a-47bf-8f52-33b5904f5ee1",
+      "id" : "1674157639034000000.e5f965f3-d57e-4cdf-ace4-735860a7e6cc",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1601,10 +1601,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821196553000.db68310c-1ddc-45ad-bc5e-910565b7e2ff",
+    "fullUrl" : "PractitionerRole/1674157639034136000.5472f513-d90c-42c1-bf58-4274137bdc1f",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821196553000.db68310c-1ddc-45ad-bc5e-910565b7e2ff",
+      "id" : "1674157639034136000.5472f513-d90c-42c1-bf58-4274137bdc1f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1616,10 +1616,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821194196000.a84b7413-f34d-4017-b614-bba3338cbc19"
+        "reference" : "Practitioner/1674157639031018000.63ed77fa-40aa-4491-b1f2-a4b1244e573b"
       },
       "organization" : {
-        "reference" : "Organization/1673381821196454000.d49a1bc9-e84a-47bf-8f52-33b5904f5ee1"
+        "reference" : "Organization/1674157639034000000.e5f965f3-d57e-4cdf-ace4-735860a7e6cc"
       },
       "code" : [ {
         "coding" : [ {
@@ -1629,10 +1629,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821198037000.fe43a0af-a619-400f-96f3-3baf130bfd82",
+    "fullUrl" : "Organization/1674157639035806000.78ebd22d-8a62-42a5-bb9d-94d61cdac107",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821198037000.fe43a0af-a619-400f-96f3-3baf130bfd82",
+      "id" : "1674157639035806000.78ebd22d-8a62-42a5-bb9d-94d61cdac107",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1658,10 +1658,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821204744000.cd917e02-708a-488a-83a3-805819ee9ae4",
+    "fullUrl" : "Observation/1674157639042974000.508cb28c-357f-4177-bfdc-767bca43551a",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821204744000.cd917e02-708a-488a-83a3-805819ee9ae4",
+      "id" : "1674157639042974000.508cb28c-357f-4177-bfdc-767bca43551a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1678,7 +1678,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821204643000.9c144b99-1807-47fd-a876-54688fa894f0"
+          "reference" : "Organization/1674157639042871000.c016798f-7101-4024-9275-1369a0fe7257"
         }
       } ],
       "identifier" : [ {
@@ -1712,23 +1712,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821203335000.a19d103a-a8d0-4a9f-879a-9f712db4f59b"
+        "reference" : "PractitionerRole/1674157639041405000.3fdc0ea1-8e2a-41b7-83d7-eceaeaa3c1b3"
       } ],
       "valueString" : "information. A negative result does not rule out the"
     }
   }, {
-    "fullUrl" : "Location/1673381821200636000.6d4742db-1c96-4102-8e3c-6d357610b5e1",
+    "fullUrl" : "Location/1674157639038253000.3b5e940d-dc52-4d61-9a76-d9839eea2c03",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821200636000.6d4742db-1c96-4102-8e3c-6d357610b5e1",
+      "id" : "1674157639038253000.3b5e940d-dc52-4d61-9a76-d9839eea2c03",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1742,10 +1742,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821201076000.272250c7-c30d-4984-9b3d-51518bdc4cd5",
+    "fullUrl" : "Practitioner/1674157639038810000.f1284c13-6651-474c-9843-9cbdc48941ae",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821201076000.272250c7-c30d-4984-9b3d-51518bdc4cd5",
+      "id" : "1674157639038810000.f1284c13-6651-474c-9843-9cbdc48941ae",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1767,7 +1767,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821200636000.6d4742db-1c96-4102-8e3c-6d357610b5e1"
+          "reference" : "Location/1674157639038253000.3b5e940d-dc52-4d61-9a76-d9839eea2c03"
         }
       } ],
       "identifier" : [ {
@@ -1793,10 +1793,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821203235000.1fed7364-e403-4b60-b2f2-2bda6c3b3da6",
+    "fullUrl" : "Organization/1674157639041303000.88db3c2f-7fe6-46e7-b14c-bcad114628e0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821203235000.1fed7364-e403-4b60-b2f2-2bda6c3b3da6",
+      "id" : "1674157639041303000.88db3c2f-7fe6-46e7-b14c-bcad114628e0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1840,10 +1840,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821203335000.a19d103a-a8d0-4a9f-879a-9f712db4f59b",
+    "fullUrl" : "PractitionerRole/1674157639041405000.3fdc0ea1-8e2a-41b7-83d7-eceaeaa3c1b3",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821203335000.a19d103a-a8d0-4a9f-879a-9f712db4f59b",
+      "id" : "1674157639041405000.3fdc0ea1-8e2a-41b7-83d7-eceaeaa3c1b3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1855,10 +1855,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821201076000.272250c7-c30d-4984-9b3d-51518bdc4cd5"
+        "reference" : "Practitioner/1674157639038810000.f1284c13-6651-474c-9843-9cbdc48941ae"
       },
       "organization" : {
-        "reference" : "Organization/1673381821203235000.1fed7364-e403-4b60-b2f2-2bda6c3b3da6"
+        "reference" : "Organization/1674157639041303000.88db3c2f-7fe6-46e7-b14c-bcad114628e0"
       },
       "code" : [ {
         "coding" : [ {
@@ -1868,10 +1868,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821204643000.9c144b99-1807-47fd-a876-54688fa894f0",
+    "fullUrl" : "Organization/1674157639042871000.c016798f-7101-4024-9275-1369a0fe7257",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821204643000.9c144b99-1807-47fd-a876-54688fa894f0",
+      "id" : "1674157639042871000.c016798f-7101-4024-9275-1369a0fe7257",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1897,10 +1897,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821211572000.6463d1f4-767f-4eeb-873c-d3a3649098f6",
+    "fullUrl" : "Observation/1674157639048993000.6dae44ce-7def-4a01-9a70-7a12cba354b3",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821211572000.6463d1f4-767f-4eeb-873c-d3a3649098f6",
+      "id" : "1674157639048993000.6dae44ce-7def-4a01-9a70-7a12cba354b3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1917,7 +1917,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821211450000.5ed5a4ef-5ca5-4c94-9a85-97f6ea174e19"
+          "reference" : "Organization/1674157639048908000.e3e5af0f-7a7a-40fa-b5c7-86cf0861ec8f"
         }
       } ],
       "identifier" : [ {
@@ -1951,23 +1951,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821209994000.a3747297-d320-45fa-93d3-c3aa05fbae1d"
+        "reference" : "PractitionerRole/1674157639047893000.d279c140-e6c1-44d7-90d0-0033a3edd690"
       } ],
       "valueString" : "possibility of infection.  False negative results may occur"
     }
   }, {
-    "fullUrl" : "Location/1673381821206845000.c3ebbc24-39e9-4a84-a813-0990daf27205",
+    "fullUrl" : "Location/1674157639044923000.09eff021-d2c5-42ec-91e5-60937190d863",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821206845000.c3ebbc24-39e9-4a84-a813-0990daf27205",
+      "id" : "1674157639044923000.09eff021-d2c5-42ec-91e5-60937190d863",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1981,10 +1981,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821207316000.1ed6df6d-2890-421f-b1ed-2335e0c572c7",
+    "fullUrl" : "Practitioner/1674157639045466000.124b5ccc-4a13-4f7f-a38e-286a374869de",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821207316000.1ed6df6d-2890-421f-b1ed-2335e0c572c7",
+      "id" : "1674157639045466000.124b5ccc-4a13-4f7f-a38e-286a374869de",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2006,7 +2006,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821206845000.c3ebbc24-39e9-4a84-a813-0990daf27205"
+          "reference" : "Location/1674157639044923000.09eff021-d2c5-42ec-91e5-60937190d863"
         }
       } ],
       "identifier" : [ {
@@ -2032,10 +2032,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821209894000.81c1b87e-aefa-4fd7-8d1e-f64a56a058c8",
+    "fullUrl" : "Organization/1674157639047816000.10746699-323e-48f5-a59c-912912023466",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821209894000.81c1b87e-aefa-4fd7-8d1e-f64a56a058c8",
+      "id" : "1674157639047816000.10746699-323e-48f5-a59c-912912023466",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2079,10 +2079,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821209994000.a3747297-d320-45fa-93d3-c3aa05fbae1d",
+    "fullUrl" : "PractitionerRole/1674157639047893000.d279c140-e6c1-44d7-90d0-0033a3edd690",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821209994000.a3747297-d320-45fa-93d3-c3aa05fbae1d",
+      "id" : "1674157639047893000.d279c140-e6c1-44d7-90d0-0033a3edd690",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2094,10 +2094,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821207316000.1ed6df6d-2890-421f-b1ed-2335e0c572c7"
+        "reference" : "Practitioner/1674157639045466000.124b5ccc-4a13-4f7f-a38e-286a374869de"
       },
       "organization" : {
-        "reference" : "Organization/1673381821209894000.81c1b87e-aefa-4fd7-8d1e-f64a56a058c8"
+        "reference" : "Organization/1674157639047816000.10746699-323e-48f5-a59c-912912023466"
       },
       "code" : [ {
         "coding" : [ {
@@ -2107,10 +2107,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821211450000.5ed5a4ef-5ca5-4c94-9a85-97f6ea174e19",
+    "fullUrl" : "Organization/1674157639048908000.e3e5af0f-7a7a-40fa-b5c7-86cf0861ec8f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821211450000.5ed5a4ef-5ca5-4c94-9a85-97f6ea174e19",
+      "id" : "1674157639048908000.e3e5af0f-7a7a-40fa-b5c7-86cf0861ec8f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2136,10 +2136,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821218282000.54cd7ed8-7073-4513-9144-3cb9cad43214",
+    "fullUrl" : "Observation/1674157639053050000.f34086cd-071f-4e83-8524-fd3971a15e8e",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821218282000.54cd7ed8-7073-4513-9144-3cb9cad43214",
+      "id" : "1674157639053050000.f34086cd-071f-4e83-8524-fd3971a15e8e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2156,7 +2156,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821218162000.fb627f8f-7334-4448-9227-0f9236a8b607"
+          "reference" : "Organization/1674157639052968000.5a87ffb2-e05f-468c-a977-e0909f179b65"
         }
       } ],
       "identifier" : [ {
@@ -2190,23 +2190,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821216225000.593b1aa3-692f-4874-a04c-9bb21d7a5991"
+        "reference" : "PractitionerRole/1674157639052070000.2bb772e2-c6b0-4257-9aae-f0917748f889"
       } ],
       "valueString" : "if specimen is improperly collected, transported or handled."
     }
   }, {
-    "fullUrl" : "Location/1673381821213273000.9018c1f2-f283-42d6-9d8a-ae208e819de0",
+    "fullUrl" : "Location/1674157639050187000.6ee3363a-58cb-440f-ab47-c403b10e1755",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821213273000.9018c1f2-f283-42d6-9d8a-ae208e819de0",
+      "id" : "1674157639050187000.6ee3363a-58cb-440f-ab47-c403b10e1755",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2220,10 +2220,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821213711000.afdabed9-46be-4c96-9fb2-677f85df3263",
+    "fullUrl" : "Practitioner/1674157639050520000.a383a910-6448-4a26-b4c0-9988871a0cf0",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821213711000.afdabed9-46be-4c96-9fb2-677f85df3263",
+      "id" : "1674157639050520000.a383a910-6448-4a26-b4c0-9988871a0cf0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2245,7 +2245,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821213273000.9018c1f2-f283-42d6-9d8a-ae208e819de0"
+          "reference" : "Location/1674157639050187000.6ee3363a-58cb-440f-ab47-c403b10e1755"
         }
       } ],
       "identifier" : [ {
@@ -2271,10 +2271,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821216074000.73e812ab-d609-4709-bb70-4369fe68b917",
+    "fullUrl" : "Organization/1674157639051989000.ae8f9a67-ab0c-43a7-9748-e6a74d60075f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821216074000.73e812ab-d609-4709-bb70-4369fe68b917",
+      "id" : "1674157639051989000.ae8f9a67-ab0c-43a7-9748-e6a74d60075f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2318,10 +2318,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821216225000.593b1aa3-692f-4874-a04c-9bb21d7a5991",
+    "fullUrl" : "PractitionerRole/1674157639052070000.2bb772e2-c6b0-4257-9aae-f0917748f889",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821216225000.593b1aa3-692f-4874-a04c-9bb21d7a5991",
+      "id" : "1674157639052070000.2bb772e2-c6b0-4257-9aae-f0917748f889",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2333,10 +2333,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821213711000.afdabed9-46be-4c96-9fb2-677f85df3263"
+        "reference" : "Practitioner/1674157639050520000.a383a910-6448-4a26-b4c0-9988871a0cf0"
       },
       "organization" : {
-        "reference" : "Organization/1673381821216074000.73e812ab-d609-4709-bb70-4369fe68b917"
+        "reference" : "Organization/1674157639051989000.ae8f9a67-ab0c-43a7-9748-e6a74d60075f"
       },
       "code" : [ {
         "coding" : [ {
@@ -2346,10 +2346,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821218162000.fb627f8f-7334-4448-9227-0f9236a8b607",
+    "fullUrl" : "Organization/1674157639052968000.5a87ffb2-e05f-468c-a977-e0909f179b65",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821218162000.fb627f8f-7334-4448-9227-0f9236a8b607",
+      "id" : "1674157639052968000.5a87ffb2-e05f-468c-a977-e0909f179b65",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2375,10 +2375,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821224507000.7a032924-9440-4202-8b76-6d18e6966486",
+    "fullUrl" : "Observation/1674157639057085000.63e3136b-d19c-45f7-ba91-15f828648d59",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821224507000.7a032924-9440-4202-8b76-6d18e6966486",
+      "id" : "1674157639057085000.63e3136b-d19c-45f7-ba91-15f828648d59",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2395,7 +2395,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821224406000.54591d08-9b05-478e-a0d4-5db78688e677"
+          "reference" : "Organization/1674157639057003000.fb94e77d-107d-4df8-aa69-c1cfcffbd354"
         }
       } ],
       "identifier" : [ {
@@ -2429,23 +2429,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821223132000.0006031a-4057-44ea-b820-bade4f2081fb"
+        "reference" : "PractitionerRole/1674157639056033000.72d08b80-91e8-4df0-b776-95c280774936"
       } ],
       "valueString" : "False negative results may also occur if amplification"
     }
   }, {
-    "fullUrl" : "Location/1673381821220358000.0f30fb23-c657-447b-8e5d-86eba4c68642",
+    "fullUrl" : "Location/1674157639054220000.b2cf4428-301e-4264-87d3-8e1986a4b430",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821220358000.0f30fb23-c657-447b-8e5d-86eba4c68642",
+      "id" : "1674157639054220000.b2cf4428-301e-4264-87d3-8e1986a4b430",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2459,10 +2459,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821220799000.e6fbf540-9949-416d-8d68-42f209486f02",
+    "fullUrl" : "Practitioner/1674157639054524000.dcbb583c-8bd3-44e6-88ed-f0ad9a75880c",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821220799000.e6fbf540-9949-416d-8d68-42f209486f02",
+      "id" : "1674157639054524000.dcbb583c-8bd3-44e6-88ed-f0ad9a75880c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2484,7 +2484,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821220358000.0f30fb23-c657-447b-8e5d-86eba4c68642"
+          "reference" : "Location/1674157639054220000.b2cf4428-301e-4264-87d3-8e1986a4b430"
         }
       } ],
       "identifier" : [ {
@@ -2510,10 +2510,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821223033000.ad30225b-cb67-466e-80d9-5b3324ce12ee",
+    "fullUrl" : "Organization/1674157639055957000.1c0f790a-9f5c-40ef-b476-f13eb5db2a28",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821223033000.ad30225b-cb67-466e-80d9-5b3324ce12ee",
+      "id" : "1674157639055957000.1c0f790a-9f5c-40ef-b476-f13eb5db2a28",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2557,10 +2557,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821223132000.0006031a-4057-44ea-b820-bade4f2081fb",
+    "fullUrl" : "PractitionerRole/1674157639056033000.72d08b80-91e8-4df0-b776-95c280774936",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821223132000.0006031a-4057-44ea-b820-bade4f2081fb",
+      "id" : "1674157639056033000.72d08b80-91e8-4df0-b776-95c280774936",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2572,10 +2572,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821220799000.e6fbf540-9949-416d-8d68-42f209486f02"
+        "reference" : "Practitioner/1674157639054524000.dcbb583c-8bd3-44e6-88ed-f0ad9a75880c"
       },
       "organization" : {
-        "reference" : "Organization/1673381821223033000.ad30225b-cb67-466e-80d9-5b3324ce12ee"
+        "reference" : "Organization/1674157639055957000.1c0f790a-9f5c-40ef-b476-f13eb5db2a28"
       },
       "code" : [ {
         "coding" : [ {
@@ -2585,10 +2585,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821224406000.54591d08-9b05-478e-a0d4-5db78688e677",
+    "fullUrl" : "Organization/1674157639057003000.fb94e77d-107d-4df8-aa69-c1cfcffbd354",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821224406000.54591d08-9b05-478e-a0d4-5db78688e677",
+      "id" : "1674157639057003000.fb94e77d-107d-4df8-aa69-c1cfcffbd354",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2614,10 +2614,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821230422000.c43e4a35-4a4d-4888-9616-5bf52f1e967d",
+    "fullUrl" : "Observation/1674157639060902000.4694c0a0-52f0-40a9-ac13-7e6ae6cf8801",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821230422000.c43e4a35-4a4d-4888-9616-5bf52f1e967d",
+      "id" : "1674157639060902000.4694c0a0-52f0-40a9-ac13-7e6ae6cf8801",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2634,7 +2634,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821230309000.8e74ac02-4f5d-4a5a-a386-f88292a133aa"
+          "reference" : "Organization/1674157639060808000.17cdb776-0dd1-4355-9aae-2394eb991af3"
         }
       } ],
       "identifier" : [ {
@@ -2668,23 +2668,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821228725000.cb0ac920-6a7c-499f-9be0-a9f8a264e4d2"
+        "reference" : "PractitionerRole/1674157639059940000.f1b8a61a-1385-4c06-a694-d86249c19820"
       } ],
       "valueString" : "inhibitors are present in the specimen or if inadequate"
     }
   }, {
-    "fullUrl" : "Location/1673381821226011000.1085357d-b127-4b14-99ae-9ced67fd89e2",
+    "fullUrl" : "Location/1674157639058206000.4b04392f-828d-40e3-9cbd-e59078ded676",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821226011000.1085357d-b127-4b14-99ae-9ced67fd89e2",
+      "id" : "1674157639058206000.4b04392f-828d-40e3-9cbd-e59078ded676",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2698,10 +2698,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821226406000.f5e9c200-90e6-4747-af72-e05bb65a419a",
+    "fullUrl" : "Practitioner/1674157639058497000.eef76ced-22cc-4505-b716-de8cbf29cc17",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821226406000.f5e9c200-90e6-4747-af72-e05bb65a419a",
+      "id" : "1674157639058497000.eef76ced-22cc-4505-b716-de8cbf29cc17",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2723,7 +2723,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821226011000.1085357d-b127-4b14-99ae-9ced67fd89e2"
+          "reference" : "Location/1674157639058206000.4b04392f-828d-40e3-9cbd-e59078ded676"
         }
       } ],
       "identifier" : [ {
@@ -2749,10 +2749,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821228606000.173a9ae0-59ec-4500-938d-7ca3d2e56ded",
+    "fullUrl" : "Organization/1674157639059858000.3cb68196-ab12-4ca5-9841-36f8deb7bf61",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821228606000.173a9ae0-59ec-4500-938d-7ca3d2e56ded",
+      "id" : "1674157639059858000.3cb68196-ab12-4ca5-9841-36f8deb7bf61",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2796,10 +2796,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821228725000.cb0ac920-6a7c-499f-9be0-a9f8a264e4d2",
+    "fullUrl" : "PractitionerRole/1674157639059940000.f1b8a61a-1385-4c06-a694-d86249c19820",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821228725000.cb0ac920-6a7c-499f-9be0-a9f8a264e4d2",
+      "id" : "1674157639059940000.f1b8a61a-1385-4c06-a694-d86249c19820",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2811,10 +2811,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821226406000.f5e9c200-90e6-4747-af72-e05bb65a419a"
+        "reference" : "Practitioner/1674157639058497000.eef76ced-22cc-4505-b716-de8cbf29cc17"
       },
       "organization" : {
-        "reference" : "Organization/1673381821228606000.173a9ae0-59ec-4500-938d-7ca3d2e56ded"
+        "reference" : "Organization/1674157639059858000.3cb68196-ab12-4ca5-9841-36f8deb7bf61"
       },
       "code" : [ {
         "coding" : [ {
@@ -2824,10 +2824,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821230309000.8e74ac02-4f5d-4a5a-a386-f88292a133aa",
+    "fullUrl" : "Organization/1674157639060808000.17cdb776-0dd1-4355-9aae-2394eb991af3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821230309000.8e74ac02-4f5d-4a5a-a386-f88292a133aa",
+      "id" : "1674157639060808000.17cdb776-0dd1-4355-9aae-2394eb991af3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2853,10 +2853,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821237179000.2078ca76-fb30-4b19-b33f-af396f4d120a",
+    "fullUrl" : "Observation/1674157639064681000.c64ec9f2-ea76-4ad2-8940-b423167eef0f",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821237179000.2078ca76-fb30-4b19-b33f-af396f4d120a",
+      "id" : "1674157639064681000.c64ec9f2-ea76-4ad2-8940-b423167eef0f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2873,7 +2873,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821237068000.b2165cb7-dc29-4269-8e85-92f8ad594638"
+          "reference" : "Organization/1674157639064595000.9bf3b3a4-4ee9-4fe8-8401-6ef8238dc96b"
         }
       } ],
       "identifier" : [ {
@@ -2907,23 +2907,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821235670000.10caf489-2483-454c-b304-96efc8718bcd"
+        "reference" : "PractitionerRole/1674157639063757000.3e30052a-d933-4d79-849a-9be5f741b573"
       } ],
       "valueString" : "levels of viruses are present in the specimen."
     }
   }, {
-    "fullUrl" : "Location/1673381821232117000.53660e24-21ef-43cd-a299-7ab6c0144d88",
+    "fullUrl" : "Location/1674157639062039000.742f5b6a-f933-4cf5-9a03-c1ee1e9d93b9",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821232117000.53660e24-21ef-43cd-a299-7ab6c0144d88",
+      "id" : "1674157639062039000.742f5b6a-f933-4cf5-9a03-c1ee1e9d93b9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2937,10 +2937,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821232565000.bdae26dd-bf3f-4361-adef-34ec9f8f4056",
+    "fullUrl" : "Practitioner/1674157639062351000.dac3c9d1-340f-435f-ae8f-bd9ecd91c15b",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821232565000.bdae26dd-bf3f-4361-adef-34ec9f8f4056",
+      "id" : "1674157639062351000.dac3c9d1-340f-435f-ae8f-bd9ecd91c15b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2962,7 +2962,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821232117000.53660e24-21ef-43cd-a299-7ab6c0144d88"
+          "reference" : "Location/1674157639062039000.742f5b6a-f933-4cf5-9a03-c1ee1e9d93b9"
         }
       } ],
       "identifier" : [ {
@@ -2988,10 +2988,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821235556000.04e190d5-5cf2-4f64-88f9-2e1bcb4ed32c",
+    "fullUrl" : "Organization/1674157639063687000.59e16649-d319-449e-b771-1a4b3a13da0c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821235556000.04e190d5-5cf2-4f64-88f9-2e1bcb4ed32c",
+      "id" : "1674157639063687000.59e16649-d319-449e-b771-1a4b3a13da0c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3035,10 +3035,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821235670000.10caf489-2483-454c-b304-96efc8718bcd",
+    "fullUrl" : "PractitionerRole/1674157639063757000.3e30052a-d933-4d79-849a-9be5f741b573",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821235670000.10caf489-2483-454c-b304-96efc8718bcd",
+      "id" : "1674157639063757000.3e30052a-d933-4d79-849a-9be5f741b573",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3050,10 +3050,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821232565000.bdae26dd-bf3f-4361-adef-34ec9f8f4056"
+        "reference" : "Practitioner/1674157639062351000.dac3c9d1-340f-435f-ae8f-bd9ecd91c15b"
       },
       "organization" : {
-        "reference" : "Organization/1673381821235556000.04e190d5-5cf2-4f64-88f9-2e1bcb4ed32c"
+        "reference" : "Organization/1674157639063687000.59e16649-d319-449e-b771-1a4b3a13da0c"
       },
       "code" : [ {
         "coding" : [ {
@@ -3063,10 +3063,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821237068000.b2165cb7-dc29-4269-8e85-92f8ad594638",
+    "fullUrl" : "Organization/1674157639064595000.9bf3b3a4-4ee9-4fe8-8401-6ef8238dc96b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821237068000.b2165cb7-dc29-4269-8e85-92f8ad594638",
+      "id" : "1674157639064595000.9bf3b3a4-4ee9-4fe8-8401-6ef8238dc96b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3092,10 +3092,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821245373000.4d74aa86-1284-4392-aa86-b3a9c308c59d",
+    "fullUrl" : "Observation/1674157639068372000.73f38868-ca2b-482f-8f54-5b84c8c29b2a",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821245373000.4d74aa86-1284-4392-aa86-b3a9c308c59d",
+      "id" : "1674157639068372000.73f38868-ca2b-482f-8f54-5b84c8c29b2a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3112,7 +3112,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821245225000.059de183-9315-4e0e-8d4a-9a0a79b5240b"
+          "reference" : "Organization/1674157639068275000.bf16b00c-983c-4af0-9eba-cb8210b6eae7"
         }
       } ],
       "identifier" : [ {
@@ -3146,22 +3146,22 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821243348000.27bca8ca-330f-45be-8ca0-7d343f1121a2"
+        "reference" : "PractitionerRole/1674157639067399000.6d631ac2-39ed-40ad-8fff-889339ff9bd1"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821239261000.7d4f321c-573c-49eb-90c6-679f81bca018",
+    "fullUrl" : "Location/1674157639065765000.e132eda7-6f15-4ce1-9cfc-9538ab2ea10c",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821239261000.7d4f321c-573c-49eb-90c6-679f81bca018",
+      "id" : "1674157639065765000.e132eda7-6f15-4ce1-9cfc-9538ab2ea10c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3175,10 +3175,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821239888000.144ae9a3-9ad4-40e1-b7a0-7c0701e3c5be",
+    "fullUrl" : "Practitioner/1674157639066048000.c667c4fa-ce7a-4ba6-aa73-fec2174f9b3f",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821239888000.144ae9a3-9ad4-40e1-b7a0-7c0701e3c5be",
+      "id" : "1674157639066048000.c667c4fa-ce7a-4ba6-aa73-fec2174f9b3f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3200,7 +3200,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821239261000.7d4f321c-573c-49eb-90c6-679f81bca018"
+          "reference" : "Location/1674157639065765000.e132eda7-6f15-4ce1-9cfc-9538ab2ea10c"
         }
       } ],
       "identifier" : [ {
@@ -3226,10 +3226,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821243163000.fb8f043d-782d-4ec4-b0da-f716f92bf2c8",
+    "fullUrl" : "Organization/1674157639067343000.2813e3f9-1fd7-4695-985c-eb686cbf1b8b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821243163000.fb8f043d-782d-4ec4-b0da-f716f92bf2c8",
+      "id" : "1674157639067343000.2813e3f9-1fd7-4695-985c-eb686cbf1b8b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3273,10 +3273,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821243348000.27bca8ca-330f-45be-8ca0-7d343f1121a2",
+    "fullUrl" : "PractitionerRole/1674157639067399000.6d631ac2-39ed-40ad-8fff-889339ff9bd1",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821243348000.27bca8ca-330f-45be-8ca0-7d343f1121a2",
+      "id" : "1674157639067399000.6d631ac2-39ed-40ad-8fff-889339ff9bd1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3288,10 +3288,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821239888000.144ae9a3-9ad4-40e1-b7a0-7c0701e3c5be"
+        "reference" : "Practitioner/1674157639066048000.c667c4fa-ce7a-4ba6-aa73-fec2174f9b3f"
       },
       "organization" : {
-        "reference" : "Organization/1673381821243163000.fb8f043d-782d-4ec4-b0da-f716f92bf2c8"
+        "reference" : "Organization/1674157639067343000.2813e3f9-1fd7-4695-985c-eb686cbf1b8b"
       },
       "code" : [ {
         "coding" : [ {
@@ -3301,10 +3301,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821245225000.059de183-9315-4e0e-8d4a-9a0a79b5240b",
+    "fullUrl" : "Organization/1674157639068275000.bf16b00c-983c-4af0-9eba-cb8210b6eae7",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821245225000.059de183-9315-4e0e-8d4a-9a0a79b5240b",
+      "id" : "1674157639068275000.bf16b00c-983c-4af0-9eba-cb8210b6eae7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3330,10 +3330,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821253592000.4a813ab6-ed38-41af-a0fe-803fcbe9d457",
+    "fullUrl" : "Observation/1674157639072326000.bb40e4c9-5e48-4a79-8194-1cdf24ddb028",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821253592000.4a813ab6-ed38-41af-a0fe-803fcbe9d457",
+      "id" : "1674157639072326000.bb40e4c9-5e48-4a79-8194-1cdf24ddb028",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3350,7 +3350,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821253469000.f60adfae-f332-438f-9c37-66488acd1f2e"
+          "reference" : "Organization/1674157639072233000.3535019b-f130-42eb-b24e-80141475cd1a"
         }
       } ],
       "identifier" : [ {
@@ -3384,23 +3384,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821251864000.0f348918-4552-4f6b-8e85-6510f0dab2f1"
+        "reference" : "PractitionerRole/1674157639071218000.6662fe0e-7108-4631-8bbe-da31fac8d025"
       } ],
       "valueString" : "Competitive inhibition studies showed that SARS-CoV-2 virus"
     }
   }, {
-    "fullUrl" : "Location/1673381821247645000.65ead674-5998-45cd-b529-24d295309d16",
+    "fullUrl" : "Location/1674157639069500000.a23cecda-d675-4cec-a1e9-9e201b07dd84",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821247645000.65ead674-5998-45cd-b529-24d295309d16",
+      "id" : "1674157639069500000.a23cecda-d675-4cec-a1e9-9e201b07dd84",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3414,10 +3414,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821248257000.f15dc45e-a187-445b-b171-4d09708989bf",
+    "fullUrl" : "Practitioner/1674157639069802000.c24ad815-cbe5-45d0-a47a-bb5f34fbe0b2",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821248257000.f15dc45e-a187-445b-b171-4d09708989bf",
+      "id" : "1674157639069802000.c24ad815-cbe5-45d0-a47a-bb5f34fbe0b2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3439,7 +3439,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821247645000.65ead674-5998-45cd-b529-24d295309d16"
+          "reference" : "Location/1674157639069500000.a23cecda-d675-4cec-a1e9-9e201b07dd84"
         }
       } ],
       "identifier" : [ {
@@ -3465,10 +3465,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821251398000.d5ec492d-c326-4c3a-919d-10e837c431e0",
+    "fullUrl" : "Organization/1674157639071121000.4b2b4132-baae-4d59-8641-e2eeb859f2b6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821251398000.d5ec492d-c326-4c3a-919d-10e837c431e0",
+      "id" : "1674157639071121000.4b2b4132-baae-4d59-8641-e2eeb859f2b6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3512,10 +3512,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821251864000.0f348918-4552-4f6b-8e85-6510f0dab2f1",
+    "fullUrl" : "PractitionerRole/1674157639071218000.6662fe0e-7108-4631-8bbe-da31fac8d025",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821251864000.0f348918-4552-4f6b-8e85-6510f0dab2f1",
+      "id" : "1674157639071218000.6662fe0e-7108-4631-8bbe-da31fac8d025",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3527,10 +3527,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821248257000.f15dc45e-a187-445b-b171-4d09708989bf"
+        "reference" : "Practitioner/1674157639069802000.c24ad815-cbe5-45d0-a47a-bb5f34fbe0b2"
       },
       "organization" : {
-        "reference" : "Organization/1673381821251398000.d5ec492d-c326-4c3a-919d-10e837c431e0"
+        "reference" : "Organization/1674157639071121000.4b2b4132-baae-4d59-8641-e2eeb859f2b6"
       },
       "code" : [ {
         "coding" : [ {
@@ -3540,10 +3540,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821253469000.f60adfae-f332-438f-9c37-66488acd1f2e",
+    "fullUrl" : "Organization/1674157639072233000.3535019b-f130-42eb-b24e-80141475cd1a",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821253469000.f60adfae-f332-438f-9c37-66488acd1f2e",
+      "id" : "1674157639072233000.3535019b-f130-42eb-b24e-80141475cd1a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3569,10 +3569,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821258270000.b53470b6-dc05-4916-9532-e6394df8b8a7",
+    "fullUrl" : "Observation/1674157639076170000.9ed08ee4-58a9-4f49-be33-1749f057b0ba",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821258270000.b53470b6-dc05-4916-9532-e6394df8b8a7",
+      "id" : "1674157639076170000.9ed08ee4-58a9-4f49-be33-1749f057b0ba",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3589,7 +3589,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821258183000.6bf64a17-6c6e-451d-8cd8-3b79902f1820"
+          "reference" : "Organization/1674157639076093000.4c092221-fe70-43d8-8624-ae4234c7cefa"
         }
       } ],
       "identifier" : [ {
@@ -3623,23 +3623,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821257156000.e82cbe04-51ea-4cc1-909a-eeb4857f2bb3"
+        "reference" : "PractitionerRole/1674157639075219000.f5acecab-bb9d-4358-89d0-19556ec7f0ae"
       } ],
       "valueString" : "can inhibit the detection and amplification of influenza A"
     }
   }, {
-    "fullUrl" : "Location/1673381821255034000.4078bd91-4a57-4502-a0f6-9d544878006c",
+    "fullUrl" : "Location/1674157639073482000.b9786070-e6ea-4330-ace1-88c35c0996d5",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821255034000.4078bd91-4a57-4502-a0f6-9d544878006c",
+      "id" : "1674157639073482000.b9786070-e6ea-4330-ace1-88c35c0996d5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3653,10 +3653,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821255391000.bfdbdf93-b539-43a4-9b17-4fe3124b9c52",
+    "fullUrl" : "Practitioner/1674157639073773000.2a6eddb3-3e99-4c0c-8973-177f7f9697eb",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821255391000.bfdbdf93-b539-43a4-9b17-4fe3124b9c52",
+      "id" : "1674157639073773000.2a6eddb3-3e99-4c0c-8973-177f7f9697eb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3678,7 +3678,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821255034000.4078bd91-4a57-4502-a0f6-9d544878006c"
+          "reference" : "Location/1674157639073482000.b9786070-e6ea-4330-ace1-88c35c0996d5"
         }
       } ],
       "identifier" : [ {
@@ -3704,10 +3704,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821257074000.bbfe4243-c305-4e18-9b19-7ddeb270ab8a",
+    "fullUrl" : "Organization/1674157639075145000.0ac43504-3b08-4a7f-980e-b81cfbdc5216",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821257074000.bbfe4243-c305-4e18-9b19-7ddeb270ab8a",
+      "id" : "1674157639075145000.0ac43504-3b08-4a7f-980e-b81cfbdc5216",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3751,10 +3751,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821257156000.e82cbe04-51ea-4cc1-909a-eeb4857f2bb3",
+    "fullUrl" : "PractitionerRole/1674157639075219000.f5acecab-bb9d-4358-89d0-19556ec7f0ae",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821257156000.e82cbe04-51ea-4cc1-909a-eeb4857f2bb3",
+      "id" : "1674157639075219000.f5acecab-bb9d-4358-89d0-19556ec7f0ae",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3766,10 +3766,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821255391000.bfdbdf93-b539-43a4-9b17-4fe3124b9c52"
+        "reference" : "Practitioner/1674157639073773000.2a6eddb3-3e99-4c0c-8973-177f7f9697eb"
       },
       "organization" : {
-        "reference" : "Organization/1673381821257074000.bbfe4243-c305-4e18-9b19-7ddeb270ab8a"
+        "reference" : "Organization/1674157639075145000.0ac43504-3b08-4a7f-980e-b81cfbdc5216"
       },
       "code" : [ {
         "coding" : [ {
@@ -3779,10 +3779,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821258183000.6bf64a17-6c6e-451d-8cd8-3b79902f1820",
+    "fullUrl" : "Organization/1674157639076093000.4c092221-fe70-43d8-8624-ae4234c7cefa",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821258183000.6bf64a17-6c6e-451d-8cd8-3b79902f1820",
+      "id" : "1674157639076093000.4c092221-fe70-43d8-8624-ae4234c7cefa",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3808,10 +3808,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821262722000.809917d4-911f-41c2-b5b1-d68be1c4c617",
+    "fullUrl" : "Observation/1674157639080446000.1a0e465c-171d-4d31-af17-ddf5986b2a2c",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821262722000.809917d4-911f-41c2-b5b1-d68be1c4c617",
+      "id" : "1674157639080446000.1a0e465c-171d-4d31-af17-ddf5986b2a2c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3828,7 +3828,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821262651000.4ac39a41-3014-4b34-a742-01bde2e69d97"
+          "reference" : "Organization/1674157639080377000.47d79699-1c8a-402b-a4e7-56cc9b431987"
         }
       } ],
       "identifier" : [ {
@@ -3862,23 +3862,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821261613000.c279dab6-2e0c-4604-9779-788ebd9c39ee"
+        "reference" : "PractitionerRole/1674157639079491000.6b0086ee-a904-4be9-a554-1ad1a5fc1b21"
       } ],
       "valueString" : "and influenza B virus RNA and may lead to false negative"
     }
   }, {
-    "fullUrl" : "Location/1673381821259694000.d278b8c5-1b1f-46ee-ba36-2468cc8f3580",
+    "fullUrl" : "Location/1674157639077752000.1e7ae01e-603d-4e78-bca2-48b5b92abd6d",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821259694000.d278b8c5-1b1f-46ee-ba36-2468cc8f3580",
+      "id" : "1674157639077752000.1e7ae01e-603d-4e78-bca2-48b5b92abd6d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3892,10 +3892,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821260015000.2827419f-52c7-4ec4-93b7-2a6f05fdd48b",
+    "fullUrl" : "Practitioner/1674157639078063000.6d1fac86-3117-4eb8-8090-16ef829002f7",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821260015000.2827419f-52c7-4ec4-93b7-2a6f05fdd48b",
+      "id" : "1674157639078063000.6d1fac86-3117-4eb8-8090-16ef829002f7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3917,7 +3917,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821259694000.d278b8c5-1b1f-46ee-ba36-2468cc8f3580"
+          "reference" : "Location/1674157639077752000.1e7ae01e-603d-4e78-bca2-48b5b92abd6d"
         }
       } ],
       "identifier" : [ {
@@ -3943,10 +3943,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821261528000.0e1049e6-9e3e-45cb-be3b-39819f6d18e1",
+    "fullUrl" : "Organization/1674157639079415000.5165a531-e636-4e65-8490-a1debfdd45e3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821261528000.0e1049e6-9e3e-45cb-be3b-39819f6d18e1",
+      "id" : "1674157639079415000.5165a531-e636-4e65-8490-a1debfdd45e3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -3990,10 +3990,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821261613000.c279dab6-2e0c-4604-9779-788ebd9c39ee",
+    "fullUrl" : "PractitionerRole/1674157639079491000.6b0086ee-a904-4be9-a554-1ad1a5fc1b21",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821261613000.c279dab6-2e0c-4604-9779-788ebd9c39ee",
+      "id" : "1674157639079491000.6b0086ee-a904-4be9-a554-1ad1a5fc1b21",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4005,10 +4005,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821260015000.2827419f-52c7-4ec4-93b7-2a6f05fdd48b"
+        "reference" : "Practitioner/1674157639078063000.6d1fac86-3117-4eb8-8090-16ef829002f7"
       },
       "organization" : {
-        "reference" : "Organization/1673381821261528000.0e1049e6-9e3e-45cb-be3b-39819f6d18e1"
+        "reference" : "Organization/1674157639079415000.5165a531-e636-4e65-8490-a1debfdd45e3"
       },
       "code" : [ {
         "coding" : [ {
@@ -4018,10 +4018,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821262651000.4ac39a41-3014-4b34-a742-01bde2e69d97",
+    "fullUrl" : "Organization/1674157639080377000.47d79699-1c8a-402b-a4e7-56cc9b431987",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821262651000.4ac39a41-3014-4b34-a742-01bde2e69d97",
+      "id" : "1674157639080377000.47d79699-1c8a-402b-a4e7-56cc9b431987",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4047,10 +4047,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821267462000.d85f806b-46a9-49b0-9790-12a5e57da432",
+    "fullUrl" : "Observation/1674157639084574000.8ff96dc2-fe17-4e12-a499-cefdb7a866a6",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821267462000.d85f806b-46a9-49b0-9790-12a5e57da432",
+      "id" : "1674157639084574000.8ff96dc2-fe17-4e12-a499-cefdb7a866a6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4067,7 +4067,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821267378000.b2141d01-803b-42a0-b442-77cb4ef76b82"
+          "reference" : "Organization/1674157639084502000.3a37f65d-e3a0-4648-8c1e-6369c2939ed0"
         }
       } ],
       "identifier" : [ {
@@ -4101,23 +4101,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821266343000.3c48280a-a8d3-4b4d-b829-a67a040c1b65"
+        "reference" : "PractitionerRole/1674157639083538000.08d52bc1-3a4b-404a-b51a-f36ca27c93d2"
       } ],
       "valueString" : "influenza virus results. If co-infection with influenza A or"
     }
   }, {
-    "fullUrl" : "Location/1673381821264398000.67992182-88c6-4d17-b384-9c04d7e26d3b",
+    "fullUrl" : "Location/1674157639081794000.85726c52-b4b3-44c8-872d-edce4c5ee5ad",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821264398000.67992182-88c6-4d17-b384-9c04d7e26d3b",
+      "id" : "1674157639081794000.85726c52-b4b3-44c8-872d-edce4c5ee5ad",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4131,10 +4131,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821264760000.8883e9ac-4605-4164-aaf9-a50d45828586",
+    "fullUrl" : "Practitioner/1674157639082107000.e789d7f5-20e7-4c89-ab29-2585cab7b66b",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821264760000.8883e9ac-4605-4164-aaf9-a50d45828586",
+      "id" : "1674157639082107000.e789d7f5-20e7-4c89-ab29-2585cab7b66b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4156,7 +4156,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821264398000.67992182-88c6-4d17-b384-9c04d7e26d3b"
+          "reference" : "Location/1674157639081794000.85726c52-b4b3-44c8-872d-edce4c5ee5ad"
         }
       } ],
       "identifier" : [ {
@@ -4182,10 +4182,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821266265000.54840c70-9377-458a-a178-d41d4e562a7e",
+    "fullUrl" : "Organization/1674157639083462000.85b0cd8a-9116-4053-b627-9026f3be699e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821266265000.54840c70-9377-458a-a178-d41d4e562a7e",
+      "id" : "1674157639083462000.85b0cd8a-9116-4053-b627-9026f3be699e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4229,10 +4229,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821266343000.3c48280a-a8d3-4b4d-b829-a67a040c1b65",
+    "fullUrl" : "PractitionerRole/1674157639083538000.08d52bc1-3a4b-404a-b51a-f36ca27c93d2",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821266343000.3c48280a-a8d3-4b4d-b829-a67a040c1b65",
+      "id" : "1674157639083538000.08d52bc1-3a4b-404a-b51a-f36ca27c93d2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4244,10 +4244,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821264760000.8883e9ac-4605-4164-aaf9-a50d45828586"
+        "reference" : "Practitioner/1674157639082107000.e789d7f5-20e7-4c89-ab29-2585cab7b66b"
       },
       "organization" : {
-        "reference" : "Organization/1673381821266265000.54840c70-9377-458a-a178-d41d4e562a7e"
+        "reference" : "Organization/1674157639083462000.85b0cd8a-9116-4053-b627-9026f3be699e"
       },
       "code" : [ {
         "coding" : [ {
@@ -4257,10 +4257,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821267378000.b2141d01-803b-42a0-b442-77cb4ef76b82",
+    "fullUrl" : "Organization/1674157639084502000.3a37f65d-e3a0-4648-8c1e-6369c2939ed0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821267378000.b2141d01-803b-42a0-b442-77cb4ef76b82",
+      "id" : "1674157639084502000.3a37f65d-e3a0-4648-8c1e-6369c2939ed0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4286,10 +4286,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821271887000.2b071859-2e21-48a8-a16a-18d1491ad441",
+    "fullUrl" : "Observation/1674157639088355000.71612cd2-b344-46fc-b933-1e945c81df7d",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821271887000.2b071859-2e21-48a8-a16a-18d1491ad441",
+      "id" : "1674157639088355000.71612cd2-b344-46fc-b933-1e945c81df7d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4306,7 +4306,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821271785000.bb5f79e8-d50c-44b9-a022-127fd8194254"
+          "reference" : "Organization/1674157639088268000.8170388c-ce6f-423e-a474-1e6171c42b4f"
         }
       } ],
       "identifier" : [ {
@@ -4340,23 +4340,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821270753000.28af44e3-002f-4dc6-b875-7b9ea00abf9f"
+        "reference" : "PractitionerRole/1674157639087382000.52d48510-4a36-4c19-9882-cb3932b3711e"
       } ],
       "valueString" : "influenza B virus is suspected in samples with a positive"
     }
   }, {
-    "fullUrl" : "Location/1673381821268827000.9b64c43b-3841-4dd8-8d0b-b81c01423db3",
+    "fullUrl" : "Location/1674157639085691000.ccd73b7f-b02f-42e6-95d9-78988dd7c009",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821268827000.9b64c43b-3841-4dd8-8d0b-b81c01423db3",
+      "id" : "1674157639085691000.ccd73b7f-b02f-42e6-95d9-78988dd7c009",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4370,10 +4370,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821269160000.90768316-0e4a-4103-bf26-fc12c7170274",
+    "fullUrl" : "Practitioner/1674157639085980000.f775d3c8-f702-4e1e-b682-a3cce66d3911",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821269160000.90768316-0e4a-4103-bf26-fc12c7170274",
+      "id" : "1674157639085980000.f775d3c8-f702-4e1e-b682-a3cce66d3911",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4395,7 +4395,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821268827000.9b64c43b-3841-4dd8-8d0b-b81c01423db3"
+          "reference" : "Location/1674157639085691000.ccd73b7f-b02f-42e6-95d9-78988dd7c009"
         }
       } ],
       "identifier" : [ {
@@ -4421,10 +4421,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821270688000.c4ac3fca-ef3e-48e0-befd-18bf33cc2d3c",
+    "fullUrl" : "Organization/1674157639087323000.53e2c28d-191b-41d7-8f2a-70e98d042bce",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821270688000.c4ac3fca-ef3e-48e0-befd-18bf33cc2d3c",
+      "id" : "1674157639087323000.53e2c28d-191b-41d7-8f2a-70e98d042bce",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4468,10 +4468,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821270753000.28af44e3-002f-4dc6-b875-7b9ea00abf9f",
+    "fullUrl" : "PractitionerRole/1674157639087382000.52d48510-4a36-4c19-9882-cb3932b3711e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821270753000.28af44e3-002f-4dc6-b875-7b9ea00abf9f",
+      "id" : "1674157639087382000.52d48510-4a36-4c19-9882-cb3932b3711e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4483,10 +4483,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821269160000.90768316-0e4a-4103-bf26-fc12c7170274"
+        "reference" : "Practitioner/1674157639085980000.f775d3c8-f702-4e1e-b682-a3cce66d3911"
       },
       "organization" : {
-        "reference" : "Organization/1673381821270688000.c4ac3fca-ef3e-48e0-befd-18bf33cc2d3c"
+        "reference" : "Organization/1674157639087323000.53e2c28d-191b-41d7-8f2a-70e98d042bce"
       },
       "code" : [ {
         "coding" : [ {
@@ -4496,10 +4496,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821271785000.bb5f79e8-d50c-44b9-a022-127fd8194254",
+    "fullUrl" : "Organization/1674157639088268000.8170388c-ce6f-423e-a474-1e6171c42b4f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821271785000.bb5f79e8-d50c-44b9-a022-127fd8194254",
+      "id" : "1674157639088268000.8170388c-ce6f-423e-a474-1e6171c42b4f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4525,10 +4525,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821276731000.f910b85e-6b0f-4a35-83f0-5deb60f406f8",
+    "fullUrl" : "Observation/1674157639092049000.f61b9768-c176-4577-90ce-7557fa8d5dc7",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821276731000.f910b85e-6b0f-4a35-83f0-5deb60f406f8",
+      "id" : "1674157639092049000.f61b9768-c176-4577-90ce-7557fa8d5dc7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4545,7 +4545,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821276628000.470f11b0-5f2c-4490-928c-ca409541d871"
+          "reference" : "Organization/1674157639091960000.95d1786b-4fd3-4cb9-b9f3-22e4d933a4ce"
         }
       } ],
       "identifier" : [ {
@@ -4579,23 +4579,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821275502000.0477f531-7db5-4228-91c5-40724998b6db"
+        "reference" : "PractitionerRole/1674157639091107000.1b663271-b598-45bc-9382-2144a81ab384"
       } ],
       "valueString" : "SARS-CoV-2 result, the sample should be re-tested with"
     }
   }, {
-    "fullUrl" : "Location/1673381821273138000.c018f4ce-5cef-47f0-9f66-edea00e9d774",
+    "fullUrl" : "Location/1674157639089427000.ee1b4f68-72be-4ce2-beb0-b9619db03fbd",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821273138000.c018f4ce-5cef-47f0-9f66-edea00e9d774",
+      "id" : "1674157639089427000.ee1b4f68-72be-4ce2-beb0-b9619db03fbd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4609,10 +4609,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821273457000.71539c2a-ada8-4cf1-beec-05d14bb932ce",
+    "fullUrl" : "Practitioner/1674157639089700000.f035fdb1-9fff-4bbb-9759-eb0becad7660",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821273457000.71539c2a-ada8-4cf1-beec-05d14bb932ce",
+      "id" : "1674157639089700000.f035fdb1-9fff-4bbb-9759-eb0becad7660",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4634,7 +4634,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821273138000.c018f4ce-5cef-47f0-9f66-edea00e9d774"
+          "reference" : "Location/1674157639089427000.ee1b4f68-72be-4ce2-beb0-b9619db03fbd"
         }
       } ],
       "identifier" : [ {
@@ -4660,10 +4660,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821275402000.77b1cd48-6d47-446f-b1b5-27169894b9be",
+    "fullUrl" : "Organization/1674157639091030000.ba763d22-c53c-4a69-9de8-ae8853e16301",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821275402000.77b1cd48-6d47-446f-b1b5-27169894b9be",
+      "id" : "1674157639091030000.ba763d22-c53c-4a69-9de8-ae8853e16301",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4707,10 +4707,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821275502000.0477f531-7db5-4228-91c5-40724998b6db",
+    "fullUrl" : "PractitionerRole/1674157639091107000.1b663271-b598-45bc-9382-2144a81ab384",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821275502000.0477f531-7db5-4228-91c5-40724998b6db",
+      "id" : "1674157639091107000.1b663271-b598-45bc-9382-2144a81ab384",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4722,10 +4722,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821273457000.71539c2a-ada8-4cf1-beec-05d14bb932ce"
+        "reference" : "Practitioner/1674157639089700000.f035fdb1-9fff-4bbb-9759-eb0becad7660"
       },
       "organization" : {
-        "reference" : "Organization/1673381821275402000.77b1cd48-6d47-446f-b1b5-27169894b9be"
+        "reference" : "Organization/1674157639091030000.ba763d22-c53c-4a69-9de8-ae8853e16301"
       },
       "code" : [ {
         "coding" : [ {
@@ -4735,10 +4735,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821276628000.470f11b0-5f2c-4490-928c-ca409541d871",
+    "fullUrl" : "Organization/1674157639091960000.95d1786b-4fd3-4cb9-b9f3-22e4d933a4ce",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821276628000.470f11b0-5f2c-4490-928c-ca409541d871",
+      "id" : "1674157639091960000.95d1786b-4fd3-4cb9-b9f3-22e4d933a4ce",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4764,10 +4764,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821282335000.058b102f-79c5-429f-ba41-4ecddb03166f",
+    "fullUrl" : "Observation/1674157639095754000.17bf9f5a-f0c0-495a-a26a-a8937f078db2",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821282335000.058b102f-79c5-429f-ba41-4ecddb03166f",
+      "id" : "1674157639095754000.17bf9f5a-f0c0-495a-a26a-a8937f078db2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4784,7 +4784,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821282238000.598b1c75-061d-44de-b709-4d76c47d924a"
+          "reference" : "Organization/1674157639095688000.062ccee6-eb43-486f-a914-1f62cb4b3e02"
         }
       } ],
       "identifier" : [ {
@@ -4818,23 +4818,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821280207000.6d17d7c4-a7f8-4b51-ab55-ce174fdd5b27"
+        "reference" : "PractitionerRole/1674157639094851000.fcf37780-080b-4c1a-83f9-3d1846b8537e"
       } ],
       "valueString" : "another FDA cleared, approved, or authorized influenza test,"
     }
   }, {
-    "fullUrl" : "Location/1673381821278088000.f3710a88-c10c-43f7-bc52-35036a11ed16",
+    "fullUrl" : "Location/1674157639093130000.efb79cf4-f081-4aed-a15b-618912750447",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821278088000.f3710a88-c10c-43f7-bc52-35036a11ed16",
+      "id" : "1674157639093130000.efb79cf4-f081-4aed-a15b-618912750447",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4848,10 +4848,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821278400000.b942a0d3-0812-4ac0-892c-f4c549236a89",
+    "fullUrl" : "Practitioner/1674157639093390000.266f8b47-b0f8-45e2-b247-df0bef3e8af3",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821278400000.b942a0d3-0812-4ac0-892c-f4c549236a89",
+      "id" : "1674157639093390000.266f8b47-b0f8-45e2-b247-df0bef3e8af3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4873,7 +4873,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821278088000.f3710a88-c10c-43f7-bc52-35036a11ed16"
+          "reference" : "Location/1674157639093130000.efb79cf4-f081-4aed-a15b-618912750447"
         }
       } ],
       "identifier" : [ {
@@ -4899,10 +4899,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821280118000.1285e53b-102a-4de0-ad08-916360d101a8",
+    "fullUrl" : "Organization/1674157639094786000.42928542-102d-49b0-b340-a4b5f0075b10",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821280118000.1285e53b-102a-4de0-ad08-916360d101a8",
+      "id" : "1674157639094786000.42928542-102d-49b0-b340-a4b5f0075b10",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4946,10 +4946,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821280207000.6d17d7c4-a7f8-4b51-ab55-ce174fdd5b27",
+    "fullUrl" : "PractitionerRole/1674157639094851000.fcf37780-080b-4c1a-83f9-3d1846b8537e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821280207000.6d17d7c4-a7f8-4b51-ab55-ce174fdd5b27",
+      "id" : "1674157639094851000.fcf37780-080b-4c1a-83f9-3d1846b8537e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -4961,10 +4961,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821278400000.b942a0d3-0812-4ac0-892c-f4c549236a89"
+        "reference" : "Practitioner/1674157639093390000.266f8b47-b0f8-45e2-b247-df0bef3e8af3"
       },
       "organization" : {
-        "reference" : "Organization/1673381821280118000.1285e53b-102a-4de0-ad08-916360d101a8"
+        "reference" : "Organization/1674157639094786000.42928542-102d-49b0-b340-a4b5f0075b10"
       },
       "code" : [ {
         "coding" : [ {
@@ -4974,10 +4974,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821282238000.598b1c75-061d-44de-b709-4d76c47d924a",
+    "fullUrl" : "Organization/1674157639095688000.062ccee6-eb43-486f-a914-1f62cb4b3e02",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821282238000.598b1c75-061d-44de-b709-4d76c47d924a",
+      "id" : "1674157639095688000.062ccee6-eb43-486f-a914-1f62cb4b3e02",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5003,10 +5003,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821287484000.04b330e6-6a58-4ccc-98a9-2a2804c30408",
+    "fullUrl" : "Observation/1674157639099402000.bf992d5a-31b6-4f55-8f5b-5023e00a34de",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821287484000.04b330e6-6a58-4ccc-98a9-2a2804c30408",
+      "id" : "1674157639099402000.bf992d5a-31b6-4f55-8f5b-5023e00a34de",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5023,7 +5023,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821287393000.158f3ff5-a283-45e7-aa96-40a89cae8ab7"
+          "reference" : "Organization/1674157639099343000.aafc4079-09dc-4169-8382-15f11c5df48c"
         }
       } ],
       "identifier" : [ {
@@ -5057,23 +5057,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821286288000.9416dc64-6b78-448a-8517-c06ed1524922"
+        "reference" : "PractitionerRole/1674157639098493000.ce40d000-2eed-4892-90d1-75a6e4f7e8a2"
       } ],
       "valueString" : "if influenza virus detection would change clinical"
     }
   }, {
-    "fullUrl" : "Location/1673381821284019000.46c94eac-c68d-4de7-9cbb-ad42cd0b6dd3",
+    "fullUrl" : "Location/1674157639096822000.e9f0a88a-46c6-4d46-8e2a-7694907f95d3",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821284019000.46c94eac-c68d-4de7-9cbb-ad42cd0b6dd3",
+      "id" : "1674157639096822000.e9f0a88a-46c6-4d46-8e2a-7694907f95d3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5087,10 +5087,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821284434000.0fefd8a9-45bd-4b64-bf00-3e061fdfd0f6",
+    "fullUrl" : "Practitioner/1674157639097110000.76238666-066f-465c-a184-189836162dae",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821284434000.0fefd8a9-45bd-4b64-bf00-3e061fdfd0f6",
+      "id" : "1674157639097110000.76238666-066f-465c-a184-189836162dae",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5112,7 +5112,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821284019000.46c94eac-c68d-4de7-9cbb-ad42cd0b6dd3"
+          "reference" : "Location/1674157639096822000.e9f0a88a-46c6-4d46-8e2a-7694907f95d3"
         }
       } ],
       "identifier" : [ {
@@ -5138,10 +5138,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821286202000.211a0254-2d57-447b-8613-4648bbead750",
+    "fullUrl" : "Organization/1674157639098429000.60faa99e-c061-42cb-ac97-35139b6806e6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821286202000.211a0254-2d57-447b-8613-4648bbead750",
+      "id" : "1674157639098429000.60faa99e-c061-42cb-ac97-35139b6806e6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5185,10 +5185,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821286288000.9416dc64-6b78-448a-8517-c06ed1524922",
+    "fullUrl" : "PractitionerRole/1674157639098493000.ce40d000-2eed-4892-90d1-75a6e4f7e8a2",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821286288000.9416dc64-6b78-448a-8517-c06ed1524922",
+      "id" : "1674157639098493000.ce40d000-2eed-4892-90d1-75a6e4f7e8a2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5200,10 +5200,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821284434000.0fefd8a9-45bd-4b64-bf00-3e061fdfd0f6"
+        "reference" : "Practitioner/1674157639097110000.76238666-066f-465c-a184-189836162dae"
       },
       "organization" : {
-        "reference" : "Organization/1673381821286202000.211a0254-2d57-447b-8613-4648bbead750"
+        "reference" : "Organization/1674157639098429000.60faa99e-c061-42cb-ac97-35139b6806e6"
       },
       "code" : [ {
         "coding" : [ {
@@ -5213,10 +5213,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821287393000.158f3ff5-a283-45e7-aa96-40a89cae8ab7",
+    "fullUrl" : "Organization/1674157639099343000.aafc4079-09dc-4169-8382-15f11c5df48c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821287393000.158f3ff5-a283-45e7-aa96-40a89cae8ab7",
+      "id" : "1674157639099343000.aafc4079-09dc-4169-8382-15f11c5df48c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5242,10 +5242,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821292218000.a816de8d-c88d-454d-a0a3-47dc938e638b",
+    "fullUrl" : "Observation/1674157639103058000.47112005-ad74-462a-8eb1-b895715441e6",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821292218000.a816de8d-c88d-454d-a0a3-47dc938e638b",
+      "id" : "1674157639103058000.47112005-ad74-462a-8eb1-b895715441e6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5262,7 +5262,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821292129000.aeca7e19-45d2-45c1-b81d-c9c9b04604ad"
+          "reference" : "Organization/1674157639102991000.829d7720-0ed2-434e-976b-cb45e53e86a3"
         }
       } ],
       "identifier" : [ {
@@ -5296,23 +5296,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821290659000.f09e22e1-7da4-4525-92bc-a8efd6aa93bf"
+        "reference" : "PractitionerRole/1674157639102158000.27a944aa-6c66-4690-a4c4-434e3e21f958"
       } ],
       "valueString" : "management."
     }
   }, {
-    "fullUrl" : "Location/1673381821288815000.3d39be88-5376-45cf-a62f-f6d5564c3dbc",
+    "fullUrl" : "Location/1674157639100513000.b12e8648-50ef-4499-adcd-8c190dc0a213",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821288815000.3d39be88-5376-45cf-a62f-f6d5564c3dbc",
+      "id" : "1674157639100513000.b12e8648-50ef-4499-adcd-8c190dc0a213",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5326,10 +5326,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821289121000.a19c6105-d491-4846-8ef9-67255bbfde5a",
+    "fullUrl" : "Practitioner/1674157639100796000.f9bad9a5-8651-4ec1-bbf8-a0892c25c754",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821289121000.a19c6105-d491-4846-8ef9-67255bbfde5a",
+      "id" : "1674157639100796000.f9bad9a5-8651-4ec1-bbf8-a0892c25c754",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5351,7 +5351,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821288815000.3d39be88-5376-45cf-a62f-f6d5564c3dbc"
+          "reference" : "Location/1674157639100513000.b12e8648-50ef-4499-adcd-8c190dc0a213"
         }
       } ],
       "identifier" : [ {
@@ -5377,10 +5377,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821290591000.41230569-8bec-437a-a776-7614c09da77f",
+    "fullUrl" : "Organization/1674157639102088000.436a2352-40e1-4efa-8b8d-7550b6141082",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821290591000.41230569-8bec-437a-a776-7614c09da77f",
+      "id" : "1674157639102088000.436a2352-40e1-4efa-8b8d-7550b6141082",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5424,10 +5424,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821290659000.f09e22e1-7da4-4525-92bc-a8efd6aa93bf",
+    "fullUrl" : "PractitionerRole/1674157639102158000.27a944aa-6c66-4690-a4c4-434e3e21f958",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821290659000.f09e22e1-7da4-4525-92bc-a8efd6aa93bf",
+      "id" : "1674157639102158000.27a944aa-6c66-4690-a4c4-434e3e21f958",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5439,10 +5439,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821289121000.a19c6105-d491-4846-8ef9-67255bbfde5a"
+        "reference" : "Practitioner/1674157639100796000.f9bad9a5-8651-4ec1-bbf8-a0892c25c754"
       },
       "organization" : {
-        "reference" : "Organization/1673381821290591000.41230569-8bec-437a-a776-7614c09da77f"
+        "reference" : "Organization/1674157639102088000.436a2352-40e1-4efa-8b8d-7550b6141082"
       },
       "code" : [ {
         "coding" : [ {
@@ -5452,10 +5452,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821292129000.aeca7e19-45d2-45c1-b81d-c9c9b04604ad",
+    "fullUrl" : "Organization/1674157639102991000.829d7720-0ed2-434e-976b-cb45e53e86a3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821292129000.aeca7e19-45d2-45c1-b81d-c9c9b04604ad",
+      "id" : "1674157639102991000.829d7720-0ed2-434e-976b-cb45e53e86a3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5481,10 +5481,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821297520000.ac85ee8c-a900-460e-b72d-20f40c1589a4",
+    "fullUrl" : "Observation/1674157639106600000.599e9920-e4bf-487d-995e-689dd59a567f",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821297520000.ac85ee8c-a900-460e-b72d-20f40c1589a4",
+      "id" : "1674157639106600000.599e9920-e4bf-487d-995e-689dd59a567f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5501,7 +5501,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821297438000.530dde80-8c54-4f6d-99b7-c4819a32f6ea"
+          "reference" : "Organization/1674157639106533000.4ba821b3-cf22-493b-bd1e-acde827e54af"
         }
       } ],
       "identifier" : [ {
@@ -5535,22 +5535,22 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821296360000.eeb71c4c-b319-49f4-9899-a864c1891cae"
+        "reference" : "PractitionerRole/1674157639105702000.c1dc4025-fe31-4c99-81b9-09d0cdd46231"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821293440000.3040c6a6-51eb-47da-9253-918fbb0cd249",
+    "fullUrl" : "Location/1674157639104082000.29625c44-1cf0-4a46-8436-adaf606f820e",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821293440000.3040c6a6-51eb-47da-9253-918fbb0cd249",
+      "id" : "1674157639104082000.29625c44-1cf0-4a46-8436-adaf606f820e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5564,10 +5564,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821293858000.fd45e8d4-0be8-452b-8f1c-8816aae7421d",
+    "fullUrl" : "Practitioner/1674157639104354000.e7ea9e43-c2aa-4c4d-9e18-df4823f95113",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821293858000.fd45e8d4-0be8-452b-8f1c-8816aae7421d",
+      "id" : "1674157639104354000.e7ea9e43-c2aa-4c4d-9e18-df4823f95113",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5589,7 +5589,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821293440000.3040c6a6-51eb-47da-9253-918fbb0cd249"
+          "reference" : "Location/1674157639104082000.29625c44-1cf0-4a46-8436-adaf606f820e"
         }
       } ],
       "identifier" : [ {
@@ -5615,10 +5615,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821296193000.cab517d4-e46c-4c03-b4e9-bdee0832c2cf",
+    "fullUrl" : "Organization/1674157639105650000.87e7858d-82f9-4f96-a7fb-e6621d26bd9f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821296193000.cab517d4-e46c-4c03-b4e9-bdee0832c2cf",
+      "id" : "1674157639105650000.87e7858d-82f9-4f96-a7fb-e6621d26bd9f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5662,10 +5662,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821296360000.eeb71c4c-b319-49f4-9899-a864c1891cae",
+    "fullUrl" : "PractitionerRole/1674157639105702000.c1dc4025-fe31-4c99-81b9-09d0cdd46231",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821296360000.eeb71c4c-b319-49f4-9899-a864c1891cae",
+      "id" : "1674157639105702000.c1dc4025-fe31-4c99-81b9-09d0cdd46231",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5677,10 +5677,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821293858000.fd45e8d4-0be8-452b-8f1c-8816aae7421d"
+        "reference" : "Practitioner/1674157639104354000.e7ea9e43-c2aa-4c4d-9e18-df4823f95113"
       },
       "organization" : {
-        "reference" : "Organization/1673381821296193000.cab517d4-e46c-4c03-b4e9-bdee0832c2cf"
+        "reference" : "Organization/1674157639105650000.87e7858d-82f9-4f96-a7fb-e6621d26bd9f"
       },
       "code" : [ {
         "coding" : [ {
@@ -5690,10 +5690,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821297438000.530dde80-8c54-4f6d-99b7-c4819a32f6ea",
+    "fullUrl" : "Organization/1674157639106533000.4ba821b3-cf22-493b-bd1e-acde827e54af",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821297438000.530dde80-8c54-4f6d-99b7-c4819a32f6ea",
+      "id" : "1674157639106533000.4ba821b3-cf22-493b-bd1e-acde827e54af",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5719,10 +5719,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821302114000.ff9e87b0-4530-4dd0-8fbc-fe4c12bf95e3",
+    "fullUrl" : "Observation/1674157639110411000.e9c4ec55-c135-4148-b08d-bdf2583e6a1a",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821302114000.ff9e87b0-4530-4dd0-8fbc-fe4c12bf95e3",
+      "id" : "1674157639110411000.e9c4ec55-c135-4148-b08d-bdf2583e6a1a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5739,7 +5739,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821302020000.18b1ee40-6ad0-4888-9e90-452e475408ec"
+          "reference" : "Organization/1674157639110327000.971ed9c7-ce7e-45c9-9e22-311dab06dfd7"
         }
       } ],
       "identifier" : [ {
@@ -5773,23 +5773,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821301000000.4d73dcff-5cc3-4c96-a16c-fe39a2e5727f"
+        "reference" : "PractitionerRole/1674157639109438000.980489d2-f3be-4d9a-960f-a86f1e98d4a0"
       } ],
       "valueString" : "This test has not been FDA cleared or approved. This test"
     }
   }, {
-    "fullUrl" : "Location/1673381821298897000.81927667-fd80-48fb-9db0-7ab98266a98e",
+    "fullUrl" : "Location/1674157639107782000.0654903b-ad42-435f-9288-928663bfb209",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821298897000.81927667-fd80-48fb-9db0-7ab98266a98e",
+      "id" : "1674157639107782000.0654903b-ad42-435f-9288-928663bfb209",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5803,10 +5803,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821299294000.7c04b8e6-b580-4e51-ad46-18f4176d06ef",
+    "fullUrl" : "Practitioner/1674157639108060000.1ab8f167-0755-40e5-aa33-955f71e47227",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821299294000.7c04b8e6-b580-4e51-ad46-18f4176d06ef",
+      "id" : "1674157639108060000.1ab8f167-0755-40e5-aa33-955f71e47227",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5828,7 +5828,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821298897000.81927667-fd80-48fb-9db0-7ab98266a98e"
+          "reference" : "Location/1674157639107782000.0654903b-ad42-435f-9288-928663bfb209"
         }
       } ],
       "identifier" : [ {
@@ -5854,10 +5854,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821300924000.8e02b0a6-c8fb-47f3-894d-58d6bb79c31a",
+    "fullUrl" : "Organization/1674157639109374000.5f62fede-6d67-4c7d-9f36-41e9526cf51a",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821300924000.8e02b0a6-c8fb-47f3-894d-58d6bb79c31a",
+      "id" : "1674157639109374000.5f62fede-6d67-4c7d-9f36-41e9526cf51a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5901,10 +5901,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821301000000.4d73dcff-5cc3-4c96-a16c-fe39a2e5727f",
+    "fullUrl" : "PractitionerRole/1674157639109438000.980489d2-f3be-4d9a-960f-a86f1e98d4a0",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821301000000.4d73dcff-5cc3-4c96-a16c-fe39a2e5727f",
+      "id" : "1674157639109438000.980489d2-f3be-4d9a-960f-a86f1e98d4a0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5916,10 +5916,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821299294000.7c04b8e6-b580-4e51-ad46-18f4176d06ef"
+        "reference" : "Practitioner/1674157639108060000.1ab8f167-0755-40e5-aa33-955f71e47227"
       },
       "organization" : {
-        "reference" : "Organization/1673381821300924000.8e02b0a6-c8fb-47f3-894d-58d6bb79c31a"
+        "reference" : "Organization/1674157639109374000.5f62fede-6d67-4c7d-9f36-41e9526cf51a"
       },
       "code" : [ {
         "coding" : [ {
@@ -5929,10 +5929,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821302020000.18b1ee40-6ad0-4888-9e90-452e475408ec",
+    "fullUrl" : "Organization/1674157639110327000.971ed9c7-ce7e-45c9-9e22-311dab06dfd7",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821302020000.18b1ee40-6ad0-4888-9e90-452e475408ec",
+      "id" : "1674157639110327000.971ed9c7-ce7e-45c9-9e22-311dab06dfd7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5958,10 +5958,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821307036000.076ec618-b436-4e1e-bc6f-58a6ae87feed",
+    "fullUrl" : "Observation/1674157639114142000.00d9b8d3-3efe-445d-8db5-36bae7a8abec",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821307036000.076ec618-b436-4e1e-bc6f-58a6ae87feed",
+      "id" : "1674157639114142000.00d9b8d3-3efe-445d-8db5-36bae7a8abec",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -5978,7 +5978,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821306945000.6a31b3d0-109d-430a-9ef7-26376d617091"
+          "reference" : "Organization/1674157639114079000.115bfa11-ec1d-4abd-a01e-2804019e75f4"
         }
       } ],
       "identifier" : [ {
@@ -6012,23 +6012,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821305823000.16eb2bf7-48ae-4344-818a-8e536287cd58"
+        "reference" : "PractitionerRole/1674157639113271000.caf672f8-b794-4427-981a-11d9e297b69a"
       } ],
       "valueString" : "has been authorized by FDA under an Emergency Use"
     }
   }, {
-    "fullUrl" : "Location/1673381821303731000.0eb125c8-edce-41a0-b4bf-20cb9becf6f5",
+    "fullUrl" : "Location/1674157639111605000.fd9e48b0-81eb-4e10-a0a8-2a6c7eb6fe82",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821303731000.0eb125c8-edce-41a0-b4bf-20cb9becf6f5",
+      "id" : "1674157639111605000.fd9e48b0-81eb-4e10-a0a8-2a6c7eb6fe82",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6042,10 +6042,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821304128000.f82c020c-a590-4358-975d-6de308e6221c",
+    "fullUrl" : "Practitioner/1674157639111887000.2eff8f0c-910d-4b6e-88c6-4a0bbe9e0493",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821304128000.f82c020c-a590-4358-975d-6de308e6221c",
+      "id" : "1674157639111887000.2eff8f0c-910d-4b6e-88c6-4a0bbe9e0493",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6067,7 +6067,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821303731000.0eb125c8-edce-41a0-b4bf-20cb9becf6f5"
+          "reference" : "Location/1674157639111605000.fd9e48b0-81eb-4e10-a0a8-2a6c7eb6fe82"
         }
       } ],
       "identifier" : [ {
@@ -6093,10 +6093,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821305751000.e68e3b66-191e-42cd-a906-2ad5c4171ba3",
+    "fullUrl" : "Organization/1674157639113206000.c479c39d-7740-48b3-9193-9a0e80f6aad2",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821305751000.e68e3b66-191e-42cd-a906-2ad5c4171ba3",
+      "id" : "1674157639113206000.c479c39d-7740-48b3-9193-9a0e80f6aad2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6140,10 +6140,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821305823000.16eb2bf7-48ae-4344-818a-8e536287cd58",
+    "fullUrl" : "PractitionerRole/1674157639113271000.caf672f8-b794-4427-981a-11d9e297b69a",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821305823000.16eb2bf7-48ae-4344-818a-8e536287cd58",
+      "id" : "1674157639113271000.caf672f8-b794-4427-981a-11d9e297b69a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6155,10 +6155,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821304128000.f82c020c-a590-4358-975d-6de308e6221c"
+        "reference" : "Practitioner/1674157639111887000.2eff8f0c-910d-4b6e-88c6-4a0bbe9e0493"
       },
       "organization" : {
-        "reference" : "Organization/1673381821305751000.e68e3b66-191e-42cd-a906-2ad5c4171ba3"
+        "reference" : "Organization/1674157639113206000.c479c39d-7740-48b3-9193-9a0e80f6aad2"
       },
       "code" : [ {
         "coding" : [ {
@@ -6168,10 +6168,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821306945000.6a31b3d0-109d-430a-9ef7-26376d617091",
+    "fullUrl" : "Organization/1674157639114079000.115bfa11-ec1d-4abd-a01e-2804019e75f4",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821306945000.6a31b3d0-109d-430a-9ef7-26376d617091",
+      "id" : "1674157639114079000.115bfa11-ec1d-4abd-a01e-2804019e75f4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6197,10 +6197,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821311462000.f8f8dc67-c59a-4475-8f73-44ee9d648b6e",
+    "fullUrl" : "Observation/1674157639117607000.ff676240-028e-4e73-b61e-675a7a271543",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821311462000.f8f8dc67-c59a-4475-8f73-44ee9d648b6e",
+      "id" : "1674157639117607000.ff676240-028e-4e73-b61e-675a7a271543",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6217,7 +6217,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821311396000.1d4f39ef-82c2-405b-9fb6-3cb32aedc03d"
+          "reference" : "Organization/1674157639117546000.a23520fd-1fb3-42ce-8968-c244f209c2fe"
         }
       } ],
       "identifier" : [ {
@@ -6251,23 +6251,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821310444000.279b5f43-3b34-482d-84cb-5809af27ccdd"
+        "reference" : "PractitionerRole/1674157639116692000.5a7b8ad8-e167-44bb-8a6f-cff2a092a829"
       } ],
       "valueString" : "Authorization (EUA) for use by authorized laboratories. This"
     }
   }, {
-    "fullUrl" : "Location/1673381821308380000.3bdd62d2-6430-4b10-8dca-d4843acc8bbc",
+    "fullUrl" : "Location/1674157639115120000.72a07a74-ab4d-4fc1-a334-83327a70ae71",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821308380000.3bdd62d2-6430-4b10-8dca-d4843acc8bbc",
+      "id" : "1674157639115120000.72a07a74-ab4d-4fc1-a334-83327a70ae71",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6281,10 +6281,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821308815000.28d05f61-dcab-40fd-b41d-1cf03c785670",
+    "fullUrl" : "Practitioner/1674157639115383000.6cb3e8a3-f781-479d-8545-4dfa04db9739",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821308815000.28d05f61-dcab-40fd-b41d-1cf03c785670",
+      "id" : "1674157639115383000.6cb3e8a3-f781-479d-8545-4dfa04db9739",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6306,7 +6306,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821308380000.3bdd62d2-6430-4b10-8dca-d4843acc8bbc"
+          "reference" : "Location/1674157639115120000.72a07a74-ab4d-4fc1-a334-83327a70ae71"
         }
       } ],
       "identifier" : [ {
@@ -6332,10 +6332,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821310374000.7d25d31e-635d-43b9-a932-33f932abd98a",
+    "fullUrl" : "Organization/1674157639116635000.75900864-6b61-4bfd-a221-cc8b960295f5",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821310374000.7d25d31e-635d-43b9-a932-33f932abd98a",
+      "id" : "1674157639116635000.75900864-6b61-4bfd-a221-cc8b960295f5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6379,10 +6379,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821310444000.279b5f43-3b34-482d-84cb-5809af27ccdd",
+    "fullUrl" : "PractitionerRole/1674157639116692000.5a7b8ad8-e167-44bb-8a6f-cff2a092a829",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821310444000.279b5f43-3b34-482d-84cb-5809af27ccdd",
+      "id" : "1674157639116692000.5a7b8ad8-e167-44bb-8a6f-cff2a092a829",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6394,10 +6394,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821308815000.28d05f61-dcab-40fd-b41d-1cf03c785670"
+        "reference" : "Practitioner/1674157639115383000.6cb3e8a3-f781-479d-8545-4dfa04db9739"
       },
       "organization" : {
-        "reference" : "Organization/1673381821310374000.7d25d31e-635d-43b9-a932-33f932abd98a"
+        "reference" : "Organization/1674157639116635000.75900864-6b61-4bfd-a221-cc8b960295f5"
       },
       "code" : [ {
         "coding" : [ {
@@ -6407,10 +6407,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821311396000.1d4f39ef-82c2-405b-9fb6-3cb32aedc03d",
+    "fullUrl" : "Organization/1674157639117546000.a23520fd-1fb3-42ce-8968-c244f209c2fe",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821311396000.1d4f39ef-82c2-405b-9fb6-3cb32aedc03d",
+      "id" : "1674157639117546000.a23520fd-1fb3-42ce-8968-c244f209c2fe",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6436,10 +6436,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821315379000.a82d615d-af08-4e4a-a9f2-b3dc0361c1fa",
+    "fullUrl" : "Observation/1674157639121409000.831cca47-4a73-4f9d-a88c-2090cfbb4c5f",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821315379000.a82d615d-af08-4e4a-a9f2-b3dc0361c1fa",
+      "id" : "1674157639121409000.831cca47-4a73-4f9d-a88c-2090cfbb4c5f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6456,7 +6456,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821315309000.cea7bf00-b050-45ed-ae6c-11b58019e9e2"
+          "reference" : "Organization/1674157639121285000.56b456c0-8be6-42f2-9240-786390f5569d"
         }
       } ],
       "identifier" : [ {
@@ -6490,23 +6490,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821314345000.6ca58412-8840-4783-821b-42419f7c758e"
+        "reference" : "PractitionerRole/1674157639120327000.dec1a55b-d581-40bd-87de-a3910113cd20"
       } ],
       "valueString" : "EUA will be effective until the declaration that"
     }
   }, {
-    "fullUrl" : "Location/1673381821312578000.ce366d3b-092a-40b2-9e0b-f83e6cb08ea0",
+    "fullUrl" : "Location/1674157639118615000.0c494ee7-429b-4617-ac1c-c1f5ce40a336",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821312578000.ce366d3b-092a-40b2-9e0b-f83e6cb08ea0",
+      "id" : "1674157639118615000.0c494ee7-429b-4617-ac1c-c1f5ce40a336",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6520,10 +6520,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821312869000.0e7f7ad5-3191-4623-a07d-962c7c8915e5",
+    "fullUrl" : "Practitioner/1674157639118953000.f062c39a-c563-40b4-ae72-86674c375937",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821312869000.0e7f7ad5-3191-4623-a07d-962c7c8915e5",
+      "id" : "1674157639118953000.f062c39a-c563-40b4-ae72-86674c375937",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6545,7 +6545,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821312578000.ce366d3b-092a-40b2-9e0b-f83e6cb08ea0"
+          "reference" : "Location/1674157639118615000.0c494ee7-429b-4617-ac1c-c1f5ce40a336"
         }
       } ],
       "identifier" : [ {
@@ -6571,10 +6571,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821314283000.c976c818-3715-4f59-981d-b89e1a07ae64",
+    "fullUrl" : "Organization/1674157639120269000.9f25805b-0324-46ef-8dca-2a51b23b8ad0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821314283000.c976c818-3715-4f59-981d-b89e1a07ae64",
+      "id" : "1674157639120269000.9f25805b-0324-46ef-8dca-2a51b23b8ad0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6618,10 +6618,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821314345000.6ca58412-8840-4783-821b-42419f7c758e",
+    "fullUrl" : "PractitionerRole/1674157639120327000.dec1a55b-d581-40bd-87de-a3910113cd20",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821314345000.6ca58412-8840-4783-821b-42419f7c758e",
+      "id" : "1674157639120327000.dec1a55b-d581-40bd-87de-a3910113cd20",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6633,10 +6633,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821312869000.0e7f7ad5-3191-4623-a07d-962c7c8915e5"
+        "reference" : "Practitioner/1674157639118953000.f062c39a-c563-40b4-ae72-86674c375937"
       },
       "organization" : {
-        "reference" : "Organization/1673381821314283000.c976c818-3715-4f59-981d-b89e1a07ae64"
+        "reference" : "Organization/1674157639120269000.9f25805b-0324-46ef-8dca-2a51b23b8ad0"
       },
       "code" : [ {
         "coding" : [ {
@@ -6646,10 +6646,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821315309000.cea7bf00-b050-45ed-ae6c-11b58019e9e2",
+    "fullUrl" : "Organization/1674157639121285000.56b456c0-8be6-42f2-9240-786390f5569d",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821315309000.cea7bf00-b050-45ed-ae6c-11b58019e9e2",
+      "id" : "1674157639121285000.56b456c0-8be6-42f2-9240-786390f5569d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6675,10 +6675,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821319827000.76840447-bdf2-42fb-8ad9-30b35ab1fc20",
+    "fullUrl" : "Observation/1674157639124893000.7472ecb8-17ce-4880-8755-942899e8d73b",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821319827000.76840447-bdf2-42fb-8ad9-30b35ab1fc20",
+      "id" : "1674157639124893000.7472ecb8-17ce-4880-8755-942899e8d73b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6695,7 +6695,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821319714000.d1bdb9a0-eefa-4f9d-8572-312cd5ad6bc7"
+          "reference" : "Organization/1674157639124830000.a426cb51-660f-45f0-90c2-23025a9e644a"
         }
       } ],
       "identifier" : [ {
@@ -6729,23 +6729,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821318402000.1510394b-003c-4c23-9462-053cd8e6b862"
+        "reference" : "PractitionerRole/1674157639124050000.987738ce-8e70-4bf9-aedf-f9e859e0611d"
       } ],
       "valueString" : "circumstances exist justifying the authorization of the"
     }
   }, {
-    "fullUrl" : "Location/1673381821316574000.c4c5ffbf-bfb0-4f2a-a411-669ca4be9044",
+    "fullUrl" : "Location/1674157639122476000.812ac8ad-14bd-465f-830c-375925614ec3",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821316574000.c4c5ffbf-bfb0-4f2a-a411-669ca4be9044",
+      "id" : "1674157639122476000.812ac8ad-14bd-465f-830c-375925614ec3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6759,10 +6759,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821316903000.76b6e3ef-d497-4a75-b2c9-fa9b54dd7cbd",
+    "fullUrl" : "Practitioner/1674157639122733000.10c916c5-9eda-46c1-829b-af720109b211",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821316903000.76b6e3ef-d497-4a75-b2c9-fa9b54dd7cbd",
+      "id" : "1674157639122733000.10c916c5-9eda-46c1-829b-af720109b211",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6784,7 +6784,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821316574000.c4c5ffbf-bfb0-4f2a-a411-669ca4be9044"
+          "reference" : "Location/1674157639122476000.812ac8ad-14bd-465f-830c-375925614ec3"
         }
       } ],
       "identifier" : [ {
@@ -6810,10 +6810,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821318346000.9b36417b-0ebe-4ecd-97c0-886a45166c48",
+    "fullUrl" : "Organization/1674157639124000000.6fcc86b5-f1f8-4b9b-b523-b3462f0db230",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821318346000.9b36417b-0ebe-4ecd-97c0-886a45166c48",
+      "id" : "1674157639124000000.6fcc86b5-f1f8-4b9b-b523-b3462f0db230",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6857,10 +6857,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821318402000.1510394b-003c-4c23-9462-053cd8e6b862",
+    "fullUrl" : "PractitionerRole/1674157639124050000.987738ce-8e70-4bf9-aedf-f9e859e0611d",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821318402000.1510394b-003c-4c23-9462-053cd8e6b862",
+      "id" : "1674157639124050000.987738ce-8e70-4bf9-aedf-f9e859e0611d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6872,10 +6872,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821316903000.76b6e3ef-d497-4a75-b2c9-fa9b54dd7cbd"
+        "reference" : "Practitioner/1674157639122733000.10c916c5-9eda-46c1-829b-af720109b211"
       },
       "organization" : {
-        "reference" : "Organization/1673381821318346000.9b36417b-0ebe-4ecd-97c0-886a45166c48"
+        "reference" : "Organization/1674157639124000000.6fcc86b5-f1f8-4b9b-b523-b3462f0db230"
       },
       "code" : [ {
         "coding" : [ {
@@ -6885,10 +6885,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821319714000.d1bdb9a0-eefa-4f9d-8572-312cd5ad6bc7",
+    "fullUrl" : "Organization/1674157639124830000.a426cb51-660f-45f0-90c2-23025a9e644a",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821319714000.d1bdb9a0-eefa-4f9d-8572-312cd5ad6bc7",
+      "id" : "1674157639124830000.a426cb51-660f-45f0-90c2-23025a9e644a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6914,10 +6914,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821323940000.f5e42eb1-b2b6-4815-a3b6-d49be808602c",
+    "fullUrl" : "Observation/1674157639128071000.aab521b9-0d58-467f-bae2-b29f65ba4e3f",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821323940000.f5e42eb1-b2b6-4815-a3b6-d49be808602c",
+      "id" : "1674157639128071000.aab521b9-0d58-467f-bae2-b29f65ba4e3f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6934,7 +6934,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821323863000.d83070a9-02a7-4177-a509-6549a1fcf8d0"
+          "reference" : "Organization/1674157639128014000.c25bb9d3-a93f-4828-a425-856d17cf9521"
         }
       } ],
       "identifier" : [ {
@@ -6968,23 +6968,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821322870000.4d1efe1a-7e40-4dfb-86a3-f79479f4e499"
+        "reference" : "PractitionerRole/1674157639127266000.8ce5527f-e4ab-4e5a-b85a-e8f7aa65bbf7"
       } ],
       "valueString" : "emergency use of in vitro diagnostic tests for detection"
     }
   }, {
-    "fullUrl" : "Location/1673381821321053000.36bcdde6-c03d-4ac5-a891-a05d23ea9859",
+    "fullUrl" : "Location/1674157639125808000.f2249b3f-e816-44a6-a218-0b0a994186d2",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821321053000.36bcdde6-c03d-4ac5-a891-a05d23ea9859",
+      "id" : "1674157639125808000.f2249b3f-e816-44a6-a218-0b0a994186d2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -6998,10 +6998,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821321372000.97867d2d-07a2-4a10-8357-73d57b2fd981",
+    "fullUrl" : "Practitioner/1674157639126066000.29b5d98b-0c93-4ab8-8351-63401719ebb6",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821321372000.97867d2d-07a2-4a10-8357-73d57b2fd981",
+      "id" : "1674157639126066000.29b5d98b-0c93-4ab8-8351-63401719ebb6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7023,7 +7023,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821321053000.36bcdde6-c03d-4ac5-a891-a05d23ea9859"
+          "reference" : "Location/1674157639125808000.f2249b3f-e816-44a6-a218-0b0a994186d2"
         }
       } ],
       "identifier" : [ {
@@ -7049,10 +7049,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821322798000.51c50be1-e9fc-4412-b907-ae19c979d504",
+    "fullUrl" : "Organization/1674157639127200000.303a4d7c-b2ab-40db-adfe-f6cf6fb9e386",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821322798000.51c50be1-e9fc-4412-b907-ae19c979d504",
+      "id" : "1674157639127200000.303a4d7c-b2ab-40db-adfe-f6cf6fb9e386",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7096,10 +7096,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821322870000.4d1efe1a-7e40-4dfb-86a3-f79479f4e499",
+    "fullUrl" : "PractitionerRole/1674157639127266000.8ce5527f-e4ab-4e5a-b85a-e8f7aa65bbf7",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821322870000.4d1efe1a-7e40-4dfb-86a3-f79479f4e499",
+      "id" : "1674157639127266000.8ce5527f-e4ab-4e5a-b85a-e8f7aa65bbf7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7111,10 +7111,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821321372000.97867d2d-07a2-4a10-8357-73d57b2fd981"
+        "reference" : "Practitioner/1674157639126066000.29b5d98b-0c93-4ab8-8351-63401719ebb6"
       },
       "organization" : {
-        "reference" : "Organization/1673381821322798000.51c50be1-e9fc-4412-b907-ae19c979d504"
+        "reference" : "Organization/1674157639127200000.303a4d7c-b2ab-40db-adfe-f6cf6fb9e386"
       },
       "code" : [ {
         "coding" : [ {
@@ -7124,10 +7124,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821323863000.d83070a9-02a7-4177-a509-6549a1fcf8d0",
+    "fullUrl" : "Organization/1674157639128014000.c25bb9d3-a93f-4828-a425-856d17cf9521",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821323863000.d83070a9-02a7-4177-a509-6549a1fcf8d0",
+      "id" : "1674157639128014000.c25bb9d3-a93f-4828-a425-856d17cf9521",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7153,10 +7153,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821328098000.8e7ead74-c826-4f69-b438-4d5d7e42bb34",
+    "fullUrl" : "Observation/1674157639131739000.585137c5-13a4-44d8-aa96-0b97e749776a",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821328098000.8e7ead74-c826-4f69-b438-4d5d7e42bb34",
+      "id" : "1674157639131739000.585137c5-13a4-44d8-aa96-0b97e749776a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7173,7 +7173,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821328003000.13a733a6-3c8b-45d8-a436-05df5abe8fd1"
+          "reference" : "Organization/1674157639131624000.2ed9a4de-243e-4d82-937f-60c2b6c59b21"
         }
       } ],
       "identifier" : [ {
@@ -7207,23 +7207,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821326992000.f8abc6de-c18b-4b38-a8ea-acd5a0e0a82e"
+        "reference" : "PractitionerRole/1674157639130573000.7daaf76e-0bbf-4bc8-941c-236d6568f963"
       } ],
       "valueString" : "and/or diagnosis of COVID-19 is terminated under Section"
     }
   }, {
-    "fullUrl" : "Location/1673381821325140000.be242da7-b6e4-44de-af22-0a6e0b77ee13",
+    "fullUrl" : "Location/1674157639128994000.ea9eb765-0aba-458c-a82c-546bc9423382",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821325140000.be242da7-b6e4-44de-af22-0a6e0b77ee13",
+      "id" : "1674157639128994000.ea9eb765-0aba-458c-a82c-546bc9423382",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7237,10 +7237,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821325473000.efad0ca4-d842-46b0-b097-66dd9d3a0fea",
+    "fullUrl" : "Practitioner/1674157639129258000.1e0a15a7-4c3f-4c66-a559-a900482e7de1",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821325473000.efad0ca4-d842-46b0-b097-66dd9d3a0fea",
+      "id" : "1674157639129258000.1e0a15a7-4c3f-4c66-a559-a900482e7de1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7262,7 +7262,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821325140000.be242da7-b6e4-44de-af22-0a6e0b77ee13"
+          "reference" : "Location/1674157639128994000.ea9eb765-0aba-458c-a82c-546bc9423382"
         }
       } ],
       "identifier" : [ {
@@ -7288,10 +7288,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821326918000.26e15175-c089-4814-928b-9e1c5419bfac",
+    "fullUrl" : "Organization/1674157639130502000.f95cda68-df17-4382-a862-34ff18701cf7",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821326918000.26e15175-c089-4814-928b-9e1c5419bfac",
+      "id" : "1674157639130502000.f95cda68-df17-4382-a862-34ff18701cf7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7335,10 +7335,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821326992000.f8abc6de-c18b-4b38-a8ea-acd5a0e0a82e",
+    "fullUrl" : "PractitionerRole/1674157639130573000.7daaf76e-0bbf-4bc8-941c-236d6568f963",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821326992000.f8abc6de-c18b-4b38-a8ea-acd5a0e0a82e",
+      "id" : "1674157639130573000.7daaf76e-0bbf-4bc8-941c-236d6568f963",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7350,10 +7350,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821325473000.efad0ca4-d842-46b0-b097-66dd9d3a0fea"
+        "reference" : "Practitioner/1674157639129258000.1e0a15a7-4c3f-4c66-a559-a900482e7de1"
       },
       "organization" : {
-        "reference" : "Organization/1673381821326918000.26e15175-c089-4814-928b-9e1c5419bfac"
+        "reference" : "Organization/1674157639130502000.f95cda68-df17-4382-a862-34ff18701cf7"
       },
       "code" : [ {
         "coding" : [ {
@@ -7363,10 +7363,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821328003000.13a733a6-3c8b-45d8-a436-05df5abe8fd1",
+    "fullUrl" : "Organization/1674157639131624000.2ed9a4de-243e-4d82-937f-60c2b6c59b21",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821328003000.13a733a6-3c8b-45d8-a436-05df5abe8fd1",
+      "id" : "1674157639131624000.2ed9a4de-243e-4d82-937f-60c2b6c59b21",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7392,10 +7392,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821332357000.edf03c22-8835-4939-8b1b-e20072f1969d",
+    "fullUrl" : "Observation/1674157639135616000.20f40668-47d5-452f-a3c7-771b4d5ca494",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821332357000.edf03c22-8835-4939-8b1b-e20072f1969d",
+      "id" : "1674157639135616000.20f40668-47d5-452f-a3c7-771b4d5ca494",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7412,7 +7412,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821332294000.c6671992-62cc-4722-92ea-8416aa91193e"
+          "reference" : "Organization/1674157639135559000.717407cc-ce72-44dd-8d6a-180f83d3bade"
         }
       } ],
       "identifier" : [ {
@@ -7446,23 +7446,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821331343000.f23fa64e-c640-4e9b-b6ed-a9e9b2ca968d"
+        "reference" : "PractitionerRole/1674157639134727000.8584bf83-8f11-47e5-b00f-7b7a33975f86"
       } ],
       "valueString" : "564(b)(2) of the Act or the EUA is revoked under Section"
     }
   }, {
-    "fullUrl" : "Location/1673381821329414000.e7bb15e0-ebd0-4570-be5c-61cc6298dade",
+    "fullUrl" : "Location/1674157639132970000.6649a24e-46a7-4004-a68b-8d18709501f3",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821329414000.e7bb15e0-ebd0-4570-be5c-61cc6298dade",
+      "id" : "1674157639132970000.6649a24e-46a7-4004-a68b-8d18709501f3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7476,10 +7476,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821329716000.3cc2b198-e6b7-4f16-bf30-da37e0226040",
+    "fullUrl" : "Practitioner/1674157639133275000.917bd964-ac82-47bb-a5e5-e1a488a222fa",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821329716000.3cc2b198-e6b7-4f16-bf30-da37e0226040",
+      "id" : "1674157639133275000.917bd964-ac82-47bb-a5e5-e1a488a222fa",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7501,7 +7501,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821329414000.e7bb15e0-ebd0-4570-be5c-61cc6298dade"
+          "reference" : "Location/1674157639132970000.6649a24e-46a7-4004-a68b-8d18709501f3"
         }
       } ],
       "identifier" : [ {
@@ -7527,10 +7527,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821331270000.0e34cd30-9207-422c-9f5e-426953951e04",
+    "fullUrl" : "Organization/1674157639134656000.d38cdc5f-0849-4cb7-bec4-3ac6d2ff0197",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821331270000.0e34cd30-9207-422c-9f5e-426953951e04",
+      "id" : "1674157639134656000.d38cdc5f-0849-4cb7-bec4-3ac6d2ff0197",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7574,10 +7574,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821331343000.f23fa64e-c640-4e9b-b6ed-a9e9b2ca968d",
+    "fullUrl" : "PractitionerRole/1674157639134727000.8584bf83-8f11-47e5-b00f-7b7a33975f86",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821331343000.f23fa64e-c640-4e9b-b6ed-a9e9b2ca968d",
+      "id" : "1674157639134727000.8584bf83-8f11-47e5-b00f-7b7a33975f86",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7589,10 +7589,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821329716000.3cc2b198-e6b7-4f16-bf30-da37e0226040"
+        "reference" : "Practitioner/1674157639133275000.917bd964-ac82-47bb-a5e5-e1a488a222fa"
       },
       "organization" : {
-        "reference" : "Organization/1673381821331270000.0e34cd30-9207-422c-9f5e-426953951e04"
+        "reference" : "Organization/1674157639134656000.d38cdc5f-0849-4cb7-bec4-3ac6d2ff0197"
       },
       "code" : [ {
         "coding" : [ {
@@ -7602,10 +7602,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821332294000.c6671992-62cc-4722-92ea-8416aa91193e",
+    "fullUrl" : "Organization/1674157639135559000.717407cc-ce72-44dd-8d6a-180f83d3bade",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821332294000.c6671992-62cc-4722-92ea-8416aa91193e",
+      "id" : "1674157639135559000.717407cc-ce72-44dd-8d6a-180f83d3bade",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7631,10 +7631,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821339107000.d4a2b377-58ea-4b10-9536-6937cfaf3604",
+    "fullUrl" : "Observation/1674157639139366000.b51ed11a-3e40-4a2f-b9e9-8d8082033df5",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821339107000.d4a2b377-58ea-4b10-9536-6937cfaf3604",
+      "id" : "1674157639139366000.b51ed11a-3e40-4a2f-b9e9-8d8082033df5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7651,7 +7651,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821339031000.1ba1aa9b-abe5-4c02-814c-b5dbde034394"
+          "reference" : "Organization/1674157639139310000.50252b0d-81da-4c9e-b8d0-c7e825558765"
         }
       } ],
       "identifier" : [ {
@@ -7685,23 +7685,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821337930000.8992f102-220b-461f-8d14-9ed161153e8e"
+        "reference" : "PractitionerRole/1674157639138524000.c620861a-55a4-46f0-8abe-81a509ba0553"
       } ],
       "valueString" : "564(g) of the Act."
     }
   }, {
-    "fullUrl" : "Location/1673381821335871000.7e3c09b6-2aef-45bb-96c2-50bfd3b167e2",
+    "fullUrl" : "Location/1674157639136740000.43d1bd39-be12-40c7-bb53-e8f11198b1d7",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821335871000.7e3c09b6-2aef-45bb-96c2-50bfd3b167e2",
+      "id" : "1674157639136740000.43d1bd39-be12-40c7-bb53-e8f11198b1d7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7715,10 +7715,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821336188000.d49b214c-aa6b-41e3-91d4-721368f42efb",
+    "fullUrl" : "Practitioner/1674157639137039000.b32a8f85-3287-4935-aa33-24bd0cddf390",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821336188000.d49b214c-aa6b-41e3-91d4-721368f42efb",
+      "id" : "1674157639137039000.b32a8f85-3287-4935-aa33-24bd0cddf390",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7740,7 +7740,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821335871000.7e3c09b6-2aef-45bb-96c2-50bfd3b167e2"
+          "reference" : "Location/1674157639136740000.43d1bd39-be12-40c7-bb53-e8f11198b1d7"
         }
       } ],
       "identifier" : [ {
@@ -7766,10 +7766,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821337826000.42a46451-7e5c-4545-ae5f-8c88d61b248b",
+    "fullUrl" : "Organization/1674157639138462000.f3d95b2f-b641-4553-b94f-4587497b89ec",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821337826000.42a46451-7e5c-4545-ae5f-8c88d61b248b",
+      "id" : "1674157639138462000.f3d95b2f-b641-4553-b94f-4587497b89ec",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7813,10 +7813,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821337930000.8992f102-220b-461f-8d14-9ed161153e8e",
+    "fullUrl" : "PractitionerRole/1674157639138524000.c620861a-55a4-46f0-8abe-81a509ba0553",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821337930000.8992f102-220b-461f-8d14-9ed161153e8e",
+      "id" : "1674157639138524000.c620861a-55a4-46f0-8abe-81a509ba0553",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7828,10 +7828,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821336188000.d49b214c-aa6b-41e3-91d4-721368f42efb"
+        "reference" : "Practitioner/1674157639137039000.b32a8f85-3287-4935-aa33-24bd0cddf390"
       },
       "organization" : {
-        "reference" : "Organization/1673381821337826000.42a46451-7e5c-4545-ae5f-8c88d61b248b"
+        "reference" : "Organization/1674157639138462000.f3d95b2f-b641-4553-b94f-4587497b89ec"
       },
       "code" : [ {
         "coding" : [ {
@@ -7841,10 +7841,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821339031000.1ba1aa9b-abe5-4c02-814c-b5dbde034394",
+    "fullUrl" : "Organization/1674157639139310000.50252b0d-81da-4c9e-b8d0-c7e825558765",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821339031000.1ba1aa9b-abe5-4c02-814c-b5dbde034394",
+      "id" : "1674157639139310000.50252b0d-81da-4c9e-b8d0-c7e825558765",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7870,10 +7870,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821343500000.bdc835ec-a2be-4e17-9bb8-440bb45306be",
+    "fullUrl" : "Observation/1674157639142939000.280759fe-040e-4ca0-9680-5dfed44cee64",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821343500000.bdc835ec-a2be-4e17-9bb8-440bb45306be",
+      "id" : "1674157639142939000.280759fe-040e-4ca0-9680-5dfed44cee64",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7890,7 +7890,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821343434000.5b81428d-2bbe-41b3-a960-8ed065d78be7"
+          "reference" : "Organization/1674157639142883000.c197be1b-05a1-45e2-a906-bca6f0666c5b"
         }
       } ],
       "identifier" : [ {
@@ -7924,22 +7924,22 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821342521000.d78e16f1-80c8-4a69-b745-db7663e4a36c"
+        "reference" : "PractitionerRole/1674157639142071000.1de34592-1921-4615-bce6-054cb21613e5"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821340435000.59e35913-bd22-449f-a6e8-50edd79c18bf",
+    "fullUrl" : "Location/1674157639140390000.db9fbd96-d457-4318-a481-a2a673635595",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821340435000.59e35913-bd22-449f-a6e8-50edd79c18bf",
+      "id" : "1674157639140390000.db9fbd96-d457-4318-a481-a2a673635595",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7953,10 +7953,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821340775000.caaa6b67-5d36-41cb-8f6c-659de8147f59",
+    "fullUrl" : "Practitioner/1674157639140669000.92897be7-23af-4366-9745-1bdc49222ac2",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821340775000.caaa6b67-5d36-41cb-8f6c-659de8147f59",
+      "id" : "1674157639140669000.92897be7-23af-4366-9745-1bdc49222ac2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -7978,7 +7978,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821340435000.59e35913-bd22-449f-a6e8-50edd79c18bf"
+          "reference" : "Location/1674157639140390000.db9fbd96-d457-4318-a481-a2a673635595"
         }
       } ],
       "identifier" : [ {
@@ -8004,10 +8004,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821342454000.03fc1c48-5394-44ce-ba25-14d26fb011e7",
+    "fullUrl" : "Organization/1674157639142018000.ba0122e7-7bcf-4210-aa00-8fa5a44e7de7",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821342454000.03fc1c48-5394-44ce-ba25-14d26fb011e7",
+      "id" : "1674157639142018000.ba0122e7-7bcf-4210-aa00-8fa5a44e7de7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8051,10 +8051,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821342521000.d78e16f1-80c8-4a69-b745-db7663e4a36c",
+    "fullUrl" : "PractitionerRole/1674157639142071000.1de34592-1921-4615-bce6-054cb21613e5",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821342521000.d78e16f1-80c8-4a69-b745-db7663e4a36c",
+      "id" : "1674157639142071000.1de34592-1921-4615-bce6-054cb21613e5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8066,10 +8066,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821340775000.caaa6b67-5d36-41cb-8f6c-659de8147f59"
+        "reference" : "Practitioner/1674157639140669000.92897be7-23af-4366-9745-1bdc49222ac2"
       },
       "organization" : {
-        "reference" : "Organization/1673381821342454000.03fc1c48-5394-44ce-ba25-14d26fb011e7"
+        "reference" : "Organization/1674157639142018000.ba0122e7-7bcf-4210-aa00-8fa5a44e7de7"
       },
       "code" : [ {
         "coding" : [ {
@@ -8079,10 +8079,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821343434000.5b81428d-2bbe-41b3-a960-8ed065d78be7",
+    "fullUrl" : "Organization/1674157639142883000.c197be1b-05a1-45e2-a906-bca6f0666c5b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821343434000.5b81428d-2bbe-41b3-a960-8ed065d78be7",
+      "id" : "1674157639142883000.c197be1b-05a1-45e2-a906-bca6f0666c5b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8108,10 +8108,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821347603000.92b86b27-11d8-48d5-af86-deec9ce26086",
+    "fullUrl" : "Observation/1674157639146552000.cb5e6d65-9b94-4f21-a076-015a922d9d9b",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821347603000.92b86b27-11d8-48d5-af86-deec9ce26086",
+      "id" : "1674157639146552000.cb5e6d65-9b94-4f21-a076-015a922d9d9b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8128,7 +8128,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821347538000.adb5dc06-7f27-498f-b6f6-b095ec80a2c0"
+          "reference" : "Organization/1674157639146467000.3dccf82a-f5d3-4eff-afd2-ce89ae99a666"
         }
       } ],
       "identifier" : [ {
@@ -8162,23 +8162,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821346511000.83f91793-8b34-4700-991c-eb5d525f3520"
+        "reference" : "PractitionerRole/1674157639145504000.a6221aea-3849-4286-b624-bcc2ef5f1b2c"
       } ],
       "valueString" : "An EUA authorized diagnostic test can be used in an"
     }
   }, {
-    "fullUrl" : "Location/1673381821344539000.9bd64a42-9876-49e3-9f82-ed818490596e",
+    "fullUrl" : "Location/1674157639143919000.37a36127-8835-4732-b74f-18e044848590",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821344539000.9bd64a42-9876-49e3-9f82-ed818490596e",
+      "id" : "1674157639143919000.37a36127-8835-4732-b74f-18e044848590",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8192,10 +8192,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821344908000.ca513d58-fcb5-4b27-a9ae-bcb321ea3c32",
+    "fullUrl" : "Practitioner/1674157639144195000.41607f9e-0a74-4c2c-ad54-e68e3ae09098",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821344908000.ca513d58-fcb5-4b27-a9ae-bcb321ea3c32",
+      "id" : "1674157639144195000.41607f9e-0a74-4c2c-ad54-e68e3ae09098",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8217,7 +8217,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821344539000.9bd64a42-9876-49e3-9f82-ed818490596e"
+          "reference" : "Location/1674157639143919000.37a36127-8835-4732-b74f-18e044848590"
         }
       } ],
       "identifier" : [ {
@@ -8243,10 +8243,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821346442000.ecbceee1-ccf6-4108-9769-af0bb6b93d52",
+    "fullUrl" : "Organization/1674157639145450000.a1f89d33-1fc5-4345-b3e2-71e63456edc3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821346442000.ecbceee1-ccf6-4108-9769-af0bb6b93d52",
+      "id" : "1674157639145450000.a1f89d33-1fc5-4345-b3e2-71e63456edc3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8290,10 +8290,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821346511000.83f91793-8b34-4700-991c-eb5d525f3520",
+    "fullUrl" : "PractitionerRole/1674157639145504000.a6221aea-3849-4286-b624-bcc2ef5f1b2c",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821346511000.83f91793-8b34-4700-991c-eb5d525f3520",
+      "id" : "1674157639145504000.a6221aea-3849-4286-b624-bcc2ef5f1b2c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8305,10 +8305,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821344908000.ca513d58-fcb5-4b27-a9ae-bcb321ea3c32"
+        "reference" : "Practitioner/1674157639144195000.41607f9e-0a74-4c2c-ad54-e68e3ae09098"
       },
       "organization" : {
-        "reference" : "Organization/1673381821346442000.ecbceee1-ccf6-4108-9769-af0bb6b93d52"
+        "reference" : "Organization/1674157639145450000.a1f89d33-1fc5-4345-b3e2-71e63456edc3"
       },
       "code" : [ {
         "coding" : [ {
@@ -8318,10 +8318,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821347538000.adb5dc06-7f27-498f-b6f6-b095ec80a2c0",
+    "fullUrl" : "Organization/1674157639146467000.3dccf82a-f5d3-4eff-afd2-ce89ae99a666",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821347538000.adb5dc06-7f27-498f-b6f6-b095ec80a2c0",
+      "id" : "1674157639146467000.3dccf82a-f5d3-4eff-afd2-ce89ae99a666",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8347,10 +8347,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821351155000.b6e1cfb1-affe-47e4-a8db-83eeef201de8",
+    "fullUrl" : "Observation/1674157639150427000.bd71b61f-fefb-4412-82fd-1ad1b33dc80d",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821351155000.b6e1cfb1-affe-47e4-a8db-83eeef201de8",
+      "id" : "1674157639150427000.bd71b61f-fefb-4412-82fd-1ad1b33dc80d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8367,7 +8367,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821351090000.8ad20f4e-6fba-4249-b42a-d39b36bc63ed"
+          "reference" : "Organization/1674157639150350000.3f78537c-5329-4d40-9748-8d7a0c9e32dc"
         }
       } ],
       "identifier" : [ {
@@ -8401,23 +8401,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821350289000.77899c57-a9d6-4f36-8f80-b866e77492de"
+        "reference" : "PractitionerRole/1674157639149405000.e01d38b0-ce70-44f6-aeea-d69054a5dd51"
       } ],
       "valueString" : "asymptomatic individual if they are suspected of COVID-19"
     }
   }, {
-    "fullUrl" : "Location/1673381821348680000.9b197cba-296d-4118-b616-edb06ca5de57",
+    "fullUrl" : "Location/1674157639147660000.13a8dad9-d726-47b7-afda-b11dde23f239",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821348680000.9b197cba-296d-4118-b616-edb06ca5de57",
+      "id" : "1674157639147660000.13a8dad9-d726-47b7-afda-b11dde23f239",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8431,10 +8431,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821348948000.d9fcb2be-866d-4aea-bf3d-d98d54aae955",
+    "fullUrl" : "Practitioner/1674157639147954000.eec36eb9-52ed-41b1-ac29-1a19a4b2ef7e",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821348948000.d9fcb2be-866d-4aea-bf3d-d98d54aae955",
+      "id" : "1674157639147954000.eec36eb9-52ed-41b1-ac29-1a19a4b2ef7e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8456,7 +8456,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821348680000.9b197cba-296d-4118-b616-edb06ca5de57"
+          "reference" : "Location/1674157639147660000.13a8dad9-d726-47b7-afda-b11dde23f239"
         }
       } ],
       "identifier" : [ {
@@ -8482,10 +8482,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821350233000.215e6e26-8508-4702-a57d-7a60823b4d61",
+    "fullUrl" : "Organization/1674157639149348000.bc90feff-309a-48c3-8293-5d54e81cc90b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821350233000.215e6e26-8508-4702-a57d-7a60823b4d61",
+      "id" : "1674157639149348000.bc90feff-309a-48c3-8293-5d54e81cc90b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8529,10 +8529,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821350289000.77899c57-a9d6-4f36-8f80-b866e77492de",
+    "fullUrl" : "PractitionerRole/1674157639149405000.e01d38b0-ce70-44f6-aeea-d69054a5dd51",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821350289000.77899c57-a9d6-4f36-8f80-b866e77492de",
+      "id" : "1674157639149405000.e01d38b0-ce70-44f6-aeea-d69054a5dd51",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8544,10 +8544,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821348948000.d9fcb2be-866d-4aea-bf3d-d98d54aae955"
+        "reference" : "Practitioner/1674157639147954000.eec36eb9-52ed-41b1-ac29-1a19a4b2ef7e"
       },
       "organization" : {
-        "reference" : "Organization/1673381821350233000.215e6e26-8508-4702-a57d-7a60823b4d61"
+        "reference" : "Organization/1674157639149348000.bc90feff-309a-48c3-8293-5d54e81cc90b"
       },
       "code" : [ {
         "coding" : [ {
@@ -8557,10 +8557,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821351090000.8ad20f4e-6fba-4249-b42a-d39b36bc63ed",
+    "fullUrl" : "Organization/1674157639150350000.3f78537c-5329-4d40-9748-8d7a0c9e32dc",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821351090000.8ad20f4e-6fba-4249-b42a-d39b36bc63ed",
+      "id" : "1674157639150350000.3f78537c-5329-4d40-9748-8d7a0c9e32dc",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8586,10 +8586,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821354515000.97500a5b-d07f-4f85-a663-2489f17f8a08",
+    "fullUrl" : "Observation/1674157639154451000.f6549bab-9219-48eb-8144-d5a3ab413ca6",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821354515000.97500a5b-d07f-4f85-a663-2489f17f8a08",
+      "id" : "1674157639154451000.f6549bab-9219-48eb-8144-d5a3ab413ca6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8606,7 +8606,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821354463000.72663b60-790d-462f-96a3-33f7fdc95a85"
+          "reference" : "Organization/1674157639154380000.cbf2fb3a-855c-4d47-808c-6c5e1ff030a4"
         }
       } ],
       "identifier" : [ {
@@ -8640,23 +8640,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821353693000.5144083a-c9d9-40a1-8b35-1a0a4dfceec1"
+        "reference" : "PractitionerRole/1674157639153430000.42fb7c4d-6f84-4022-a42f-37efa5a41c82"
       } ],
       "valueString" : "for various reasons, such as known exposure or working in a"
     }
   }, {
-    "fullUrl" : "Location/1673381821352132000.d37da8ff-c5bc-43f3-b983-b9f1c3035168",
+    "fullUrl" : "Location/1674157639151558000.7da77f6b-5a0a-4170-819b-b3840ad288f9",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821352132000.d37da8ff-c5bc-43f3-b983-b9f1c3035168",
+      "id" : "1674157639151558000.7da77f6b-5a0a-4170-819b-b3840ad288f9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8670,10 +8670,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821352394000.cef1a102-cc7c-421a-b827-afa9131e79a4",
+    "fullUrl" : "Practitioner/1674157639151842000.2e4d871b-a650-4adc-ba1d-75472d6e53c3",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821352394000.cef1a102-cc7c-421a-b827-afa9131e79a4",
+      "id" : "1674157639151842000.2e4d871b-a650-4adc-ba1d-75472d6e53c3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8695,7 +8695,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821352132000.d37da8ff-c5bc-43f3-b983-b9f1c3035168"
+          "reference" : "Location/1674157639151558000.7da77f6b-5a0a-4170-819b-b3840ad288f9"
         }
       } ],
       "identifier" : [ {
@@ -8721,10 +8721,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821353640000.9cbd1f03-c799-4377-b135-ac88a0c34fc2",
+    "fullUrl" : "Organization/1674157639153366000.4d68b6dd-9a13-4979-a8fd-8b3595991f41",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821353640000.9cbd1f03-c799-4377-b135-ac88a0c34fc2",
+      "id" : "1674157639153366000.4d68b6dd-9a13-4979-a8fd-8b3595991f41",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8768,10 +8768,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821353693000.5144083a-c9d9-40a1-8b35-1a0a4dfceec1",
+    "fullUrl" : "PractitionerRole/1674157639153430000.42fb7c4d-6f84-4022-a42f-37efa5a41c82",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821353693000.5144083a-c9d9-40a1-8b35-1a0a4dfceec1",
+      "id" : "1674157639153430000.42fb7c4d-6f84-4022-a42f-37efa5a41c82",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8783,10 +8783,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821352394000.cef1a102-cc7c-421a-b827-afa9131e79a4"
+        "reference" : "Practitioner/1674157639151842000.2e4d871b-a650-4adc-ba1d-75472d6e53c3"
       },
       "organization" : {
-        "reference" : "Organization/1673381821353640000.9cbd1f03-c799-4377-b135-ac88a0c34fc2"
+        "reference" : "Organization/1674157639153366000.4d68b6dd-9a13-4979-a8fd-8b3595991f41"
       },
       "code" : [ {
         "coding" : [ {
@@ -8796,10 +8796,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821354463000.72663b60-790d-462f-96a3-33f7fdc95a85",
+    "fullUrl" : "Organization/1674157639154380000.cbf2fb3a-855c-4d47-808c-6c5e1ff030a4",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821354463000.72663b60-790d-462f-96a3-33f7fdc95a85",
+      "id" : "1674157639154380000.cbf2fb3a-855c-4d47-808c-6c5e1ff030a4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8825,10 +8825,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821358595000.191b2ee7-ec37-45aa-9e8f-6a9a81d534eb",
+    "fullUrl" : "Observation/1674157639158249000.01724dc2-dfc2-48dc-9c4e-8292fb06dcf9",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821358595000.191b2ee7-ec37-45aa-9e8f-6a9a81d534eb",
+      "id" : "1674157639158249000.01724dc2-dfc2-48dc-9c4e-8292fb06dcf9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8845,7 +8845,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821358532000.20edb377-2384-4980-a6a9-816bf7d81daf"
+          "reference" : "Organization/1674157639158185000.b3ef36d2-d3f0-4f99-bbc7-6dc87fa0d01f"
         }
       } ],
       "identifier" : [ {
@@ -8879,23 +8879,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821357659000.0312a740-d498-41b9-ae05-5fe389889020"
+        "reference" : "PractitionerRole/1674157639157337000.955320c4-f584-40c2-b229-f731eb95dcdd"
       } ],
       "valueString" : "high-risk environment. Individuals suspected of COVID-19"
     }
   }, {
-    "fullUrl" : "Location/1673381821355868000.818dfa48-31e4-43fe-8f57-731f917999da",
+    "fullUrl" : "Location/1674157639155530000.9f018433-1742-4c4d-8c33-b308a80513fd",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821355868000.818dfa48-31e4-43fe-8f57-731f917999da",
+      "id" : "1674157639155530000.9f018433-1742-4c4d-8c33-b308a80513fd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8909,10 +8909,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821356179000.22d2cf69-d0b5-4212-b344-3475707259e8",
+    "fullUrl" : "Practitioner/1674157639155843000.f5e67db2-2e2f-4cc5-8c62-1f17a2850f43",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821356179000.22d2cf69-d0b5-4212-b344-3475707259e8",
+      "id" : "1674157639155843000.f5e67db2-2e2f-4cc5-8c62-1f17a2850f43",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -8934,7 +8934,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821355868000.818dfa48-31e4-43fe-8f57-731f917999da"
+          "reference" : "Location/1674157639155530000.9f018433-1742-4c4d-8c33-b308a80513fd"
         }
       } ],
       "identifier" : [ {
@@ -8960,10 +8960,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821357597000.fe3c1829-d4ac-4269-a1f2-db7079b4012a",
+    "fullUrl" : "Organization/1674157639157274000.5ad6bee7-363b-4e20-8fbf-a2dff65ea213",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821357597000.fe3c1829-d4ac-4269-a1f2-db7079b4012a",
+      "id" : "1674157639157274000.5ad6bee7-363b-4e20-8fbf-a2dff65ea213",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9007,10 +9007,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821357659000.0312a740-d498-41b9-ae05-5fe389889020",
+    "fullUrl" : "PractitionerRole/1674157639157337000.955320c4-f584-40c2-b229-f731eb95dcdd",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821357659000.0312a740-d498-41b9-ae05-5fe389889020",
+      "id" : "1674157639157337000.955320c4-f584-40c2-b229-f731eb95dcdd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9022,10 +9022,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821356179000.22d2cf69-d0b5-4212-b344-3475707259e8"
+        "reference" : "Practitioner/1674157639155843000.f5e67db2-2e2f-4cc5-8c62-1f17a2850f43"
       },
       "organization" : {
-        "reference" : "Organization/1673381821357597000.fe3c1829-d4ac-4269-a1f2-db7079b4012a"
+        "reference" : "Organization/1674157639157274000.5ad6bee7-363b-4e20-8fbf-a2dff65ea213"
       },
       "code" : [ {
         "coding" : [ {
@@ -9035,10 +9035,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821358532000.20edb377-2384-4980-a6a9-816bf7d81daf",
+    "fullUrl" : "Organization/1674157639158185000.b3ef36d2-d3f0-4f99-bbc7-6dc87fa0d01f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821358532000.20edb377-2384-4980-a6a9-816bf7d81daf",
+      "id" : "1674157639158185000.b3ef36d2-d3f0-4f99-bbc7-6dc87fa0d01f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9064,10 +9064,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821362188000.dfe22b09-a0d9-4c0a-8fc9-458633839bf7",
+    "fullUrl" : "Observation/1674157639162031000.e98982f1-9736-49bd-96cd-eda167344f51",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821362188000.dfe22b09-a0d9-4c0a-8fc9-458633839bf7",
+      "id" : "1674157639162031000.e98982f1-9736-49bd-96cd-eda167344f51",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9084,7 +9084,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821362130000.904a3c91-8c6f-4909-aada-22b042bdbbdb"
+          "reference" : "Organization/1674157639161966000.bb9ee46b-1d14-4624-9694-042329d95eb6"
         }
       } ],
       "identifier" : [ {
@@ -9118,23 +9118,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821361322000.baa7b80f-0f01-4bc0-a503-8607d8bb5391"
+        "reference" : "PractitionerRole/1674157639160987000.3c092004-5d1f-477a-ab74-4e00c8c6b50a"
       } ],
       "valueString" : "infection may be symptomatic, pre-symptomatic, or"
     }
   }, {
-    "fullUrl" : "Location/1673381821359681000.d17e94b9-2b07-42b3-8c61-21db0c220965",
+    "fullUrl" : "Location/1674157639159343000.85931224-d496-4113-920a-1b48e00a835d",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821359681000.d17e94b9-2b07-42b3-8c61-21db0c220965",
+      "id" : "1674157639159343000.85931224-d496-4113-920a-1b48e00a835d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9148,10 +9148,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821359941000.a8edfc2c-d35c-43f1-b7e8-208dff99ce16",
+    "fullUrl" : "Practitioner/1674157639159619000.eef6b035-d89a-41e8-9a3d-01a77bf7118b",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821359941000.a8edfc2c-d35c-43f1-b7e8-208dff99ce16",
+      "id" : "1674157639159619000.eef6b035-d89a-41e8-9a3d-01a77bf7118b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9173,7 +9173,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821359681000.d17e94b9-2b07-42b3-8c61-21db0c220965"
+          "reference" : "Location/1674157639159343000.85931224-d496-4113-920a-1b48e00a835d"
         }
       } ],
       "identifier" : [ {
@@ -9199,10 +9199,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821361270000.0befed02-f4e9-44c3-85c3-e7621fe50680",
+    "fullUrl" : "Organization/1674157639160922000.8a2bbc59-987b-437d-8966-967765469aca",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821361270000.0befed02-f4e9-44c3-85c3-e7621fe50680",
+      "id" : "1674157639160922000.8a2bbc59-987b-437d-8966-967765469aca",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9246,10 +9246,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821361322000.baa7b80f-0f01-4bc0-a503-8607d8bb5391",
+    "fullUrl" : "PractitionerRole/1674157639160987000.3c092004-5d1f-477a-ab74-4e00c8c6b50a",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821361322000.baa7b80f-0f01-4bc0-a503-8607d8bb5391",
+      "id" : "1674157639160987000.3c092004-5d1f-477a-ab74-4e00c8c6b50a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9261,10 +9261,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821359941000.a8edfc2c-d35c-43f1-b7e8-208dff99ce16"
+        "reference" : "Practitioner/1674157639159619000.eef6b035-d89a-41e8-9a3d-01a77bf7118b"
       },
       "organization" : {
-        "reference" : "Organization/1673381821361270000.0befed02-f4e9-44c3-85c3-e7621fe50680"
+        "reference" : "Organization/1674157639160922000.8a2bbc59-987b-437d-8966-967765469aca"
       },
       "code" : [ {
         "coding" : [ {
@@ -9274,10 +9274,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821362130000.904a3c91-8c6f-4909-aada-22b042bdbbdb",
+    "fullUrl" : "Organization/1674157639161966000.bb9ee46b-1d14-4624-9694-042329d95eb6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821362130000.904a3c91-8c6f-4909-aada-22b042bdbbdb",
+      "id" : "1674157639161966000.bb9ee46b-1d14-4624-9694-042329d95eb6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9303,10 +9303,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821365792000.70aba614-5584-49ee-989f-767d57ce6563",
+    "fullUrl" : "Observation/1674157639165761000.7f60e839-4f42-416e-821a-96efdb9dbd50",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821365792000.70aba614-5584-49ee-989f-767d57ce6563",
+      "id" : "1674157639165761000.7f60e839-4f42-416e-821a-96efdb9dbd50",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9323,7 +9323,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821365726000.5068eabb-4f18-430f-8ee1-4c36d3bdecdb"
+          "reference" : "Organization/1674157639165703000.50eebb36-e889-49f5-8096-91b118d71038"
         }
       } ],
       "identifier" : [ {
@@ -9357,23 +9357,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821364862000.3f70fa8f-25eb-44d4-af9d-a048f8d3b496"
+        "reference" : "PractitionerRole/1674157639164777000.c5fbf689-5a48-4c88-bb73-1b8275bad171"
       } ],
       "valueString" : "asymptomatic. The decision to order a test for an individual"
     }
   }, {
-    "fullUrl" : "Location/1673381821363211000.36890e0d-7f66-4c79-9009-110dd571517b",
+    "fullUrl" : "Location/1674157639163163000.01697d42-9594-4aa0-9d70-720a1efcb330",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821363211000.36890e0d-7f66-4c79-9009-110dd571517b",
+      "id" : "1674157639163163000.01697d42-9594-4aa0-9d70-720a1efcb330",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9387,10 +9387,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821363480000.c59aefc1-f7eb-4798-87ac-a629c9557493",
+    "fullUrl" : "Practitioner/1674157639163455000.f1bdbf22-2e31-4ba9-97e7-bc23bc319a99",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821363480000.c59aefc1-f7eb-4798-87ac-a629c9557493",
+      "id" : "1674157639163455000.f1bdbf22-2e31-4ba9-97e7-bc23bc319a99",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9412,7 +9412,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821363211000.36890e0d-7f66-4c79-9009-110dd571517b"
+          "reference" : "Location/1674157639163163000.01697d42-9594-4aa0-9d70-720a1efcb330"
         }
       } ],
       "identifier" : [ {
@@ -9438,10 +9438,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821364801000.693c5628-36e0-411f-bd0b-018f847e3ed6",
+    "fullUrl" : "Organization/1674157639164725000.1ccff669-6bef-4a86-b45d-4391da63f3ec",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821364801000.693c5628-36e0-411f-bd0b-018f847e3ed6",
+      "id" : "1674157639164725000.1ccff669-6bef-4a86-b45d-4391da63f3ec",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9485,10 +9485,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821364862000.3f70fa8f-25eb-44d4-af9d-a048f8d3b496",
+    "fullUrl" : "PractitionerRole/1674157639164777000.c5fbf689-5a48-4c88-bb73-1b8275bad171",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821364862000.3f70fa8f-25eb-44d4-af9d-a048f8d3b496",
+      "id" : "1674157639164777000.c5fbf689-5a48-4c88-bb73-1b8275bad171",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9500,10 +9500,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821363480000.c59aefc1-f7eb-4798-87ac-a629c9557493"
+        "reference" : "Practitioner/1674157639163455000.f1bdbf22-2e31-4ba9-97e7-bc23bc319a99"
       },
       "organization" : {
-        "reference" : "Organization/1673381821364801000.693c5628-36e0-411f-bd0b-018f847e3ed6"
+        "reference" : "Organization/1674157639164725000.1ccff669-6bef-4a86-b45d-4391da63f3ec"
       },
       "code" : [ {
         "coding" : [ {
@@ -9513,10 +9513,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821365726000.5068eabb-4f18-430f-8ee1-4c36d3bdecdb",
+    "fullUrl" : "Organization/1674157639165703000.50eebb36-e889-49f5-8096-91b118d71038",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821365726000.5068eabb-4f18-430f-8ee1-4c36d3bdecdb",
+      "id" : "1674157639165703000.50eebb36-e889-49f5-8096-91b118d71038",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9542,10 +9542,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821369948000.d50677c4-af8f-4909-8b37-1be8bf8b6255",
+    "fullUrl" : "Observation/1674157639169470000.f2291a21-3c5b-470d-8fea-b83a07e972eb",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821369948000.d50677c4-af8f-4909-8b37-1be8bf8b6255",
+      "id" : "1674157639169470000.f2291a21-3c5b-470d-8fea-b83a07e972eb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9562,7 +9562,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821369873000.02103fd9-444d-4687-b0cf-f9f4dd54930c"
+          "reference" : "Organization/1674157639169403000.bad8b2af-55cb-4b94-bb0b-4e2c0ae4315b"
         }
       } ],
       "identifier" : [ {
@@ -9596,23 +9596,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821368997000.16afabeb-a303-4ae5-88ce-ca11b2dcbcc2"
+        "reference" : "PractitionerRole/1674157639168615000.e307bf26-88f5-46fc-ab5f-424e92ccd068"
       } ],
       "valueString" : "suspected of COVID-19 is at the discretion of the health"
     }
   }, {
-    "fullUrl" : "Location/1673381821367052000.bf67eb5e-0495-4c89-9e6f-dda9e73221e7",
+    "fullUrl" : "Location/1674157639166831000.dbd8e3f9-fc2b-4a7c-8094-33ce7f826ec5",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821367052000.bf67eb5e-0495-4c89-9e6f-dda9e73221e7",
+      "id" : "1674157639166831000.dbd8e3f9-fc2b-4a7c-8094-33ce7f826ec5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9626,10 +9626,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821367353000.7dfad9a1-9610-4130-a492-d6fea0f0f281",
+    "fullUrl" : "Practitioner/1674157639167101000.99ebb873-0ac7-4d6c-8c98-070c3117702f",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821367353000.7dfad9a1-9610-4130-a492-d6fea0f0f281",
+      "id" : "1674157639167101000.99ebb873-0ac7-4d6c-8c98-070c3117702f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9651,7 +9651,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821367052000.bf67eb5e-0495-4c89-9e6f-dda9e73221e7"
+          "reference" : "Location/1674157639166831000.dbd8e3f9-fc2b-4a7c-8094-33ce7f826ec5"
         }
       } ],
       "identifier" : [ {
@@ -9677,10 +9677,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821368932000.64c930e7-589c-458e-9f09-3fbd365fee04",
+    "fullUrl" : "Organization/1674157639168557000.fa8dd1b1-b60c-47af-bb83-ee54689103c5",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821368932000.64c930e7-589c-458e-9f09-3fbd365fee04",
+      "id" : "1674157639168557000.fa8dd1b1-b60c-47af-bb83-ee54689103c5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9724,10 +9724,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821368997000.16afabeb-a303-4ae5-88ce-ca11b2dcbcc2",
+    "fullUrl" : "PractitionerRole/1674157639168615000.e307bf26-88f5-46fc-ab5f-424e92ccd068",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821368997000.16afabeb-a303-4ae5-88ce-ca11b2dcbcc2",
+      "id" : "1674157639168615000.e307bf26-88f5-46fc-ab5f-424e92ccd068",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9739,10 +9739,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821367353000.7dfad9a1-9610-4130-a492-d6fea0f0f281"
+        "reference" : "Practitioner/1674157639167101000.99ebb873-0ac7-4d6c-8c98-070c3117702f"
       },
       "organization" : {
-        "reference" : "Organization/1673381821368932000.64c930e7-589c-458e-9f09-3fbd365fee04"
+        "reference" : "Organization/1674157639168557000.fa8dd1b1-b60c-47af-bb83-ee54689103c5"
       },
       "code" : [ {
         "coding" : [ {
@@ -9752,10 +9752,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821369873000.02103fd9-444d-4687-b0cf-f9f4dd54930c",
+    "fullUrl" : "Organization/1674157639169403000.bad8b2af-55cb-4b94-bb0b-4e2c0ae4315b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821369873000.02103fd9-444d-4687-b0cf-f9f4dd54930c",
+      "id" : "1674157639169403000.bad8b2af-55cb-4b94-bb0b-4e2c0ae4315b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9781,10 +9781,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821373701000.2be49fb6-bf18-4a19-bb75-1fe4d728ae98",
+    "fullUrl" : "Observation/1674157639172989000.76bfb272-b2db-4f35-a1c1-fb03b2afa32c",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821373701000.2be49fb6-bf18-4a19-bb75-1fe4d728ae98",
+      "id" : "1674157639172989000.76bfb272-b2db-4f35-a1c1-fb03b2afa32c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9801,7 +9801,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821373636000.d97f1339-256a-40a4-aaf9-0097e492f232"
+          "reference" : "Organization/1674157639172944000.2c4db2df-57dd-4e7d-b208-65f714a97af6"
         }
       } ],
       "identifier" : [ {
@@ -9835,23 +9835,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821372794000.d6c30a76-4b92-49f4-b8b4-ed00c6f47022"
+        "reference" : "PractitionerRole/1674157639172201000.bbc56f44-d28a-412e-ad8e-00c11b07733e"
       } ],
       "valueString" : "care provider or individual authorized to order a test."
     }
   }, {
-    "fullUrl" : "Location/1673381821371091000.a5cb00ef-1a72-48a6-a3f6-1e05c081bc18",
+    "fullUrl" : "Location/1674157639170556000.a36bfb88-ca20-4983-baf0-8e5c4321a3d0",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821371091000.a5cb00ef-1a72-48a6-a3f6-1e05c081bc18",
+      "id" : "1674157639170556000.a36bfb88-ca20-4983-baf0-8e5c4321a3d0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9865,10 +9865,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821371386000.ca926c5a-ed14-4f3a-aa78-1429d8f35e8b",
+    "fullUrl" : "Practitioner/1674157639170842000.de06b396-07d2-4b4a-8629-39a24359b074",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821371386000.ca926c5a-ed14-4f3a-aa78-1429d8f35e8b",
+      "id" : "1674157639170842000.de06b396-07d2-4b4a-8629-39a24359b074",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9890,7 +9890,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821371091000.a5cb00ef-1a72-48a6-a3f6-1e05c081bc18"
+          "reference" : "Location/1674157639170556000.a36bfb88-ca20-4983-baf0-8e5c4321a3d0"
         }
       } ],
       "identifier" : [ {
@@ -9916,10 +9916,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821372703000.6689e027-c2fb-4651-9f2c-14784297a97a",
+    "fullUrl" : "Organization/1674157639172114000.1d6ac3e8-ca0d-473f-a897-d0be49964cfa",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821372703000.6689e027-c2fb-4651-9f2c-14784297a97a",
+      "id" : "1674157639172114000.1d6ac3e8-ca0d-473f-a897-d0be49964cfa",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9963,10 +9963,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821372794000.d6c30a76-4b92-49f4-b8b4-ed00c6f47022",
+    "fullUrl" : "PractitionerRole/1674157639172201000.bbc56f44-d28a-412e-ad8e-00c11b07733e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821372794000.d6c30a76-4b92-49f4-b8b4-ed00c6f47022",
+      "id" : "1674157639172201000.bbc56f44-d28a-412e-ad8e-00c11b07733e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -9978,10 +9978,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821371386000.ca926c5a-ed14-4f3a-aa78-1429d8f35e8b"
+        "reference" : "Practitioner/1674157639170842000.de06b396-07d2-4b4a-8629-39a24359b074"
       },
       "organization" : {
-        "reference" : "Organization/1673381821372703000.6689e027-c2fb-4651-9f2c-14784297a97a"
+        "reference" : "Organization/1674157639172114000.1d6ac3e8-ca0d-473f-a897-d0be49964cfa"
       },
       "code" : [ {
         "coding" : [ {
@@ -9991,10 +9991,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821373636000.d97f1339-256a-40a4-aaf9-0097e492f232",
+    "fullUrl" : "Organization/1674157639172944000.2c4db2df-57dd-4e7d-b208-65f714a97af6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821373636000.d97f1339-256a-40a4-aaf9-0097e492f232",
+      "id" : "1674157639172944000.2c4db2df-57dd-4e7d-b208-65f714a97af6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10020,10 +10020,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821377282000.c1b22d11-10bb-4891-8cf3-24c858398543",
+    "fullUrl" : "Observation/1674157639176352000.bef976ce-d2b3-426e-bff3-ac40d9f8a41d",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821377282000.c1b22d11-10bb-4891-8cf3-24c858398543",
+      "id" : "1674157639176352000.bef976ce-d2b3-426e-bff3-ac40d9f8a41d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10040,7 +10040,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821377225000.6991e833-3798-46b4-92ae-6fb2719b4636"
+          "reference" : "Organization/1674157639176302000.d07e77f8-10c2-4fd1-916e-a710c1afd3f3"
         }
       } ],
       "identifier" : [ {
@@ -10074,23 +10074,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821376397000.b917289c-3c00-4420-9910-d6622adf2471"
+        "reference" : "PractitionerRole/1674157639175530000.c4a21c91-7a0b-430e-8274-8d686334c7e8"
       } ],
       "valueString" : "Laboratory results must be considered in the context of the"
     }
   }, {
-    "fullUrl" : "Location/1673381821374792000.d17504a9-bb8e-492c-8a38-4c920ba53120",
+    "fullUrl" : "Location/1674157639173980000.464f5327-b421-4b0e-9b0e-2e2b15790be7",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821374792000.d17504a9-bb8e-492c-8a38-4c920ba53120",
+      "id" : "1674157639173980000.464f5327-b421-4b0e-9b0e-2e2b15790be7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10104,10 +10104,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821375065000.59ece543-57bf-4ad0-b6b9-010f6940d349",
+    "fullUrl" : "Practitioner/1674157639174254000.fad4c0ef-7507-48b6-a033-1f2c3736279d",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821375065000.59ece543-57bf-4ad0-b6b9-010f6940d349",
+      "id" : "1674157639174254000.fad4c0ef-7507-48b6-a033-1f2c3736279d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10129,7 +10129,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821374792000.d17504a9-bb8e-492c-8a38-4c920ba53120"
+          "reference" : "Location/1674157639173980000.464f5327-b421-4b0e-9b0e-2e2b15790be7"
         }
       } ],
       "identifier" : [ {
@@ -10155,10 +10155,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821376348000.e2256292-df4c-490e-9301-44194a4fbfa8",
+    "fullUrl" : "Organization/1674157639175484000.05eba304-6c1d-49b9-9ffc-9f62a0bb4529",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821376348000.e2256292-df4c-490e-9301-44194a4fbfa8",
+      "id" : "1674157639175484000.05eba304-6c1d-49b9-9ffc-9f62a0bb4529",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10202,10 +10202,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821376397000.b917289c-3c00-4420-9910-d6622adf2471",
+    "fullUrl" : "PractitionerRole/1674157639175530000.c4a21c91-7a0b-430e-8274-8d686334c7e8",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821376397000.b917289c-3c00-4420-9910-d6622adf2471",
+      "id" : "1674157639175530000.c4a21c91-7a0b-430e-8274-8d686334c7e8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10217,10 +10217,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821375065000.59ece543-57bf-4ad0-b6b9-010f6940d349"
+        "reference" : "Practitioner/1674157639174254000.fad4c0ef-7507-48b6-a033-1f2c3736279d"
       },
       "organization" : {
-        "reference" : "Organization/1673381821376348000.e2256292-df4c-490e-9301-44194a4fbfa8"
+        "reference" : "Organization/1674157639175484000.05eba304-6c1d-49b9-9ffc-9f62a0bb4529"
       },
       "code" : [ {
         "coding" : [ {
@@ -10230,10 +10230,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821377225000.6991e833-3798-46b4-92ae-6fb2719b4636",
+    "fullUrl" : "Organization/1674157639176302000.d07e77f8-10c2-4fd1-916e-a710c1afd3f3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821377225000.6991e833-3798-46b4-92ae-6fb2719b4636",
+      "id" : "1674157639176302000.d07e77f8-10c2-4fd1-916e-a710c1afd3f3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10259,10 +10259,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821380790000.48168bb0-de4a-442f-aa56-34089917b4e1",
+    "fullUrl" : "Observation/1674157639179777000.26ad9b06-a182-452a-ad99-929c3c7b0830",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821380790000.48168bb0-de4a-442f-aa56-34089917b4e1",
+      "id" : "1674157639179777000.26ad9b06-a182-452a-ad99-929c3c7b0830",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10279,7 +10279,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821380732000.4276022d-2450-4b24-b49c-aa8431b4ee51"
+          "reference" : "Organization/1674157639179702000.171dd105-8472-452c-aae6-f55d74fec2e1"
         }
       } ],
       "identifier" : [ {
@@ -10313,23 +10313,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821379936000.c0502c9f-c5dd-4912-a2ec-76f8d8a877c9"
+        "reference" : "PractitionerRole/1674157639178884000.82f45590-8f3d-418c-8fec-a6f83466a799"
       } ],
       "valueString" : "individuals clinical and other information."
     }
   }, {
-    "fullUrl" : "Location/1673381821378350000.96f886c2-0f82-4b94-8b40-691deb55ad4d",
+    "fullUrl" : "Location/1674157639177340000.4ee44c1e-036e-4d24-bf18-86bdf75e3c71",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821378350000.96f886c2-0f82-4b94-8b40-691deb55ad4d",
+      "id" : "1674157639177340000.4ee44c1e-036e-4d24-bf18-86bdf75e3c71",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10343,10 +10343,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821378617000.4d9511d3-776d-4a27-bcac-87f71c84ec73",
+    "fullUrl" : "Practitioner/1674157639177591000.42e39178-8cab-441a-bd9a-4ed3f45ebd05",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821378617000.4d9511d3-776d-4a27-bcac-87f71c84ec73",
+      "id" : "1674157639177591000.42e39178-8cab-441a-bd9a-4ed3f45ebd05",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10368,7 +10368,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821378350000.96f886c2-0f82-4b94-8b40-691deb55ad4d"
+          "reference" : "Location/1674157639177340000.4ee44c1e-036e-4d24-bf18-86bdf75e3c71"
         }
       } ],
       "identifier" : [ {
@@ -10394,10 +10394,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821379891000.45debc62-2ca2-49ca-8a90-e0a35e9f6de3",
+    "fullUrl" : "Organization/1674157639178831000.a4455e04-62a5-4d30-85bf-ea4e30ff89b7",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821379891000.45debc62-2ca2-49ca-8a90-e0a35e9f6de3",
+      "id" : "1674157639178831000.a4455e04-62a5-4d30-85bf-ea4e30ff89b7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10441,10 +10441,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821379936000.c0502c9f-c5dd-4912-a2ec-76f8d8a877c9",
+    "fullUrl" : "PractitionerRole/1674157639178884000.82f45590-8f3d-418c-8fec-a6f83466a799",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821379936000.c0502c9f-c5dd-4912-a2ec-76f8d8a877c9",
+      "id" : "1674157639178884000.82f45590-8f3d-418c-8fec-a6f83466a799",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10456,10 +10456,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821378617000.4d9511d3-776d-4a27-bcac-87f71c84ec73"
+        "reference" : "Practitioner/1674157639177591000.42e39178-8cab-441a-bd9a-4ed3f45ebd05"
       },
       "organization" : {
-        "reference" : "Organization/1673381821379891000.45debc62-2ca2-49ca-8a90-e0a35e9f6de3"
+        "reference" : "Organization/1674157639178831000.a4455e04-62a5-4d30-85bf-ea4e30ff89b7"
       },
       "code" : [ {
         "coding" : [ {
@@ -10469,10 +10469,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821380732000.4276022d-2450-4b24-b49c-aa8431b4ee51",
+    "fullUrl" : "Organization/1674157639179702000.171dd105-8472-452c-aae6-f55d74fec2e1",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821380732000.4276022d-2450-4b24-b49c-aa8431b4ee51",
+      "id" : "1674157639179702000.171dd105-8472-452c-aae6-f55d74fec2e1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10498,10 +10498,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821384758000.e8ea4254-35f8-48b0-8321-add84b3f6921",
+    "fullUrl" : "Observation/1674157639183254000.95c10adc-a649-49c2-9c5b-ff78c6de4ffa",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821384758000.e8ea4254-35f8-48b0-8321-add84b3f6921",
+      "id" : "1674157639183254000.95c10adc-a649-49c2-9c5b-ff78c6de4ffa",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10518,7 +10518,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821384672000.cb2022ab-f87d-4af3-b8a9-4e72607bf8a0"
+          "reference" : "Organization/1674157639183197000.b51043ad-f956-4aaf-9eec-d810a79f95e6"
         }
       } ],
       "identifier" : [ {
@@ -10552,22 +10552,22 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821383612000.ecd280f3-8fce-4a87-bcee-a05ca3d89c95"
+        "reference" : "PractitionerRole/1674157639182390000.9ee94c05-5b14-42f5-bbc6-a957dac561ab"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821381807000.26b6a360-ad69-49ce-baad-fc5c604a3b31",
+    "fullUrl" : "Location/1674157639180797000.f5c68804-dfb8-4b1e-80c4-8472db06cc7b",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821381807000.26b6a360-ad69-49ce-baad-fc5c604a3b31",
+      "id" : "1674157639180797000.f5c68804-dfb8-4b1e-80c4-8472db06cc7b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10581,10 +10581,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821382072000.0395e6ff-7125-431d-8015-58d1b1d1ddb1",
+    "fullUrl" : "Practitioner/1674157639181067000.37b5b333-1bef-435a-88bb-993f084d4d19",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821382072000.0395e6ff-7125-431d-8015-58d1b1d1ddb1",
+      "id" : "1674157639181067000.37b5b333-1bef-435a-88bb-993f084d4d19",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10606,7 +10606,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821381807000.26b6a360-ad69-49ce-baad-fc5c604a3b31"
+          "reference" : "Location/1674157639180797000.f5c68804-dfb8-4b1e-80c4-8472db06cc7b"
         }
       } ],
       "identifier" : [ {
@@ -10632,10 +10632,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821383554000.21b460d2-13a3-430e-856f-d0ce022abb8d",
+    "fullUrl" : "Organization/1674157639182332000.d3544fd5-93f5-4036-9ecd-a6e93bc60291",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821383554000.21b460d2-13a3-430e-856f-d0ce022abb8d",
+      "id" : "1674157639182332000.d3544fd5-93f5-4036-9ecd-a6e93bc60291",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10679,10 +10679,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821383612000.ecd280f3-8fce-4a87-bcee-a05ca3d89c95",
+    "fullUrl" : "PractitionerRole/1674157639182390000.9ee94c05-5b14-42f5-bbc6-a957dac561ab",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821383612000.ecd280f3-8fce-4a87-bcee-a05ca3d89c95",
+      "id" : "1674157639182390000.9ee94c05-5b14-42f5-bbc6-a957dac561ab",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10694,10 +10694,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821382072000.0395e6ff-7125-431d-8015-58d1b1d1ddb1"
+        "reference" : "Practitioner/1674157639181067000.37b5b333-1bef-435a-88bb-993f084d4d19"
       },
       "organization" : {
-        "reference" : "Organization/1673381821383554000.21b460d2-13a3-430e-856f-d0ce022abb8d"
+        "reference" : "Organization/1674157639182332000.d3544fd5-93f5-4036-9ecd-a6e93bc60291"
       },
       "code" : [ {
         "coding" : [ {
@@ -10707,10 +10707,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821384672000.cb2022ab-f87d-4af3-b8a9-4e72607bf8a0",
+    "fullUrl" : "Organization/1674157639183197000.b51043ad-f956-4aaf-9eec-d810a79f95e6",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821384672000.cb2022ab-f87d-4af3-b8a9-4e72607bf8a0",
+      "id" : "1674157639183197000.b51043ad-f956-4aaf-9eec-d810a79f95e6",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10736,10 +10736,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821388576000.a41c9774-ae79-4bd3-bbbb-acb3dc93f135",
+    "fullUrl" : "Observation/1674157639186710000.bda2aa74-cad0-4219-8b76-2ed07ddd5f35",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821388576000.a41c9774-ae79-4bd3-bbbb-acb3dc93f135",
+      "id" : "1674157639186710000.bda2aa74-cad0-4219-8b76-2ed07ddd5f35",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10756,7 +10756,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821388494000.5ff36c4d-40bb-4019-aab5-4539644c11fc"
+          "reference" : "Organization/1674157639186660000.5c506c4f-f9ff-481a-9474-09c076e6c3fe"
         }
       } ],
       "identifier" : [ {
@@ -10790,23 +10790,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821387531000.853fb7a3-43ff-4245-8bb6-d7926d0429e9"
+        "reference" : "PractitionerRole/1674157639185852000.489b10ce-92ee-4164-94fc-f4f0b7b39890"
       } ],
       "valueString" : "Fact sheets for health care providers and patients are"
     }
   }, {
-    "fullUrl" : "Location/1673381821385878000.3823a618-fb91-4d74-bb99-4d924df6cfbf",
+    "fullUrl" : "Location/1674157639184264000.97ca6269-9e55-4a87-8371-bfdaf299a586",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821385878000.3823a618-fb91-4d74-bb99-4d924df6cfbf",
+      "id" : "1674157639184264000.97ca6269-9e55-4a87-8371-bfdaf299a586",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10820,10 +10820,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821386143000.fa796f7c-a7cc-40d5-818f-62a2e4923fde",
+    "fullUrl" : "Practitioner/1674157639184523000.5ca6d20b-e35e-4a4e-88f5-09499c46f996",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821386143000.fa796f7c-a7cc-40d5-818f-62a2e4923fde",
+      "id" : "1674157639184523000.5ca6d20b-e35e-4a4e-88f5-09499c46f996",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10845,7 +10845,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821385878000.3823a618-fb91-4d74-bb99-4d924df6cfbf"
+          "reference" : "Location/1674157639184264000.97ca6269-9e55-4a87-8371-bfdaf299a586"
         }
       } ],
       "identifier" : [ {
@@ -10871,10 +10871,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821387481000.59312c26-9aa0-4a1c-95c9-8f485f3982c6",
+    "fullUrl" : "Organization/1674157639185798000.59c580c4-b2e0-4ff3-b1f5-b8483e37975a",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821387481000.59312c26-9aa0-4a1c-95c9-8f485f3982c6",
+      "id" : "1674157639185798000.59c580c4-b2e0-4ff3-b1f5-b8483e37975a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10918,10 +10918,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821387531000.853fb7a3-43ff-4245-8bb6-d7926d0429e9",
+    "fullUrl" : "PractitionerRole/1674157639185852000.489b10ce-92ee-4164-94fc-f4f0b7b39890",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821387531000.853fb7a3-43ff-4245-8bb6-d7926d0429e9",
+      "id" : "1674157639185852000.489b10ce-92ee-4164-94fc-f4f0b7b39890",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10933,10 +10933,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821386143000.fa796f7c-a7cc-40d5-818f-62a2e4923fde"
+        "reference" : "Practitioner/1674157639184523000.5ca6d20b-e35e-4a4e-88f5-09499c46f996"
       },
       "organization" : {
-        "reference" : "Organization/1673381821387481000.59312c26-9aa0-4a1c-95c9-8f485f3982c6"
+        "reference" : "Organization/1674157639185798000.59c580c4-b2e0-4ff3-b1f5-b8483e37975a"
       },
       "code" : [ {
         "coding" : [ {
@@ -10946,10 +10946,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821388494000.5ff36c4d-40bb-4019-aab5-4539644c11fc",
+    "fullUrl" : "Organization/1674157639186660000.5c506c4f-f9ff-481a-9474-09c076e6c3fe",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821388494000.5ff36c4d-40bb-4019-aab5-4539644c11fc",
+      "id" : "1674157639186660000.5c506c4f-f9ff-481a-9474-09c076e6c3fe",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10975,10 +10975,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821392207000.214b33bd-338e-4ddf-bc08-98cd835148ff",
+    "fullUrl" : "Observation/1674157639190173000.135c6b91-6b76-4148-9ca9-075723d78092",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821392207000.214b33bd-338e-4ddf-bc08-98cd835148ff",
+      "id" : "1674157639190173000.135c6b91-6b76-4148-9ca9-075723d78092",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -10995,7 +10995,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821392162000.b943925a-ac79-4956-9878-5e805ec53160"
+          "reference" : "Organization/1674157639190124000.71693a6c-e6f2-4c6a-a432-a7ed843d60af"
         }
       } ],
       "identifier" : [ {
@@ -11029,23 +11029,23 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821391364000.38deef48-4010-4fff-a278-b0217e00454f"
+        "reference" : "PractitionerRole/1674157639189329000.576c0e82-073e-4781-aaec-07e0476ecb29"
       } ],
       "valueString" : "available upon request from the Microbiology Laboratory."
     }
   }, {
-    "fullUrl" : "Location/1673381821389703000.3ec52166-019d-4a68-afbf-555bf42324eb",
+    "fullUrl" : "Location/1674157639187716000.06594ece-3478-4402-a8ff-c2cdd41540f0",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821389703000.3ec52166-019d-4a68-afbf-555bf42324eb",
+      "id" : "1674157639187716000.06594ece-3478-4402-a8ff-c2cdd41540f0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11059,10 +11059,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821389973000.75e64642-7fc9-48de-900e-1928af4f4533",
+    "fullUrl" : "Practitioner/1674157639187977000.eef46bdb-7822-42c2-b4ac-9ad93d0faf0a",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821389973000.75e64642-7fc9-48de-900e-1928af4f4533",
+      "id" : "1674157639187977000.eef46bdb-7822-42c2-b4ac-9ad93d0faf0a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11084,7 +11084,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821389703000.3ec52166-019d-4a68-afbf-555bf42324eb"
+          "reference" : "Location/1674157639187716000.06594ece-3478-4402-a8ff-c2cdd41540f0"
         }
       } ],
       "identifier" : [ {
@@ -11110,10 +11110,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821391303000.b259b799-5170-4d4a-bb23-c8c41ef0138b",
+    "fullUrl" : "Organization/1674157639189268000.caffa00e-07ce-4a68-8a14-f3a56ead9d54",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821391303000.b259b799-5170-4d4a-bb23-c8c41ef0138b",
+      "id" : "1674157639189268000.caffa00e-07ce-4a68-8a14-f3a56ead9d54",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11157,10 +11157,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821391364000.38deef48-4010-4fff-a278-b0217e00454f",
+    "fullUrl" : "PractitionerRole/1674157639189329000.576c0e82-073e-4781-aaec-07e0476ecb29",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821391364000.38deef48-4010-4fff-a278-b0217e00454f",
+      "id" : "1674157639189329000.576c0e82-073e-4781-aaec-07e0476ecb29",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11172,10 +11172,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821389973000.75e64642-7fc9-48de-900e-1928af4f4533"
+        "reference" : "Practitioner/1674157639187977000.eef46bdb-7822-42c2-b4ac-9ad93d0faf0a"
       },
       "organization" : {
-        "reference" : "Organization/1673381821391303000.b259b799-5170-4d4a-bb23-c8c41ef0138b"
+        "reference" : "Organization/1674157639189268000.caffa00e-07ce-4a68-8a14-f3a56ead9d54"
       },
       "code" : [ {
         "coding" : [ {
@@ -11185,10 +11185,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821392162000.b943925a-ac79-4956-9878-5e805ec53160",
+    "fullUrl" : "Organization/1674157639190124000.71693a6c-e6f2-4c6a-a432-a7ed843d60af",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821392162000.b943925a-ac79-4956-9878-5e805ec53160",
+      "id" : "1674157639190124000.71693a6c-e6f2-4c6a-a432-a7ed843d60af",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11214,10 +11214,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Observation/1673381821395675000.e941d7f3-d2dc-4f54-a978-187ede6657c7",
+    "fullUrl" : "Observation/1674157639193633000.74638af9-103f-414f-bb30-5de35772ef1f",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673381821395675000.e941d7f3-d2dc-4f54-a978-187ede6657c7",
+      "id" : "1674157639193633000.74638af9-103f-414f-bb30-5de35772ef1f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11234,7 +11234,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673381821395625000.33933997-bb78-4927-9357-f5f3a642fb65"
+          "reference" : "Organization/1674157639193584000.072f0bb9-d003-4915-9ec1-3d3da36561f0"
         }
       } ],
       "identifier" : [ {
@@ -11268,23 +11268,23 @@
         "text" : "SARS coronavirus RNA[Presence] in Specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectiveDateTime" : "2028-08-02T07:02:01-06:00",
       "issued" : "2028-08-02T07:34:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673381821394822000.97c5ffcf-c9a1-4c5e-bb3f-b0895fde6a70"
+        "reference" : "PractitionerRole/1674157639192804000.f3e2a265-b633-4550-ab86-43009d7c287f"
       } ],
       "valueString" : "NEGATIVE"
     }
   }, {
-    "fullUrl" : "Location/1673381821393189000.a31e5081-c52d-4e8b-8f2f-a81ccdec372d",
+    "fullUrl" : "Location/1674157639191203000.54522d45-72e8-4c71-bcb4-ccd04087becb",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821393189000.a31e5081-c52d-4e8b-8f2f-a81ccdec372d",
+      "id" : "1674157639191203000.54522d45-72e8-4c71-bcb4-ccd04087becb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11298,10 +11298,10 @@
       "name" : "SKY RIDGE MEDICAL CE"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821393447000.d84d940b-6264-41dd-84bc-0d72742d1e79",
+    "fullUrl" : "Practitioner/1674157639191456000.417de27e-46d7-4d0e-a80c-83027c8264b9",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821393447000.d84d940b-6264-41dd-84bc-0d72742d1e79",
+      "id" : "1674157639191456000.417de27e-46d7-4d0e-a80c-83027c8264b9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11323,7 +11323,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821393189000.a31e5081-c52d-4e8b-8f2f-a81ccdec372d"
+          "reference" : "Location/1674157639191203000.54522d45-72e8-4c71-bcb4-ccd04087becb"
         }
       } ],
       "identifier" : [ {
@@ -11349,10 +11349,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821394766000.ba4dcede-abde-469d-88ef-1b459f779991",
+    "fullUrl" : "Organization/1674157639192753000.bbab9daf-215a-45cc-a9c2-2a0d95ddeda2",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821394766000.ba4dcede-abde-469d-88ef-1b459f779991",
+      "id" : "1674157639192753000.bbab9daf-215a-45cc-a9c2-2a0d95ddeda2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11395,10 +11395,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821394822000.97c5ffcf-c9a1-4c5e-bb3f-b0895fde6a70",
+    "fullUrl" : "PractitionerRole/1674157639192804000.f3e2a265-b633-4550-ab86-43009d7c287f",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821394822000.97c5ffcf-c9a1-4c5e-bb3f-b0895fde6a70",
+      "id" : "1674157639192804000.f3e2a265-b633-4550-ab86-43009d7c287f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11410,10 +11410,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821393447000.d84d940b-6264-41dd-84bc-0d72742d1e79"
+        "reference" : "Practitioner/1674157639191456000.417de27e-46d7-4d0e-a80c-83027c8264b9"
       },
       "organization" : {
-        "reference" : "Organization/1673381821394766000.ba4dcede-abde-469d-88ef-1b459f779991"
+        "reference" : "Organization/1674157639192753000.bbab9daf-215a-45cc-a9c2-2a0d95ddeda2"
       },
       "code" : [ {
         "coding" : [ {
@@ -11423,10 +11423,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821395625000.33933997-bb78-4927-9357-f5f3a642fb65",
+    "fullUrl" : "Organization/1674157639193584000.072f0bb9-d003-4915-9ec1-3d3da36561f0",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821395625000.33933997-bb78-4927-9357-f5f3a642fb65",
+      "id" : "1674157639193584000.072f0bb9-d003-4915-9ec1-3d3da36561f0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11452,10 +11452,10 @@
       "name" : "SKY RIDGE MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Specimen/1673381821637090000.a8b57c05-5125-4ec9-ba09-7b36eef3f94d",
+    "fullUrl" : "Specimen/1674157639374459000.8690b2d2-88db-4884-baa1-ba3c59d31dad",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1673381821637090000.a8b57c05-5125-4ec9-ba09-7b36eef3f94d",
+      "id" : "1674157639374459000.8690b2d2-88db-4884-baa1-ba3c59d31dad",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11520,10 +11520,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Specimen/1673381821638256000.6feeeab8-7fc1-4a2a-a0cc-7afed8116f65",
+    "fullUrl" : "Specimen/1674157639375791000.7862dbf3-7451-4e45-8bb1-e5d9acf0c677",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1673381821638256000.6feeeab8-7fc1-4a2a-a0cc-7afed8116f65",
+      "id" : "1674157639375791000.7862dbf3-7451-4e45-8bb1-e5d9acf0c677",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -11588,10 +11588,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1673381821643671000.34a86f96-382d-41e6-870e-9421069bc488",
+    "fullUrl" : "DiagnosticReport/1674157639380685000.1e6b597b-fd30-4514-8b57-da10b9182f26",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1673381821643671000.34a86f96-382d-41e6-870e-9421069bc488",
+      "id" : "1674157639380685000.1e6b597b-fd30-4514-8b57-da10b9182f26",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -11630,18 +11630,17 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "PGN",
+            "display" : "Placer Group Number"
           } ]
         },
-        "system" : "urn:id:M6059622.1",
-        "value" : "21:SR:B0026316S.1"
+        "system" : "urn:id:M6059622",
+        "value" : "21:SR:B0026316S"
       }, {
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
+            "code" : "PLAC"
           } ]
         },
         "system" : "urn:id:M6059622.1",
@@ -11650,17 +11649,16 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PGN",
-            "display" : "Placer Group Number"
+            "code" : "FILL",
+            "display" : "Filler Identifier"
           } ]
         },
-        "system" : "urn:id:M6059622",
-        "value" : "21:SR:B0026316S"
+        "system" : "urn:id:M6059622.1",
+        "value" : "21:SR:B0026316S.1"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1673381821645473000.a3bff4f5-f836-41a3-97ca-e8d27ab7d7b5"
+        "reference" : "ServiceRequest/1674157639382620000.07ced8fd-779f-4510-abe3-f51ed21061e2"
       } ],
-      "status" : "final",
       "code" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/alternate-identifier",
@@ -11680,10 +11678,10 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectivePeriod" : {
         "start" : "2028-08-02T07:02:01-06:00",
@@ -11691,109 +11689,109 @@
       },
       "issued" : "2028-08-02T07:34:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1673381821637090000.a8b57c05-5125-4ec9-ba09-7b36eef3f94d"
+        "reference" : "Specimen/1674157639374459000.8690b2d2-88db-4884-baa1-ba3c59d31dad"
       } ],
       "result" : [ {
-        "reference" : "Observation/1673381821161542000.52150245-0a0c-45f3-9408-6b0bfb7deb57"
+        "reference" : "Observation/1674157638997099000.885713a2-3430-4176-8213-92e25ec50b67"
       }, {
-        "reference" : "Observation/1673381821168614000.6d2bdc0c-1f6b-48a8-a752-ec898bf709c2"
+        "reference" : "Observation/1674157639003971000.f595cb9e-c700-43c4-95cc-1aad9fa7bb7b"
       }, {
-        "reference" : "Observation/1673381821175670000.730f6692-5ffa-48b5-a484-c10a27151ce3"
+        "reference" : "Observation/1674157639009999000.8a9a57f4-cd2d-42b9-828c-27dbceb22ca1"
       }, {
-        "reference" : "Observation/1673381821185637000.ed514958-0dcc-4d12-ba9d-d499205dbc89"
+        "reference" : "Observation/1674157639019385000.1fb07a22-e689-4c69-80e3-9b0b0f02e4d0"
       }, {
-        "reference" : "Observation/1673381821191996000.2ec903f1-48f3-475b-adba-8348bc92e1f1"
+        "reference" : "Observation/1674157639028243000.95fc1546-4336-4c48-9aac-870962f62a60"
       }, {
-        "reference" : "Observation/1673381821198144000.60cdcd0a-c8c0-4f08-b1dc-015641df1277"
+        "reference" : "Observation/1674157639035908000.d36a5168-7fa8-4d61-8703-c44fe9ea6ccb"
       }, {
-        "reference" : "Observation/1673381821204744000.cd917e02-708a-488a-83a3-805819ee9ae4"
+        "reference" : "Observation/1674157639042974000.508cb28c-357f-4177-bfdc-767bca43551a"
       }, {
-        "reference" : "Observation/1673381821211572000.6463d1f4-767f-4eeb-873c-d3a3649098f6"
+        "reference" : "Observation/1674157639048993000.6dae44ce-7def-4a01-9a70-7a12cba354b3"
       }, {
-        "reference" : "Observation/1673381821218282000.54cd7ed8-7073-4513-9144-3cb9cad43214"
+        "reference" : "Observation/1674157639053050000.f34086cd-071f-4e83-8524-fd3971a15e8e"
       }, {
-        "reference" : "Observation/1673381821224507000.7a032924-9440-4202-8b76-6d18e6966486"
+        "reference" : "Observation/1674157639057085000.63e3136b-d19c-45f7-ba91-15f828648d59"
       }, {
-        "reference" : "Observation/1673381821230422000.c43e4a35-4a4d-4888-9616-5bf52f1e967d"
+        "reference" : "Observation/1674157639060902000.4694c0a0-52f0-40a9-ac13-7e6ae6cf8801"
       }, {
-        "reference" : "Observation/1673381821237179000.2078ca76-fb30-4b19-b33f-af396f4d120a"
+        "reference" : "Observation/1674157639064681000.c64ec9f2-ea76-4ad2-8940-b423167eef0f"
       }, {
-        "reference" : "Observation/1673381821245373000.4d74aa86-1284-4392-aa86-b3a9c308c59d"
+        "reference" : "Observation/1674157639068372000.73f38868-ca2b-482f-8f54-5b84c8c29b2a"
       }, {
-        "reference" : "Observation/1673381821253592000.4a813ab6-ed38-41af-a0fe-803fcbe9d457"
+        "reference" : "Observation/1674157639072326000.bb40e4c9-5e48-4a79-8194-1cdf24ddb028"
       }, {
-        "reference" : "Observation/1673381821258270000.b53470b6-dc05-4916-9532-e6394df8b8a7"
+        "reference" : "Observation/1674157639076170000.9ed08ee4-58a9-4f49-be33-1749f057b0ba"
       }, {
-        "reference" : "Observation/1673381821262722000.809917d4-911f-41c2-b5b1-d68be1c4c617"
+        "reference" : "Observation/1674157639080446000.1a0e465c-171d-4d31-af17-ddf5986b2a2c"
       }, {
-        "reference" : "Observation/1673381821267462000.d85f806b-46a9-49b0-9790-12a5e57da432"
+        "reference" : "Observation/1674157639084574000.8ff96dc2-fe17-4e12-a499-cefdb7a866a6"
       }, {
-        "reference" : "Observation/1673381821271887000.2b071859-2e21-48a8-a16a-18d1491ad441"
+        "reference" : "Observation/1674157639088355000.71612cd2-b344-46fc-b933-1e945c81df7d"
       }, {
-        "reference" : "Observation/1673381821276731000.f910b85e-6b0f-4a35-83f0-5deb60f406f8"
+        "reference" : "Observation/1674157639092049000.f61b9768-c176-4577-90ce-7557fa8d5dc7"
       }, {
-        "reference" : "Observation/1673381821282335000.058b102f-79c5-429f-ba41-4ecddb03166f"
+        "reference" : "Observation/1674157639095754000.17bf9f5a-f0c0-495a-a26a-a8937f078db2"
       }, {
-        "reference" : "Observation/1673381821287484000.04b330e6-6a58-4ccc-98a9-2a2804c30408"
+        "reference" : "Observation/1674157639099402000.bf992d5a-31b6-4f55-8f5b-5023e00a34de"
       }, {
-        "reference" : "Observation/1673381821292218000.a816de8d-c88d-454d-a0a3-47dc938e638b"
+        "reference" : "Observation/1674157639103058000.47112005-ad74-462a-8eb1-b895715441e6"
       }, {
-        "reference" : "Observation/1673381821297520000.ac85ee8c-a900-460e-b72d-20f40c1589a4"
+        "reference" : "Observation/1674157639106600000.599e9920-e4bf-487d-995e-689dd59a567f"
       }, {
-        "reference" : "Observation/1673381821302114000.ff9e87b0-4530-4dd0-8fbc-fe4c12bf95e3"
+        "reference" : "Observation/1674157639110411000.e9c4ec55-c135-4148-b08d-bdf2583e6a1a"
       }, {
-        "reference" : "Observation/1673381821307036000.076ec618-b436-4e1e-bc6f-58a6ae87feed"
+        "reference" : "Observation/1674157639114142000.00d9b8d3-3efe-445d-8db5-36bae7a8abec"
       }, {
-        "reference" : "Observation/1673381821311462000.f8f8dc67-c59a-4475-8f73-44ee9d648b6e"
+        "reference" : "Observation/1674157639117607000.ff676240-028e-4e73-b61e-675a7a271543"
       }, {
-        "reference" : "Observation/1673381821315379000.a82d615d-af08-4e4a-a9f2-b3dc0361c1fa"
+        "reference" : "Observation/1674157639121409000.831cca47-4a73-4f9d-a88c-2090cfbb4c5f"
       }, {
-        "reference" : "Observation/1673381821319827000.76840447-bdf2-42fb-8ad9-30b35ab1fc20"
+        "reference" : "Observation/1674157639124893000.7472ecb8-17ce-4880-8755-942899e8d73b"
       }, {
-        "reference" : "Observation/1673381821323940000.f5e42eb1-b2b6-4815-a3b6-d49be808602c"
+        "reference" : "Observation/1674157639128071000.aab521b9-0d58-467f-bae2-b29f65ba4e3f"
       }, {
-        "reference" : "Observation/1673381821328098000.8e7ead74-c826-4f69-b438-4d5d7e42bb34"
+        "reference" : "Observation/1674157639131739000.585137c5-13a4-44d8-aa96-0b97e749776a"
       }, {
-        "reference" : "Observation/1673381821332357000.edf03c22-8835-4939-8b1b-e20072f1969d"
+        "reference" : "Observation/1674157639135616000.20f40668-47d5-452f-a3c7-771b4d5ca494"
       }, {
-        "reference" : "Observation/1673381821339107000.d4a2b377-58ea-4b10-9536-6937cfaf3604"
+        "reference" : "Observation/1674157639139366000.b51ed11a-3e40-4a2f-b9e9-8d8082033df5"
       }, {
-        "reference" : "Observation/1673381821343500000.bdc835ec-a2be-4e17-9bb8-440bb45306be"
+        "reference" : "Observation/1674157639142939000.280759fe-040e-4ca0-9680-5dfed44cee64"
       }, {
-        "reference" : "Observation/1673381821347603000.92b86b27-11d8-48d5-af86-deec9ce26086"
+        "reference" : "Observation/1674157639146552000.cb5e6d65-9b94-4f21-a076-015a922d9d9b"
       }, {
-        "reference" : "Observation/1673381821351155000.b6e1cfb1-affe-47e4-a8db-83eeef201de8"
+        "reference" : "Observation/1674157639150427000.bd71b61f-fefb-4412-82fd-1ad1b33dc80d"
       }, {
-        "reference" : "Observation/1673381821354515000.97500a5b-d07f-4f85-a663-2489f17f8a08"
+        "reference" : "Observation/1674157639154451000.f6549bab-9219-48eb-8144-d5a3ab413ca6"
       }, {
-        "reference" : "Observation/1673381821358595000.191b2ee7-ec37-45aa-9e8f-6a9a81d534eb"
+        "reference" : "Observation/1674157639158249000.01724dc2-dfc2-48dc-9c4e-8292fb06dcf9"
       }, {
-        "reference" : "Observation/1673381821362188000.dfe22b09-a0d9-4c0a-8fc9-458633839bf7"
+        "reference" : "Observation/1674157639162031000.e98982f1-9736-49bd-96cd-eda167344f51"
       }, {
-        "reference" : "Observation/1673381821365792000.70aba614-5584-49ee-989f-767d57ce6563"
+        "reference" : "Observation/1674157639165761000.7f60e839-4f42-416e-821a-96efdb9dbd50"
       }, {
-        "reference" : "Observation/1673381821369948000.d50677c4-af8f-4909-8b37-1be8bf8b6255"
+        "reference" : "Observation/1674157639169470000.f2291a21-3c5b-470d-8fea-b83a07e972eb"
       }, {
-        "reference" : "Observation/1673381821373701000.2be49fb6-bf18-4a19-bb75-1fe4d728ae98"
+        "reference" : "Observation/1674157639172989000.76bfb272-b2db-4f35-a1c1-fb03b2afa32c"
       }, {
-        "reference" : "Observation/1673381821377282000.c1b22d11-10bb-4891-8cf3-24c858398543"
+        "reference" : "Observation/1674157639176352000.bef976ce-d2b3-426e-bff3-ac40d9f8a41d"
       }, {
-        "reference" : "Observation/1673381821380790000.48168bb0-de4a-442f-aa56-34089917b4e1"
+        "reference" : "Observation/1674157639179777000.26ad9b06-a182-452a-ad99-929c3c7b0830"
       }, {
-        "reference" : "Observation/1673381821384758000.e8ea4254-35f8-48b0-8321-add84b3f6921"
+        "reference" : "Observation/1674157639183254000.95c10adc-a649-49c2-9c5b-ff78c6de4ffa"
       }, {
-        "reference" : "Observation/1673381821388576000.a41c9774-ae79-4bd3-bbbb-acb3dc93f135"
+        "reference" : "Observation/1674157639186710000.bda2aa74-cad0-4219-8b76-2ed07ddd5f35"
       }, {
-        "reference" : "Observation/1673381821392207000.214b33bd-338e-4ddf-bc08-98cd835148ff"
+        "reference" : "Observation/1674157639190173000.135c6b91-6b76-4148-9ca9-075723d78092"
       }, {
-        "reference" : "Observation/1673381821395675000.e941d7f3-d2dc-4f54-a978-187ede6657c7"
+        "reference" : "Observation/1674157639193633000.74638af9-103f-414f-bb30-5de35772ef1f"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821645213000.5da0f1d7-638e-4c2e-92e9-dbf3130f92fd",
+    "fullUrl" : "Practitioner/1674157639382384000.b0db9be4-459e-4e66-8f21-4621b687ac57",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821645213000.5da0f1d7-638e-4c2e-92e9-dbf3130f92fd",
+      "id" : "1674157639382384000.b0db9be4-459e-4e66-8f21-4621b687ac57",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -11813,10 +11811,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821646567000.9d18c580-7398-400f-990f-a83f7b7c211b",
+    "fullUrl" : "Location/1674157639383677000.0ddcd57b-84f0-4968-819d-51280025114a",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821646567000.9d18c580-7398-400f-990f-a83f7b7c211b",
+      "id" : "1674157639383677000.0ddcd57b-84f0-4968-819d-51280025114a",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -11834,10 +11832,10 @@
       "name" : "SRM"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821646904000.d15f61fe-1dea-497d-bb5d-44a4c526c2d7",
+    "fullUrl" : "Practitioner/1674157639384013000.a0bdb989-3b2c-4fd0-9deb-f3f1a40b03c0",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821646904000.d15f61fe-1dea-497d-bb5d-44a4c526c2d7",
+      "id" : "1674157639384013000.a0bdb989-3b2c-4fd0-9deb-f3f1a40b03c0",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -11863,7 +11861,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821646567000.9d18c580-7398-400f-990f-a83f7b7c211b"
+          "reference" : "Location/1674157639383677000.0ddcd57b-84f0-4968-819d-51280025114a"
         }
       } ],
       "identifier" : [ {
@@ -11908,10 +11906,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821648959000.7e812701-ac0e-4e20-9707-19496af46610",
+    "fullUrl" : "Organization/1674157639385800000.9fa4690c-e722-4260-b22d-1c6368df1041",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821648959000.7e812701-ac0e-4e20-9707-19496af46610",
+      "id" : "1674157639385800000.9fa4690c-e722-4260-b22d-1c6368df1041",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -11966,10 +11964,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821649031000.32772138-d573-482f-9de3-a9fc15919b6b",
+    "fullUrl" : "PractitionerRole/1674157639385856000.9e36d4a7-d13e-4108-9aa9-ec8e11da6d1e",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821649031000.32772138-d573-482f-9de3-a9fc15919b6b",
+      "id" : "1674157639385856000.9e36d4a7-d13e-4108-9aa9-ec8e11da6d1e",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -11985,17 +11983,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821646904000.d15f61fe-1dea-497d-bb5d-44a4c526c2d7"
+        "reference" : "Practitioner/1674157639384013000.a0bdb989-3b2c-4fd0-9deb-f3f1a40b03c0"
       },
       "organization" : {
-        "reference" : "Organization/1673381821648959000.7e812701-ac0e-4e20-9707-19496af46610"
+        "reference" : "Organization/1674157639385800000.9fa4690c-e722-4260-b22d-1c6368df1041"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1673381821645473000.a3bff4f5-f836-41a3-97ca-e8d27ab7d7b5",
+    "fullUrl" : "ServiceRequest/1674157639382620000.07ced8fd-779f-4510-abe3-f51ed21061e2",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1673381821645473000.a3bff4f5-f836-41a3-97ca-e8d27ab7d7b5",
+      "id" : "1674157639382620000.07ced8fd-779f-4510-abe3-f51ed21061e2",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12022,7 +12020,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1673381821645213000.5da0f1d7-638e-4c2e-92e9-dbf3130f92fd"
+          "reference" : "Practitioner/1674157639382384000.b0db9be4-459e-4e66-8f21-4621b687ac57"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -12112,7 +12110,7 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "occurrenceTiming" : {
         "repeat" : {
@@ -12124,7 +12122,7 @@
       },
       "authoredOn" : "2028-08-02T07:34:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1673381821649031000.32772138-d573-482f-9de3-a9fc15919b6b"
+        "reference" : "PractitionerRole/1674157639385856000.9e36d4a7-d13e-4108-9aa9-ec8e11da6d1e"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -12178,10 +12176,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1673381821651661000.0d1342d4-4e54-4f76-b539-5f54006f78b0",
+    "fullUrl" : "DiagnosticReport/1674157639387902000.e1add07e-a330-4aa6-a370-3bee0191a335",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1673381821651661000.0d1342d4-4e54-4f76-b539-5f54006f78b0",
+      "id" : "1674157639387902000.e1add07e-a330-4aa6-a370-3bee0191a335",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12220,18 +12218,17 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "PGN",
+            "display" : "Placer Group Number"
           } ]
         },
-        "system" : "urn:id:M6059622.2",
-        "value" : "21:SR:B0026316S.2"
+        "system" : "urn:id:M6059622",
+        "value" : "21:SR:B0026316S"
       }, {
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
+            "code" : "PLAC"
           } ]
         },
         "system" : "urn:id:M6059622.2",
@@ -12240,17 +12237,16 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PGN",
-            "display" : "Placer Group Number"
+            "code" : "FILL",
+            "display" : "Filler Identifier"
           } ]
         },
-        "system" : "urn:id:M6059622",
-        "value" : "21:SR:B0026316S"
+        "system" : "urn:id:M6059622.2",
+        "value" : "21:SR:B0026316S.2"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1673381821653600000.d9d6dff1-c5e0-4949-bdc8-b6c1e50455e5"
+        "reference" : "ServiceRequest/1674157639389518000.3c148e36-bf51-420d-9740-c17f7edf3273"
       } ],
-      "status" : "final",
       "code" : {
         "coding" : [ {
           "system" : "L",
@@ -12259,10 +12255,10 @@
         "text" : "Novel Coronavirus 2019 NON-PUI"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "encounter" : {
-        "reference" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6"
+        "reference" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c"
       },
       "effectivePeriod" : {
         "start" : "2028-08-02T07:02:01-06:00",
@@ -12270,14 +12266,14 @@
       },
       "issued" : "2028-08-02T07:34:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1673381821638256000.6feeeab8-7fc1-4a2a-a0cc-7afed8116f65"
+        "reference" : "Specimen/1674157639375791000.7862dbf3-7451-4e45-8bb1-e5d9acf0c677"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821653326000.61e3cf21-42a3-47b1-bb6d-33bf4118ce41",
+    "fullUrl" : "Practitioner/1674157639389275000.e930f723-76fe-4762-9c49-d26ebc51d008",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821653326000.61e3cf21-42a3-47b1-bb6d-33bf4118ce41",
+      "id" : "1674157639389275000.e930f723-76fe-4762-9c49-d26ebc51d008",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12297,10 +12293,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821654813000.eb982109-eeb4-4450-a440-19b5dc7cd987",
+    "fullUrl" : "Location/1674157639390535000.c6b7e47a-cb7b-447e-b6d9-736ce68b0433",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821654813000.eb982109-eeb4-4450-a440-19b5dc7cd987",
+      "id" : "1674157639390535000.c6b7e47a-cb7b-447e-b6d9-736ce68b0433",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12318,10 +12314,10 @@
       "name" : "SRM"
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821655216000.b9bfe860-fa8e-4b30-8c45-6e2e157bb1cb",
+    "fullUrl" : "Practitioner/1674157639390879000.bdbad9ac-f634-42db-b3fb-aea8587c4642",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821655216000.b9bfe860-fa8e-4b30-8c45-6e2e157bb1cb",
+      "id" : "1674157639390879000.bdbad9ac-f634-42db-b3fb-aea8587c4642",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12347,7 +12343,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673381821654813000.eb982109-eeb4-4450-a440-19b5dc7cd987"
+          "reference" : "Location/1674157639390535000.c6b7e47a-cb7b-447e-b6d9-736ce68b0433"
         }
       } ],
       "identifier" : [ {
@@ -12392,10 +12388,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821657249000.3724e5bb-5ed9-4d52-8e42-23c19c636bf8",
+    "fullUrl" : "Organization/1674157639392547000.d1516dca-3086-4cc6-9d79-cb38c17ee926",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821657249000.3724e5bb-5ed9-4d52-8e42-23c19c636bf8",
+      "id" : "1674157639392547000.d1516dca-3086-4cc6-9d79-cb38c17ee926",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12450,10 +12446,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673381821657345000.2a037d4b-32e2-4ce1-9335-3966d02025d8",
+    "fullUrl" : "PractitionerRole/1674157639392645000.b12ae520-9e07-4cc3-b5a7-b9cb34129d96",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673381821657345000.2a037d4b-32e2-4ce1-9335-3966d02025d8",
+      "id" : "1674157639392645000.b12ae520-9e07-4cc3-b5a7-b9cb34129d96",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12469,17 +12465,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673381821655216000.b9bfe860-fa8e-4b30-8c45-6e2e157bb1cb"
+        "reference" : "Practitioner/1674157639390879000.bdbad9ac-f634-42db-b3fb-aea8587c4642"
       },
       "organization" : {
-        "reference" : "Organization/1673381821657249000.3724e5bb-5ed9-4d52-8e42-23c19c636bf8"
+        "reference" : "Organization/1674157639392547000.d1516dca-3086-4cc6-9d79-cb38c17ee926"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1673381821653600000.d9d6dff1-c5e0-4949-bdc8-b6c1e50455e5",
+    "fullUrl" : "ServiceRequest/1674157639389518000.3c148e36-bf51-420d-9740-c17f7edf3273",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1673381821653600000.d9d6dff1-c5e0-4949-bdc8-b6c1e50455e5",
+      "id" : "1674157639389518000.3c148e36-bf51-420d-9740-c17f7edf3273",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12506,7 +12502,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1673381821653326000.61e3cf21-42a3-47b1-bb6d-33bf4118ce41"
+          "reference" : "Practitioner/1674157639389275000.e930f723-76fe-4762-9c49-d26ebc51d008"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -12585,7 +12581,7 @@
         "text" : "Novel Coronavirus 2019 NON-PUI"
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "occurrenceTiming" : {
         "repeat" : {
@@ -12597,7 +12593,7 @@
       },
       "authoredOn" : "2028-08-02T07:34:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1673381821657345000.2a037d4b-32e2-4ce1-9335-3966d02025d8"
+        "reference" : "PractitionerRole/1674157639392645000.b12ae520-9e07-4cc3-b5a7-b9cb34129d96"
       },
       "reasonCode" : [ {
         "extension" : [ {
@@ -12651,10 +12647,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24",
+    "fullUrl" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150",
     "resource" : {
       "resourceType" : "Patient",
-      "id" : "1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24",
+      "id" : "1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12881,15 +12877,15 @@
           "country" : "USA"
         },
         "organization" : {
-          "reference" : "Organization/1673381821105686000.39f77e73-5b46-4d32-a9ff-d3b834f61282"
+          "reference" : "Organization/1674157638940255000.f677fa3d-2e9a-45ed-acba-d550a4207ba9"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673381821105686000.39f77e73-5b46-4d32-a9ff-d3b834f61282",
+    "fullUrl" : "Organization/1674157638940255000.f677fa3d-2e9a-45ed-acba-d550a4207ba9",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673381821105686000.39f77e73-5b46-4d32-a9ff-d3b834f61282",
+      "id" : "1674157638940255000.f677fa3d-2e9a-45ed-acba-d550a4207ba9",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -12921,10 +12917,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Encounter/1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6",
+    "fullUrl" : "Encounter/1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c",
     "resource" : {
       "resourceType" : "Encounter",
-      "id" : "1673381821119808000.9892193b-ad1a-4676-b1ce-40df6839d9c6",
+      "id" : "1674157638953275000.f7cf571a-0f1c-4a3a-89a8-5967a440f94c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -12977,7 +12973,7 @@
         } ]
       },
       "subject" : {
-        "reference" : "Patient/1673381821106720000.b5ef4236-aef4-406a-bb2a-11fdecc3ad24"
+        "reference" : "Patient/1674157638941036000.6fa77c3b-dafe-463e-a65b-82884d04d150"
       },
       "participant" : [ {
         "type" : [ {
@@ -12988,7 +12984,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673381821114894000.0340922a-7703-4481-ad15-26ef5e43bd13"
+          "reference" : "Practitioner/1674157638949006000.46f20165-b8a2-466e-b896-a473f7837c18"
         }
       }, {
         "type" : [ {
@@ -12999,7 +12995,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673381821116989000.8b446b02-78d5-4520-a97f-bf07c0ae0089"
+          "reference" : "Practitioner/1674157638950889000.36863483-3caf-46b9-8bfb-ebb2f87affba"
         }
       }, {
         "type" : [ {
@@ -13010,7 +13006,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673381821118873000.c4f2bee1-c943-4a6f-bd20-9635938abc71"
+          "reference" : "Practitioner/1674157638952523000.102d14b1-fde9-4451-b796-dbf6c4ead3ec"
         }
       }, {
         "type" : [ {
@@ -13021,7 +13017,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673381821120749000.05a9fe40-91f2-4899-b0ca-b4ee9970bf78"
+          "reference" : "Practitioner/1674157638954229000.c4ed70f0-5652-4174-a93d-192c270febc2"
         }
       } ],
       "period" : {
@@ -13036,16 +13032,16 @@
       },
       "location" : [ {
         "location" : {
-          "reference" : "Location/1673381821151565000.d8a8fe4e-7418-467f-b9b8-8eead3f00ce1"
+          "reference" : "Location/1674157638984818000.4430558d-a92d-4bf3-bb5c-14b702f30458"
         },
         "status" : "active"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821114894000.0340922a-7703-4481-ad15-26ef5e43bd13",
+    "fullUrl" : "Practitioner/1674157638949006000.46f20165-b8a2-466e-b896-a473f7837c18",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821114894000.0340922a-7703-4481-ad15-26ef5e43bd13",
+      "id" : "1674157638949006000.46f20165-b8a2-466e-b896-a473f7837c18",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -13088,10 +13084,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821116989000.8b446b02-78d5-4520-a97f-bf07c0ae0089",
+    "fullUrl" : "Practitioner/1674157638950889000.36863483-3caf-46b9-8bfb-ebb2f87affba",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821116989000.8b446b02-78d5-4520-a97f-bf07c0ae0089",
+      "id" : "1674157638950889000.36863483-3caf-46b9-8bfb-ebb2f87affba",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -13133,10 +13129,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821118873000.c4f2bee1-c943-4a6f-bd20-9635938abc71",
+    "fullUrl" : "Practitioner/1674157638952523000.102d14b1-fde9-4451-b796-dbf6c4ead3ec",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821118873000.c4f2bee1-c943-4a6f-bd20-9635938abc71",
+      "id" : "1674157638952523000.102d14b1-fde9-4451-b796-dbf6c4ead3ec",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -13178,10 +13174,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673381821120749000.05a9fe40-91f2-4899-b0ca-b4ee9970bf78",
+    "fullUrl" : "Practitioner/1674157638954229000.c4ed70f0-5652-4174-a93d-192c270febc2",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673381821120749000.05a9fe40-91f2-4899-b0ca-b4ee9970bf78",
+      "id" : "1674157638954229000.c4ed70f0-5652-4174-a93d-192c270febc2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -13224,10 +13220,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673381821151565000.d8a8fe4e-7418-467f-b9b8-8eead3f00ce1",
+    "fullUrl" : "Location/1674157638984818000.4430558d-a92d-4bf3-bb5c-14b702f30458",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673381821151565000.d8a8fe4e-7418-467f-b9b8-8eead3f00ce1",
+      "id" : "1674157638984818000.4430558d-a92d-4bf3-bb5c-14b702f30458",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",

--- a/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0014.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_1_20220518-0014.fhir
@@ -1,14 +1,14 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1673379920524089000.f30adae3-811a-4149-afcd-7f9ef4910f8b",
+  "id" : "1674159385415367000.0bea31c7-709a-4eb7-934e-acf0c3c4a6bd",
   "meta" : {
-    "lastUpdated" : "2023-01-10T13:45:20.537-06:00"
+    "lastUpdated" : "2023-01-19T13:16:25.423-07:00"
   },
   "identifier" : {
     "value" : "MT_COCZS_ORU_ZSPHELR.1.6384446"
   },
   "type" : "message",
-  "timestamp" : "2028-08-14T14:50:01.000-05:00",
+  "timestamp" : "2028-08-14T12:50:01.000-07:00",
   "entry" : [ {
     "fullUrl" : "MessageHeader/0a494db8-c6f4-3901-9ba7-44651a20ea87",
     "resource" : {
@@ -31,17 +31,17 @@
       },
       "destination" : [ {
         "target" : {
-          "reference" : "Device/1673379920637613000.73454983-668c-48c9-b8cd-8e589ee681e7"
+          "reference" : "Device/1674159385489571000.f7c83b54-fc48-48b4-a889-1640db8544fd"
         }
       } ],
       "sender" : {
-        "reference" : "Organization/1673379920631682000.5e137e01-2889-4f81-bf03-667c5e7afffb"
+        "reference" : "Organization/1674159385486643000.98f0e656-7c2b-4ec3-bafe-01e9686cd57e"
       },
       "source" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
           "valueReference" : {
-            "reference" : "Organization/1673379920648731000.ef364d91-12db-4991-8154-e83a791c4592"
+            "reference" : "Organization/1674159385497264000.c909f08f-36ed-45a0-95cf-341d90a90f4f"
           }
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
@@ -56,10 +56,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1673379920631682000.5e137e01-2889-4f81-bf03-667c5e7afffb",
+    "fullUrl" : "Organization/1674159385486643000.98f0e656-7c2b-4ec3-bafe-01e9686cd57e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379920631682000.5e137e01-2889-4f81-bf03-667c5e7afffb",
+      "id" : "1674159385486643000.98f0e656-7c2b-4ec3-bafe-01e9686cd57e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -75,10 +75,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1673379920637613000.73454983-668c-48c9-b8cd-8e589ee681e7",
+    "fullUrl" : "Device/1674159385489571000.f7c83b54-fc48-48b4-a889-1640db8544fd",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1673379920637613000.73454983-668c-48c9-b8cd-8e589ee681e7",
+      "id" : "1674159385489571000.f7c83b54-fc48-48b4-a889-1640db8544fd",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -91,10 +91,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1673379920648731000.ef364d91-12db-4991-8154-e83a791c4592",
+    "fullUrl" : "Organization/1674159385497264000.c909f08f-36ed-45a0-95cf-341d90a90f4f",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379920648731000.ef364d91-12db-4991-8154-e83a791c4592",
+      "id" : "1674159385497264000.c909f08f-36ed-45a0-95cf-341d90a90f4f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -132,10 +132,10 @@
       "name" : "MEDITECH, Inc."
     }
   }, {
-    "fullUrl" : "Provenance/1673379922245971000.8e3492dc-99ad-4115-884c-47aecbd9a2af",
+    "fullUrl" : "Provenance/1674159386775940000.38237eec-c309-439a-8c2a-29804c8cdf7e",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1673379922245971000.8e3492dc-99ad-4115-884c-47aecbd9a2af",
+      "id" : "1674159386775940000.38237eec-c309-439a-8c2a-29804c8cdf7e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -162,21 +162,21 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1673379922245089000.552f0e06-66d8-4d3e-a1a7-90ab615a54ca"
+          "reference" : "Organization/1674159386775083000.768979eb-1801-439c-abdf-fd0c86ea64be"
         }
       } ],
       "entity" : [ {
         "role" : "source",
         "what" : {
-          "reference" : "Device/1673379922247376000.67dd38b4-2b54-44b9-b49f-7ca96f5a2f85"
+          "reference" : "Device/1674159386777579000.48b7fdce-0b67-4cd3-9199-43213c9ded6a"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379922245089000.552f0e06-66d8-4d3e-a1a7-90ab615a54ca",
+    "fullUrl" : "Organization/1674159386775083000.768979eb-1801-439c-abdf-fd0c86ea64be",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379922245089000.552f0e06-66d8-4d3e-a1a7-90ab615a54ca",
+      "id" : "1674159386775083000.768979eb-1801-439c-abdf-fd0c86ea64be",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -203,10 +203,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1673379922247376000.67dd38b4-2b54-44b9-b49f-7ca96f5a2f85",
+    "fullUrl" : "Device/1674159386777579000.48b7fdce-0b67-4cd3-9199-43213c9ded6a",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1673379922247376000.67dd38b4-2b54-44b9-b49f-7ca96f5a2f85",
+      "id" : "1674159386777579000.48b7fdce-0b67-4cd3-9199-43213c9ded6a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -224,10 +224,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Observation/1673379922371197000.2243a5f4-378e-4df7-8c20-01988b27311c",
+    "fullUrl" : "Observation/1674159386884687000.44bf58ef-08c9-4fb0-a549-5a1810769ee2",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673379922371197000.2243a5f4-378e-4df7-8c20-01988b27311c",
+      "id" : "1674159386884687000.44bf58ef-08c9-4fb0-a549-5a1810769ee2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -241,7 +241,7 @@
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673379922371028000.af40d469-55c5-43d5-886e-07d94e88bcd1"
+          "reference" : "Organization/1674159386884558000.e245498f-79a5-43c6-af8c-d8b9dbfe5d69"
         }
       } ],
       "identifier" : [ {
@@ -268,15 +268,15 @@
         "text" : "Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay"
       },
       "subject" : {
-        "reference" : "Patient/1673379922303783000.149756fa-fd4e-4595-8789-7cee8f36895e"
+        "reference" : "Patient/1674159386823903000.f22a4106-4367-475b-b6c3-87c3e1ca38e2"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379922324523000.88ef3305-8ae6-4400-a9cd-9f4fa22be88f"
+        "reference" : "Encounter/1674159386841201000.98dce3c5-beeb-4bb1-8c9a-764e4f3966a2"
       },
       "effectiveDateTime" : "2028-08-14T08:05:01-06:00",
       "issued" : "2021-08-16T10:47:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673379922368678000.25168279-b23c-4abd-9407-79377d277b58"
+        "reference" : "PractitionerRole/1674159386882223000.605e81c5-014e-458a-9eeb-6e13d1e0889f"
       } ],
       "valueCodeableConcept" : {
         "coding" : [ {
@@ -290,10 +290,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673379922363256000.307257bd-2653-46f2-8718-214f7c272b0e",
+    "fullUrl" : "Location/1674159386877314000.42c4608e-1459-4089-b542-a5184edee3e9",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379922363256000.307257bd-2653-46f2-8718-214f7c272b0e",
+      "id" : "1674159386877314000.42c4608e-1459-4089-b542-a5184edee3e9",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -307,10 +307,10 @@
       "name" : "SWEDISH MEDICAL CENT"
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922364344000.4d97cb37-c1fb-4a2f-af2c-9231b9037d71",
+    "fullUrl" : "Practitioner/1674159386878086000.6ba87f3f-fdc8-4f23-97f6-05cc329b024e",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922364344000.4d97cb37-c1fb-4a2f-af2c-9231b9037d71",
+      "id" : "1674159386878086000.6ba87f3f-fdc8-4f23-97f6-05cc329b024e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -332,7 +332,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673379922363256000.307257bd-2653-46f2-8718-214f7c272b0e"
+          "reference" : "Location/1674159386877314000.42c4608e-1459-4089-b542-a5184edee3e9"
         }
       } ],
       "identifier" : [ {
@@ -358,10 +358,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379922368532000.501d1bc6-d4f5-426c-9fd2-86a8cbe075b6",
+    "fullUrl" : "Organization/1674159386882055000.4c3b9463-6857-4ba4-a454-72257185367c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379922368532000.501d1bc6-d4f5-426c-9fd2-86a8cbe075b6",
+      "id" : "1674159386882055000.4c3b9463-6857-4ba4-a454-72257185367c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -404,10 +404,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379922368678000.25168279-b23c-4abd-9407-79377d277b58",
+    "fullUrl" : "PractitionerRole/1674159386882223000.605e81c5-014e-458a-9eeb-6e13d1e0889f",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379922368678000.25168279-b23c-4abd-9407-79377d277b58",
+      "id" : "1674159386882223000.605e81c5-014e-458a-9eeb-6e13d1e0889f",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -419,10 +419,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379922364344000.4d97cb37-c1fb-4a2f-af2c-9231b9037d71"
+        "reference" : "Practitioner/1674159386878086000.6ba87f3f-fdc8-4f23-97f6-05cc329b024e"
       },
       "organization" : {
-        "reference" : "Organization/1673379922368532000.501d1bc6-d4f5-426c-9fd2-86a8cbe075b6"
+        "reference" : "Organization/1674159386882055000.4c3b9463-6857-4ba4-a454-72257185367c"
       },
       "code" : [ {
         "coding" : [ {
@@ -432,10 +432,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379922371028000.af40d469-55c5-43d5-886e-07d94e88bcd1",
+    "fullUrl" : "Organization/1674159386884558000.e245498f-79a5-43c6-af8c-d8b9dbfe5d69",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379922371028000.af40d469-55c5-43d5-886e-07d94e88bcd1",
+      "id" : "1674159386884558000.e245498f-79a5-43c6-af8c-d8b9dbfe5d69",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -461,10 +461,10 @@
       "name" : "SWEDISH MEDICAL CENTER"
     }
   }, {
-    "fullUrl" : "Specimen/1673379922537143000.5c8bf012-947d-4287-a10b-4d3ed4571c2d",
+    "fullUrl" : "Specimen/1674159387039769000.1420ee72-f62a-4472-aa07-c4298c59db16",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1673379922537143000.5c8bf012-947d-4287-a10b-4d3ed4571c2d",
+      "id" : "1674159387039769000.1420ee72-f62a-4472-aa07-c4298c59db16",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -495,10 +495,10 @@
       }
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1673379922540425000.c3c1b750-1b00-4a22-b1a6-f834c127723e",
+    "fullUrl" : "DiagnosticReport/1674159387042443000.f6cbc048-521c-45d0-af31-6e0190160333",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1673379922540425000.c3c1b750-1b00-4a22-b1a6-f834c127723e",
+      "id" : "1674159387042443000.f6cbc048-521c-45d0-af31-6e0190160333",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -537,18 +537,17 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "PGN",
+            "display" : "Placer Group Number"
           } ]
         },
-        "system" : "urn:id:L15735128.1",
-        "value" : "0816:ZS:S00004R.1"
+        "system" : "urn:id:L15735128",
+        "value" : "0816:ZS:S00004R"
       }, {
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
+            "code" : "PLAC"
           } ]
         },
         "system" : "urn:id:L15735128.1",
@@ -557,15 +556,15 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PGN",
-            "display" : "Placer Group Number"
+            "code" : "FILL",
+            "display" : "Filler Identifier"
           } ]
         },
-        "system" : "urn:id:L15735128",
-        "value" : "0816:ZS:S00004R"
+        "system" : "urn:id:L15735128.1",
+        "value" : "0816:ZS:S00004R.1"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1673379922542996000.d9c6cad8-daee-4ad1-8431-2882be501d1f"
+        "reference" : "ServiceRequest/1674159387044597000.997255e6-1796-4026-a111-c85b43b34cbc"
       } ],
       "status" : "partial",
       "code" : {
@@ -576,10 +575,10 @@
         "text" : "HEPATITIS B SURFACE ANTIGEN"
       },
       "subject" : {
-        "reference" : "Patient/1673379922303783000.149756fa-fd4e-4595-8789-7cee8f36895e"
+        "reference" : "Patient/1674159386823903000.f22a4106-4367-475b-b6c3-87c3e1ca38e2"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379922324523000.88ef3305-8ae6-4400-a9cd-9f4fa22be88f"
+        "reference" : "Encounter/1674159386841201000.98dce3c5-beeb-4bb1-8c9a-764e4f3966a2"
       },
       "effectivePeriod" : {
         "start" : "2028-08-14T08:05:01-06:00",
@@ -587,17 +586,17 @@
       },
       "issued" : "2021-08-16T10:47:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1673379922537143000.5c8bf012-947d-4287-a10b-4d3ed4571c2d"
+        "reference" : "Specimen/1674159387039769000.1420ee72-f62a-4472-aa07-c4298c59db16"
       } ],
       "result" : [ {
-        "reference" : "Observation/1673379922371197000.2243a5f4-378e-4df7-8c20-01988b27311c"
+        "reference" : "Observation/1674159386884687000.44bf58ef-08c9-4fb0-a549-5a1810769ee2"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922542577000.15766d14-dd20-4300-9466-309628212e23",
+    "fullUrl" : "Practitioner/1674159387044247000.8bcf558f-bcf8-4d2d-a61d-b4da30a1c33c",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922542577000.15766d14-dd20-4300-9466-309628212e23",
+      "id" : "1674159387044247000.8bcf558f-bcf8-4d2d-a61d-b4da30a1c33c",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -617,10 +616,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673379922544908000.fb23597d-facc-4e9e-b08a-00551bc063c1",
+    "fullUrl" : "Location/1674159387046260000.a727356a-c1e5-4c6d-97b8-81836d00a768",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379922544908000.fb23597d-facc-4e9e-b08a-00551bc063c1",
+      "id" : "1674159387046260000.a727356a-c1e5-4c6d-97b8-81836d00a768",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -638,10 +637,10 @@
       "name" : "COCZS"
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922545733000.49468123-d733-425f-8ce1-27920d227402",
+    "fullUrl" : "Practitioner/1674159387047004000.4c7f9d25-17c8-4878-b5c2-827bab33c91b",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922545733000.49468123-d733-425f-8ce1-27920d227402",
+      "id" : "1674159387047004000.4c7f9d25-17c8-4878-b5c2-827bab33c91b",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -667,7 +666,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673379922544908000.fb23597d-facc-4e9e-b08a-00551bc063c1"
+          "reference" : "Location/1674159387046260000.a727356a-c1e5-4c6d-97b8-81836d00a768"
         }
       } ],
       "identifier" : [ {
@@ -719,10 +718,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379922549072000.3424c51e-7c39-4fa6-ad99-8c5aaa6c7083",
+    "fullUrl" : "Organization/1674159387049791000.78a7a280-c71e-4ce1-90ad-840d437fcb75",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379922549072000.3424c51e-7c39-4fa6-ad99-8c5aaa6c7083",
+      "id" : "1674159387049791000.78a7a280-c71e-4ce1-90ad-840d437fcb75",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -777,10 +776,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379922549173000.05114ecb-fba8-462f-858f-dd70a3e9dbb7",
+    "fullUrl" : "PractitionerRole/1674159387049880000.1996c3c8-aa3d-485d-be41-517f0154cba8",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379922549173000.05114ecb-fba8-462f-858f-dd70a3e9dbb7",
+      "id" : "1674159387049880000.1996c3c8-aa3d-485d-be41-517f0154cba8",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -796,17 +795,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379922545733000.49468123-d733-425f-8ce1-27920d227402"
+        "reference" : "Practitioner/1674159387047004000.4c7f9d25-17c8-4878-b5c2-827bab33c91b"
       },
       "organization" : {
-        "reference" : "Organization/1673379922549072000.3424c51e-7c39-4fa6-ad99-8c5aaa6c7083"
+        "reference" : "Organization/1674159387049791000.78a7a280-c71e-4ce1-90ad-840d437fcb75"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1673379922542996000.d9c6cad8-daee-4ad1-8431-2882be501d1f",
+    "fullUrl" : "ServiceRequest/1674159387044597000.997255e6-1796-4026-a111-c85b43b34cbc",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1673379922542996000.d9c6cad8-daee-4ad1-8431-2882be501d1f",
+      "id" : "1674159387044597000.997255e6-1796-4026-a111-c85b43b34cbc",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -830,7 +829,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1673379922542577000.15766d14-dd20-4300-9466-309628212e23"
+          "reference" : "Practitioner/1674159387044247000.8bcf558f-bcf8-4d2d-a61d-b4da30a1c33c"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -909,7 +908,7 @@
         "text" : "HEPATITIS B SURFACE ANTIGEN"
       },
       "subject" : {
-        "reference" : "Patient/1673379922303783000.149756fa-fd4e-4595-8789-7cee8f36895e"
+        "reference" : "Patient/1674159386823903000.f22a4106-4367-475b-b6c3-87c3e1ca38e2"
       },
       "occurrenceTiming" : {
         "repeat" : {
@@ -921,7 +920,7 @@
       },
       "authoredOn" : "2028-08-14T13:50:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1673379922549173000.05114ecb-fba8-462f-858f-dd70a3e9dbb7"
+        "reference" : "PractitionerRole/1674159387049880000.1996c3c8-aa3d-485d-be41-517f0154cba8"
       },
       "reasonCode" : [ {
         "coding" : [ {
@@ -932,10 +931,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Patient/1673379922303783000.149756fa-fd4e-4595-8789-7cee8f36895e",
+    "fullUrl" : "Patient/1674159386823903000.f22a4106-4367-475b-b6c3-87c3e1ca38e2",
     "resource" : {
       "resourceType" : "Patient",
-      "id" : "1673379922303783000.149756fa-fd4e-4595-8789-7cee8f36895e",
+      "id" : "1674159386823903000.f22a4106-4367-475b-b6c3-87c3e1ca38e2",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1161,15 +1160,15 @@
           "country" : "USA"
         },
         "organization" : {
-          "reference" : "Organization/1673379922302699000.798d5848-41bc-4f5d-a0a8-cb24c1f3ee5b"
+          "reference" : "Organization/1674159386823035000.936bea06-6fda-49dd-8110-d10ee3a04d10"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379922302699000.798d5848-41bc-4f5d-a0a8-cb24c1f3ee5b",
+    "fullUrl" : "Organization/1674159386823035000.936bea06-6fda-49dd-8110-d10ee3a04d10",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379922302699000.798d5848-41bc-4f5d-a0a8-cb24c1f3ee5b",
+      "id" : "1674159386823035000.936bea06-6fda-49dd-8110-d10ee3a04d10",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1201,10 +1200,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Encounter/1673379922324523000.88ef3305-8ae6-4400-a9cd-9f4fa22be88f",
+    "fullUrl" : "Encounter/1674159386841201000.98dce3c5-beeb-4bb1-8c9a-764e4f3966a2",
     "resource" : {
       "resourceType" : "Encounter",
-      "id" : "1673379922324523000.88ef3305-8ae6-4400-a9cd-9f4fa22be88f",
+      "id" : "1674159386841201000.98dce3c5-beeb-4bb1-8c9a-764e4f3966a2",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1257,7 +1256,7 @@
         } ]
       },
       "subject" : {
-        "reference" : "Patient/1673379922303783000.149756fa-fd4e-4595-8789-7cee8f36895e"
+        "reference" : "Patient/1674159386823903000.f22a4106-4367-475b-b6c3-87c3e1ca38e2"
       },
       "participant" : [ {
         "type" : [ {
@@ -1268,7 +1267,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379922313675000.8d9c6aad-b3ab-450b-b9c5-b617f677fd85"
+          "reference" : "Practitioner/1674159386832414000.c259ef04-e263-4c50-a6cd-3120d06b97a7"
         }
       }, {
         "type" : [ {
@@ -1279,7 +1278,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379922317013000.22653d36-ee2a-40e8-b70d-990223aa17a5"
+          "reference" : "Practitioner/1674159386834927000.b6a96beb-fe6c-4779-a728-14e8ff0f2d8e"
         }
       }, {
         "type" : [ {
@@ -1290,7 +1289,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379922319573000.6f2e2db8-ef1d-473b-a603-57d8f2143ad7"
+          "reference" : "Practitioner/1674159386837191000.2c88c3bf-b7bb-4a02-979b-fc432df42d3b"
         }
       }, {
         "type" : [ {
@@ -1301,7 +1300,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379922322098000.d6aad2c0-990d-4071-bab4-ab22c4d99480"
+          "reference" : "Practitioner/1674159386839304000.8da227a1-4b5f-42c3-ae48-3d2bf3634955"
         }
       }, {
         "type" : [ {
@@ -1312,7 +1311,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379922323843000.3efeaf87-8fe6-49bf-b269-1b0b2b68b163"
+          "reference" : "Practitioner/1674159386840683000.775a68f5-dab5-49d1-92fb-9c77e8ec6280"
         }
       }, {
         "type" : [ {
@@ -1323,7 +1322,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379922325731000.eb6fa897-f161-4b0c-95ca-81a39dd43c04"
+          "reference" : "Practitioner/1674159386842596000.5981de66-e71c-47c7-ad91-4d4001c99855"
         }
       } ],
       "period" : {
@@ -1343,16 +1342,16 @@
       },
       "location" : [ {
         "location" : {
-          "reference" : "Location/1673379922359362000.d5ee88f0-3c4b-4b64-b61b-062473b84737"
+          "reference" : "Location/1674159386874345000.2509b4f6-7872-4395-9db1-8cb933575a0c"
         },
         "status" : "active"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922313675000.8d9c6aad-b3ab-450b-b9c5-b617f677fd85",
+    "fullUrl" : "Practitioner/1674159386832414000.c259ef04-e263-4c50-a6cd-3120d06b97a7",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922313675000.8d9c6aad-b3ab-450b-b9c5-b617f677fd85",
+      "id" : "1674159386832414000.c259ef04-e263-4c50-a6cd-3120d06b97a7",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1395,10 +1394,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922317013000.22653d36-ee2a-40e8-b70d-990223aa17a5",
+    "fullUrl" : "Practitioner/1674159386834927000.b6a96beb-fe6c-4779-a728-14e8ff0f2d8e",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922317013000.22653d36-ee2a-40e8-b70d-990223aa17a5",
+      "id" : "1674159386834927000.b6a96beb-fe6c-4779-a728-14e8ff0f2d8e",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1440,10 +1439,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922319573000.6f2e2db8-ef1d-473b-a603-57d8f2143ad7",
+    "fullUrl" : "Practitioner/1674159386837191000.2c88c3bf-b7bb-4a02-979b-fc432df42d3b",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922319573000.6f2e2db8-ef1d-473b-a603-57d8f2143ad7",
+      "id" : "1674159386837191000.2c88c3bf-b7bb-4a02-979b-fc432df42d3b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1485,10 +1484,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922322098000.d6aad2c0-990d-4071-bab4-ab22c4d99480",
+    "fullUrl" : "Practitioner/1674159386839304000.8da227a1-4b5f-42c3-ae48-3d2bf3634955",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922322098000.d6aad2c0-990d-4071-bab4-ab22c4d99480",
+      "id" : "1674159386839304000.8da227a1-4b5f-42c3-ae48-3d2bf3634955",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1531,10 +1530,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922323843000.3efeaf87-8fe6-49bf-b269-1b0b2b68b163",
+    "fullUrl" : "Practitioner/1674159386840683000.775a68f5-dab5-49d1-92fb-9c77e8ec6280",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922323843000.3efeaf87-8fe6-49bf-b269-1b0b2b68b163",
+      "id" : "1674159386840683000.775a68f5-dab5-49d1-92fb-9c77e8ec6280",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1577,10 +1576,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379922325731000.eb6fa897-f161-4b0c-95ca-81a39dd43c04",
+    "fullUrl" : "Practitioner/1674159386842596000.5981de66-e71c-47c7-ad91-4d4001c99855",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379922325731000.eb6fa897-f161-4b0c-95ca-81a39dd43c04",
+      "id" : "1674159386842596000.5981de66-e71c-47c7-ad91-4d4001c99855",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1623,10 +1622,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673379922359362000.d5ee88f0-3c4b-4b64-b61b-062473b84737",
+    "fullUrl" : "Location/1674159386874345000.2509b4f6-7872-4395-9db1-8cb933575a0c",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379922359362000.d5ee88f0-3c4b-4b64-b61b-062473b84737",
+      "id" : "1674159386874345000.2509b4f6-7872-4395-9db1-8cb933575a0c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",

--- a/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_2_20220803-0001.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_co_2_20220803-0001.fhir
@@ -1,14 +1,14 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1673379983504463000.ca4dbb98-6982-4086-8dce-967a47901470",
+  "id" : "1674159428884968000.8331e447-6e19-4580-8f6e-ce94bc6907f2",
   "meta" : {
-    "lastUpdated" : "2023-01-10T13:46:23.513-06:00"
+    "lastUpdated" : "2023-01-19T13:17:08.892-07:00"
   },
   "identifier" : {
     "value" : "MT_COCNB_ORU_NBPHELR.1.5348467"
   },
   "type" : "message",
-  "timestamp" : "2022-08-03T05:07:05.000-05:00",
+  "timestamp" : "2022-08-03T03:07:05.000-07:00",
   "entry" : [ {
     "fullUrl" : "MessageHeader/f13b2ed3-fdf0-3939-b505-6dd0daf19cd6",
     "resource" : {
@@ -31,7 +31,7 @@
       },
       "destination" : [ {
         "target" : {
-          "reference" : "Device/1673379983594604000.ad2a7b01-1e55-48c0-90bc-e9634e73261a"
+          "reference" : "Device/1674159428962771000.91253b04-e8e4-467f-b10e-65427f5f6443"
         },
         "endpoint" : "urn:oid:2.16.840.1.114222.4.1.144.2.5",
         "receiver" : {
@@ -39,13 +39,13 @@
         }
       } ],
       "sender" : {
-        "reference" : "Organization/1673379983589193000.c668ea70-5572-4a9e-bae1-9aa30afbf191"
+        "reference" : "Organization/1674159428957788000.1e25c23e-58dd-48b3-8e6e-d9f8a23b9a70"
       },
       "source" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
           "valueReference" : {
-            "reference" : "Organization/1673379983606650000.b737a19b-ee64-45a7-9c57-60c5057247e3"
+            "reference" : "Organization/1674159428972515000.aa0c12a5-2f31-426c-933b-2161fe30e1ba"
           }
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
@@ -60,10 +60,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1673379983589193000.c668ea70-5572-4a9e-bae1-9aa30afbf191",
+    "fullUrl" : "Organization/1674159428957788000.1e25c23e-58dd-48b3-8e6e-d9f8a23b9a70",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379983589193000.c668ea70-5572-4a9e-bae1-9aa30afbf191",
+      "id" : "1674159428957788000.1e25c23e-58dd-48b3-8e6e-d9f8a23b9a70",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -79,10 +79,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1673379983594604000.ad2a7b01-1e55-48c0-90bc-e9634e73261a",
+    "fullUrl" : "Device/1674159428962771000.91253b04-e8e4-467f-b10e-65427f5f6443",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1673379983594604000.ad2a7b01-1e55-48c0-90bc-e9634e73261a",
+      "id" : "1674159428962771000.91253b04-e8e4-467f-b10e-65427f5f6443",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -129,10 +129,10 @@
       "name" : "CDPHE"
     }
   }, {
-    "fullUrl" : "Organization/1673379983606650000.b737a19b-ee64-45a7-9c57-60c5057247e3",
+    "fullUrl" : "Organization/1674159428972515000.aa0c12a5-2f31-426c-933b-2161fe30e1ba",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379983606650000.b737a19b-ee64-45a7-9c57-60c5057247e3",
+      "id" : "1674159428972515000.aa0c12a5-2f31-426c-933b-2161fe30e1ba",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -170,10 +170,10 @@
       "name" : "MEDITECH, Inc."
     }
   }, {
-    "fullUrl" : "Provenance/1673379985050617000.97ec4642-be0a-4299-ac79-b5f35f80d096",
+    "fullUrl" : "Provenance/1674159430300309000.34ae82cb-3591-47a6-a57d-67ee585da817",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1673379985050617000.97ec4642-be0a-4299-ac79-b5f35f80d096",
+      "id" : "1674159430300309000.34ae82cb-3591-47a6-a57d-67ee585da817",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -200,21 +200,21 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1673379985049772000.9c4309a9-9149-4864-97ac-08112194ee7e"
+          "reference" : "Organization/1674159430299146000.b1c64f1f-8419-4307-879d-b5a74368a4b1"
         }
       } ],
       "entity" : [ {
         "role" : "source",
         "what" : {
-          "reference" : "Device/1673379985052516000.2999bf81-a1ea-43c1-8f31-8026c154a8f3"
+          "reference" : "Device/1674159430301429000.7e7a3f86-748a-4d7b-86e3-25d3baf8075b"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985049772000.9c4309a9-9149-4864-97ac-08112194ee7e",
+    "fullUrl" : "Organization/1674159430299146000.b1c64f1f-8419-4307-879d-b5a74368a4b1",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985049772000.9c4309a9-9149-4864-97ac-08112194ee7e",
+      "id" : "1674159430299146000.b1c64f1f-8419-4307-879d-b5a74368a4b1",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -241,10 +241,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Device/1673379985052516000.2999bf81-a1ea-43c1-8f31-8026c154a8f3",
+    "fullUrl" : "Device/1674159430301429000.7e7a3f86-748a-4d7b-86e3-25d3baf8075b",
     "resource" : {
       "resourceType" : "Device",
-      "id" : "1673379985052516000.2999bf81-a1ea-43c1-8f31-8026c154a8f3",
+      "id" : "1674159430301429000.7e7a3f86-748a-4d7b-86e3-25d3baf8075b",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -262,10 +262,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Observation/1673379985150079000.9accc97a-3dd6-44b7-9b68-401e46976136",
+    "fullUrl" : "Observation/1674159430396067000.d885b1d7-82b2-4f76-9271-34a8aa731c9a",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673379985150079000.9accc97a-3dd6-44b7-9b68-401e46976136",
+      "id" : "1674159430396067000.d885b1d7-82b2-4f76-9271-34a8aa731c9a",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -282,7 +282,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673379985149861000.504c9f38-e3f7-416c-b8a0-db7e2e410cf9"
+          "reference" : "Organization/1674159430395927000.17106650-df99-46d2-8359-b157aeb931b3"
         }
       } ],
       "identifier" : [ {
@@ -316,15 +316,15 @@
         "text" : "SARS coronavirus RNA[Presence] in Specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4"
+        "reference" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438"
       },
       "effectiveDateTime" : "2022-06-21T13:36:00-06:00",
       "issued" : "2022-08-03T04:06:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673379985146885000.0311b22a-f92c-4bd6-b633-717f942294f6"
+        "reference" : "PractitionerRole/1674159430393613000.84493109-adaa-4db8-a131-96982e5ea706"
       } ],
       "valueCodeableConcept" : {
         "extension" : [ {
@@ -351,10 +351,10 @@
       }
     }
   }, {
-    "fullUrl" : "Location/1673379985143205000.a2a83adc-fb17-481b-9845-470b6f44548e",
+    "fullUrl" : "Location/1674159430389677000.925deb76-0d22-45b8-a4fa-ea51c70d9dcc",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379985143205000.a2a83adc-fb17-481b-9845-470b6f44548e",
+      "id" : "1674159430389677000.925deb76-0d22-45b8-a4fa-ea51c70d9dcc",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -368,10 +368,10 @@
       "name" : "N. SUBURBAN MED. CEN"
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985143792000.6e13012e-77da-4fca-8a5f-866c39d3faf2",
+    "fullUrl" : "Practitioner/1674159430390241000.61a64aaf-ac74-4de9-a223-8a62be2e3525",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985143792000.6e13012e-77da-4fca-8a5f-866c39d3faf2",
+      "id" : "1674159430390241000.61a64aaf-ac74-4de9-a223-8a62be2e3525",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -393,7 +393,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673379985143205000.a2a83adc-fb17-481b-9845-470b6f44548e"
+          "reference" : "Location/1674159430389677000.925deb76-0d22-45b8-a4fa-ea51c70d9dcc"
         }
       } ],
       "identifier" : [ {
@@ -419,10 +419,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985146623000.863451a4-395a-4dda-b4f1-e868bf1037f8",
+    "fullUrl" : "Organization/1674159430393285000.afff5dc5-ab70-4b35-bf93-27ad3c3ecbd8",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985146623000.863451a4-395a-4dda-b4f1-e868bf1037f8",
+      "id" : "1674159430393285000.afff5dc5-ab70-4b35-bf93-27ad3c3ecbd8",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -465,10 +465,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379985146885000.0311b22a-f92c-4bd6-b633-717f942294f6",
+    "fullUrl" : "PractitionerRole/1674159430393613000.84493109-adaa-4db8-a131-96982e5ea706",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379985146885000.0311b22a-f92c-4bd6-b633-717f942294f6",
+      "id" : "1674159430393613000.84493109-adaa-4db8-a131-96982e5ea706",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -480,10 +480,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379985143792000.6e13012e-77da-4fca-8a5f-866c39d3faf2"
+        "reference" : "Practitioner/1674159430390241000.61a64aaf-ac74-4de9-a223-8a62be2e3525"
       },
       "organization" : {
-        "reference" : "Organization/1673379985146623000.863451a4-395a-4dda-b4f1-e868bf1037f8"
+        "reference" : "Organization/1674159430393285000.afff5dc5-ab70-4b35-bf93-27ad3c3ecbd8"
       },
       "code" : [ {
         "coding" : [ {
@@ -493,10 +493,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985149861000.504c9f38-e3f7-416c-b8a0-db7e2e410cf9",
+    "fullUrl" : "Organization/1674159430395927000.17106650-df99-46d2-8359-b157aeb931b3",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985149861000.504c9f38-e3f7-416c-b8a0-db7e2e410cf9",
+      "id" : "1674159430395927000.17106650-df99-46d2-8359-b157aeb931b3",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -509,10 +509,10 @@
       }
     }
   }, {
-    "fullUrl" : "Observation/1673379985157929000.b925455a-94ce-4a27-a40f-bae5d77b3ad7",
+    "fullUrl" : "Observation/1674159430404702000.fbc0dcd6-5f3d-4082-9c74-cf72ce7342b0",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673379985157929000.b925455a-94ce-4a27-a40f-bae5d77b3ad7",
+      "id" : "1674159430404702000.fbc0dcd6-5f3d-4082-9c74-cf72ce7342b0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -529,7 +529,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673379985157814000.0c80e43f-6292-4624-8006-30752b5d4cde"
+          "reference" : "Organization/1674159430404570000.8c96bf08-d313-4acc-b364-c0cff23d34b5"
         }
       } ],
       "identifier" : [ {
@@ -563,15 +563,15 @@
         "text" : "Influenza virus A RNA [Presence] in Unspecified specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4"
+        "reference" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438"
       },
       "effectiveDateTime" : "2022-06-21T13:36:00-06:00",
       "issued" : "2022-08-03T04:06:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673379985156275000.6edf26a2-3a06-4484-a362-74d2ee6cfdc5"
+        "reference" : "PractitionerRole/1674159430402512000.bb8b0cb2-b46f-4d66-9759-6782be2f05ab"
       } ],
       "valueCodeableConcept" : {
         "extension" : [ {
@@ -592,10 +592,10 @@
       }
     }
   }, {
-    "fullUrl" : "Location/1673379985153216000.9d261c41-b4f1-435a-adce-52b75256633b",
+    "fullUrl" : "Location/1674159430399500000.669b932e-2c03-4e14-ad1b-79e302e48fb0",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379985153216000.9d261c41-b4f1-435a-adce-52b75256633b",
+      "id" : "1674159430399500000.669b932e-2c03-4e14-ad1b-79e302e48fb0",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -609,10 +609,10 @@
       "name" : "N. SUBURBAN MED. CEN"
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985153806000.69f9a13f-6002-44da-a2a8-161ea7cd7659",
+    "fullUrl" : "Practitioner/1674159430400024000.099ba7bf-1d44-4245-b5f6-33ea857c9888",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985153806000.69f9a13f-6002-44da-a2a8-161ea7cd7659",
+      "id" : "1674159430400024000.099ba7bf-1d44-4245-b5f6-33ea857c9888",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -634,7 +634,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673379985153216000.9d261c41-b4f1-435a-adce-52b75256633b"
+          "reference" : "Location/1674159430399500000.669b932e-2c03-4e14-ad1b-79e302e48fb0"
         }
       } ],
       "identifier" : [ {
@@ -660,10 +660,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985156175000.4a6ed4d7-8391-458e-bde4-a8b4956abd13",
+    "fullUrl" : "Organization/1674159430402408000.bc0fbd15-5f85-4616-a543-287e034829ed",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985156175000.4a6ed4d7-8391-458e-bde4-a8b4956abd13",
+      "id" : "1674159430402408000.bc0fbd15-5f85-4616-a543-287e034829ed",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -706,10 +706,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379985156275000.6edf26a2-3a06-4484-a362-74d2ee6cfdc5",
+    "fullUrl" : "PractitionerRole/1674159430402512000.bb8b0cb2-b46f-4d66-9759-6782be2f05ab",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379985156275000.6edf26a2-3a06-4484-a362-74d2ee6cfdc5",
+      "id" : "1674159430402512000.bb8b0cb2-b46f-4d66-9759-6782be2f05ab",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -721,10 +721,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379985153806000.69f9a13f-6002-44da-a2a8-161ea7cd7659"
+        "reference" : "Practitioner/1674159430400024000.099ba7bf-1d44-4245-b5f6-33ea857c9888"
       },
       "organization" : {
-        "reference" : "Organization/1673379985156175000.4a6ed4d7-8391-458e-bde4-a8b4956abd13"
+        "reference" : "Organization/1674159430402408000.bc0fbd15-5f85-4616-a543-287e034829ed"
       },
       "code" : [ {
         "coding" : [ {
@@ -734,10 +734,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985157814000.0c80e43f-6292-4624-8006-30752b5d4cde",
+    "fullUrl" : "Organization/1674159430404570000.8c96bf08-d313-4acc-b364-c0cff23d34b5",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985157814000.0c80e43f-6292-4624-8006-30752b5d4cde",
+      "id" : "1674159430404570000.8c96bf08-d313-4acc-b364-c0cff23d34b5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -750,10 +750,10 @@
       }
     }
   }, {
-    "fullUrl" : "Observation/1673379985166886000.a6d48beb-437d-4e84-9436-3b82ffe34314",
+    "fullUrl" : "Observation/1674159430414405000.cf6310c3-02a6-4e04-a7e5-e9929c8c54bb",
     "resource" : {
       "resourceType" : "Observation",
-      "id" : "1673379985166886000.a6d48beb-437d-4e84-9436-3b82ffe34314",
+      "id" : "1674159430414405000.cf6310c3-02a6-4e04-a7e5-e9929c8c54bb",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -770,7 +770,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/producer-id",
         "valueReference" : {
-          "reference" : "Organization/1673379985166461000.b29bc442-6c8f-4984-b996-87ae7a172ad8"
+          "reference" : "Organization/1674159430414284000.1825ad8c-145f-4adf-b7e5-dc35f878c96c"
         }
       } ],
       "identifier" : [ {
@@ -804,15 +804,15 @@
         "text" : "Influenza virus B RNA [Presence] in Unspecified specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4"
+        "reference" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438"
       },
       "effectiveDateTime" : "2022-06-21T13:36:00-06:00",
       "issued" : "2022-08-03T04:06:00-06:00",
       "performer" : [ {
-        "reference" : "PractitionerRole/1673379985164434000.4dc9547a-867d-4c97-8f17-7f55072c0a9d"
+        "reference" : "PractitionerRole/1674159430411977000.268da52d-7338-4ae3-9a26-66f5b2bf3410"
       } ],
       "valueCodeableConcept" : {
         "extension" : [ {
@@ -833,10 +833,10 @@
       }
     }
   }, {
-    "fullUrl" : "Location/1673379985160295000.717cf02a-592c-4b70-8de5-7a1fc4459478",
+    "fullUrl" : "Location/1674159430407447000.8590899a-ba13-498b-91ff-18edb732ff7d",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379985160295000.717cf02a-592c-4b70-8de5-7a1fc4459478",
+      "id" : "1674159430407447000.8590899a-ba13-498b-91ff-18edb732ff7d",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -850,10 +850,10 @@
       "name" : "N. SUBURBAN MED. CEN"
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985160955000.b3ab8108-c93e-49bd-bd29-c75ca0648851",
+    "fullUrl" : "Practitioner/1674159430408198000.6dad0bf4-16bc-4f3b-ac5e-a2878c1a8b72",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985160955000.b3ab8108-c93e-49bd-bd29-c75ca0648851",
+      "id" : "1674159430408198000.6dad0bf4-16bc-4f3b-ac5e-a2878c1a8b72",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -875,7 +875,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
         "valueReference" : {
-          "reference" : "Location/1673379985160295000.717cf02a-592c-4b70-8de5-7a1fc4459478"
+          "reference" : "Location/1674159430407447000.8590899a-ba13-498b-91ff-18edb732ff7d"
         }
       } ],
       "identifier" : [ {
@@ -901,10 +901,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985164318000.5f27145d-6a0b-4f06-9db5-c88223888431",
+    "fullUrl" : "Organization/1674159430411845000.79d99cda-8726-4cef-b736-3401a1b4e317",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985164318000.5f27145d-6a0b-4f06-9db5-c88223888431",
+      "id" : "1674159430411845000.79d99cda-8726-4cef-b736-3401a1b4e317",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -947,10 +947,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379985164434000.4dc9547a-867d-4c97-8f17-7f55072c0a9d",
+    "fullUrl" : "PractitionerRole/1674159430411977000.268da52d-7338-4ae3-9a26-66f5b2bf3410",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379985164434000.4dc9547a-867d-4c97-8f17-7f55072c0a9d",
+      "id" : "1674159430411977000.268da52d-7338-4ae3-9a26-66f5b2bf3410",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -962,10 +962,10 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379985160955000.b3ab8108-c93e-49bd-bd29-c75ca0648851"
+        "reference" : "Practitioner/1674159430408198000.6dad0bf4-16bc-4f3b-ac5e-a2878c1a8b72"
       },
       "organization" : {
-        "reference" : "Organization/1673379985164318000.5f27145d-6a0b-4f06-9db5-c88223888431"
+        "reference" : "Organization/1674159430411845000.79d99cda-8726-4cef-b736-3401a1b4e317"
       },
       "code" : [ {
         "coding" : [ {
@@ -975,10 +975,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985166461000.b29bc442-6c8f-4984-b996-87ae7a172ad8",
+    "fullUrl" : "Organization/1674159430414284000.1825ad8c-145f-4adf-b7e5-dc35f878c96c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985166461000.b29bc442-6c8f-4984-b996-87ae7a172ad8",
+      "id" : "1674159430414284000.1825ad8c-145f-4adf-b7e5-dc35f878c96c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -991,10 +991,10 @@
       }
     }
   }, {
-    "fullUrl" : "Specimen/1673379985344733000.52afaefd-bc9e-4309-9047-8c5f5100ae94",
+    "fullUrl" : "Specimen/1674159430572288000.1c1b901a-9a02-4af1-b148-dea2b460ccd5",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1673379985344733000.52afaefd-bc9e-4309-9047-8c5f5100ae94",
+      "id" : "1674159430572288000.1c1b901a-9a02-4af1-b148-dea2b460ccd5",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1059,10 +1059,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Specimen/1673379985346527000.1eae6e00-d3cb-4504-9a83-a9671509c14d",
+    "fullUrl" : "Specimen/1674159430574390000.9abdf3a3-e198-4209-98c5-531740eec806",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1673379985346527000.1eae6e00-d3cb-4504-9a83-a9671509c14d",
+      "id" : "1674159430574390000.9abdf3a3-e198-4209-98c5-531740eec806",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1127,10 +1127,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Specimen/1673379985347983000.90b6c4c7-804a-488c-92a4-e69fa16830d9",
+    "fullUrl" : "Specimen/1674159430575856000.2a982235-d287-4d67-a254-4b14f51a31ff",
     "resource" : {
       "resourceType" : "Specimen",
-      "id" : "1673379985347983000.90b6c4c7-804a-488c-92a4-e69fa16830d9",
+      "id" : "1674159430575856000.2a982235-d287-4d67-a254-4b14f51a31ff",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -1195,10 +1195,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1673379985355127000.48db3cbd-4115-4581-bfa2-167b1b26e0e9",
+    "fullUrl" : "DiagnosticReport/1674159430582273000.847b9777-3ffe-4913-8b52-2759cc12edf3",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1673379985355127000.48db3cbd-4115-4581-bfa2-167b1b26e0e9",
+      "id" : "1674159430582273000.847b9777-3ffe-4913-8b52-2759cc12edf3",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1241,12 +1241,12 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "PGN",
+            "display" : "Placer Group Number"
           } ]
         },
-        "system" : "urn:id:M7586249.2",
-        "value" : "22:NB:B0016908S.2"
+        "system" : "urn:id:M7586249",
+        "value" : "22:NB:B0016908S"
       }, {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
@@ -1255,8 +1255,7 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
+            "code" : "PLAC"
           } ]
         },
         "system" : "urn:id:M7586249.2",
@@ -1269,15 +1268,15 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PGN",
-            "display" : "Placer Group Number"
+            "code" : "FILL",
+            "display" : "Filler Identifier"
           } ]
         },
-        "system" : "urn:id:M7586249",
-        "value" : "22:NB:B0016908S"
+        "system" : "urn:id:M7586249.2",
+        "value" : "22:NB:B0016908S.2"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1673379985358007000.d417e99e-c3d6-47cd-ac90-9f55d01cb8e1"
+        "reference" : "ServiceRequest/1674159430584822000.94017889-5867-4fa3-9374-c22b3abe6b19"
       } ],
       "status" : "final",
       "code" : {
@@ -1299,10 +1298,10 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4"
+        "reference" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438"
       },
       "effectivePeriod" : {
         "start" : "2022-06-21T13:36:00-06:00",
@@ -1310,17 +1309,17 @@
       },
       "issued" : "2022-08-03T04:06:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1673379985344733000.52afaefd-bc9e-4309-9047-8c5f5100ae94"
+        "reference" : "Specimen/1674159430572288000.1c1b901a-9a02-4af1-b148-dea2b460ccd5"
       } ],
       "result" : [ {
-        "reference" : "Observation/1673379985150079000.9accc97a-3dd6-44b7-9b68-401e46976136"
+        "reference" : "Observation/1674159430396067000.d885b1d7-82b2-4f76-9271-34a8aa731c9a"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985357381000.596d9019-8abf-4630-88be-a9138a5c3760",
+    "fullUrl" : "Practitioner/1674159430584442000.c683668b-8dd0-4d45-a72f-9d71e4c69d6f",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985357381000.596d9019-8abf-4630-88be-a9138a5c3760",
+      "id" : "1674159430584442000.c683668b-8dd0-4d45-a72f-9d71e4c69d6f",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1338,10 +1337,10 @@
       "identifier" : [ { } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985359581000.e4383f5c-7884-4e4c-ae4f-55e605f083ae",
+    "fullUrl" : "Practitioner/1674159430586280000.c8e28231-b6a5-4478-8c0b-a9fe0ecb0f55",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985359581000.e4383f5c-7884-4e4c-ae4f-55e605f083ae",
+      "id" : "1674159430586280000.c8e28231-b6a5-4478-8c0b-a9fe0ecb0f55",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1376,10 +1375,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985364935000.db88ae5f-caee-481d-9cbf-243a71292256",
+    "fullUrl" : "Organization/1674159430591754000.a103ad29-5f59-4678-93cd-7278cf7da92c",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985364935000.db88ae5f-caee-481d-9cbf-243a71292256",
+      "id" : "1674159430591754000.a103ad29-5f59-4678-93cd-7278cf7da92c",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1433,10 +1432,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379985365050000.10749bec-3b88-4e07-8538-4b6a2ff13c97",
+    "fullUrl" : "PractitionerRole/1674159430591894000.7f6c9e67-8354-42fb-84e6-b4cb1170d47b",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379985365050000.10749bec-3b88-4e07-8538-4b6a2ff13c97",
+      "id" : "1674159430591894000.7f6c9e67-8354-42fb-84e6-b4cb1170d47b",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1452,17 +1451,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379985359581000.e4383f5c-7884-4e4c-ae4f-55e605f083ae"
+        "reference" : "Practitioner/1674159430586280000.c8e28231-b6a5-4478-8c0b-a9fe0ecb0f55"
       },
       "organization" : {
-        "reference" : "Organization/1673379985364935000.db88ae5f-caee-481d-9cbf-243a71292256"
+        "reference" : "Organization/1674159430591754000.a103ad29-5f59-4678-93cd-7278cf7da92c"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1673379985358007000.d417e99e-c3d6-47cd-ac90-9f55d01cb8e1",
+    "fullUrl" : "ServiceRequest/1674159430584822000.94017889-5867-4fa3-9374-c22b3abe6b19",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1673379985358007000.d417e99e-c3d6-47cd-ac90-9f55d01cb8e1",
+      "id" : "1674159430584822000.94017889-5867-4fa3-9374-c22b3abe6b19",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1489,7 +1488,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1673379985357381000.596d9019-8abf-4630-88be-a9138a5c3760"
+          "reference" : "Practitioner/1674159430584442000.c683668b-8dd0-4d45-a72f-9d71e4c69d6f"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -1590,19 +1589,19 @@
         "text" : "SARS-CoV-2 RNA Resp Ql NAA+probe"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "occurrenceDateTime" : "2022-06-21T13:36:00Z",
       "authoredOn" : "2022-08-03T04:07:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1673379985365050000.10749bec-3b88-4e07-8538-4b6a2ff13c97"
+        "reference" : "PractitionerRole/1674159430591894000.7f6c9e67-8354-42fb-84e6-b4cb1170d47b"
       }
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1673379985368838000.a9ec2cad-a797-47a7-a75e-b1bc50a71ca1",
+    "fullUrl" : "DiagnosticReport/1674159430595659000.2b64af00-0083-4935-ae2d-1435852e80d6",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1673379985368838000.a9ec2cad-a797-47a7-a75e-b1bc50a71ca1",
+      "id" : "1674159430595659000.2b64af00-0083-4935-ae2d-1435852e80d6",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1641,18 +1640,17 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "PGN",
+            "display" : "Placer Group Number"
           } ]
         },
-        "system" : "urn:id:M7586249.3",
-        "value" : "22:NB:B0016908S.3"
+        "system" : "urn:id:M7586249",
+        "value" : "22:NB:B0016908S"
       }, {
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
+            "code" : "PLAC"
           } ]
         },
         "system" : "urn:id:M7586249.3",
@@ -1661,15 +1659,15 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PGN",
-            "display" : "Placer Group Number"
+            "code" : "FILL",
+            "display" : "Filler Identifier"
           } ]
         },
-        "system" : "urn:id:M7586249",
-        "value" : "22:NB:B0016908S"
+        "system" : "urn:id:M7586249.3",
+        "value" : "22:NB:B0016908S.3"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1673379985371033000.39cf89a4-3d39-4940-abfd-693535043754"
+        "reference" : "ServiceRequest/1674159430598195000.51f69396-faa6-408c-be84-40d35d432beb"
       } ],
       "status" : "final",
       "code" : {
@@ -1691,10 +1689,10 @@
         "text" : "Influenza virus A RNA [Presence] in Unspecified specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4"
+        "reference" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438"
       },
       "effectivePeriod" : {
         "start" : "2022-06-21T13:36:00-06:00",
@@ -1702,17 +1700,17 @@
       },
       "issued" : "2022-08-03T04:06:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1673379985346527000.1eae6e00-d3cb-4504-9a83-a9671509c14d"
+        "reference" : "Specimen/1674159430574390000.9abdf3a3-e198-4209-98c5-531740eec806"
       } ],
       "result" : [ {
-        "reference" : "Observation/1673379985157929000.b925455a-94ce-4a27-a40f-bae5d77b3ad7"
+        "reference" : "Observation/1674159430404702000.fbc0dcd6-5f3d-4082-9c74-cf72ce7342b0"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985370686000.aa777411-341e-404f-aafc-84bad02a669f",
+    "fullUrl" : "Practitioner/1674159430597860000.e9c8fdf6-88d8-4605-9a72-1224f91e16be",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985370686000.aa777411-341e-404f-aafc-84bad02a669f",
+      "id" : "1674159430597860000.e9c8fdf6-88d8-4605-9a72-1224f91e16be",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1730,10 +1728,10 @@
       "identifier" : [ { } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985372332000.bf7d17df-9f68-4106-ba49-e11b2dcc9e18",
+    "fullUrl" : "Practitioner/1674159430599586000.cc860860-375a-43a7-b382-7722dde20bf1",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985372332000.bf7d17df-9f68-4106-ba49-e11b2dcc9e18",
+      "id" : "1674159430599586000.cc860860-375a-43a7-b382-7722dde20bf1",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1768,10 +1766,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985374947000.d57c8198-e0e6-41d9-afa9-716a3fd874cf",
+    "fullUrl" : "Organization/1674159430602012000.eea6acb6-db8b-40d6-b6f1-8ed9b45b4fdf",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985374947000.d57c8198-e0e6-41d9-afa9-716a3fd874cf",
+      "id" : "1674159430602012000.eea6acb6-db8b-40d6-b6f1-8ed9b45b4fdf",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1825,10 +1823,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379985375067000.f95d9931-9e64-4246-8b39-6668f7a7464c",
+    "fullUrl" : "PractitionerRole/1674159430602111000.28c592e4-5290-4756-9930-1c35d28638c4",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379985375067000.f95d9931-9e64-4246-8b39-6668f7a7464c",
+      "id" : "1674159430602111000.28c592e4-5290-4756-9930-1c35d28638c4",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1844,17 +1842,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379985372332000.bf7d17df-9f68-4106-ba49-e11b2dcc9e18"
+        "reference" : "Practitioner/1674159430599586000.cc860860-375a-43a7-b382-7722dde20bf1"
       },
       "organization" : {
-        "reference" : "Organization/1673379985374947000.d57c8198-e0e6-41d9-afa9-716a3fd874cf"
+        "reference" : "Organization/1674159430602012000.eea6acb6-db8b-40d6-b6f1-8ed9b45b4fdf"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1673379985371033000.39cf89a4-3d39-4940-abfd-693535043754",
+    "fullUrl" : "ServiceRequest/1674159430598195000.51f69396-faa6-408c-be84-40d35d432beb",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1673379985371033000.39cf89a4-3d39-4940-abfd-693535043754",
+      "id" : "1674159430598195000.51f69396-faa6-408c-be84-40d35d432beb",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -1881,7 +1879,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1673379985370686000.aa777411-341e-404f-aafc-84bad02a669f"
+          "reference" : "Practitioner/1674159430597860000.e9c8fdf6-88d8-4605-9a72-1224f91e16be"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -1970,19 +1968,19 @@
         "text" : "Influenza virus A RNA [Presence] in Unspecified specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "occurrenceDateTime" : "2022-06-21T13:36:00Z",
       "authoredOn" : "2022-08-03T04:07:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1673379985375067000.f95d9931-9e64-4246-8b39-6668f7a7464c"
+        "reference" : "PractitionerRole/1674159430602111000.28c592e4-5290-4756-9930-1c35d28638c4"
       }
     }
   }, {
-    "fullUrl" : "DiagnosticReport/1673379985377778000.0a445119-955e-4768-b6b6-2b68db9187c5",
+    "fullUrl" : "DiagnosticReport/1674159430604450000.3193846e-5742-485b-85c8-03d6151ad7c7",
     "resource" : {
       "resourceType" : "DiagnosticReport",
-      "id" : "1673379985377778000.0a445119-955e-4768-b6b6-2b68db9187c5",
+      "id" : "1674159430604450000.3193846e-5742-485b-85c8-03d6151ad7c7",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2021,18 +2019,17 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "FILL",
-            "display" : "Filler Identifier"
+            "code" : "PGN",
+            "display" : "Placer Group Number"
           } ]
         },
-        "system" : "urn:id:M7586249.4",
-        "value" : "22:NB:B0016908S.4"
+        "system" : "urn:id:M7586249",
+        "value" : "22:NB:B0016908S"
       }, {
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
+            "code" : "PLAC"
           } ]
         },
         "system" : "urn:id:M7586249.4",
@@ -2041,15 +2038,15 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PGN",
-            "display" : "Placer Group Number"
+            "code" : "FILL",
+            "display" : "Filler Identifier"
           } ]
         },
-        "system" : "urn:id:M7586249",
-        "value" : "22:NB:B0016908S"
+        "system" : "urn:id:M7586249.4",
+        "value" : "22:NB:B0016908S.4"
       } ],
       "basedOn" : [ {
-        "reference" : "ServiceRequest/1673379985380189000.dc3dec13-8ce0-473f-a6e1-24cc28ca69c2"
+        "reference" : "ServiceRequest/1674159430606825000.847f5ad7-de79-43ac-a24b-0b750fb08938"
       } ],
       "status" : "final",
       "code" : {
@@ -2071,10 +2068,10 @@
         "text" : "Influenza virus B RNA [Presence] in Unspecified specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "encounter" : {
-        "reference" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4"
+        "reference" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438"
       },
       "effectivePeriod" : {
         "start" : "2022-06-21T13:36:00-06:00",
@@ -2082,17 +2079,17 @@
       },
       "issued" : "2022-08-03T04:06:00-06:00",
       "specimen" : [ {
-        "reference" : "Specimen/1673379985347983000.90b6c4c7-804a-488c-92a4-e69fa16830d9"
+        "reference" : "Specimen/1674159430575856000.2a982235-d287-4d67-a254-4b14f51a31ff"
       } ],
       "result" : [ {
-        "reference" : "Observation/1673379985166886000.a6d48beb-437d-4e84-9436-3b82ffe34314"
+        "reference" : "Observation/1674159430414405000.cf6310c3-02a6-4e04-a7e5-e9929c8c54bb"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985379781000.11cdf0e6-11ce-48fa-a5b8-be47d45912d1",
+    "fullUrl" : "Practitioner/1674159430606441000.a189462a-e17d-4e74-b54a-28168fc0ab88",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985379781000.11cdf0e6-11ce-48fa-a5b8-be47d45912d1",
+      "id" : "1674159430606441000.a189462a-e17d-4e74-b54a-28168fc0ab88",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2110,10 +2107,10 @@
       "identifier" : [ { } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985381337000.b2fddff5-5b37-42b2-8cb7-3e07e2d5f51a",
+    "fullUrl" : "Practitioner/1674159430607878000.ff406cc8-4cb8-471d-9ff9-a11fb4a47c3c",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985381337000.b2fddff5-5b37-42b2-8cb7-3e07e2d5f51a",
+      "id" : "1674159430607878000.ff406cc8-4cb8-471d-9ff9-a11fb4a47c3c",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2148,10 +2145,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1673379985384226000.79ee939d-74c8-4564-b0ab-6a6ac7746b50",
+    "fullUrl" : "Organization/1674159430610171000.bc10528e-9bdc-4ed2-a85e-9b146f09cd7d",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1673379985384226000.79ee939d-74c8-4564-b0ab-6a6ac7746b50",
+      "id" : "1674159430610171000.bc10528e-9bdc-4ed2-a85e-9b146f09cd7d",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2205,10 +2202,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "PractitionerRole/1673379985384387000.e7652e92-9648-4d0d-bfd6-e3d919e1ea01",
+    "fullUrl" : "PractitionerRole/1674159430610280000.29e9f2c5-ba07-4d94-9eaf-cc6088a238ad",
     "resource" : {
       "resourceType" : "PractitionerRole",
-      "id" : "1673379985384387000.e7652e92-9648-4d0d-bfd6-e3d919e1ea01",
+      "id" : "1674159430610280000.29e9f2c5-ba07-4d94-9eaf-cc6088a238ad",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2224,17 +2221,17 @@
         } ]
       },
       "practitioner" : {
-        "reference" : "Practitioner/1673379985381337000.b2fddff5-5b37-42b2-8cb7-3e07e2d5f51a"
+        "reference" : "Practitioner/1674159430607878000.ff406cc8-4cb8-471d-9ff9-a11fb4a47c3c"
       },
       "organization" : {
-        "reference" : "Organization/1673379985384226000.79ee939d-74c8-4564-b0ab-6a6ac7746b50"
+        "reference" : "Organization/1674159430610171000.bc10528e-9bdc-4ed2-a85e-9b146f09cd7d"
       }
     }
   }, {
-    "fullUrl" : "ServiceRequest/1673379985380189000.dc3dec13-8ce0-473f-a6e1-24cc28ca69c2",
+    "fullUrl" : "ServiceRequest/1674159430606825000.847f5ad7-de79-43ac-a24b-0b750fb08938",
     "resource" : {
       "resourceType" : "ServiceRequest",
-      "id" : "1673379985380189000.dc3dec13-8ce0-473f-a6e1-24cc28ca69c2",
+      "id" : "1674159430606825000.847f5ad7-de79-43ac-a24b-0b750fb08938",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2261,7 +2258,7 @@
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
         "valueReference" : {
-          "reference" : "Practitioner/1673379985379781000.11cdf0e6-11ce-48fa-a5b8-be47d45912d1"
+          "reference" : "Practitioner/1674159430606441000.a189462a-e17d-4e74-b54a-28168fc0ab88"
         }
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entering-organization",
@@ -2350,19 +2347,19 @@
         "text" : "Influenza virus B RNA [Presence] in Unspecified specimen by NAA with probe detection"
       },
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "occurrenceDateTime" : "2022-06-21T13:36:00Z",
       "authoredOn" : "2022-08-03T04:07:00Z",
       "requester" : {
-        "reference" : "PractitionerRole/1673379985384387000.e7652e92-9648-4d0d-bfd6-e3d919e1ea01"
+        "reference" : "PractitionerRole/1674159430610280000.29e9f2c5-ba07-4d94-9eaf-cc6088a238ad"
       }
     }
   }, {
-    "fullUrl" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6",
+    "fullUrl" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934",
     "resource" : {
       "resourceType" : "Patient",
-      "id" : "1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6",
+      "id" : "1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934",
       "meta" : {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
@@ -2546,10 +2543,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Encounter/1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4",
+    "fullUrl" : "Encounter/1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438",
     "resource" : {
       "resourceType" : "Encounter",
-      "id" : "1673379985107178000.ed7dd502-90b4-4a06-8b04-b82bfa8c64d4",
+      "id" : "1674159430351942000.ba81249d-bb08-4a2b-aec8-0527b5c3b438",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2595,7 +2592,7 @@
         } ]
       } ],
       "subject" : {
-        "reference" : "Patient/1673379985096710000.815171ee-260d-4b52-a905-aa0951a242b6"
+        "reference" : "Patient/1674159430342604000.36474c70-bbe3-4034-bd60-449ffe4fa934"
       },
       "participant" : [ {
         "type" : [ {
@@ -2606,7 +2603,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379985104672000.420bb60b-d1aa-4070-ae05-12722821403f"
+          "reference" : "Practitioner/1674159430350038000.3a484844-12b4-46c7-8460-8ca2364fc9d4"
         }
       }, {
         "type" : [ {
@@ -2617,7 +2614,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379985106550000.684a367b-5fb6-4689-b4c3-40b3a6a1634d"
+          "reference" : "Practitioner/1674159430351559000.e8d7e6ce-a22c-4a22-b6f8-075a1fd4f813"
         }
       }, {
         "type" : [ {
@@ -2628,7 +2625,7 @@
           } ]
         } ],
         "individual" : {
-          "reference" : "Practitioner/1673379985108380000.16ebffe3-63c2-47de-8e9c-a806fef9948f"
+          "reference" : "Practitioner/1674159430353246000.2782251b-773b-412d-87d1-1954443abb0c"
         }
       } ],
       "hospitalization" : {
@@ -2640,16 +2637,16 @@
       },
       "location" : [ {
         "location" : {
-          "reference" : "Location/1673379985140365000.2c780cdf-4289-42e6-9060-f4bf0868a905"
+          "reference" : "Location/1674159430387193000.1ccb40a2-8b55-4775-9867-d57909714889"
         },
         "status" : "active"
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985104672000.420bb60b-d1aa-4070-ae05-12722821403f",
+    "fullUrl" : "Practitioner/1674159430350038000.3a484844-12b4-46c7-8460-8ca2364fc9d4",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985104672000.420bb60b-d1aa-4070-ae05-12722821403f",
+      "id" : "1674159430350038000.3a484844-12b4-46c7-8460-8ca2364fc9d4",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2671,10 +2668,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985106550000.684a367b-5fb6-4689-b4c3-40b3a6a1634d",
+    "fullUrl" : "Practitioner/1674159430351559000.e8d7e6ce-a22c-4a22-b6f8-075a1fd4f813",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985106550000.684a367b-5fb6-4689-b4c3-40b3a6a1634d",
+      "id" : "1674159430351559000.e8d7e6ce-a22c-4a22-b6f8-075a1fd4f813",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2696,10 +2693,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Practitioner/1673379985108380000.16ebffe3-63c2-47de-8e9c-a806fef9948f",
+    "fullUrl" : "Practitioner/1674159430353246000.2782251b-773b-412d-87d1-1954443abb0c",
     "resource" : {
       "resourceType" : "Practitioner",
-      "id" : "1673379985108380000.16ebffe3-63c2-47de-8e9c-a806fef9948f",
+      "id" : "1674159430353246000.2782251b-773b-412d-87d1-1954443abb0c",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
@@ -2721,10 +2718,10 @@
       } ]
     }
   }, {
-    "fullUrl" : "Location/1673379985140365000.2c780cdf-4289-42e6-9060-f4bf0868a905",
+    "fullUrl" : "Location/1674159430387193000.1ccb40a2-8b55-4775-9867-d57909714889",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1673379985140365000.2c780cdf-4289-42e6-9060-f4bf0868a905",
+      "id" : "1674159430387193000.1ccb40a2-8b55-4775-9867-d57909714889",
       "meta" : {
         "extension" : [ {
           "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",


### PR DESCRIPTION
This PR updates the Service Request and Diagnostic Report resources from the HL7 v2 OBR segment using the latest HL7 v2 to FHIR mapping documents. It also added some mapping between OBR and the Specimen resource.

[Updated mapping documents for OBR](https://cdc.sharepoint.com/:x:/r/teams/USDSatCDC/_layouts/15/Doc.aspx?sourcedoc=%7B3FE6736B-8FD5-48D0-8908-F2D2E323B952%7D&file=HL7%20to%20FHIR%20-%20OBR%20Segment.xlsx&action=default&mobileredirect=true&cid=e4c27b8f-bd2e-43f6-a5c5-877a9941c36a), copy of file attached:
[HL7 to FHIR - OBR Segment.xlsx](https://github.com/CDCgov/prime-reportstream/files/10460810/HL7.to.FHIR.-.OBR.Segment.xlsx)



Test Steps:

1. Build this branch and run the unit and integration tests. Verify they all pass. Alternatively you can verify the Github Actions build passes. Note the HL7 to FHIR to HL7 integration test data was not changed, so the result of our HL7 to FHIR to HL7 conversion remains the same = no data changes.

## Changes
- Updated HL7 v2 to FHIR mappings
- Updated FHIR files in integrations tests

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

## Linked Issues
- Fixes #7566
