### PR TITLE
Possible for frontend-react's yarn.lock to get out-of-sync

### DIFF
--- a/.environment/pre-commit.runner.sh
+++ b/.environment/pre-commit.runner.sh
@@ -16,6 +16,7 @@ CHECKS_TO_RUN=(
     ${REPO_ROOT}/.environment/ktlint/run-ktlintCheck.sh
     ${REPO_ROOT}/.environment/terraform-fmt/run-terraform-fmt.sh
     ${REPO_ROOT}/.environment/eslint/run-eslintCheck.sh
+    ${REPO_ROOT}/.environment/yarn/run-yarnCheck.sh
 )
 
 function error() {

--- a/.environment/yarn/run-yarnCheck.sh
+++ b/.environment/yarn/run-yarnCheck.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+function note() {
+    echo "yarn-check> info: ${*}"
+}
+
+function yarn_lock_check() {
+    note "Checking Yarn lock integrity"
+    yarn check --integrity
+}
+
+cd frontend-react
+yarn_lock_check
+RC=$?
+
+if [[ ${RC?} != 0 ]]; then
+    echo "yarn-check> ERROR: Your yarn lock file is out of sync."
+fi
+
+exit ${RC?} 


### PR DESCRIPTION
Fixes #5152

This PR adds a new pre-commit check to ensure the frontend's yarn lock file is in sync.