### PR TITLE
Experience-7948: Update validate API endpoint to allow Senders to specify schemas

### DIFF
--- a/prime-router/src/main/kotlin/azure/RequestFunction.kt
+++ b/prime-router/src/main/kotlin/azure/RequestFunction.kt
@@ -181,7 +181,7 @@ abstract class RequestFunction(
      */
     @Throws(InvalidParameterException::class)
     internal fun getDummySender(schemaName: String?, formatName: String?): TopicSender {
-        val errMsgPrefix = "No client found in header so expected valid " +
+        val errMsgPrefix = "Expected valid " +
             "'$SCHEMA_PARAMETER' and '$FORMAT_PARAMETER' query parameters but found error: "
         if (schemaName != null && formatName != null) {
             val schema = workflowEngine.metadata.findSchema(schemaName)
@@ -200,7 +200,7 @@ abstract class RequestFunction(
                 schema.topic
             )
         } else {
-            throw InvalidParameterException("$errMsgPrefix 'SchemaName' and 'format' parameters must not be null")
+            throw InvalidParameterException("$errMsgPrefix 'schema' and 'format' parameters must not be null")
         }
     }
 }

--- a/prime-router/src/main/kotlin/azure/ValidateFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ValidateFunction.kt
@@ -74,24 +74,22 @@ class ValidateFunction(
                 }
             }
 
-            if (sender == null) {
-                sender =
-                    try {
-                        getDummySender(schema, format)
-                    } catch (e: InvalidParameterException) {
-                        return HttpUtilities.bad(request, e.message.toString())
-                    }
-            }
+            sender = sender ?: getDummySender(schema, format)
 
             actionHistory.trackActionParams(request)
-            processRequest(request, sender as Sender)
+            processRequest(request, sender)
         } catch (ex: Exception) {
-            if (ex.message != null) {
-                logger.error(ex.message!!, ex)
-            } else {
-                logger.error(ex)
+            when (ex) {
+                is InvalidParameterException -> HttpUtilities.bad(request, ex.message.toString())
+                else -> {
+                    if (ex.message != null) {
+                        logger.error(ex.message!!, ex)
+                    } else {
+                        logger.error(ex)
+                    }
+                    HttpUtilities.internalErrorResponse(request)
+                }
             }
-            HttpUtilities.internalErrorResponse(request)
         }
     }
 


### PR DESCRIPTION
This changeset updates the `validate` endpoint to allow Senders to specify schemas.  The use case here is that we want to let authenticated Senders validate against their predefined schemas but also to validate against one of the three master schemas (CSV, CSV OTC, HL7) that will be provided as options on the front end.  This required a bit of reworking around when to use the real Sender versus the dummy Sender:

Use a dummy Sender when:
- `client` is not provided
- `client`, `schema`, and `format` are all provided but don't match up with Sender settings

Use a real Sender when:
- only `client` is provided (backwards compatibility with current functionality)
- `client`, `schema`, and `format` are all provided and match up with Sender settings

The reason for this is that we're still abiding by Sender-specific settings during validation (specifically around [`allowDuplicates`](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/src/main/kotlin/azure/ValidateFunction.kt#L100)), and we need to pull in the real Sender settings for that.  Otherwise, there'd be different error responses between this flow and the actual upload to send, which would be poor UX and would kind of defeat the point of this feature.  I also considered two other options to account for this, but they wouldn't work out as far as I know:

- Always use the dummy Sender.  This would simplify a lot of logic, but it'd bypass Sender-specific settings needed during validation.
- Pull in a Sender by the specified schema.  I don't think would actually be the right move because we're not indexing on `values.schema`/`values.format` on the `setting` table so we can't guarantee that we'd only get one unique Sender per pair.  Plus, there'd be potential performance implications since there isn't an index there -- not a huge deal at the moment since we have <3000 records in the `setting` table now (I think), but still not a scalable solution.

If anyone has any suggestions, I'm all ears!

To test this out:
- Call the endpoint with matching `client`, `schema`, and `format` --> ensure that the validation is running against the real Sender (can flip `allowDuplicates` as a way to check)
- Call the endpoint with only `client` --> ensure that the validation is running against the real Sender
- Call the endpoint with mismatched `client`, `schema`, and `format` --> ensure that the validation is running against the dummy Sender
- Call the endpoint with only `schema` and `format` --> ensure that the validation is running against the dummy Sender

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
<strike>- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? </strike>
- [x] Added tests?

## Linked Issues
- Fixes #7948 