### PR TITLE
Experience-7773: Add schema dropdown on validator page

### DIFF
--- a/frontend-react/src/components/FileHandlers/FileHandler.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandler.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { showError } from "../AlertNotifications";
 import { useSessionContext } from "../../contexts/SessionContext";
-import { useSenderResource } from "../../hooks/UseSenderResource";
 import { OverallStatus, WatersResponse } from "../../config/endpoints/waters";
 import Spinner from "../Spinner"; // TODO: refactor to use suspense
 import useFileHandler, {
@@ -12,18 +11,20 @@ import useFileHandler, {
 } from "../../hooks/UseFileHandler";
 import { parseCsvForError } from "../../utils/FileUtils";
 import { useWatersUploader } from "../../hooks/network/WatersHooks";
-import { NoServicesBanner } from "../alerts/NoServicesAlert";
 import { useOrganizationSettings } from "../../hooks/UseOrganizationSettings";
 import { EventName, trackAppInsightEvent } from "../../utils/Analytics";
+import useSenderSchemaOptions from "../../senders/hooks/UseSenderSchemaOptions";
+import { useSenderResource } from "../../hooks/UseSenderResource";
+import { RSSender } from "../../config/endpoints/settings";
+import { MembershipSettings } from "../../hooks/UseOktaMemberships";
 
+import { FileHandlerForm } from "./FileHandlerForm";
 import {
     RequestLevel,
     FileQualityFilterDisplay,
     FileSuccessDisplay,
-    FileWarningBanner,
     RequestedChangesDisplay,
 } from "./FileHandlerMessaging";
-import { FileHandlerForm } from "./FileHandlerForm";
 
 const FileHandlerSpinner = ({ message }: { message: string }) => (
     <div className="grid-col flex-1 display-flex flex-column flex-align-center margin-top-4">
@@ -47,25 +48,48 @@ const errorMessagingMap = {
     },
 };
 
-interface FileHandlerProps {
-    headingText: string;
-    successMessage: string;
-    resetText: string;
-    submitText: string;
-    showSuccessMetadata: boolean;
-    showWarningBanner: boolean;
-    warningText?: string;
+export const SUCCESS_DESCRIPTIONS = {
+    [FileType.CSV]: "The file meets the standard CSV schema.",
+    [FileType.HL7]:
+        "The file meets the ReportStream standard HL7 v2.5.1 schema.",
+};
+
+export const UPLOAD_PROMPT_DESCRIPTIONS = {
+    [FileType.CSV]:
+        "Select a CSV formatted file to validate. Make sure that your file has a .csv extension.",
+    [FileType.HL7]:
+        "Select an HL7 v2.5.1 formatted file to validate. Make sure that your file has a .hl7 extension.",
+};
+
+/**
+ * Given a user's membership settings and their Sender details,
+ * return the client string to send to the validate endpoint
+ *
+ * Only send the client when the selected schema matches the Sender's schema --
+ * this is to account for factoring in Sender settings into the validation
+ * e.g., allowDuplicates in https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/src/main/kotlin/azure/ValidateFunction.kt#L100
+ *
+ * @param selectedSchemaName { string | undefined }
+ * @param activeMembership { MembershipSettings | undefined}
+ * @param sender { RSSender | undefined }
+ * @returns {string} The value sent as the client header (can be a blank string)
+ */
+export function getClientHeader(
+    selectedSchemaName: string | undefined,
+    activeMembership: MembershipSettings | null | undefined,
+    sender: RSSender | undefined
+) {
+    const parsedName = activeMembership?.parsedName;
+    const senderName = activeMembership?.service;
+
+    if (parsedName && senderName && sender?.schemaName === selectedSchemaName) {
+        return `${parsedName}.${senderName}`;
+    }
+
+    return "";
 }
 
-const FileHandler = ({
-    headingText,
-    successMessage,
-    resetText,
-    submitText,
-    showSuccessMetadata,
-    showWarningBanner,
-    warningText,
-}: FileHandlerProps) => {
+function FileHandler() {
     const { state, dispatch } = useFileHandler();
     const [fileContent, setFileContent] = useState("");
 
@@ -84,6 +108,7 @@ const FileHandler = ({
         localError,
         overallStatus,
         reportItems,
+        selectedSchemaOption,
     } = state;
 
     useEffect(() => {
@@ -93,15 +118,12 @@ const FileHandler = ({
     }, [localError]);
 
     const { activeMembership } = useSessionContext();
+    const { senderDetail } = useSenderResource();
     // TODO: Transition from isLoading to Suspense component
-    const { data: organization, isLoading: organizationLoading } =
-        useOrganizationSettings();
-    // need to fetch sender from API to grab cvs vs hl7 format info
-    const { senderDetail: sender, senderIsLoading } = useSenderResource();
+    const { data: organization } = useOrganizationSettings();
+    const { schemaOptions, isLoading: isSenderSchemaOptionsLoading } =
+        useSenderSchemaOptions();
 
-    const parsedName = activeMembership?.parsedName;
-    const senderName = activeMembership?.service;
-    const client = `${parsedName}.${senderName}`;
     const uploaderCallback = useCallback(
         (data?: WatersResponse) => {
             dispatch({
@@ -149,7 +171,12 @@ const FileHandler = ({
         event.preventDefault();
 
         if (fileContent.length === 0) {
-            showError(`No File Contents To ${submitText}`);
+            showError("No file contents to validate");
+            return;
+        }
+
+        if (!selectedSchemaOption) {
+            showError("No schema selected");
             return;
         }
 
@@ -163,7 +190,13 @@ const FileHandler = ({
                 contentType: contentType,
                 fileContent: fileContent,
                 fileName: fileName,
-                client: client,
+                client: getClientHeader(
+                    selectedSchemaOption.value,
+                    activeMembership,
+                    senderDetail
+                ),
+                schema: selectedSchemaOption.value,
+                format: selectedSchemaOption.format,
             });
 
             eventData = {
@@ -182,7 +215,7 @@ const FileHandler = ({
         if (eventData) {
             trackAppInsightEvent(EventName.FILE_VALIDATOR, {
                 fileValidator: {
-                    schema: sender?.schemaName,
+                    schema: selectedSchemaOption?.value,
                     fileType: fileType,
                     sender: organization?.name,
                     ...eventData,
@@ -196,40 +229,21 @@ const FileHandler = ({
         dispatch({ type: FileHandlerActionType.RESET });
     };
 
-    const submitted = useMemo(
-        () => !!(reportId || errors.length || overallStatus),
-        [reportId, errors.length, overallStatus]
-    );
-
-    const successDescription =
-        fileType === FileType.HL7
-            ? "The file meets the ReportStream standard HL7 v2.5.1 schema."
-            : "The file meets the standard CSV schema.";
-
-    const warningHeading = `${successMessage} with recommended edits`;
-
-    const warningDescription =
-        "The following warnings were returned while processing your file. We recommend addressing warnings to enhance clarity.";
+    const submitted = !!(reportId || errors.length || overallStatus);
 
     // default to FILE messaging here, partly to simplify typecheck
-    const errorMessaging = useMemo(
-        () => errorMessagingMap[errorType || ErrorType.FILE],
-        [errorType]
-    );
+    const errorMessaging = errorMessagingMap[errorType || ErrorType.FILE];
 
-    const formLabel = useMemo(() => {
-        if (!sender) {
-            return "";
-        }
-        const fileTypeDescription =
-            sender.format === "CSV" ? "a CSV" : "an HL7 v2.5.1";
-        return `Select ${fileTypeDescription} formatted file to ${submitText.toLowerCase()}. Make sure that your file has a .${sender.format.toLowerCase()} extension.`;
-    }, [sender, submitText]);
+    let formLabel = "";
+    let successDescription = "";
+    if (selectedSchemaOption) {
+        formLabel = UPLOAD_PROMPT_DESCRIPTIONS[selectedSchemaOption.format];
+        successDescription = SUCCESS_DESCRIPTIONS[selectedSchemaOption.format];
+    }
 
     // Array containing only qualityFilterMessages that have filteredReportItems.
-    const qualityFilterMessages = useMemo(
-        () => reportItems?.filter((d) => d.filteredReportItems.length > 0),
-        [reportItems]
+    const qualityFilterMessages = reportItems?.filter(
+        (d) => d.filteredReportItems.length > 0
     );
 
     const hasQualityFilterMessages =
@@ -241,26 +255,15 @@ const FileHandler = ({
         (reportId || overallStatus === OverallStatus.VALID) &&
         !hasQualityFilterMessages;
 
-    if (senderIsLoading || organizationLoading) {
+    if (isSenderSchemaOptionsLoading) {
         return <FileHandlerSpinner message="Loading..." />;
-    }
-
-    if (!sender) {
-        return (
-            <div className="grid-container usa-section margin-bottom-10">
-                <h1 className="margin-top-0 margin-bottom-5">{headingText}</h1>
-                <h2 className="font-sans-lg">{organization?.description}</h2>
-                <NoServicesBanner
-                    organization={organization?.description}
-                    serviceType={"sender"}
-                />
-            </div>
-        );
     }
 
     return (
         <div className="grid-container usa-section margin-bottom-10">
-            <h1 className="margin-top-0 margin-bottom-5">{headingText}</h1>
+            <h1 className="margin-top-0 margin-bottom-5">
+                ReportStream File Validator
+            </h1>
             <h2 className="font-sans-lg">{organization?.description}</h2>
             {fileName && (
                 <>
@@ -273,9 +276,6 @@ const FileHandler = ({
                     <p className="margin-top-05">{fileName}</p>
                 </>
             )}
-            {showWarningBanner && (
-                <FileWarningBanner message={warningText || ""} />
-            )}
             {isFileSuccess && warnings.length === 0 && (
                 <FileSuccessDisplay
                     extendedMetadata={{
@@ -283,17 +283,17 @@ const FileHandler = ({
                         timestamp: successTimestamp,
                         reportId,
                     }}
-                    heading={successMessage}
+                    heading="Validate another file"
                     message={successDescription}
-                    showExtendedMetadata={showSuccessMetadata}
+                    showExtendedMetadata={false}
                 />
             )}
             {warnings.length > 0 && (
                 <RequestedChangesDisplay
                     title={RequestLevel.WARNING}
                     data={warnings}
-                    message={warningDescription}
-                    heading={warningHeading}
+                    message="The following warnings were returned while processing your file. We recommend addressing warnings to enhance clarity."
+                    heading="File validated with recommended edits"
                 />
             )}
             {errors.length > 0 && (
@@ -321,13 +321,22 @@ const FileHandler = ({
                     submitted={submitted}
                     cancellable={cancellable}
                     fileName={fileName}
+                    fileType={fileType}
                     formLabel={formLabel}
-                    resetText={resetText}
-                    submitText={submitText}
+                    resetText="Validate another file"
+                    submitText="Validate"
+                    schemaOptions={schemaOptions}
+                    selectedSchemaOption={selectedSchemaOption}
+                    onSchemaChange={(schemaOption) =>
+                        dispatch({
+                            type: FileHandlerActionType.SCHEMA_SELECTED,
+                            payload: schemaOption,
+                        })
+                    }
                 />
             )}
         </div>
     );
-};
+}
 
 export default FileHandler;

--- a/frontend-react/src/components/FileHandlers/FileHandlerForm.test.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandlerForm.test.tsx
@@ -1,110 +1,135 @@
 import { screen, fireEvent } from "@testing-library/react";
 
 import { renderWithBase } from "../../utils/CustomRenderUtils";
+import { STANDARD_SCHEMA_OPTIONS } from "../../senders/hooks/UseSenderSchemaOptions";
+import { FileType } from "../../hooks/UseFileHandler";
 
-import { FileHandlerForm } from "./FileHandlerForm";
+import { FileHandlerForm, FileHandlerFormProps } from "./FileHandlerForm";
 
 describe("FileHandlerForm", () => {
-    test("renders proper submitted, cancellable state", async () => {
-        const resetSpy = jest.fn();
-        renderWithBase(
-            <FileHandlerForm
-                handleSubmit={() => {}}
-                handleFileChange={() => {}}
-                resetState={resetSpy}
-                fileInputResetValue={0}
-                submitted={true}
-                cancellable={true}
-                fileName="any"
-                formLabel="any"
-                resetText="any"
-                submitText="any"
-            />
+    const DEFAULT_PROPS: FileHandlerFormProps = {
+        handleSubmit: () => {},
+        handleFileChange: () => {},
+        resetState: () => {},
+        fileInputResetValue: 0,
+        submitted: false,
+        cancellable: true,
+        fileName: "file.file",
+        formLabel: "Label",
+        resetText: "Reset",
+        submitText: "Submit",
+        schemaOptions: STANDARD_SCHEMA_OPTIONS,
+        selectedSchemaOption: null,
+        onSchemaChange: () => {},
+    };
+
+    function doRender(props: Partial<FileHandlerFormProps> = {}) {
+        return renderWithBase(
+            <FileHandlerForm {...DEFAULT_PROPS} {...props} />
         );
+    }
 
-        // this is to make sure that after the form is submitted that we remove the input
-        // this test id is added by trussworks, so... hopefully they don't change it?
-        const input = screen.queryByTestId("file-input-input");
-        expect(input).not.toBeInTheDocument();
-
-        const cancelButton = await screen.findByText("Cancel");
-        expect(cancelButton).toHaveAttribute("type", "button");
-
-        fireEvent.click(cancelButton);
-
-        expect(resetSpy).toHaveBeenCalledTimes(1);
-    });
-
-    // going to go ahead and deal with testing handlers here as well, in one big test
-    test("renders proper unsubmitted default state, including handler behavior", async () => {
-        const resetSpy = jest.fn();
+    describe("when unsubmitted (default state)", () => {
         const submitSpy = jest.fn((e) => e.preventDefault()); // to prevent error message in console
         const fileChangeSpy = jest.fn();
 
-        renderWithBase(
-            <FileHandlerForm
-                handleSubmit={submitSpy}
-                handleFileChange={fileChangeSpy}
-                resetState={resetSpy}
-                fileInputResetValue={0}
-                submitted={false}
-                cancellable={false}
-                fileName="file.file"
-                formLabel="somebody's form label"
-                resetText="any"
-                submitText="CLICK HERE"
-            />
-        );
+        beforeEach(() => {
+            doRender({
+                submitted: false,
+                handleSubmit: submitSpy,
+                handleFileChange: fileChangeSpy,
+            });
+        });
 
-        // make sure basic elements are present
-        const input = await screen.findByTestId("file-input-input"); //
-        expect(input).toBeInTheDocument();
+        test("renders the input", () => {
+            expect(screen.getByTestId("file-input-input")).toBeVisible();
+        });
 
-        const label = await screen.findByTestId("label");
-        expect(label).toHaveTextContent("somebody's form label");
-
-        const submitButton = await screen.findByText("CLICK HERE");
-        expect(submitButton).toHaveAttribute("type", "submit");
-
-        // test file change
-        fireEvent.change(input /*, fileChangeEvent */);
-
-        expect(fileChangeSpy).toHaveBeenCalledTimes(1);
-
-        // // For some reason this comes through with a null currentTarget
-        // // I feel like it's going to be very hard to get this to work, so skipping for now
-        // expect(fileChangeSpy).toHaveBeenCalledWith(
-        //     expect.objectContaining(fileChangeEvent)
-        // );
-
-        fireEvent.click(submitButton);
-        expect(submitSpy).toHaveBeenCalledTimes(1);
+        test("renders the schema options", () => {
+            STANDARD_SCHEMA_OPTIONS.forEach(({ title }) => {
+                expect(screen.getByText(title)).toBeVisible();
+            });
+        });
     });
 
-    test("renders a reset button instead of submit button when submitted", async () => {
+    describe("when submitted", () => {
+        beforeEach(() => {
+            doRender({
+                submitted: true,
+            });
+        });
+
+        test("renders a reset button instead of a submit button", () => {
+            expect(screen.getByText("Reset")).toBeVisible();
+            expect(screen.queryByText("Submit")).not.toBeInTheDocument();
+        });
+
+        test("omits the file input", () => {
+            // this is to make sure that after the form is submitted that we remove the input
+            // this test id is added by trussworks, so... hopefully they don't change it?
+            const input = screen.queryByTestId("file-input-input");
+            expect(input).not.toBeInTheDocument();
+        });
+    });
+
+    describe("when cancellable", () => {
         const resetSpy = jest.fn();
-        const submitSpy = jest.fn();
-        const fileChangeSpy = jest.fn();
-        renderWithBase(
-            <FileHandlerForm
-                handleSubmit={submitSpy}
-                handleFileChange={fileChangeSpy}
-                resetState={resetSpy}
-                fileInputResetValue={0}
-                submitted={true}
-                cancellable={false}
-                fileName="file.file"
-                formLabel="somebody's form label"
-                resetText="CLICK HERE"
-                submitText=""
-            />
-        );
 
-        const resetButton = await screen.findByText("CLICK HERE");
-        expect(resetButton).toHaveAttribute("type", "button");
+        beforeEach(() => {
+            doRender({
+                cancellable: true,
+                resetState: resetSpy,
+            });
+        });
 
-        fireEvent.click(resetButton);
+        describe("when clicking cancel", () => {
+            beforeEach(() => {
+                const cancelButton = screen.getByText("Cancel");
+                expect(cancelButton).toHaveAttribute("type", "button");
 
-        expect(resetSpy).toHaveBeenCalledTimes(1);
+                fireEvent.click(cancelButton);
+            });
+
+            test("calls the resetState callback", () => {
+                expect(resetSpy).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
+    // NOTE: based on Trussworks data-testid values: https://github.com/trussworks/react-uswds/blob/main/src/components/forms/FileInput/FileInput.tsx#L196
+    describe("with accept values", () => {
+        describe("when a schema option is selected", () => {
+            beforeEach(() => {
+                doRender({
+                    selectedSchemaOption: {
+                        title: "whatever-csv",
+                        value: "whatever-csv",
+                        format: FileType.CSV,
+                    },
+                });
+            });
+
+            test("only allows files from the selected format", () => {
+                expect(screen.getByTestId("file-input-input")).toHaveAttribute(
+                    "accept",
+                    ".csv"
+                );
+            });
+        });
+
+        describe("when a schema option is not selected", () => {
+            beforeEach(() => {
+                doRender({
+                    selectedSchemaOption: null,
+                });
+            });
+
+            test("allows .csv and .hl7 files", () => {
+                expect(screen.getByTestId("file-input-input")).toHaveAttribute(
+                    "accept",
+                    ".csv,.hl7"
+                );
+            });
+        });
     });
 });

--- a/frontend-react/src/components/FileHandlers/FileHandlerForm.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandlerForm.tsx
@@ -1,15 +1,20 @@
-import React from "react";
+import React, { useRef } from "react";
 import {
     Button,
     Form,
     FormGroup,
     Label,
     FileInput,
+    FileInputRef,
+    Dropdown,
 } from "@trussworks/react-uswds";
+
+import { SchemaOption } from "../../senders/hooks/UseSenderSchemaOptions";
+import { FileType } from "../../hooks/UseFileHandler";
 
 import { FileHandlerSubmitButton } from "./FileHandlerButton";
 
-interface FileHandlerFormProps {
+export interface FileHandlerFormProps {
     handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
     handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     resetState: () => void; // to handle resetting any parent state
@@ -17,10 +22,16 @@ interface FileHandlerFormProps {
     submitted: boolean;
     cancellable: boolean;
     fileName: string;
+    fileType?: FileType;
     formLabel: string;
     resetText: string;
     submitText: string;
+    schemaOptions: SchemaOption[];
+    selectedSchemaOption: SchemaOption | null;
+    onSchemaChange: (schemaOption: SchemaOption | null) => void;
 }
+
+const BASE_ACCEPT_VALUE = [".csv", ".hl7"].join(",");
 
 // form for submitting files to the api
 // all state is controlled from above, and necessary elements and control functions are passed in
@@ -32,10 +43,20 @@ export const FileHandlerForm = ({
     submitted,
     cancellable,
     fileName,
+    fileType,
     formLabel,
     resetText,
     submitText,
+    schemaOptions,
+    selectedSchemaOption,
+    onSchemaChange,
 }: FileHandlerFormProps) => {
+    const isDisabled = fileName.length === 0 || !selectedSchemaOption;
+    const fileInputRef = useRef<FileInputRef>(null);
+    const accept = selectedSchemaOption
+        ? `.${selectedSchemaOption.format.toLowerCase()}`
+        : BASE_ACCEPT_VALUE;
+
     return (
         <Form onSubmit={(e) => handleSubmit(e)} className="rs-full-width-form">
             {!submitted && (
@@ -52,8 +73,11 @@ export const FileHandlerForm = ({
                         id="upload-csv-input"
                         name="upload-csv-input"
                         aria-describedby="upload-csv-input-label"
+                        data-testid="upload-csv-input"
                         onChange={(e) => handleFileChange(e)}
                         required
+                        ref={fileInputRef}
+                        accept={accept}
                     />
                 </FormGroup>
             )}
@@ -67,9 +91,35 @@ export const FileHandlerForm = ({
                 </div>
                 <div className="grid-col flex-1" />
                 <div className="grid-col flex-1 display-flex flex-column flex-align-end">
+                    {!submitted && (
+                        <Dropdown
+                            id="upload-schema-select"
+                            name="upload-schema-select"
+                            value={selectedSchemaOption?.value || ""}
+                            onChange={(e) => {
+                                const option =
+                                    schemaOptions.find(
+                                        ({ value }) => value === e.target.value
+                                    ) || null;
+
+                                if (option?.format !== fileType) {
+                                    fileInputRef.current?.clearFiles();
+                                }
+
+                                onSchemaChange(option);
+                            }}
+                        >
+                            <option value="">Select a schema</option>
+                            {schemaOptions.map(({ title, value }) => (
+                                <option key={value} value={value}>
+                                    {title}
+                                </option>
+                            ))}
+                        </Dropdown>
+                    )}
                     <FileHandlerSubmitButton
                         submitted={submitted}
-                        disabled={fileName.length === 0}
+                        disabled={isDisabled}
                         reset={resetState}
                         resetText={resetText}
                         submitText={submitText}

--- a/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandlerMessaging.tsx
@@ -43,6 +43,8 @@ export const FileSuccessDisplay = ({
                 message={message}
             />
             <div>
+                {/* TODO: can probably remove since it's not being used now */}
+
                 {showExtendedMetadata && (
                     <>
                         {reportId && (

--- a/frontend-react/src/hooks/UseCreateFetch.ts
+++ b/frontend-react/src/hooks/UseCreateFetch.ts
@@ -39,20 +39,12 @@ function createTypeWrapperForAuthorizedFetch(
     ): Promise<T> {
         const headerOverrides = options?.headers || {};
         const headers = { ...authHeaders, ...headerOverrides };
-        // this system assumes that we want to be making authenticated
-        // requests whenever possible
-        if (!headers.authorization || headers.authorization.length < 8) {
-            console.warn(
-                `Unauthenticated request to '${EndpointConfig.url}'\n Options:`,
-                options,
-                `\n Endpoint: `,
-                EndpointConfig
-            );
-        }
+
         const axiosConfig = EndpointConfig.toAxiosConfig({
             ...options,
             headers,
         });
+
         return axios(axiosConfig)
             .then(({ data }) => data)
             .catch((e: AxiosError) => {

--- a/frontend-react/src/hooks/UseFileHandler.ts
+++ b/frontend-react/src/hooks/UseFileHandler.ts
@@ -4,6 +4,7 @@ import pick from "lodash.pick";
 import { ResponseError, WatersResponse } from "../config/endpoints/waters";
 import { Destination } from "../resources/ActionDetailsResource";
 import { PAYLOAD_MAX_BYTES, PAYLOAD_MAX_KBYTES } from "../utils/FileUtils";
+import { SchemaOption } from "../senders/hooks/UseSenderSchemaOptions";
 
 export enum ErrorType {
     SERVER = "server",
@@ -37,6 +38,7 @@ export interface FileHandlerState {
     warnings: ResponseError[];
     localError: string;
     overallStatus: string;
+    selectedSchemaOption: SchemaOption | null;
 }
 
 export enum FileHandlerActionType {
@@ -44,6 +46,7 @@ export enum FileHandlerActionType {
     PREPARE_FOR_REQUEST = "PREPARE_FOR_REQUEST",
     FILE_SELECTED = "FILE_SELECTED",
     REQUEST_COMPLETE = "REQUEST_COMPLETE",
+    SCHEMA_SELECTED = "SCHEMA_SELECTED",
 }
 
 export interface RequestCompletePayload {
@@ -54,7 +57,13 @@ interface FileSelectedPayload {
     file: File;
 }
 
-type FileHandlerActionPayload = RequestCompletePayload | FileSelectedPayload;
+type SchemaSelectedPayload = SchemaOption;
+
+type FileHandlerActionPayload =
+    | RequestCompletePayload
+    | FileSelectedPayload
+    | SchemaSelectedPayload
+    | null;
 
 interface FileHandlerAction {
     type: FileHandlerActionType;
@@ -79,6 +88,7 @@ export const INITIAL_STATE = {
     warnings: [],
     localError: "",
     overallStatus: "",
+    selectedSchemaOption: null,
 };
 
 // Currently returning a static object, but leaving this as a function
@@ -223,18 +233,40 @@ function reducer(
                 payload as RequestCompletePayload
             );
             return { ...state, ...requestCompleteState };
+        case FileHandlerActionType.SCHEMA_SELECTED:
+            const selectedSchemaOption = payload as SchemaOption | null;
+
+            // reset anything related to the file if the selected schema format
+            // and the file format don't match
+            if (selectedSchemaOption?.format !== state.fileType) {
+                return {
+                    ...state,
+                    fileContent: "",
+                    fileInputResetValue: state.fileInputResetValue + 1,
+                    fileName: "",
+                    contentType: undefined,
+                    selectedSchemaOption,
+                };
+            }
+
+            return {
+                ...state,
+                selectedSchemaOption,
+            };
         default:
             return state;
     }
 }
 
+export type UseFileHandlerHookResult = {
+    state: FileHandlerState;
+    dispatch: React.Dispatch<FileHandlerAction>;
+};
+
 // this layer of abstraction around the reducer may not be necessary, but following
 // the pattern laid down in UsePagination for now, in case we need to make this more
 // complex later - DWS
-function useFileHandler(): {
-    state: FileHandlerState;
-    dispatch: React.Dispatch<FileHandlerAction>;
-} {
+function useFileHandler(): UseFileHandlerHookResult {
     const [state, dispatch] = useReducer<FileHandlerReducer>(
         reducer,
         getInitialState()

--- a/frontend-react/src/hooks/UseSenderResource.ts
+++ b/frontend-react/src/hooks/UseSenderResource.ts
@@ -5,7 +5,14 @@ import { RSSender, servicesEndpoints } from "../config/endpoints/settings";
 import { useAuthorizedFetch } from "../contexts/AuthorizedFetchContext";
 
 const { senderDetail } = servicesEndpoints;
-export const useSenderResource = () => {
+
+export type UseSenderResourceHookResult = {
+    senderDetail?: RSSender;
+    senderIsLoading: boolean;
+    isInitialLoading: boolean;
+};
+
+export const useSenderResource = (): UseSenderResourceHookResult => {
     const { authorizedFetch, rsUseQuery } = useAuthorizedFetch<RSSender>();
     /* Access the session. */
     const { activeMembership } = useSessionContext();
@@ -23,7 +30,7 @@ export const useSenderResource = () => {
             authorizedFetch,
         ]
     );
-    const { data, isLoading } = rsUseQuery(
+    const { data, isLoading, isInitialLoading } = rsUseQuery(
         [senderDetail.queryKey, activeMembership],
         memoizedDataFetch,
         {
@@ -31,5 +38,6 @@ export const useSenderResource = () => {
                 !!activeMembership?.parsedName && !!activeMembership.service,
         }
     );
-    return { senderDetail: data, senderIsLoading: isLoading };
+
+    return { senderDetail: data, senderIsLoading: isLoading, isInitialLoading };
 };

--- a/frontend-react/src/hooks/network/WatersHooks.test.ts
+++ b/frontend-react/src/hooks/network/WatersHooks.test.ts
@@ -5,7 +5,8 @@ import {
     WatersTestHeaderValue,
 } from "../../__mocks__/WatersMockServer";
 import { QueryWrapper } from "../../utils/CustomRenderUtils";
-import { ContentType } from "../UseFileHandler";
+import { ContentType, FileType } from "../UseFileHandler";
+import { STANDARD_SCHEMA_OPTIONS } from "../../senders/hooks/UseSenderSchemaOptions";
 
 import { useWatersUploader } from "./WatersHooks";
 
@@ -40,6 +41,8 @@ describe("useWatersUploader", () => {
                 fileName: "",
                 // test response trigger
                 client: WatersTestHeaderValue.TEST_NAME,
+                format: FileType.CSV,
+                schema: STANDARD_SCHEMA_OPTIONS[0].value,
             });
             await waitForNextUpdate();
             expect(result.current.isWorking).toEqual(true);

--- a/frontend-react/src/hooks/network/WatersHooks.ts
+++ b/frontend-react/src/hooks/network/WatersHooks.ts
@@ -1,8 +1,8 @@
-import { useMutation } from "@tanstack/react-query";
+import { UseMutateAsyncFunction, useMutation } from "@tanstack/react-query";
 
 import { useAuthorizedFetch } from "../../contexts/AuthorizedFetchContext";
 import { watersEndpoints, WatersResponse } from "../../config/endpoints/waters";
-import { ContentType } from "../UseFileHandler";
+import { ContentType, FileType } from "../UseFileHandler";
 import { RSNetworkError } from "../../utils/RSNetworkError";
 
 export interface WatersPostArgs {
@@ -10,9 +10,28 @@ export interface WatersPostArgs {
     fileName: string;
     fileContent: string;
     contentType?: ContentType;
+    schema: string;
+    format: FileType;
 }
 
 const { validate } = watersEndpoints;
+
+export type UseWatersUploaderSendFileMutation = UseMutateAsyncFunction<
+    WatersResponse,
+    RSNetworkError<WatersResponse>,
+    WatersPostArgs
+>;
+
+export type UseWatersUploaderResult = {
+    sendFile: UseWatersUploaderSendFileMutation;
+    isWorking: boolean;
+    uploaderError: RSNetworkError<WatersResponse> | null;
+};
+
+export const FORMAT_TO_CONTENT_TYPE = {
+    [FileType.CSV]: ContentType.CSV,
+    [FileType.HL7]: ContentType.HL7,
+};
 
 /** Uploads a file to ReportStream */
 export const useWatersUploader = (
@@ -21,18 +40,23 @@ export const useWatersUploader = (
     const { authorizedFetch } = useAuthorizedFetch<WatersResponse>();
 
     const mutationFunction = ({
-        contentType,
         fileContent,
         client,
         fileName,
+        schema,
+        format,
     }: WatersPostArgs) => {
         return authorizedFetch(validate, {
             headers: {
-                "Content-Type": contentType || ContentType.CSV,
+                "Content-Type": FORMAT_TO_CONTENT_TYPE[format],
                 payloadName: fileName,
                 client: client,
             },
             data: fileContent,
+            params: {
+                format,
+                schema,
+            },
         });
     };
     const mutation = useMutation<

--- a/frontend-react/src/pages/Validate.tsx
+++ b/frontend-react/src/pages/Validate.tsx
@@ -6,16 +6,7 @@ import { AuthElement } from "../components/AuthElement";
 import { withCatch } from "../components/RSErrorBoundary";
 
 const Validate = () => {
-    return withCatch(
-        <FileHandler
-            headingText="ReportStream File Validator"
-            successMessage="File validated"
-            resetText="Validate another file"
-            submitText="Validate"
-            showSuccessMetadata={false}
-            showWarningBanner={false}
-        />
-    );
+    return withCatch(<FileHandler />);
 };
 
 export default Validate;

--- a/frontend-react/src/senders/hooks/UseSenderSchemaOptions/UseSenderSchemaOptions.test.ts
+++ b/frontend-react/src/senders/hooks/UseSenderSchemaOptions/UseSenderSchemaOptions.test.ts
@@ -1,0 +1,146 @@
+import { renderHook, RenderHookResult } from "@testing-library/react-hooks";
+
+import { QueryWrapper } from "../../../utils/CustomRenderUtils";
+import { UseSenderResourceHookResult } from "../../../hooks/UseSenderResource";
+import { CustomerStatus } from "../../../utils/TemporarySettingsAPITypes";
+import * as useSenderResourceExports from "../../../hooks/UseSenderResource";
+import { FileType } from "../../../hooks/UseFileHandler";
+
+import useSenderSchemaOptions, {
+    STANDARD_SCHEMA_OPTIONS,
+    UseSenderSchemaOptionsHookResult,
+} from "./";
+
+describe("useSenderSchemaOptions", () => {
+    let renderer: RenderHookResult<undefined, UseSenderSchemaOptionsHookResult>;
+
+    function doRenderHook({
+        senderDetail = undefined,
+        senderIsLoading = false,
+        isInitialLoading = false,
+    }: UseSenderResourceHookResult) {
+        jest.spyOn(
+            useSenderResourceExports,
+            "useSenderResource"
+        ).mockReturnValueOnce({
+            senderDetail,
+            senderIsLoading,
+            isInitialLoading,
+        });
+
+        return renderHook(() => useSenderSchemaOptions(), {
+            wrapper: QueryWrapper(),
+        });
+    }
+
+    describe("when not logged in", () => {
+        beforeEach(() => {
+            renderer = doRenderHook({
+                senderIsLoading: false,
+                isInitialLoading: false,
+            });
+        });
+
+        test("returns the standard schema options", () => {
+            expect(renderer.result.current.isLoading).toEqual(false);
+            expect(renderer.result.current.schemaOptions).toEqual(
+                STANDARD_SCHEMA_OPTIONS
+            );
+        });
+    });
+
+    describe("when logged in", () => {
+        describe("when sender detail query is loading", () => {
+            beforeEach(() => {
+                renderer = doRenderHook({
+                    senderIsLoading: true,
+                    isInitialLoading: true,
+                });
+            });
+
+            test("returns the loading state and the standard schema options", () => {
+                expect(renderer.result.current.isLoading).toEqual(true);
+                expect(renderer.result.current.schemaOptions).toEqual(
+                    STANDARD_SCHEMA_OPTIONS
+                );
+            });
+        });
+
+        describe("when sender detail query is disabled", () => {
+            beforeEach(() => {
+                renderer = doRenderHook({
+                    senderIsLoading: true,
+                    isInitialLoading: false,
+                });
+            });
+
+            test("returns the loading state and the standard schema options", () => {
+                expect(renderer.result.current.isLoading).toEqual(false);
+                expect(renderer.result.current.schemaOptions).toEqual(
+                    STANDARD_SCHEMA_OPTIONS
+                );
+            });
+        });
+
+        describe("as a Sender", () => {
+            describe("when the Sender has a different schema than the standard schema options", () => {
+                beforeEach(() => {
+                    renderer = doRenderHook({
+                        senderDetail: {
+                            allowDuplicates: true,
+                            customerStatus: CustomerStatus.ACTIVE,
+                            format: FileType.CSV,
+                            name: "test",
+                            organizationName: "test",
+                            processingType: "sync",
+                            schemaName: "test/test-csv",
+                            topic: "covid-19",
+                        },
+                        senderIsLoading: true,
+                        isInitialLoading: false,
+                    });
+                });
+
+                test("returns the standard schema options in addition to the Sender schema", () => {
+                    expect(renderer.result.current.isLoading).toEqual(false);
+                    expect(renderer.result.current.schemaOptions).toEqual([
+                        {
+                            format: FileType.CSV,
+                            title: "test/test-csv (CSV)",
+                            value: "test/test-csv",
+                        },
+                        ...STANDARD_SCHEMA_OPTIONS,
+                    ]);
+                });
+            });
+
+            describe("when the Sender has the same schema as one of the standard schema options", () => {
+                beforeEach(() => {
+                    const schemaOption = STANDARD_SCHEMA_OPTIONS[0];
+
+                    renderer = doRenderHook({
+                        senderDetail: {
+                            allowDuplicates: true,
+                            customerStatus: CustomerStatus.ACTIVE,
+                            format: schemaOption.format,
+                            name: "test",
+                            organizationName: "test",
+                            processingType: "sync",
+                            schemaName: schemaOption.value,
+                            topic: "covid-19",
+                        },
+                        senderIsLoading: true,
+                        isInitialLoading: false,
+                    });
+                });
+
+                test("returns the de-duplicated standard schema options", () => {
+                    expect(renderer.result.current.isLoading).toEqual(false);
+                    expect(renderer.result.current.schemaOptions).toEqual(
+                        STANDARD_SCHEMA_OPTIONS
+                    );
+                });
+            });
+        });
+    });
+});

--- a/frontend-react/src/senders/hooks/UseSenderSchemaOptions/index.ts
+++ b/frontend-react/src/senders/hooks/UseSenderSchemaOptions/index.ts
@@ -1,0 +1,70 @@
+import { useSenderResource } from "../../../hooks/UseSenderResource";
+import { FileType } from "../../../hooks/UseFileHandler";
+
+export enum StandardSchema {
+    CSV = "upload-covid-19",
+    CSV_OTC = "csv-otc-covid-19",
+    HL7 = "standard/standard-covid-19",
+}
+
+export const STANDARD_SCHEMA_VALUES: string[] = Object.values(StandardSchema);
+
+export type SchemaOption = {
+    value: string;
+    format: FileType;
+    title: string;
+};
+
+export type UseSenderSchemaOptionsHookResult = {
+    isLoading: boolean;
+    schemaOptions: SchemaOption[];
+};
+
+export const STANDARD_SCHEMA_OPTIONS: SchemaOption[] = [
+    {
+        value: StandardSchema.CSV,
+        format: FileType.CSV,
+        title: `${StandardSchema.CSV} (${FileType.CSV})`,
+    },
+    {
+        value: StandardSchema.CSV_OTC,
+        format: FileType.CSV,
+        title: `${StandardSchema.CSV_OTC} (${FileType.CSV})`,
+    },
+    {
+        value: StandardSchema.HL7,
+        format: FileType.HL7,
+        title: `${StandardSchema.HL7} (${FileType.HL7})`,
+    },
+];
+
+export default function useSenderSchemaOptions(): UseSenderSchemaOptionsHookResult {
+    const {
+        senderDetail,
+        senderIsLoading,
+        isInitialLoading: isSenderInitialLoading,
+    } = useSenderResource();
+
+    const isLoading = senderIsLoading && isSenderInitialLoading;
+
+    const schemaOptions =
+        !isLoading &&
+        senderDetail &&
+        !(Object.values(StandardSchema) as string[]).includes(
+            senderDetail.schemaName
+        )
+            ? ([
+                  {
+                      value: senderDetail.schemaName,
+                      format: senderDetail.format,
+                      title: `${senderDetail.schemaName} (${senderDetail.format})`,
+                  },
+                  ...STANDARD_SCHEMA_OPTIONS,
+              ] as SchemaOption[])
+            : STANDARD_SCHEMA_OPTIONS;
+
+    return {
+        isLoading,
+        schemaOptions,
+    };
+}


### PR DESCRIPTION
This PR ...

This changeset adds a dropdown to the validator page to allow the user to select between schema options to validate against.  To accommodate this, I've added a `useSenderSchemaOptions` hook that always returns the three "master" schemas" in addition to the designated Sender schema if the current user is logged is as a Sender.

This also includes a decent amount of cleanup/rewrites because the logic in useFileHandler, FileHandler, and FileHandlerForm is oddly coupled together.  Will comment below!

To generate test files to validate against different schemas, you can use the CLI tool:
```
./prime data --input-fake <item_count> --input-schema <schema> --output <output_destination>
```

like:

```
./prime data --input-fake 10 --input-schema hl7/hcintegrations-covid-19 --output ~/Desktop/whatever.hl7
```

This seems to generate lots of duplicate columns so those have to be removed or validation will complain about those, but this is a starting point for test data!

Test Steps:
As an admin:
1. Log in
2. Go to http://localhost:3000/file-handler/validate
3. Verify that the three master schemas are available options
4. Upload a file to validate against the selected schemas --> ensure you get the right success/warning/error messages

As a Sender:
1. Log in
2. Go to http://localhost:3000/file-handler/validate
3. Verify that the three master schemas AND the Sender schema are available options
4. Upload a file to validate against the selected schemas --> ensure you get the right success/warning/error messages

This can also be tested against a logged-out user by changing [this line](https://github.com/CDCgov/prime-reportstream/blob/master/frontend-react/src/pages/Validate.tsx#L23) to be `export const ValidateWithAuth = Validate;` just to get around the authentication stuff.  The validate call will still work.

## Changes
As an admin or unauthenticated user:
<img width="1202" alt="Screenshot 2023-02-06 at 11 18 46" src="https://user-images.githubusercontent.com/2421042/217026752-3a3ceac0-419c-4acd-8172-94b4102f2aaa.png">

As a Sender:
<img width="1204" alt="Screenshot 2023-02-06 at 11 19 10" src="https://user-images.githubusercontent.com/2421042/217026753-b28c337d-7cf1-49c2-8457-41fa1617a170.png">

## Checklist

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

## Linked Issues
- Fixes #7773

## To Be Done
- #8200