### PR TITLE
Only run yarn integrity check when package.json/yarn.lock changed

### DIFF
--- a/.environment/yarn/run-yarnCheck.sh
+++ b/.environment/yarn/run-yarnCheck.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 
+isModified=0
+
 function note() {
     echo "yarn-check> info: ${*}"
+}
+
+function modified_check() {
+    MODIFIED_PACKAGE_COUNT=$(git status --porcelain | grep "package.json$" | wc -l)
+    MODIFIED_LOCK_COUNT=$(git status --porcelain | grep "yarn.lock$" | wc -l)
+    if [ ${MODIFIED_PACKAGE_COUNT} != 0 ] || [ ${MODIFIED_LOCK_COUNT} != 0 ]; then
+        isModified=1
+    else
+        isModified=0
+    fi
 }
 
 function yarn_lock_check() {
@@ -10,11 +22,16 @@ function yarn_lock_check() {
 }
 
 cd frontend-react
-yarn_lock_check
+modified_check
+if [[ ${isModified} == 1 ]]; then
+    yarn_lock_check
+else
+    note "Skipping this check"
+fi
 RC=$?
 
 if [[ ${RC?} != 0 ]]; then
-    echo "yarn-check> ERROR: Your yarn lock file is out of sync. Please run yarn install and try again."
+    note "ERROR: Your yarn lock file is out of sync. Please run yarn install and try again."
 fi
 
 exit ${RC?} 


### PR DESCRIPTION
Fixes #8363

This PR fixes a bug from my yarn integrity check addition whereas developers making changes outside of frontend-react are forced to install node/yarn due to the script not verifying if a yarn integrity check is necessary. The script will now check if package.json and/or yarn.lock has been changed before trying to call the integrity check which should return pre-commit back to previous expected behavior.