### PR TITLE
Experience-8565: Fix incorrect HL7 schema for validator options

### DIFF
--- a/frontend-react/src/senders/hooks/UseSenderSchemaOptions/index.ts
+++ b/frontend-react/src/senders/hooks/UseSenderSchemaOptions/index.ts
@@ -4,7 +4,7 @@ import { FileType } from "../../../hooks/UseFileHandler";
 export enum StandardSchema {
     CSV = "upload-covid-19",
     CSV_OTC = "csv-otc-covid-19",
-    HL7 = "standard/standard-covid-19",
+    HL7 = "hl7/hl7-ingest-covid-19-prod",
 }
 
 export const STANDARD_SCHEMA_VALUES: string[] = Object.values(StandardSchema);


### PR DESCRIPTION
This changeset updates the HL7 schema option for the validator. Incorrect: `standard/standard-covid-19`
Correct: `hl7/hl7-ingest-covid-19-prod`

Test Steps:
1. Log in as an admin
2. Go to /file-handler/validate
3. Click on the "Select a schema" dropdown and choose `hl7/hl7-ingest-covid-19-prod`
4. Ensure validation works with an HL7 file with the selected schema

## Changes
<img width="1042" alt="Screenshot 2023-03-02 at 11 40 57" src="https://user-images.githubusercontent.com/2421042/222495253-1104bf98-1c02-4d98-b3ee-5a7f6efe44c1.png">

<img width="1046" alt="Screenshot 2023-03-02 at 11 45 02" src="https://user-images.githubusercontent.com/2421042/222495391-9ff7183a-495b-4eb6-bc3a-9e851b33a9bd.png">

## Checklist

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
<strike>- [ ] Added tests?</strike>

## Linked Issues
- Fixes #8565 