### PR TITLE
chore: update yarn.lock

### DIFF
--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -3217,7 +3217,7 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@xmldom/xmldom@^0.8.3":
+"@xmldom/xmldom@0.8.6", "@xmldom/xmldom@^0.8.3":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
   integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==


### PR DESCRIPTION
Just noticed this smallllllll update to the yarn.lock when installing on Node v16.19.1
