### PR TITLE
Experience-8026: Widen grid container

### DIFF
--- a/frontend-react/src/components/Admin/AdminLastMileFailuresTable.tsx
+++ b/frontend-react/src/components/Admin/AdminLastMileFailuresTable.tsx
@@ -382,7 +382,7 @@ ${data.receiver}`;
     };
 
     return (
-        <section className="grid-container rs-maxwidth-vw80">
+        <section>
             <h2>Last Mile failures</h2>
 
             <form autoComplete="off" className="grid-row margin-0">

--- a/frontend-react/src/components/Admin/AdminReceiverDashboard.tsx
+++ b/frontend-react/src/components/Admin/AdminReceiverDashboard.tsx
@@ -875,7 +875,7 @@ export function AdminReceiverDashboard() {
     }, []);
 
     return (
-        <section className="grid-container">
+        <article>
             <h4>Receiver Status Dashboard</h4>
             <section>
                 CRON job results that check if receivers are working.
@@ -1017,7 +1017,7 @@ export function AdminReceiverDashboard() {
             >
                 <ModalInfoRender subData={currentDataForModal} />
             </Modal>
-        </section>
+        </article>
     );
 }
 

--- a/frontend-react/src/components/Admin/OrgsTable.tsx
+++ b/frontend-react/src/components/Admin/OrgsTable.tsx
@@ -88,10 +88,7 @@ export function OrgsTable() {
             <Helmet>
                 <title>Admin-Organizations</title>
             </Helmet>
-            <section
-                id="orgsettings"
-                className="grid-container margin-bottom-5"
-            >
+            <section id="orgsettings" className="margin-bottom-5">
                 <h2>Organizations ({orgs.length})</h2>
                 <form autoComplete="off" className="grid-row">
                     <div className="flex-fill">

--- a/frontend-react/src/components/Content/PageGenerationTools.tsx
+++ b/frontend-react/src/components/Content/PageGenerationTools.tsx
@@ -9,7 +9,7 @@ export const contentContainer = (
     crumbs: CrumbConfig[]
 ) => {
     const wrappedElement = (
-        <div className="grid-container rs-documentation usa-prose">
+        <div className="rs-documentation usa-prose">
             <Content />
         </div>
     );

--- a/frontend-react/src/components/Content/Templates/IACardGridTemplate.tsx
+++ b/frontend-react/src/components/Content/Templates/IACardGridTemplate.tsx
@@ -41,12 +41,12 @@ export const IACardGridTemplate = ({
     return (
         <>
             <div className="rs-hero__index">
-                <div className="grid-container">
+                <div>
                     <h1>{pageName}</h1>
                     <h2>{subtitle}</h2>
                 </div>
             </div>
-            <div className="grid-container usa-prose margin-top-6">
+            <div className="usa-prose margin-top-6">
                 <div className="grid-row grid-gap">
                     {!contentIsMapped ? (
                         <ArraySection dirs={directories} />

--- a/frontend-react/src/components/Crumbs.tsx
+++ b/frontend-react/src/components/Crumbs.tsx
@@ -11,14 +11,13 @@ interface CrumbConfig {
 
 interface CrumbsProps {
     crumbList?: CrumbConfig[];
-    noPadding?: boolean;
     previousPage?: string;
 }
 
-const Crumbs = ({ crumbList, noPadding, previousPage }: CrumbsProps) => {
+const Crumbs = ({ crumbList, previousPage }: CrumbsProps) => {
     if (crumbList || previousPage) {
         return (
-            <div className={!noPadding ? "grid-container" : ""}>
+            <div>
                 {Boolean(previousPage) ? (
                     <div className="font-sans-lg line-height-sans-4 margin-top-8">
                         <IconButton
@@ -57,7 +56,7 @@ const Crumbs = ({ crumbList, noPadding, previousPage }: CrumbsProps) => {
         );
     } else {
         return (
-            <div className="grid-container margin-top-5">
+            <div className="margin-top-5">
                 <span>No crumbs given</span>
             </div>
         );

--- a/frontend-react/src/components/FileHandlers/FileHandler.tsx
+++ b/frontend-react/src/components/FileHandlers/FileHandler.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import { showError } from "../AlertNotifications";
 import { useSessionContext } from "../../contexts/SessionContext";
@@ -260,82 +261,86 @@ function FileHandler() {
     }
 
     return (
-        <div className="grid-container usa-section margin-bottom-10">
-            <h1 className="margin-top-0 margin-bottom-5">
-                ReportStream File Validator
-            </h1>
-            <h2 className="font-sans-lg">{organization?.description}</h2>
-            {fileName && (
-                <>
-                    <p
-                        id="validatedFilename"
-                        className="text-normal text-base margin-bottom-0"
-                    >
-                        File name
-                    </p>
-                    <p className="margin-top-05">{fileName}</p>
-                </>
-            )}
-            {isFileSuccess && warnings.length === 0 && (
-                <FileSuccessDisplay
-                    extendedMetadata={{
-                        destinations,
-                        timestamp: successTimestamp,
-                        reportId,
-                    }}
-                    heading="Validate another file"
-                    message={successDescription}
-                    showExtendedMetadata={false}
-                />
-            )}
-            {warnings.length > 0 && (
-                <RequestedChangesDisplay
-                    title={RequestLevel.WARNING}
-                    data={warnings}
-                    message="The following warnings were returned while processing your file. We recommend addressing warnings to enhance clarity."
-                    heading="File validated with recommended edits"
-                />
-            )}
-            {errors.length > 0 && (
-                <RequestedChangesDisplay
-                    title={RequestLevel.ERROR}
-                    data={errors}
-                    message={errorMessaging.message}
-                    heading={errorMessaging.heading}
-                />
-            )}
-            {hasQualityFilterMessages && (
-                <FileQualityFilterDisplay
-                    destinations={qualityFilterMessages}
-                    heading=""
-                    message={`The file does not meet the jurisdiction's schema. Please resolve the errors below.`}
-                />
-            )}
-            {isWorking && <FileHandlerSpinner message="Processing file..." />}
-            {!isWorking && (
-                <FileHandlerForm
-                    handleSubmit={handleSubmit}
-                    handleFileChange={handleFileChange}
-                    resetState={resetState}
-                    fileInputResetValue={fileInputResetValue}
-                    submitted={submitted}
-                    cancellable={cancellable}
-                    fileName={fileName}
-                    fileType={fileType}
-                    formLabel={formLabel}
-                    resetText="Validate another file"
-                    submitText="Validate"
-                    schemaOptions={schemaOptions}
-                    selectedSchemaOption={selectedSchemaOption}
-                    onSchemaChange={(schemaOption) =>
-                        dispatch({
-                            type: FileHandlerActionType.SCHEMA_SELECTED,
-                            payload: schemaOption,
-                        })
-                    }
-                />
-            )}
-        </div>
+        <GridContainer>
+            <article className="usa-section">
+                <h1 className="margin-top-0 margin-bottom-5">
+                    ReportStream File Validator
+                </h1>
+                <h2 className="font-sans-lg">{organization?.description}</h2>
+                {fileName && (
+                    <>
+                        <p
+                            id="validatedFilename"
+                            className="text-normal text-base margin-bottom-0"
+                        >
+                            File name
+                        </p>
+                        <p className="margin-top-05">{fileName}</p>
+                    </>
+                )}
+                {isFileSuccess && warnings.length === 0 && (
+                    <FileSuccessDisplay
+                        extendedMetadata={{
+                            destinations,
+                            timestamp: successTimestamp,
+                            reportId,
+                        }}
+                        heading="Validate another file"
+                        message={successDescription}
+                        showExtendedMetadata={false}
+                    />
+                )}
+                {warnings.length > 0 && (
+                    <RequestedChangesDisplay
+                        title={RequestLevel.WARNING}
+                        data={warnings}
+                        message="The following warnings were returned while processing your file. We recommend addressing warnings to enhance clarity."
+                        heading="File validated with recommended edits"
+                    />
+                )}
+                {errors.length > 0 && (
+                    <RequestedChangesDisplay
+                        title={RequestLevel.ERROR}
+                        data={errors}
+                        message={errorMessaging.message}
+                        heading={errorMessaging.heading}
+                    />
+                )}
+                {hasQualityFilterMessages && (
+                    <FileQualityFilterDisplay
+                        destinations={qualityFilterMessages}
+                        heading=""
+                        message={`The file does not meet the jurisdiction's schema. Please resolve the errors below.`}
+                    />
+                )}
+                {isWorking && (
+                    <FileHandlerSpinner message="Processing file..." />
+                )}
+                {!isWorking && (
+                    <FileHandlerForm
+                        handleSubmit={handleSubmit}
+                        handleFileChange={handleFileChange}
+                        resetState={resetState}
+                        fileInputResetValue={fileInputResetValue}
+                        submitted={submitted}
+                        cancellable={cancellable}
+                        fileName={fileName}
+                        fileType={fileType}
+                        formLabel={formLabel}
+                        resetText="Validate another file"
+                        submitText="Validate"
+                        schemaOptions={schemaOptions}
+                        selectedSchemaOption={selectedSchemaOption}
+                        onSchemaChange={(schemaOption) =>
+                            dispatch({
+                                type: FileHandlerActionType.SCHEMA_SELECTED,
+                                payload: schemaOption,
+                            })
+                        }
+                    />
+                )}
+            </article>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/components/HipaaNotice.tsx
+++ b/frontend-react/src/components/HipaaNotice.tsx
@@ -1,6 +1,6 @@
 export default function HipaaNotice() {
     return (
-        <section className="grid-container usa-section usa-prose font-sans-2xs text-base-darker">
+        <section className="usa-section usa-prose font-sans-2xs text-base-darker">
             <p>
                 Data aggregated with ReportStream may be subject to the Privacy
                 Act of 1974, the Health Insurance Portability and Accountability

--- a/frontend-react/src/components/MessageTracker/MessageDetails.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageDetails.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Button, Accordion } from "@trussworks/react-uswds";
+import { Button, Accordion, GridContainer } from "@trussworks/react-uswds";
 import { AccordionItemProps } from "@trussworks/react-uswds/lib/components/Accordion/Accordion";
 
 import { AuthElement } from "../AuthElement";
@@ -67,11 +67,8 @@ export function MessageDetails() {
     const { folderLocation, sendingOrg, fileName } = parseFileLocation(fileUrl);
 
     return (
-        <>
-            <div
-                className="grid-container margin-bottom-10"
-                data-testid="container"
-            >
+        <GridContainer containerSize="widescreen">
+            <article className="margin-bottom-10" data-testid="container">
                 <div>
                     <h2>Message ID Search</h2>
                     <Button
@@ -190,8 +187,8 @@ export function MessageDetails() {
                         <h3>No Data to Display</h3>
                     </>
                 )}
-            </div>
-        </>
+            </article>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/components/MessageTracker/MessageTracker.tsx
+++ b/frontend-react/src/components/MessageTracker/MessageTracker.tsx
@@ -65,7 +65,7 @@ const MessageTrackerTableContent: React.FC<MessageListTableContentProps> = ({
             {hasSearched && (
                 <Table
                     title=""
-                    classes={"rs-no-padding margin-top-5"}
+                    classes="rs-no-padding margin-top-5"
                     config={tableConfig}
                 />
             )}
@@ -97,7 +97,7 @@ export function MessageTracker() {
     };
 
     return (
-        <section className="grid-container margin-bottom-5 tablet:margin-top-6">
+        <section className="margin-bottom-5 tablet:margin-top-6">
             <h1>Message ID Search</h1>
 
             <Form onSubmit={(e) => searchMessageId(e)} className="maxw-full">

--- a/frontend-react/src/components/Table/Table.tsx
+++ b/frontend-react/src/components/Table/Table.tsx
@@ -124,10 +124,7 @@ const Table = ({
         return config.rows;
     }, [config.rows, filterManager?.sortSettings]);
 
-    const wrapperClasses = useMemo(
-        () => `grid-container margin-bottom-10 ${classes}`,
-        [classes]
-    );
+    const wrapperClasses = `margin-bottom-10 ${classes}`;
 
     const addRow = useCallback(() => {
         setRowToEdit(memoizedRows?.length || 0);
@@ -154,7 +151,7 @@ const Table = ({
                 datasetAction={memoizedDatasetAction}
                 rowToEdit={rowToEdit}
             />
-            <div className="grid-col-12">
+            <div>
                 <table
                     className="usa-table usa-table--borderless usa-table--striped prime-table"
                     aria-label="Submission history from the last 30 days"

--- a/frontend-react/src/components/Table/TableFilters.tsx
+++ b/frontend-react/src/components/Table/TableFilters.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../hooks/filters/UseDateRange";
 
 export enum StyleClass {
-    CONTAINER = "grid-container filter-container",
+    CONTAINER = "filter-container",
     DATE_CONTAINER = "date-picker-container tablet:grid-col",
 }
 

--- a/frontend-react/src/pages/admin/AdminLastMileFailures.tsx
+++ b/frontend-react/src/pages/admin/AdminLastMileFailures.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from "react";
 import { Helmet } from "react-helmet-async";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import Spinner from "../../components/Spinner";
 import HipaaNotice from "../../components/HipaaNotice";
@@ -10,19 +11,18 @@ import { FeatureName } from "../../AppRouter";
 
 export function AdminLastMileFailures() {
     return (
-        <>
+        <GridContainer containerSize="widescreen">
             <Helmet>
                 <title>{FeatureName.ADMIN}</title>
             </Helmet>
-            <section className="grid-container margin-bottom-5">
+            <article className="margin-bottom-5">
                 <h3 className="margin-bottom-0">
                     <Suspense fallback={<Spinner />} />
                 </h3>
-            </section>
-            <section className="grid-container margin-top-0" />
-            <AdminLastMileFailuresTable />
+                <AdminLastMileFailuresTable />
+            </article>
             <HipaaNotice />
-        </>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/pages/admin/AdminMain.tsx
+++ b/frontend-react/src/pages/admin/AdminMain.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { NetworkErrorBoundary } from "rest-hooks";
 import { Helmet } from "react-helmet-async";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import HipaaNotice from "../../components/HipaaNotice";
 import Spinner from "../../components/Spinner";
@@ -15,18 +16,21 @@ export function AdminMain() {
         <NetworkErrorBoundary
             fallbackComponent={() => <ErrorPage type="page" />}
         >
-            <Helmet>
-                <title>{FeatureName.ADMIN}</title>
-            </Helmet>
-            <NetworkErrorBoundary
-                fallbackComponent={() => <ErrorPage type="message" />}
-            >
-                <Suspense fallback={<Spinner />}>
-                    <section className="grid-container margin-top-0" />
-                    <OrgsTable />
-                </Suspense>
-            </NetworkErrorBoundary>
-            <HipaaNotice />
+            <GridContainer>
+                <article>
+                    <Helmet>
+                        <title>{FeatureName.ADMIN}</title>
+                    </Helmet>
+                    <NetworkErrorBoundary
+                        fallbackComponent={() => <ErrorPage type="message" />}
+                    >
+                        <Suspense fallback={<Spinner />}>
+                            <OrgsTable />
+                        </Suspense>
+                    </NetworkErrorBoundary>
+                    <HipaaNotice />
+                </article>
+            </GridContainer>
         </NetworkErrorBoundary>
     );
 }

--- a/frontend-react/src/pages/admin/AdminMessageTracker.tsx
+++ b/frontend-react/src/pages/admin/AdminMessageTracker.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import HipaaNotice from "../../components/HipaaNotice";
 import { MemberType } from "../../hooks/UseOktaMemberships";
@@ -9,13 +10,15 @@ import { withCatchAndSuspense } from "../../components/RSErrorBoundary";
 
 export function AdminMessageTracker() {
     return (
-        <>
+        <GridContainer containerSize="widescreen">
             <Helmet>
                 <title>Message Id Search</title>
             </Helmet>
-            <MessageTracker />
-            <HipaaNotice />
-        </>
+            <article>
+                <MessageTracker />
+                <HipaaNotice />
+            </article>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/pages/admin/AdminReceiverDashPage.tsx
+++ b/frontend-react/src/pages/admin/AdminReceiverDashPage.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from "react-helmet-async";
 import React from "react";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import HipaaNotice from "../../components/HipaaNotice";
 import { AdminReceiverDashboard } from "../../components/Admin/AdminReceiverDashboard";
@@ -8,14 +9,15 @@ import { AuthElement } from "../../components/AuthElement";
 
 export function AdminReceiverDashPage() {
     return (
-        <>
+        <GridContainer containerSize="widescreen">
             <Helmet>
                 <title>Admin Destination Dashboard</title>
             </Helmet>
-            <section className="grid-container margin-top-0" />
-            <AdminReceiverDashboard />
-            <HipaaNotice />
-        </>
+            <article>
+                <AdminReceiverDashboard />
+                <HipaaNotice />
+            </article>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/pages/deliveries/Deliveries.tsx
+++ b/frontend-react/src/pages/deliveries/Deliveries.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import HipaaNotice from "../../components/HipaaNotice";
 import Title from "../../components/Title";
@@ -15,16 +16,16 @@ function Deliveries() {
     const { data: orgDetails } = useOrganizationSettings();
     const { description } = orgDetails || {};
     return (
-        <>
+        <GridContainer containerSize="widescreen">
             <Helmet>
                 <title>{FeatureName.DAILY_DATA}</title>
             </Helmet>
-            <section className="grid-container margin-bottom-5 tablet:margin-top-6">
+            <article className="padding-bottom-5 tablet:padding-top-6">
                 <Title preTitle={description} title={FeatureName.DAILY_DATA} />
-            </section>
-            {withCatchAndSuspense(<DeliveriesTable />)}
-            <HipaaNotice />
-        </>
+                {withCatchAndSuspense(<DeliveriesTable />)}
+                <HipaaNotice />
+            </article>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/pages/deliveries/Table/DeliveriesTable.tsx
+++ b/frontend-react/src/pages/deliveries/Table/DeliveriesTable.tsx
@@ -37,7 +37,7 @@ const ServiceDisplay = ({
     handleSetActive: (v: string) => void;
 }) => {
     return (
-        <div className="grid-container grid-col-12">
+        <div className="grid-col-12">
             {services && services?.length > 1 ? (
                 <ServicesDropdown
                     services={services}
@@ -216,16 +216,12 @@ export const DeliveriesTable = () => {
     if (loadingServices) return <Spinner />;
 
     if (isDisabled) {
-        return (
-            <div className="grid-container">
-                <AdminFetchAlert />
-            </div>
-        );
+        return <AdminFetchAlert />;
     }
 
     if (!loadingServices && !activeService)
         return (
-            <div className="grid-container usa-section margin-bottom-10">
+            <div className="usa-section margin-bottom-10">
                 <NoServicesBanner
                     featureName="Active Services"
                     organization=""

--- a/frontend-react/src/pages/deliveries/details/DeliveryDetail.tsx
+++ b/frontend-react/src/pages/deliveries/details/DeliveryDetail.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import HipaaNotice from "../../../components/HipaaNotice";
 import { useReportsDetail } from "../../../hooks/network/History/DeliveryHooks";
@@ -15,14 +16,16 @@ const DetailsContent = () => {
     const { reportDetail } = useReportsDetail(reportId!!);
 
     return (
-        <>
-            <Summary report={reportDetail} />
-            <DeliveryInfo report={reportDetail} />
-            {withCatchAndSuspense(
-                <DeliveryFacilitiesTable reportId={reportId!!} />
-            )}
-            <HipaaNotice />
-        </>
+        <GridContainer containerSize="widescreen">
+            <article>
+                <Summary report={reportDetail} />
+                <DeliveryInfo report={reportDetail} />
+                {withCatchAndSuspense(
+                    <DeliveryFacilitiesTable reportId={reportId!!} />
+                )}
+                <HipaaNotice />
+            </article>
+        </GridContainer>
     );
 };
 

--- a/frontend-react/src/pages/deliveries/details/DeliveryFacilitiesTable.tsx
+++ b/frontend-react/src/pages/deliveries/details/DeliveryFacilitiesTable.tsx
@@ -24,7 +24,7 @@ function DeliveryFacilitiesTable(props: FacilitiesTableProps) {
     };
 
     return (
-        <section id="facilities" className="grid-container margin-bottom-5">
+        <section id="facilities" className="margin-bottom-5">
             <h2>Facilities reporting ({reportFacilities?.length || 0})</h2>
             <Table config={tableConfig} />
         </section>

--- a/frontend-react/src/pages/deliveries/details/DeliveryInfo.tsx
+++ b/frontend-react/src/pages/deliveries/details/DeliveryInfo.tsx
@@ -14,7 +14,7 @@ function DeliveryInfo(props: Props) {
 
     if (!report) return <></>;
     return (
-        <section className="grid-container margin-top-0 margin-bottom-5">
+        <section className="margin-top-0 margin-bottom-5">
             <hr />
             <div id="details" className="grid-row grid-gap margin-top-0">
                 <div className="tablet:grid-col">

--- a/frontend-react/src/pages/deliveries/details/Summary.tsx
+++ b/frontend-react/src/pages/deliveries/details/Summary.tsx
@@ -21,11 +21,10 @@ function Summary(props: Props) {
             { label: FeatureName.DAILY_DATA, path: "/daily-data" },
             { label: "Details" },
         ],
-        noPadding: true,
     };
 
     return (
-        <div className="grid-container grid-row tablet:margin-top-6">
+        <div className="grid-row tablet:margin-top-6">
             <div className="grid-col-fill">
                 <Crumbs {...crumbProps} />
                 <Title preTitle={description} title={report?.reportId || ""} />

--- a/frontend-react/src/pages/resources/Resources.tsx
+++ b/frontend-react/src/pages/resources/Resources.tsx
@@ -1,3 +1,5 @@
+import { GridContainer } from "@trussworks/react-uswds";
+
 import { IACardGridProps } from "../../components/Content/Templates/IACardGridTemplate";
 import {
     resourcesDirectories,
@@ -22,4 +24,10 @@ const rootProps: IATemplateProps<IACardGridProps> = {
 };
 /** Use this component in the main App Router! It will handle rendering everything
  * and set the Helmet values */
-export const Resources = () => <IATemplate {...rootProps} {...rootProps} />;
+export function Resources() {
+    return (
+        <GridContainer>
+            <IATemplate {...rootProps} />
+        </GridContainer>
+    );
+}

--- a/frontend-react/src/pages/submissions/SubmissionDetails.tsx
+++ b/frontend-react/src/pages/submissions/SubmissionDetails.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import { NetworkErrorBoundary, useResource } from "rest-hooks";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import { getStoredOrg } from "../../utils/SessionStorageTools";
 import Spinner from "../../components/Spinner";
@@ -98,10 +99,7 @@ function SubmissionDetailsContent() {
         return <ErrorPage type="page" />;
     } else {
         return (
-            <div
-                className="grid-container margin-bottom-10"
-                data-testid="container"
-            >
+            <div className="margin-bottom-10" data-testid="container">
                 <div className="grid-col-12">
                     <Title
                         preTitle={preTitle}
@@ -134,7 +132,7 @@ function SubmissionDetails() {
     ];
     const location = useLocation();
     return (
-        <>
+        <GridContainer containerSize="widescreen">
             <Crumbs
                 crumbList={crumbs}
                 previousPage={(location.state as any)?.previousPage}
@@ -146,7 +144,7 @@ function SubmissionDetails() {
                     <SubmissionDetailsContent />
                 </Suspense>
             </NetworkErrorBoundary>
-        </>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/pages/submissions/Submissions.tsx
+++ b/frontend-react/src/pages/submissions/Submissions.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
+import { GridContainer } from "@trussworks/react-uswds";
 
 import { useOrganizationSettings } from "../../hooks/UseOrganizationSettings";
 import HipaaNotice from "../../components/HipaaNotice";
@@ -16,16 +17,16 @@ function SubmissionHistoryContent() {
     const { description } = orgDetails || {};
 
     return (
-        <>
-            <Helmet>
-                <title>{FeatureName.SUBMISSIONS}</title>
-            </Helmet>
-            <section className="grid-container margin-top-5">
+        <GridContainer containerSize="widescreen">
+            <article className="padding-top-5">
+                <Helmet>
+                    <title>{FeatureName.SUBMISSIONS}</title>
+                </Helmet>
                 <Title title="Submission History" preTitle={description} />
-            </section>
-            <SubmissionTable />
-            <HipaaNotice />
-        </>
+                <SubmissionTable />
+                <HipaaNotice />
+            </article>
+        </GridContainer>
     );
 }
 

--- a/frontend-react/src/pages/support/Support.tsx
+++ b/frontend-react/src/pages/support/Support.tsx
@@ -1,3 +1,5 @@
+import { GridContainer } from "@trussworks/react-uswds";
+
 import { IACardGridProps } from "../../components/Content/Templates/IACardGridTemplate";
 import {
     supportDirectories,
@@ -22,4 +24,10 @@ const templateProps: IATemplateProps<IACardGridProps> = {
 };
 /** Use this component in the main App Router! It will handle rendering everything
  * and set the Helmet values */
-export const Support = () => <IATemplate {...templateProps} />;
+export function Support() {
+    return (
+        <GridContainer>
+            <IATemplate {...templateProps} />
+        </GridContainer>
+    );
+}

--- a/frontend-react/src/styles/_uswds_overrides.scss
+++ b/frontend-react/src/styles/_uswds_overrides.scss
@@ -1,4 +1,5 @@
 @use 'uswds-core' as *;
+@use "uswds_custom_theme" as *;
 
 /*
 * * * * * ==============================
@@ -109,8 +110,12 @@ main {
 // TABLE
 
 .usa-table {
-  display: block;
-  overflow-x: auto;
+    width: 100%;
+
+    @media (max-width: $tablet) {
+        display: block;
+        overflow-x: auto;
+    }
 }
 
 // MODAL


### PR DESCRIPTION
This changeset updates the follow pages' containers to be widescreen (up to 1400px) since they're the most data-heavy:
- Daily Data
- Submissions
- Message Tracker

The Public Validator page will continue to be on 1024px to align with the rest of the public pages.

Additionally, there's some cleanup regarding containers in the codebase across several different pages, and I've updated `grid-container` modifier classes to use the GridContainer component instead.  There are a lot of `grid-container` modifier classes used around the codebase, and it really shouldn't be used this much; it should be used at the highest ancestor node of common width, and all descendants should naturally expand to their own widths inside of that.  The grid container sets a maximum width, yes, but it also includes padding to account for grid gutters -- if this is used too frequently, there'll be a lot of horizontal jaggedness across the website.

**tl;dr In most cases, a grid container should be used at the top of the page and nowhere else.**  There are obviously use cases for nested grid containers, but they should be rare and should be brought up by design rather than used anywhere we need a maximum width -- especially not in components that should be able to be rendered agnostically to the wrapping context.

Daily Data:
<img width="1733" alt="Screenshot 2023-03-13 at 10 43 58" src="https://user-images.githubusercontent.com/2421042/224741533-3aa05b55-ed56-480a-a713-d0a6363c6e2f.png">
<img width="1733" alt="Screenshot 2023-03-13 at 10 44 38" src="https://user-images.githubusercontent.com/2421042/224741539-0f0b6336-3b97-4b69-bb2b-0a9dad8d119b.png">

Submissions:
<img width="1733" alt="Screenshot 2023-03-13 at 10 44 08" src="https://user-images.githubusercontent.com/2421042/224741534-ee13c70c-cbfb-441e-ab1c-0aff65ccf46f.png">
<img width="1733" alt="Screenshot 2023-03-13 at 10 44 25" src="https://user-images.githubusercontent.com/2421042/224741536-8e6594b7-c590-4b04-a156-b7cb3c4e5d22.png">

Message Tracker:
<img width="1733" alt="Screenshot 2023-03-13 at 10 44 52" src="https://user-images.githubusercontent.com/2421042/224741543-3d0b847f-e7cd-4d99-bd94-605eef4d0a72.png">
<img width="1733" alt="Screenshot 2023-03-13 at 10 44 57" src="https://user-images.githubusercontent.com/2421042/224741546-f3384c57-54d7-4c36-a7e1-042a739bc51f.png">
