### PR TITLE
change staging to look at restore2 when using old FQDN

### DIFF
--- a/operations/dnsmasq/config/staging/hosts.local
+++ b/operations/dnsmasq/config/staging/hosts.local
@@ -13,9 +13,11 @@
 # Databases #
 #############
 
-10.0.5.17 pdhstaging-pgsql.postgres.database.azure.com pdhstaging-pgsql.privatelink.postgres.database.azure.com
-10.1.5.5  pdhstaging-pgsql-replica.postgres.database.azure.com pdhstaging-pgsql-replica.privatelink.postgres.database.azure.com
-
+#Temp change to make them point at restore2
+#10.0.5.17 pdhstaging-pgsql.postgres.database.azure.com pdhstaging-pgsql.privatelink.postgres.database.azure.com
+#10.1.5.5  pdhstaging-pgsql-replica.postgres.database.azure.com pdhstaging-pgsql-replica.privatelink.postgres.database.azure.com
+10.0.5.14 pdhstaging-pgsql.postgres.database.azure.com pdhstaging-pgsql.privatelink.postgres.database.azure.com
+10.1.5.14  pdhstaging-pgsql-replica.postgres.database.azure.com pdhstaging-pgsql-replica.privatelink.postgres.database.azure.com
 
 ####################
 # Storage Accounts #


### PR DESCRIPTION
Quick change so VPN users will resolve the _old_ DB's FQDN to restore2. This should allow them to run prime test without changing scripts etc.