### PR TITLE
Upgrade to Cypress v12

### DIFF
--- a/frontend-react/cypress.config.ts
+++ b/frontend-react/cypress.config.ts
@@ -1,4 +1,5 @@
 import path from "path";
+
 import dotenv from "dotenv";
 import { defineConfig } from "cypress";
 
@@ -12,9 +13,36 @@ const cypressConfig = require(path.resolve(
     `./cypress/cypress.${cypressEnv}.json`
 ));
 
+function getEnvOrDefault(name: string, dfault?: string) {
+    if (!!cypressConfig[name]) {
+        return cypressConfig[name];
+    }
+
+    if (dfault) {
+        return dfault;
+    }
+
+    throw new Error(`No value supplied for env variable ${name}`);
+}
+
+const env = {
+    ...cypressConfig,
+    oktaClientId: getEnvOrDefault(
+        "oktaClientId",
+        process.env.REACT_APP_OKTA_CLIENTID
+    ),
+    oktaSecret: getEnvOrDefault(
+        "oktaSecret",
+        process.env.REACT_APP_OKTA_SECRET
+    ),
+    oktaUrl: getEnvOrDefault("oktaUrl", process.env.REACT_APP_OKTA_URL),
+    baseUrl: getEnvOrDefault("baseUrl", process.env.REACT_APP_BASE_URL),
+    basePageTitle: process.env.REACT_APP_TITLE,
+};
+
 export default defineConfig({
     e2e: {
-        baseUrl: cypressConfig.baseUrl,
+        baseUrl: env.baseUrl,
         specPattern: "cypress/e2e/**/*.cy.(js|ts)",
         setupNodeEvents(on) {
             // configure plugins here
@@ -35,16 +63,7 @@ export default defineConfig({
             });
         },
     },
-    env: {
-        ...cypressConfig,
-        okta_domain: process.env.REACT_APP_OKTA_DOMAIN,
-        okta_client_id: process.env.REACT_APP_OKTA_CLIENTID,
-        okta_secret: process.env.REACT_APP_OKTA_SECRET,
-        okta_url: process.env.REACT_APP_OKTA_URL,
-
-        base_page_title: process.env.REACT_APP_TITLE,
-    },
-
+    env,
     viewportHeight: 768,
     viewportWidth: 1440,
 });

--- a/frontend-react/cypress.config.ts
+++ b/frontend-react/cypress.config.ts
@@ -13,13 +13,13 @@ const cypressConfig = require(path.resolve(
     `./cypress/cypress.${cypressEnv}.json`
 ));
 
-function getEnvOrDefault(name: string, dfault?: string) {
+function getEnvOrDefault(name: string, defaultValue?: string) {
     if (!!cypressConfig[name]) {
         return cypressConfig[name];
     }
 
-    if (dfault) {
-        return dfault;
+    if (defaultValue) {
+        return defaultValue;
     }
 
     throw new Error(`No value supplied for env variable ${name}`);

--- a/frontend-react/cypress/support/commands/auth.ts
+++ b/frontend-react/cypress/support/commands/auth.ts
@@ -17,9 +17,10 @@ const SECRET = Cypress.env("oktaSecret");
 const CLIENT_ID = Cypress.env("oktaClientId");
 const REDIRECT_URI = `${Cypress.env("baseUrl")}/login/callback`;
 const RESPONSE_MODE = "okta_post_message";
+const URL = Cypress.env("oktaUrl");
 
 const oktaAuthConfig: OktaAuthOptions = {
-    issuer: "https://hhs-prime.oktapreview.com/oauth2/default",
+    issuer: `${URL}/oauth2/default`,
     clientId: CLIENT_ID,
     redirectUri: REDIRECT_URI,
     responseMode: RESPONSE_MODE,
@@ -34,7 +35,7 @@ function loginByOktaApi() {
     // log in with username and password
     return (
         cy
-            .request("POST", "https://hhs-prime.oktapreview.com/api/v1/authn", {
+            .request("POST", `${URL}/api/v1/authn`, {
                 username: USERNAME,
                 password: PASSWORD,
                 options: {
@@ -49,7 +50,7 @@ function loginByOktaApi() {
                 const passCode = authenticator.generate(SECRET);
                 return cy.request(
                     "POST",
-                    `https://hhs-prime.oktapreview.com/api/v1/authn/factors/${factorId}/verify`,
+                    `${URL}/api/v1/authn/factors/${factorId}/verify`,
                     {
                         passCode,
                         stateToken,

--- a/frontend-react/cypress/support/pages/Base.ts
+++ b/frontend-react/cypress/support/pages/Base.ts
@@ -7,7 +7,7 @@ export class BasePage extends BasePageComponent {
     path = "/";
 
     get baseTitle() {
-        return Cypress.env("base_page_title");
+        return Cypress.env("basePageTitle");
     }
 
     go() {

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -92,6 +92,7 @@
     "eslintConfig": {
         "extends": [
             "react-app",
+            "plugin:cypress/recommended",
             "plugin:import/recommended",
             "plugin:import/typescript",
             "prettier"
@@ -100,7 +101,8 @@
             "testing-library",
             "unused-imports",
             "jest-dom",
-            "prettier"
+            "prettier",
+            "chai-friendly"
         ],
         "env": {
             "browser": true,
@@ -166,14 +168,12 @@
             },
             {
                 "files": [
-                    "**/__tests__/**/*.[jt]s?(x)",
-                    "**/?(*.)+(spec|test).[jt]s?(x)",
-                    "**/cypress/**/*.[jt]s?(x)"
+                    "./src/**/__tests__/**/*.[jt]s?(x)",
+                    "./src/**/?(*.)+(spec|test).[jt]s?(x)"
                 ],
                 "extends": [
                     "plugin:testing-library/react",
-                    "plugin:jest-dom/recommended",
-                    "plugin:cypress/recommended"
+                    "plugin:jest-dom/recommended"
                 ],
                 "rules": {
                     "testing-library/no-render-in-setup": [
@@ -186,6 +186,19 @@
                     "testing-library/prefer-screen-queries": "warn",
                     "testing-library/no-unnecessary-act": "warn",
                     "testing-library/no-await-sync-query": "warn"
+                }
+            },
+            {
+                "files": [
+                    "**/cypress/**/*.[jt]s?(x)"
+                ],
+                "extends": [
+                    "plugin:cypress/recommended"
+                ],
+                "rules": {
+                    "no-unused-expressions": "off",
+                    "@typescript-eslint/no-unused-expressions": "off",
+                    "chai-friendly/no-unused-expressions": "error"
                 }
             }
         ],
@@ -212,7 +225,7 @@
     },
     "devDependencies": {
         "@rest-hooks/test": "^7.3.1",
-        "@testing-library/cypress": "^8.0.7",
+        "@testing-library/cypress": "^9.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.2",
         "@testing-library/react-hooks": "^8.0.1",
@@ -230,17 +243,18 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/react-scroll-sync": "^0.8.3",
         "@types/testing-library__jest-dom": "^5.14.2",
-        "cypress": "^10.11.0",
+        "cypress": "^12.5.1",
         "cypress-each": "^1.13.1",
-        "cypress-localstorage-commands": "^2.1.0",
+        "cypress-localstorage-commands": "^2.2.2",
         "cypress-plugin-tab": "^1.0.5",
         "dotenv": "^16.0.3",
         "env-cmd": "^10.1.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-jest-dom": "^4.0.1",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-testing-library": "^5.9.1",
+        "eslint-plugin-testing-library": "^5.10.1",
         "eslint-plugin-unused-imports": "2.0.0",
         "jest-canvas-mock": "^2.3.1",
         "msw": "^0.36.8",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -92,7 +92,6 @@
     "eslintConfig": {
         "extends": [
             "react-app",
-            "plugin:cypress/recommended",
             "plugin:import/recommended",
             "plugin:import/typescript",
             "prettier"

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -100,8 +100,7 @@
             "testing-library",
             "unused-imports",
             "jest-dom",
-            "prettier",
-            "chai-friendly"
+            "prettier"
         ],
         "env": {
             "browser": true,
@@ -188,6 +187,9 @@
                 }
             },
             {
+                "plugins": [
+                    "chai-friendly"
+                ],
                 "files": [
                     "**/cypress/**/*.[jt]s?(x)"
                 ],

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -2232,10 +2232,10 @@
     "@tanstack/query-core" "4.20.9"
     use-sync-external-store "^1.2.0"
 
-"@testing-library/cypress@^8.0.7":
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.7.tgz#18315eba3cf8852808afadf122e4858406384015"
-  integrity sha512-3HTV725rOS+YHve/gD9coZp/UcPK5xhr4H0GMnq/ni6USdtzVtSOG9WBFtd8rYnrXk8rrGD+0toRFYouJNIG0Q==
+"@testing-library/cypress@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-9.0.0.tgz#3facad49c4654a99bbd138f83f33b415d2d6f097"
+  integrity sha512-c1XiCGeHGGTWn0LAU12sFUfoX3qfId5gcSE2yHode+vsyHDWraxDPALjVnHd4/Fa3j4KBcc5k++Ccy6A9qnkMA==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@testing-library/dom" "^8.1.0"
@@ -2921,6 +2921,14 @@
     "@typescript-eslint/types" "5.48.2"
     "@typescript-eslint/visitor-keys" "5.48.2"
 
+"@typescript-eslint/scope-manager@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz#a993d89a0556ea16811db48eabd7c5b72dcb83d1"
+  integrity sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==
+  dependencies:
+    "@typescript-eslint/types" "5.52.0"
+    "@typescript-eslint/visitor-keys" "5.52.0"
+
 "@typescript-eslint/type-utils@5.48.2":
   version "5.48.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.48.2.tgz#7d3aeca9fa37a7ab7e3d9056a99b42f342c48ad7"
@@ -2945,6 +2953,11 @@
   version "5.48.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.48.2.tgz#635706abb1ec164137f92148f06f794438c97b8e"
   integrity sha512-hE7dA77xxu7ByBc6KCzikgfRyBCTst6dZQpwaTy25iMYOnbNljDT4hjhrGEJJ0QoMjrfqrx+j1l1B9/LtKeuqA==
+
+"@typescript-eslint/types@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.52.0.tgz#19e9abc6afb5bd37a1a9bea877a1a836c0b3241b"
+  integrity sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==
 
 "@typescript-eslint/typescript-estree@5.30.0":
   version "5.30.0"
@@ -2979,6 +2992,19 @@
   dependencies:
     "@typescript-eslint/types" "5.48.2"
     "@typescript-eslint/visitor-keys" "5.48.2"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz#6408cb3c2ccc01c03c278cb201cf07e73347dfca"
+  integrity sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==
+  dependencies:
+    "@typescript-eslint/types" "5.52.0"
+    "@typescript-eslint/visitor-keys" "5.52.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -3025,6 +3051,20 @@
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@^5.43.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.52.0.tgz#b260bb5a8f6b00a0ed51db66bdba4ed5e4845a72"
+  integrity sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.52.0"
+    "@typescript-eslint/types" "5.52.0"
+    "@typescript-eslint/typescript-estree" "5.52.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.0.tgz#07721d23daca2ec4c2da7f1e660d41cd78bacac3"
@@ -3047,6 +3087,14 @@
   integrity sha512-z9njZLSkwmjFWUelGEwEbdf4NwKvfHxvGC0OcGN1Hp/XNDIcJ7D5DpPNPv6x6/mFvc1tQHsaWmpD/a4gOvvCJQ==
   dependencies:
     "@typescript-eslint/types" "5.48.2"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz#e38c971259f44f80cfe49d97dbffa38e3e75030f"
+  integrity sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==
+  dependencies:
+    "@typescript-eslint/types" "5.52.0"
     eslint-visitor-keys "^3.3.0"
 
 "@uswds/uswds@^3.1.0":
@@ -4668,10 +4716,10 @@ cypress-each@^1.13.1:
   resolved "https://registry.yarnpkg.com/cypress-each/-/cypress-each-1.13.1.tgz#65121a7f9fe865a6ea52e0751133b4e0e84f47a8"
   integrity sha512-YbVfrjk4gWTDLOV8YAb3tA6ovQiyl90zvl4M7aLADD0aUBei6nOSXI7xu6LVgLlVcLkM4jRSS2jBIiifauGgpQ==
 
-cypress-localstorage-commands@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cypress-localstorage-commands/-/cypress-localstorage-commands-2.1.0.tgz#6fc299ec60b6b5ccfc09dd23d004866b7444ee78"
-  integrity sha512-DIJLCIh+CcKulAxMVEng6EhpW691emHRqFUD4dK2HUn86Xzt3ABL3SkmxW4rXgvQt697nTDpZC+jo5K5BwndrQ==
+cypress-localstorage-commands@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cypress-localstorage-commands/-/cypress-localstorage-commands-2.2.2.tgz#bbecb1d5b7dd3863a5ced4131acc6b878136311c"
+  integrity sha512-mONoaxoMAFOSsF+SIDx30hysD3XOY8kPLxjtORdZWDj3sJs+u03XOddTDETPIbLch0DWy5Dtyw1ou3EsFGYZAQ==
 
 cypress-plugin-tab@^1.0.5:
   version "1.0.5"
@@ -4680,10 +4728,10 @@ cypress-plugin-tab@^1.0.5:
   dependencies:
     ally.js "^1.4.1"
 
-cypress@^10.11.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.11.0.tgz#e9fbdd7638bae3d8fb7619fd75a6330d11ebb4e8"
-  integrity sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==
+cypress@^12.5.1:
+  version "12.5.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.5.1.tgz#effdcccdd5a6187d61d497300903d4f3b5b21b6e"
+  integrity sha512-ZmCmJ3lsyeOpBfh410m5+AO2CO1AxAzFBt7k6/uVbNcrNZje1vdiwYTpj2ksPKg9mjr9lR6V8tmlDNMvr4H/YQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -5309,6 +5357,11 @@ eslint-module-utils@^2.7.3:
     debug "^3.2.7"
     find-up "^2.1.0"
 
+eslint-plugin-chai-friendly@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz#0ebfbb2c1244f5de2997f3963d155758234f2b0f"
+  integrity sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==
+
 eslint-plugin-cypress@^2.12.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
@@ -5410,12 +5463,19 @@ eslint-plugin-react@^7.27.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-testing-library@^5.0.1, eslint-plugin-testing-library@^5.9.1:
+eslint-plugin-testing-library@^5.0.1:
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.9.1.tgz#12e4bd34c48683ee98af4df2e3318ec9f51dcf8a"
   integrity sha512-6BQp3tmb79jLLasPHJmy8DnxREe+2Pgf7L+7o09TSWPfdqqtQfRZmZNetr5mOs3yqZk/MRNxpN3RUpJe0wB4LQ==
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
+
+eslint-plugin-testing-library@^5.10.1:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.1.tgz#16ef8adb74d59a4dda24db1d5e750a0ee9b79471"
+  integrity sha512-GRy87AqUi2Ij69pe0YnOXm3oGBCgnFwfIv+Hu9q/kT3jL0pX1cXA7aO+oJnvdpbJy2+riOPqGsa3iAkL888NLg==
+  dependencies:
+    "@typescript-eslint/utils" "^5.43.0"
 
 eslint-plugin-unused-imports@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #8055

This PR updates cypress to v12 and updates related dependencies to their latest versions. ESLint rules were modified (as suggested here: **https://github.com/testing-library/eslint-plugin-testing-library/discussions/533#discussioncomment-1949661**) to not use testing-library rules on cypress files to fix false-positives. ESLint plugin chai-friendly was added to cypress ruleset to allow unused-expressions on chai method chains.