### PR TITLE
Experience-8602: Add FHIR format to list of options

### DIFF
--- a/frontend-react/src/hooks/UseFileHandler.ts
+++ b/frontend-react/src/hooks/UseFileHandler.ts
@@ -11,6 +11,7 @@ export enum ErrorType {
     FILE = "file",
 }
 
+// TODO: consolidate with Format in TemporarySettingsAPITypes.ts
 export enum FileType {
     "CSV" = "CSV",
     "HL7" = "HL7",

--- a/frontend-react/src/utils/TemporarySettingsAPITypes.test.ts
+++ b/frontend-react/src/utils/TemporarySettingsAPITypes.test.ts
@@ -17,7 +17,7 @@ describe("Settings API Types", () => {
             JSON.stringify({ title: "test" }, null, 6)
         );
         expect(obj.getAllEnums()).toEqual(
-            new Map([["format", ["CSV", "HL7"]]])
+            new Map([["format", ["CSV", "HL7", "FHIR"]]])
         );
         expect(obj.description()).toEqual("A test sample object");
     });

--- a/frontend-react/src/utils/TemporarySettingsAPITypes.ts
+++ b/frontend-react/src/utils/TemporarySettingsAPITypes.ts
@@ -7,9 +7,11 @@ enum Jurisdiction {
     COUNTY = "COUNTY",
 }
 
+// TODO: Consolidate with FileType in UseFileHandler.ts
 enum Format {
     CSV = "CSV",
     HL7 = "HL7",
+    FHIR = "FHIR",
 }
 
 enum CustomerStatus {


### PR DESCRIPTION
Pretty simple change!  Just adding FHIR as an available format in addition to CSV and HL7.  This'll allow us to update Sender formats through the admin Organization settings view.

Test Steps:
1. Log in as an admin
2. Go to the Organization settings page
3. Choose an Organization with a Sender service and click 'Edit'
4. Click the Format dropdown --> ensure that `FHIR` shows up as an option and that it can be saved as such

## Changes
<img width="1443" alt="Screenshot 2023-03-06 at 10 14 46" src="https://user-images.githubusercontent.com/2421042/223152613-bddf1f60-ae54-4d20-a2e9-4b0d8e465b39.png">

## Checklist

### Testing
- [x] Tested locally?
<strike>- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?</strike>
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
<strike>- [ ] Added tests?</strike>

## Linked Issues
- Fixes #8602 