### PR TITLE
7998 date range filter bug fix

### DIFF
--- a/frontend-react/src/components/Table/TableFilters.test.tsx
+++ b/frontend-react/src/components/Table/TableFilters.test.tsx
@@ -121,7 +121,10 @@ describe("when validating values", () => {
 
 describe("isValidDateString", () => {
     test("returns true only when the date string is well-formed and a valid date", () => {
+        expect(isValidDateString("1/1/23")).toEqual(true);
         expect(isValidDateString("1/1/2023")).toEqual(true);
+        expect(isValidDateString("01/1/2023")).toEqual(true);
+        expect(isValidDateString("01/01/2023")).toEqual(true);
         expect(isValidDateString("01/01/2023")).toEqual(true);
 
         expect(isValidDateString("")).toEqual(false);

--- a/frontend-react/src/components/Table/TableFilters.test.tsx
+++ b/frontend-react/src/components/Table/TableFilters.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { renderWithRouter } from "../../utils/CustomRenderUtils";
 import { mockCursorManager } from "../../hooks/filters/mocks/MockCursorManager";
@@ -46,5 +47,35 @@ describe("Helper functions", () => {
             inclusiveDateString("3000-01-01T00:00:00.000Z")
         ).toISOString();
         expect(includedDate).toEqual("3000-01-01T23:59:59.999Z");
+    });
+});
+
+describe("Rendering with invalid dates", () => {
+    const consoleErrorSpy = jest.spyOn(global.console, "error");
+    let startDateNode: HTMLElement;
+    let endDateNode: HTMLElement;
+
+    beforeEach(() => {
+        renderWithRouter(
+            <TableFilters
+                filterManager={mockFilterManager}
+                cursorManager={mockCursorManager}
+            />
+        );
+
+        startDateNode = screen.getAllByTestId("date-picker-external-input")[0];
+        endDateNode = screen.getAllByTestId("date-picker-external-input")[1];
+    });
+
+    test("in Start Range does not throw an error", async () => {
+        await userEvent.type(startDateNode, "abc");
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    test("in End Range does not throw an error", async () => {
+        await userEvent.type(endDateNode, "abc");
+
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 });

--- a/frontend-react/src/components/Table/TableFilters.test.tsx
+++ b/frontend-react/src/components/Table/TableFilters.test.tsx
@@ -5,7 +5,7 @@ import { renderWithRouter } from "../../utils/CustomRenderUtils";
 import { mockCursorManager } from "../../hooks/filters/mocks/MockCursorManager";
 import { mockFilterManager } from "../../hooks/filters/mocks/MockFilterManager";
 
-import TableFilters, { inclusiveDateString } from "./TableFilters";
+import TableFilters, { isValidDateString } from "./TableFilters";
 
 describe("Rendering", () => {
     beforeEach(() => {
@@ -34,26 +34,14 @@ describe("Rendering", () => {
     });
 });
 
-describe("Helper functions", () => {
-    test("inclusiveDate without time should add EOD time to date", () => {
-        const includedDate = new Date(
-            inclusiveDateString("2022-04-21")
-        ).toISOString();
-        expect(includedDate).toEqual("2022-04-21T23:59:59.999Z");
-    });
+describe("when validating values", () => {
+    const VALID_FROM = "01/01/2023";
+    const VALID_TO = "02/02/2023";
+    const INVALID_DATE = "99/99/9999";
 
-    test("inclusiveDate with time should add EOD time to date", () => {
-        const includedDate = new Date(
-            inclusiveDateString("3000-01-01T00:00:00.000Z")
-        ).toISOString();
-        expect(includedDate).toEqual("3000-01-01T23:59:59.999Z");
-    });
-});
-
-describe("Rendering with invalid dates", () => {
-    const consoleErrorSpy = jest.spyOn(global.console, "error");
     let startDateNode: HTMLElement;
     let endDateNode: HTMLElement;
+    let filterButtonNode: HTMLElement;
 
     beforeEach(() => {
         renderWithRouter(
@@ -63,19 +51,83 @@ describe("Rendering with invalid dates", () => {
             />
         );
 
-        startDateNode = screen.getAllByTestId("date-picker-external-input")[0];
-        endDateNode = screen.getAllByTestId("date-picker-external-input")[1];
+        [startDateNode, endDateNode] = screen.getAllByTestId(
+            "date-picker-external-input"
+        );
+        filterButtonNode = screen.getByText("Filter");
     });
 
-    test("in Start Range does not throw an error", async () => {
-        await userEvent.type(startDateNode, "abc");
-
-        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    describe("by default", () => {
+        test("enables the Filter button with the fallback values", () => {
+            expect(filterButtonNode).toHaveProperty("disabled", false);
+        });
     });
 
-    test("in End Range does not throw an error", async () => {
-        await userEvent.type(endDateNode, "abc");
+    describe("when both values are valid", () => {
+        beforeEach(async () => {
+            await userEvent.type(startDateNode, VALID_FROM);
+            await userEvent.type(endDateNode, VALID_TO);
+        });
 
-        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        test("enables the Filter button", () => {
+            expect(filterButtonNode).toHaveProperty("disabled", true);
+        });
+    });
+
+    describe("when both values are invalid", () => {
+        beforeEach(async () => {
+            await userEvent.type(startDateNode, INVALID_DATE);
+            await userEvent.type(endDateNode, INVALID_DATE);
+        });
+
+        test("disables the Filter button", () => {
+            expect(filterButtonNode).toHaveProperty("disabled", true);
+        });
+    });
+
+    describe("when the from range is invalid", () => {
+        beforeEach(async () => {
+            await userEvent.type(startDateNode, INVALID_DATE);
+            await userEvent.type(endDateNode, VALID_TO);
+        });
+
+        test("disables the Filter button", () => {
+            expect(filterButtonNode).toHaveProperty("disabled", true);
+        });
+    });
+
+    describe("when the to range is invalid", () => {
+        beforeEach(async () => {
+            await userEvent.type(startDateNode, VALID_FROM);
+            await userEvent.type(endDateNode, INVALID_DATE);
+        });
+
+        test("disables the Filter button", () => {
+            expect(filterButtonNode).toHaveProperty("disabled", true);
+        });
+    });
+
+    describe("when the from value is greater than the to value", () => {
+        beforeEach(async () => {
+            await userEvent.type(startDateNode, VALID_TO);
+            await userEvent.type(endDateNode, VALID_FROM);
+        });
+
+        test("disables the Filter button", () => {
+            expect(filterButtonNode).toHaveProperty("disabled", true);
+        });
+    });
+});
+
+describe("isValidDateString", () => {
+    test("returns true only when the date string is well-formed and a valid date", () => {
+        expect(isValidDateString("1/1/2023")).toEqual(true);
+        expect(isValidDateString("01/01/2023")).toEqual(true);
+
+        expect(isValidDateString("")).toEqual(false);
+        expect(isValidDateString("99/99")).toEqual(false);
+        expect(isValidDateString("99/99/9999")).toEqual(false);
+        expect(isValidDateString("01/99/2023")).toEqual(false);
+        expect(isValidDateString("abc")).toEqual(false);
     });
 });

--- a/frontend-react/src/components/Table/TableFilters.tsx
+++ b/frontend-react/src/components/Table/TableFilters.tsx
@@ -12,6 +12,7 @@ import {
     FALLBACK_TO,
     RangeSettingsActionType,
 } from "../../hooks/filters/UseDateRange";
+import { showError } from "../AlertNotifications";
 
 export enum StyleClass {
     CONTAINER = "grid-container filter-container",
@@ -26,9 +27,10 @@ interface SubmissionFilterProps {
 
 /* This helper ensures start range values are inclusive
  * of the day set in the date picker. */
-const inclusiveDateString = (originalDate: string) => {
-    let inclusiveDate = new Date(originalDate);
-    return new Date(inclusiveDate.setUTCHours(23, 59, 59, 999)).toISOString();
+const inclusiveDateString = (originalDateStr: string) => {
+    return new Date(
+        new Date(originalDateStr).setUTCHours(23, 59, 59, 999)
+    ).toISOString();
 };
 
 /* This component contains the UI for selecting query parameters.
@@ -47,11 +49,15 @@ function TableFilters({
      * state to hold these so updates don't render immediately after setting a filter */
     const [rangeFrom, setRangeFrom] = useState<string>(FALLBACK_FROM);
     const [rangeTo, setRangeTo] = useState<string>(FALLBACK_TO);
+    let from: string;
+    let to: string;
 
-    let from = !isNaN(Date.parse(rangeFrom))
-        ? new Date(rangeFrom).toISOString()
-        : "";
-    let to = !isNaN(Date.parse(rangeTo)) ? inclusiveDateString(rangeTo) : "";
+    try {
+        from = new Date(rangeFrom).toISOString();
+        to = inclusiveDateString(rangeTo);
+    } catch (e: any) {
+        showError("Invalid date value.");
+    }
 
     const updateRange = () => {
         filterManager.updateRange({
@@ -96,7 +102,7 @@ function TableFilters({
                         id: "start-date",
                         name: "start-date-picker",
                         onChange: (val?: string) => {
-                            if (val) {
+                            if (val && Date.parse(val)) {
                                 setRangeFrom(val);
                             }
                         },
@@ -107,7 +113,7 @@ function TableFilters({
                         id: "end-date",
                         name: "end-date-picker",
                         onChange: (val?: string) => {
-                            if (val) {
+                            if (val && Date.parse(val)) {
                                 setRangeTo(val);
                             }
                         },

--- a/frontend-react/src/components/Table/TableFilters.tsx
+++ b/frontend-react/src/components/Table/TableFilters.tsx
@@ -27,10 +27,8 @@ interface SubmissionFilterProps {
 /* This helper ensures start range values are inclusive
  * of the day set in the date picker. */
 const inclusiveDateString = (originalDate: string) => {
-    let inclusiveDateDate = new Date(originalDate);
-    return new Date(
-        inclusiveDateDate.setUTCHours(23, 59, 59, 999)
-    ).toISOString();
+    let inclusiveDate = new Date(originalDate);
+    return new Date(inclusiveDate.setUTCHours(23, 59, 59, 999)).toISOString();
 };
 
 /* This component contains the UI for selecting query parameters.
@@ -50,8 +48,10 @@ function TableFilters({
     const [rangeFrom, setRangeFrom] = useState<string>(FALLBACK_FROM);
     const [rangeTo, setRangeTo] = useState<string>(FALLBACK_TO);
 
-    let from = new Date(rangeFrom).toISOString();
-    let to = inclusiveDateString(rangeTo);
+    let from = !isNaN(Date.parse(rangeFrom))
+        ? new Date(rangeFrom).toISOString()
+        : "";
+    let to = !isNaN(Date.parse(rangeTo)) ? inclusiveDateString(rangeTo) : "";
 
     const updateRange = () => {
         filterManager.updateRange({
@@ -91,23 +91,25 @@ function TableFilters({
                 <DateRangePicker
                     className={StyleClass.DATE_CONTAINER}
                     startDateLabel="From (Start Range):"
+                    startDateHint="mm/dd/yyyy"
                     startDatePickerProps={{
                         id: "start-date",
                         name: "start-date-picker",
                         onChange: (val?: string) => {
-                            val
-                                ? setRangeFrom(val)
-                                : console.warn("Start Range is undefined");
+                            if (val) {
+                                setRangeFrom(val);
+                            }
                         },
                     }}
                     endDateLabel="Until (End Range):"
+                    endDateHint="mm/dd/yyyy"
                     endDatePickerProps={{
                         id: "end-date",
                         name: "end-date-picker",
                         onChange: (val?: string) => {
-                            val
-                                ? setRangeTo(val)
-                                : console.warn("Start Range is undefined");
+                            if (val) {
+                                setRangeTo(val);
+                            }
                         },
                     }}
                 />

--- a/frontend-react/src/components/Table/TableFilters.tsx
+++ b/frontend-react/src/components/Table/TableFilters.tsx
@@ -25,7 +25,11 @@ interface SubmissionFilterProps {
     onFilterClick?: ({ from, to }: { from: string; to: string }) => void;
 }
 
-const DATE_RE = /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4}$/;
+// using a regex to check for format because of different browsers' implementations of Date
+// e.g.:
+//   new Date('11') in Chrome --> Date representation of 11/01/2001
+//   new Date('11') in Firefox --> Invalid Date
+const DATE_RE = /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}$/;
 
 export function isValidDateString(dateStr?: string) {
     // need to check for value format (mm/dd/yyyy) and date validity (no 99/99/9999)

--- a/frontend-react/src/components/Table/TableFilters.tsx
+++ b/frontend-react/src/components/Table/TableFilters.tsx
@@ -10,9 +10,9 @@ import {
 import {
     FALLBACK_FROM,
     FALLBACK_TO,
+    getEndOfDay,
     RangeSettingsActionType,
 } from "../../hooks/filters/UseDateRange";
-import { showError } from "../AlertNotifications";
 
 export enum StyleClass {
     CONTAINER = "grid-container filter-container",
@@ -25,13 +25,14 @@ interface SubmissionFilterProps {
     onFilterClick?: ({ from, to }: { from: string; to: string }) => void;
 }
 
-/* This helper ensures start range values are inclusive
- * of the day set in the date picker. */
-const inclusiveDateString = (originalDateStr: string) => {
-    return new Date(
-        new Date(originalDateStr).setUTCHours(23, 59, 59, 999)
-    ).toISOString();
-};
+const DATE_RE = /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4}$/;
+
+export function isValidDateString(dateStr?: string) {
+    // need to check for value format (mm/dd/yyyy) and date validity (no 99/99/9999)
+    return (
+        DATE_RE.test(dateStr || "") && !Number.isNaN(Date.parse(dateStr || ""))
+    );
+}
 
 /* This component contains the UI for selecting query parameters.
  * When the `Apply` button is clicked, these should be updated in
@@ -44,31 +45,26 @@ function TableFilters({
     cursorManager,
     onFilterClick,
 }: SubmissionFilterProps) {
-    /* Local state to hold values before pushing to context. Pushing to context
-     * will trigger a re-render due to the API call fetching new data. We have local
-     * state to hold these so updates don't render immediately after setting a filter */
+    // store ISO strings to pass to FilterManager when user clicks 'Filter'
+    // TODO: Remove FilterManager and CursorManager
     const [rangeFrom, setRangeFrom] = useState<string>(FALLBACK_FROM);
     const [rangeTo, setRangeTo] = useState<string>(FALLBACK_TO);
-    let from: string;
-    let to: string;
-
-    try {
-        from = new Date(rangeFrom).toISOString();
-        to = inclusiveDateString(rangeTo);
-    } catch (e: any) {
-        showError("Invalid date value.");
-    }
+    const isFilterEnabled = Boolean(
+        rangeFrom && rangeTo && rangeFrom < rangeTo
+    );
 
     const updateRange = () => {
         filterManager.updateRange({
             type: RangeSettingsActionType.RESET,
-            payload: { from, to },
+            payload: { from: rangeFrom, to: rangeTo },
         });
         cursorManager &&
             cursorManager.update({
                 type: CursorActionType.RESET,
                 payload:
-                    filterManager.sortSettings.order === "DESC" ? to : from,
+                    filterManager.sortSettings.order === "DESC"
+                        ? rangeTo
+                        : rangeFrom,
             });
     };
 
@@ -77,7 +73,7 @@ function TableFilters({
         updateRange();
 
         // call onFilterClick with the specified range
-        if (onFilterClick) onFilterClick({ from, to });
+        if (onFilterClick) onFilterClick({ from: rangeFrom, to: rangeTo });
     };
 
     /* Clears manager and local state values */
@@ -102,10 +98,13 @@ function TableFilters({
                         id: "start-date",
                         name: "start-date-picker",
                         onChange: (val?: string) => {
-                            if (val && Date.parse(val)) {
-                                setRangeFrom(val);
+                            if (isValidDateString(val)) {
+                                setRangeFrom(new Date(val!!).toISOString());
+                            } else {
+                                setRangeFrom("");
                             }
                         },
+                        defaultValue: rangeFrom,
                     }}
                     endDateLabel="Until (End Range):"
                     endDateHint="mm/dd/yyyy"
@@ -113,15 +112,21 @@ function TableFilters({
                         id: "end-date",
                         name: "end-date-picker",
                         onChange: (val?: string) => {
-                            if (val && Date.parse(val)) {
-                                setRangeTo(val);
+                            if (isValidDateString(val)) {
+                                setRangeTo(
+                                    getEndOfDay(new Date(val!!)).toISOString()
+                                );
+                            } else {
+                                setRangeTo("");
                             }
                         },
+                        defaultValue: rangeTo,
                     }}
                 />
                 <div className="button-container">
                     <div className={StyleClass.DATE_CONTAINER}>
                         <Button
+                            disabled={!isFilterEnabled}
                             onClick={() => applyToFilterManager()}
                             type={"button"}
                         >
@@ -130,7 +135,7 @@ function TableFilters({
                     </div>
                     <div className={StyleClass.DATE_CONTAINER}>
                         <Button
-                            onClick={() => clearAll()}
+                            onClick={clearAll}
                             type={"button"}
                             name="clear-button"
                             unstyled
@@ -145,4 +150,3 @@ function TableFilters({
 }
 
 export default TableFilters;
-export { inclusiveDateString };

--- a/frontend-react/src/hooks/filters/UseDateRange.test.ts
+++ b/frontend-react/src/hooks/filters/UseDateRange.test.ts
@@ -1,6 +1,9 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 
-import useDateRange, { RangeSettingsActionType } from "./UseDateRange";
+import useDateRange, {
+    getEndOfDay,
+    RangeSettingsActionType,
+} from "./UseDateRange";
 
 describe("UseDateRange", () => {
     test("renders with default values", () => {
@@ -79,5 +82,18 @@ describe("UseDateRange", () => {
             from: "2022-12-31T00:00:00.000Z",
             to: "2022-01-01T00:00:00.000Z",
         });
+    });
+});
+
+describe("getEndOfDay", () => {
+    const date = new Date("2023-02-17T00:00:00.000Z");
+
+    test("returns the end of the day in UTC", () => {
+        expect(getEndOfDay(date)).toEqual(new Date("2023-02-17T23:59:59.999Z"));
+    });
+
+    test("does not modify the original Date instance", () => {
+        getEndOfDay(date);
+        expect(date.toISOString()).toEqual("2023-02-17T00:00:00.000Z");
     });
 });

--- a/frontend-react/src/hooks/filters/UseDateRange.ts
+++ b/frontend-react/src/hooks/filters/UseDateRange.ts
@@ -50,6 +50,13 @@ const rangeReducer = (
     }
 };
 
+export function getEndOfDay(date: Date) {
+    // return a new Date instance so we don't mutate old one
+    const newDate = new Date(date);
+    newDate.setUTCHours(23, 59, 59, 999);
+    return newDate;
+}
+
 const FALLBACK_FROM = new Date("2000-01-01").toISOString();
 const FALLBACK_TO = new Date("3000-01-01").toISOString();
 

--- a/frontend-react/src/hooks/filters/mocks/MockFilterManager.ts
+++ b/frontend-react/src/hooks/filters/mocks/MockFilterManager.ts
@@ -9,7 +9,7 @@ const fakeDispatch = <T>(): Dispatch<T> => {
     return (_v: T) => {};
 };
 
-export const mockFilterManager = {
+export const mockFilterManager: FilterManager = {
     rangeSettings: {
         from: new Date("2022-01-01").toISOString(),
         to: new Date("2022-12-31").toISOString(),
@@ -18,6 +18,7 @@ export const mockFilterManager = {
         column: "",
         order: "DESC",
         locally: false,
+        localOrder: "DESC",
     },
     pageSettings: {
         size: 10,
@@ -26,4 +27,5 @@ export const mockFilterManager = {
     updateRange: fakeDispatch<RangeSettingsAction>(),
     updateSort: fakeDispatch<SortSettingsAction>(),
     updatePage: fakeDispatch<PageSettingsAction>(),
-} as FilterManager;
+    resetAll: () => {},
+};


### PR DESCRIPTION
This PR ...

Fixes bug - Typing non-numeric characters into date range filter fields errors out

Test Steps:
1. Log into RS
2. Select a State(For Daily Data) or a Federal(For Submissions) organization
3. Go to Daily Data and enter in a non-numeric character into the start range and/or end range
4. Click Filter
5. Notice that an error is not thrown and the table lists the default result set

## Changes
Added check for valid date before calling toISOString.
Added startDateHint to DateRangePicker
![Screenshot 2023-02-15 at 3 25 44 PM](https://user-images.githubusercontent.com/102491809/219215483-22bdb937-51aa-4fb4-8780-9c8cf3d1cc07.png)


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Fixes
- #7998
