### PR TITLE
7545 UP Routing function sends message to Translate function even when data will go to no receivers

### DIFF
--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -97,6 +97,7 @@ class BlobAccess : Logging {
                 Event.EventAction.PROCESS -> "process/$subfolderNameChecked$reportName"
                 Event.EventAction.ROUTE -> "route/$subfolderNameChecked$reportName"
                 Event.EventAction.TRANSLATE -> "translate/$subfolderNameChecked$reportName"
+                Event.EventAction.NONE -> "none/$subfolderNameChecked$reportName"
                 else -> "other/$subfolderNameChecked$reportName"
             }
             val digest = sha256Digest(blobBytes)

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRRouter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRRouter.kt
@@ -202,47 +202,61 @@ class FHIRRouter(
             // get the receivers that this bundle should go to
             val listOfReceivers = applyFilters(bundle, report)
 
-            // add the receivers, if any, to the fhir bundle
-            if (listOfReceivers.isNotEmpty()) {
+            // check if there are any receivers
+            val hasReceivers = listOfReceivers.isNotEmpty()
+
+            // create item lineage
+            report.itemLineages = listOf(
+                ItemLineage(
+                    null,
+                    message.reportId,
+                    1,
+                    report.id,
+                    1,
+                    null,
+                    null,
+                    null,
+                    report.getItemHashForRow(1)
+                )
+            )
+
+            // create none event
+            var translateEvent = ProcessEvent(
+                Event.EventAction.NONE,
+                message.reportId,
+                Options.None,
+                emptyMap(),
+                emptyList()
+            )
+
+            if (hasReceivers) {
+                // add the receivers to the fhir bundle
                 FHIRBundleHelpers.addReceivers(bundle, listOfReceivers)
 
-                // create item lineage
-                report.itemLineages = listOf(
-                    ItemLineage(
-                        null,
-                        message.reportId,
-                        1,
-                        report.id,
-                        1,
-                        null,
-                        null,
-                        null,
-                        report.getItemHashForRow(1)
-                    )
-                )
-
-                // create translate event
-                val translateEvent = ProcessEvent(
+                // create translate event - used instead of none event
+                translateEvent = ProcessEvent(
                     Event.EventAction.TRANSLATE,
                     message.reportId,
                     Options.None,
                     emptyMap(),
                     emptyList()
                 )
+            }
 
-                // upload new copy to blobstore
-                val bodyBytes = FhirTranscoder.encode(bundle).toByteArray()
-                val blobInfo = BlobAccess.uploadBody(
-                    Report.Format.FHIR,
-                    bodyBytes,
-                    report.name,
-                    message.blobSubFolderName,
-                    translateEvent.eventAction
-                )
+            // upload new copy to blobstore
+            val bodyBytes = FhirTranscoder.encode(bundle).toByteArray()
+            val blobInfo = BlobAccess.uploadBody(
+                Report.Format.FHIR,
+                bodyBytes,
+                report.name,
+                message.blobSubFolderName,
+                translateEvent.eventAction
+            )
 
-                // ensure tracking is set
-                actionHistory.trackCreatedReport(translateEvent, report, blobInfo)
+            // ensure tracking is set
+            actionHistory.trackCreatedReport(translateEvent, report, blobInfo)
 
+            if (hasReceivers) {
                 // insert translate task into Task table
                 this.insertTranslateTask(
                     report,
@@ -250,17 +264,19 @@ class FHIRRouter(
                     blobInfo.blobUrl,
                     translateEvent
                 )
+            }
 
-                // nullify the previous task next_action
-                db.updateTask(
-                    message.reportId,
-                    TaskAction.none,
-                    null,
-                    null,
-                    finishedField = Tables.TASK.ROUTED_AT,
-                    null
-                )
+            // nullify the previous task next_action
+            db.updateTask(
+                message.reportId,
+                TaskAction.none,
+                null,
+                null,
+                finishedField = Tables.TASK.ROUTED_AT,
+                null
+            )
 
+            if (hasReceivers) {
                 // move to translation (send to <elrTranslationQueueName> queue). This passes the same message on, but
                 //  the destinations have been updated in the FHIR
                 this.queue.sendMessage(
@@ -271,48 +287,6 @@ class FHIRRouter(
                         BlobAccess.digestToString(blobInfo.digest),
                         message.blobSubFolderName
                     ).serialize()
-                )
-            } else {
-                // create item lineage
-                report.itemLineages = listOf(
-                    ItemLineage(
-                        null,
-                        message.reportId,
-                        1,
-                        report.id,
-                        1,
-                        null,
-                        null,
-                        null,
-                        report.getItemHashForRow(1)
-                    )
-                )
-
-                // create none event
-                val noneEvent = ProcessEvent(
-                    Event.EventAction.NONE,
-                    message.reportId,
-                    Options.None,
-                    emptyMap(),
-                    emptyList()
-                )
-
-                // encode the event body
-                val bodyBytes = FhirTranscoder.encode(bundle).toByteArray()
-                val digest = BlobAccess.sha256Digest(bodyBytes)
-                val blobInfo = BlobAccess.BlobInfo(report.bodyFormat, report.bodyURL, digest)
-
-                // ensure tracking is set
-                actionHistory.trackCreatedReport(noneEvent, report, blobInfo)
-
-                // nullify the previous task next_action
-                db.updateTask(
-                    message.reportId,
-                    TaskAction.none,
-                    null,
-                    null,
-                    finishedField = Tables.TASK.ROUTED_AT,
-                    null
                 )
             }
         } catch (e: IllegalArgumentException) {

--- a/prime-router/src/test/kotlin/fhirengine/engine/fhirRouterTests/RoutingTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/fhirRouterTests/RoutingTests.kt
@@ -618,6 +618,52 @@ class RoutingTests {
     }
 
     @Test
+    fun `test bundle with no receivers is not routed to translate function`() {
+        val fhirData = File("src/test/resources/fhirengine/engine/routing/valid.fhir").readText()
+
+        mockkObject(BlobAccess)
+        mockkObject(FHIRBundleHelpers)
+
+        // set up
+        val settings = FileSettings().loadOrganizations(oneOrganization)
+        val actionHistory = mockk<ActionHistory>()
+        val actionLogger = mockk<ActionLogger>()
+
+        val engine = spyk(makeFhirEngine(metadata, settings, TaskAction.route) as FHIRRouter)
+        val message = spyk(RawSubmission(UUID.randomUUID(), "http://blob.url", "test", "test-sender"))
+
+        val bodyFormat = Report.Format.FHIR
+        val bodyUrl = "http://anyblob.com"
+
+        every { engine.applyFilters(any(), any()) } returns emptyList()
+
+        every { actionLogger.hasErrors() } returns false
+        every { message.downloadContent() }.returns(fhirData)
+        every { BlobAccess.uploadBlob(any(), any()) } returns "test"
+        every { accessSpy.insertTask(any(), bodyFormat.toString(), bodyUrl, any()) }.returns(Unit)
+        every { actionHistory.trackCreatedReport(any(), any(), any()) }.returns(Unit)
+        every { actionHistory.trackExistingInputReport(any()) }.returns(Unit)
+        every { queueMock.sendMessage(any(), any()) }
+            .returns(Unit)
+        every { FHIRBundleHelpers.addReceivers(any(), any()) } returns Unit
+
+        // act
+        engine.doWork(message, actionLogger, actionHistory)
+
+        // assert
+        verify(exactly = 1) {
+            actionHistory.trackExistingInputReport(any())
+            actionHistory.trackCreatedReport(any(), any(), any())
+            BlobAccess.Companion.uploadBlob(any(), any())
+        }
+        verify(exactly = 0) {
+            queueMock.sendMessage(any(), any())
+            accessSpy.insertTask(any(), any(), any(), any())
+            FHIRBundleHelpers.addReceivers(any(), any())
+        }
+    }
+
+    @Test
     fun ` test constantResolver for routing constants - succeed`() {
         val fhirData = File("src/test/resources/fhirengine/engine/routing/valid.fhir").readText()
         val bundle = FhirTranscoder.decode(fhirData)


### PR DESCRIPTION
This PR adds an alternate routing process for FHIR bundles with no receivers that skips sending a message to the translate function, eliminating a minor inefficiency.

Test Steps:
1. Use the `Single HL7 Full ELR` test to submit data to be routed. Ensure the data sent does not have a valid receiver.
2. Retrieve the report `id` from the data returned from the API call.
3. Allow time for the data to be routed, then confirm no calls to the translate function for this report lineage on the `report_file`, `action`, and `task` tables.

## Changes
- Changed the FHIR routing process to omit steps to create a message for and send a message to the translation queue. This event is tracked as `EventAction.NONE` rather than `EventAction.TRANSLATE`.
- Added `EventAction.NONE` as a possible action for `blobURL` creation. This should prevent primary key constraint violations if other `EventAction` types cause the `other` string to be written to `blobURL`.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

## Linked Issues
- Fixes #7545 