### PR TITLE
Experience-8549: Fix incorrect setting type history

### DIFF
--- a/frontend-react/src/network/api/Organizations/SettingRevisions.ts
+++ b/frontend-react/src/network/api/Organizations/SettingRevisions.ts
@@ -39,7 +39,7 @@ export const useSettingRevisionEndpointsQuery = (
         useAuthorizedFetch<SettingRevision[]>();
 
     // get all lookup tables in order to get metadata
-    return rsUseQuery(["org", "settingType"], async () =>
+    return rsUseQuery(["history", params.org, params.settingType], async () =>
         authorizedFetch(settingRevisionEndpoints.getList, {
             segments: params,
         })


### PR DESCRIPTION
This changeset updates the setting revision query key to be cached on the Organization and setting type (Sender|Receiver).  Originally, it was being cached on the strings "org" and "settingType" verbatim, which means that all revision histories would get the same response that's in the query cache.  This just updates the query key to be more dynamic.

Test Steps:
1. Log in as an admin
2. Choose an Organization with multiple Sender/Receiver channels to edit
3. Click on the different "History" links (using the back button/without refreshing the page) and verify that only the correct revision histories are shown for the specific setting type (Organization|Sender|Receiver)

## Changes
![2023-03-01 17 06 35](https://user-images.githubusercontent.com/2421042/222276025-42c8b783-cba0-4110-99cc-0686492df05b.gif)

## Checklist

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests? -- not sure if it's really needed since this is just updating a query key 🤷 

## Linked Issues
- Fixes #8549 