### PR TITLE
Create ITEM table and link to related tables

### DIFF
--- a/prime-router/src/main/kotlin/Report.kt
+++ b/prime-router/src/main/kotlin/Report.kt
@@ -1422,7 +1422,8 @@ class Report : Logging {
                     grandParentTrackingValue,
                     null,
                     null,
-                    itemHash
+                    itemHash,
+                    null
                 )
             } else {
                 val trackingElementValue =
@@ -1436,7 +1437,8 @@ class Report : Logging {
                     trackingElementValue,
                     null,
                     null,
-                    itemHash
+                    itemHash,
+                    null
                 )
             }
         }
@@ -1467,7 +1469,8 @@ class Report : Logging {
                         it.trackingId,
                         it.transportResult,
                         null,
-                        it.itemHash
+                        it.itemHash,
+                        null
                     )
             }
             val retval = mutableListOf<ItemLineage>()

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -84,7 +84,8 @@ class FHIRConverter(
                         null,
                         null,
                         null,
-                        report.getItemHashForRow(1)
+                        report.getItemHashForRow(1),
+                        null
                     )
                 )
 

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRRouter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRRouter.kt
@@ -218,7 +218,8 @@ class FHIRRouter(
                     null,
                     null,
                     null,
-                    report.getItemHashForRow(1)
+                    report.getItemHashForRow(1),
+                    null
                 )
             )
 

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7MessageHelpers.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7MessageHelpers.kt
@@ -59,7 +59,8 @@ object HL7MessageHelpers : Logging {
                 null,
                 null,
                 null,
-                "0" // Hash is only used for deduplication when receiving
+                "0", // Hash is only used for deduplication when receiving
+                null
             )
         }
 

--- a/prime-router/src/main/resources/db/migration/V61__create_item_table.sql
+++ b/prime-router/src/main/resources/db/migration/V61__create_item_table.sql
@@ -1,0 +1,36 @@
+/*
+This SQL creates the tables of the DB. The Flyway tool applies this migration to create the database
+
+Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+use VARCHAR(63) for names in organization and schema
+
+Copy a version of this comment into the next migration
+*/
+
+/*
+    An item can be a covid test result or any other message (HL7 v2), row (CSV), bundle (FHIR), et. al.
+*/
+CREATE TABLE item (
+    -- Key
+                            id SERIAL PRIMARY KEY,
+
+    -- Value
+                            report_id UUID,
+                            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    -- Foreign Key
+                            CONSTRAINT report_id
+                                FOREIGN KEY(report_id)
+                                REFERENCES report_file(report_id)
+);
+
+/*
+    Add FK references to ITEM table in related tables
+ */
+ALTER TABLE item_lineage ADD COLUMN item_id INT
+    CONSTRAINT item_lineage_item_id_fkey REFERENCES item (id);
+
+ALTER TABLE covid_result_metadata ADD COLUMN item_id INT
+    CONSTRAINT covid_result_metadata_item_id_fkey REFERENCES item (id);
+
+ALTER TABLE elr_result_metadata ADD COLUMN item_id INT
+    CONSTRAINT elr_result_metadata_item_id_fkey REFERENCES item (id);

--- a/prime-router/src/test/kotlin/azure/MessagesFunctionsTests.kt
+++ b/prime-router/src/test/kotlin/azure/MessagesFunctionsTests.kt
@@ -85,6 +85,7 @@ class MessagesFunctionsTests {
             null,
             null,
             null,
+            null,
             null
         )
     }

--- a/prime-router/src/test/kotlin/azure/SenderFilesFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/SenderFilesFunctionTests.kt
@@ -119,6 +119,7 @@ class SenderFilesFunctionTests {
             null,
             null,
             null,
+            null,
             null
         )
     }


### PR DESCRIPTION
Create a new `item` table in the database and links it to `report_file`, `covid_result_metadata`, and `elr_result_metadata`. This should help us implement a non-covid-specific message tracker API, as well as possibly simplifying queries like `report_facilities(UUID)`

Test Steps:
1. run `./gradlew clean package` and verify migration passes

## Changes
- Create `item` table and its relationships
- Wherever the POJOs are used, pass `null` for the item id, for now

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #8032 

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #8147
- #8033