### PR TITLE
Experience-8161: Remove makeOktaHook logic

### DIFF
--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -1,6 +1,5 @@
 import { GovBanner } from "@trussworks/react-uswds";
 import { toRelativeUrl } from "@okta/okta-auth-js";
-import { useOktaAuth } from "@okta/okta-react";
 import { useIdleTimer } from "react-idle-timer";
 import React, { Suspense, useEffect, useRef } from "react";
 import { NetworkErrorBoundary } from "rest-hooks";
@@ -109,7 +108,6 @@ const App = () => {
         <AppWrapper
             oktaAuth={OKTA_AUTH}
             restoreOriginalUri={restoreOriginalUri}
-            oktaHook={useOktaAuth}
         >
             <Suspense fallback={<Spinner size={"fullpage"} />}>
                 <NetworkErrorBoundary

--- a/frontend-react/src/components/AppWrapper.tsx
+++ b/frontend-react/src/components/AppWrapper.tsx
@@ -6,7 +6,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { AppInsightsContext } from "@microsoft/applicationinsights-react-js";
 import { HelmetProvider } from "react-helmet-async";
 
-import SessionProvider, { OktaHook } from "../contexts/SessionContext";
+import SessionProvider from "../contexts/SessionContext";
 import { AuthorizedFetchProvider } from "../contexts/AuthorizedFetchContext";
 import { appQueryClient } from "../network/QueryClients";
 import { FeatureFlagProvider } from "../contexts/FeatureFlagContext";
@@ -21,14 +21,12 @@ const AppInsightsProvider = (props: PropsWithChildren<{}>) => (
 interface AppWrapperProps {
     oktaAuth: OktaAuth;
     restoreOriginalUri: (_oktaAuth: any, originalUri: string) => void;
-    oktaHook: OktaHook;
 }
 
 export const AppWrapper = ({
     children,
     oktaAuth,
     restoreOriginalUri,
-    oktaHook,
 }: PropsWithChildren<AppWrapperProps>) => {
     return (
         <HelmetProvider>
@@ -37,7 +35,7 @@ export const AppWrapper = ({
                 restoreOriginalUri={restoreOriginalUri}
             >
                 <AppInsightsProvider>
-                    <SessionProvider oktaHook={oktaHook}>
+                    <SessionProvider>
                         <QueryClientProvider client={appQueryClient}>
                             <AuthorizedFetchProvider>
                                 <FeatureFlagProvider>

--- a/frontend-react/src/components/SenderModeBanner.test.tsx
+++ b/frontend-react/src/components/SenderModeBanner.test.tsx
@@ -1,10 +1,7 @@
 import { screen } from "@testing-library/react";
 
 import { orgServer } from "../__mocks__/OrganizationMockServer";
-import {
-    makeOktaHook,
-    renderWithFullAppContext,
-} from "../utils/CustomRenderUtils";
+import { renderWithFullAppContext } from "../utils/CustomRenderUtils";
 import { mockSessionContext } from "../contexts/__mocks__/SessionContext";
 import { MemberType } from "../hooks/UseOktaMemberships";
 
@@ -33,14 +30,7 @@ describe("SenderModeBanner", () => {
             isUserReceiver: false,
             isUserSender: true,
         });
-        renderWithFullAppContext(
-            <SenderModeBanner />,
-            makeOktaHook({
-                authState: {
-                    isAuthenticated: true,
-                },
-            })
-        );
+        renderWithFullAppContext(<SenderModeBanner />);
         const text = await screen.findByText("Learn more about onboarding.");
         expect(text).toBeInTheDocument();
     });

--- a/frontend-react/src/utils/CustomRenderUtils.tsx
+++ b/frontend-react/src/utils/CustomRenderUtils.tsx
@@ -48,19 +48,15 @@ const RouterWrapper: FC = ({ children }) => {
     );
 };
 
-export const SessionWrapper =
-    (mockOkta: OktaHook) =>
-    ({ children }: PropsWithChildren<{}>) => {
-        return (
-            <BaseWrapper>
-                <RouterWrapper>
-                    <SessionProvider oktaHook={mockOkta}>
-                        {children}
-                    </SessionProvider>
-                </RouterWrapper>
-            </BaseWrapper>
-        );
-    };
+export const SessionWrapper = ({ children }: PropsWithChildren<{}>) => {
+    return (
+        <BaseWrapper>
+            <RouterWrapper>
+                <SessionProvider>{children}</SessionProvider>
+            </RouterWrapper>
+        </BaseWrapper>
+    );
+};
 
 export const QueryWrapper =
     (client: QueryClient = new QueryClient()) =>
@@ -86,25 +82,23 @@ const FeatureFlagWrapper: FC = ({ children }) => {
     );
 };
 
-const AppWrapper =
-    (mockOkta: OktaHook) =>
-    ({ children }: PropsWithChildren<{}>) => {
-        return (
-            <BaseWrapper>
-                <RouterWrapper>
-                    <SessionProvider oktaHook={mockOkta}>
-                        <QueryClientProvider client={testQueryClient}>
-                            <AuthorizedFetchProvider>
-                                <FeatureFlagProvider>
-                                    {children}
-                                </FeatureFlagProvider>
-                            </AuthorizedFetchProvider>
-                        </QueryClientProvider>
-                    </SessionProvider>
-                </RouterWrapper>
-            </BaseWrapper>
-        );
-    };
+const AppWrapper = ({ children }: PropsWithChildren<{}>) => {
+    return (
+        <BaseWrapper>
+            <RouterWrapper>
+                <SessionProvider>
+                    <QueryClientProvider client={testQueryClient}>
+                        <AuthorizedFetchProvider>
+                            <FeatureFlagProvider>
+                                {children}
+                            </FeatureFlagProvider>
+                        </AuthorizedFetchProvider>
+                    </QueryClientProvider>
+                </SessionProvider>
+            </RouterWrapper>
+        </BaseWrapper>
+    );
+};
 
 export const renderWithBase = (
     ui: ReactElement,
@@ -122,11 +116,10 @@ const renderWithRouter = (
 
 const renderWithSession = (
     ui: ReactElement,
-    oktaHook?: OktaHook,
     options?: Omit<RenderOptions, "wrapper">
 ) =>
     render(ui, {
-        wrapper: SessionWrapper(oktaHook || makeOktaHook()),
+        wrapper: SessionWrapper,
         ...options,
     });
 
@@ -151,7 +144,7 @@ export const renderWithFullAppContext = (
     options?: Omit<RenderOptions, "wrapper">
 ) => {
     return render(ui, {
-        wrapper: AppWrapper(oktaHook || makeOktaHook()),
+        wrapper: AppWrapper,
         ...options,
     });
 };


### PR DESCRIPTION
This changeset removes the makeOktaHook logic that's fed into SessionProvider and a few test utilities.  There's a temporary workaround to fall back on an empty object in SessionProvider from the `useOktaAuth` call -- this is to account for components being rendered outside of Okta's Security Provider, in which case `useOktaAuth` calls return `null`.  This will be fixed as part of [#8292](https://app.zenhub.com/workspaces/experience-607d9d5e68b95200150fec37/issues/gh/cdcgov/prime-reportstream/8292); it'd just be easier to remove this logic beforehand.

Ultimately, there's no reason for us to have to pass a stand-in for `useOktaAuth` as a prop when we could just mock it if we really need to.

Test Steps:
N/A

## Checklist

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
<strike>- [ ] Added tests?</strike>

## Linked Issues
- Fixes #8161 

## To Be Done
- #8292 