### PR TITLE
8129 Turn Utah Blue on the public map

### DIFF
--- a/frontend-react/src/content/live.json
+++ b/frontend-react/src/content/live.json
@@ -128,10 +128,10 @@
       "status": "Live",
       "state": "Texas"
     },
-      {
-          "status": "Live",
-          "state": "Utah"
-      },
+    {
+      "status": "Live",
+      "state": "Utah"
+    },
     {
       "status": "Live",
       "state": "Vermont"

--- a/frontend-react/src/content/live.json
+++ b/frontend-react/src/content/live.json
@@ -128,6 +128,10 @@
       "status": "Live",
       "state": "Texas"
     },
+      {
+          "status": "Live",
+          "state": "Utah"
+      },
     {
       "status": "Live",
       "state": "Vermont"

--- a/frontend-react/src/content/usa_w_territories.svg
+++ b/frontend-react/src/content/usa_w_territories.svg
@@ -59,7 +59,7 @@
     .tn, /* Tennessee */
     /* .tt, Trust Territories */
     .tx, /* Texas */
-    /* .ut, Utah */
+    .ut, /* Utah */
     /* .va, Virginia */
     /* .vi, Virgin Islands */
     .vt, /* Vermont */


### PR DESCRIPTION
This PR ...

Turns Utah Blue on the public map

Test Steps:
1. In RS, navigate to Product -> Where we're live
2. See that Utah is listed and the state is blue on the map

## Changes
![Screenshot 2023-02-03 at 3 24 29 PM](https://user-images.githubusercontent.com/102491809/216729494-a9262ada-eaac-4a82-a8b1-c40486c8b59d.png)
![Screenshot 2023-02-03 at 3 24 36 PM](https://user-images.githubusercontent.com/102491809/216729495-a31b8bee-78fa-49ce-b934-b89b270203cd.png)


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?
