### PR TITLE
8357- update otc schema with aoes

### DIFF
--- a/prime-router/docs/schema_documentation/csv-otc-covid-19.md
+++ b/prime-router/docs/schema_documentation/csv-otc-covid-19.md
@@ -31,6 +31,43 @@
 
 ---
 
+**Name**: employed_in_healthcare
+
+**ReportStream Internal Name**: employed_in_healthcare
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 95418-0
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+Y|YES|LOCAL
+Y|Y|LOCAL
+N|NO|LOCAL
+N|N|LOCAL
+UNK|Unknown|LOCAL
+UNK|U|LOCAL
+UNK|UNK|LOCAL
+UNK|N/A|LOCAL
+UNK|NA|LOCAL
+UNK|NR|LOCAL
+UNK|NP|LOCAL
+UNK|maybe|LOCAL
+
+**Documentation**:
+Translate multiple inbound Y/N/U AOE values to RS values
+---
+
 **Name**: equipment_model_name
 
 **ReportStream Internal Name**: equipment_model_name
@@ -69,6 +106,117 @@
 
 **Documentation**:
 Accension number
+---
+
+**Name**: first_test
+
+**ReportStream Internal Name**: first_test
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 95417-2
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+Y|YES|LOCAL
+Y|Y|LOCAL
+N|NO|LOCAL
+N|N|LOCAL
+UNK|Unknown|LOCAL
+UNK|U|LOCAL
+UNK|UNK|LOCAL
+UNK|N/A|LOCAL
+UNK|NA|LOCAL
+UNK|NR|LOCAL
+UNK|NP|LOCAL
+UNK|maybe|LOCAL
+
+**Documentation**:
+Translate multiple inbound Y/N/U AOE values to RS values
+---
+
+**Name**: hospitalized
+
+**ReportStream Internal Name**: hospitalized
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 77974-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+Y|YES|LOCAL
+Y|Y|LOCAL
+N|NO|LOCAL
+N|N|LOCAL
+UNK|Unknown|LOCAL
+UNK|U|LOCAL
+UNK|UNK|LOCAL
+UNK|N/A|LOCAL
+UNK|NA|LOCAL
+UNK|NR|LOCAL
+UNK|NP|LOCAL
+UNK|maybe|LOCAL
+
+**Documentation**:
+Translate multiple inbound Y/N/U AOE values to RS values
+---
+
+**Name**: icu
+
+**ReportStream Internal Name**: icu
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 95420-6
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+Y|YES|LOCAL
+Y|Y|LOCAL
+N|NO|LOCAL
+N|N|LOCAL
+UNK|Unknown|LOCAL
+UNK|U|LOCAL
+UNK|UNK|LOCAL
+UNK|N/A|LOCAL
+UNK|NA|LOCAL
+UNK|NR|LOCAL
+UNK|NP|LOCAL
+UNK|maybe|LOCAL
+
+**Documentation**:
+Translate multiple inbound Y/N/U AOE values to RS values
 ---
 
 **Name**: illness_onset_date
@@ -1080,6 +1228,50 @@ The patient's second address line
 The patient's zip code
 ---
 
+**Name**: pregnant
+
+**ReportStream Internal Name**: pregnant
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 82810-3
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+77386006|Pregnant|SNOMED_CT
+77386006|Currently Pregnant|SNOMED_CT
+77386006|Y|SNOMED_CT
+77386006|YES|SNOMED_CT
+77386006|77386006|SNOMED_CT
+60001007|Not Pregnant|SNOMED_CT
+60001007|Not Currently Pregnant|SNOMED_CT
+60001007|N|SNOMED_CT
+60001007|NO|SNOMED_CT
+60001007|60001007|SNOMED_CT
+261665006|Unknown|SNOMED_CT
+261665006|U|SNOMED_CT
+261665006|UNK|SNOMED_CT
+261665006|N/A|SNOMED_CT
+261665006|NA|SNOMED_CT
+261665006|NR|SNOMED_CT
+261665006|NP|SNOMED_CT
+261665006|maybe|SNOMED_CT
+261665006|261665006|SNOMED_CT
+
+**Documentation**:
+Translate multiple inbound values into the Pregnancy SNOMED Codes
+---
+
 **Name**: processing_mode_code
 
 **ReportStream Internal Name**: processing_mode_code
@@ -1119,6 +1311,110 @@ P|P|HL7
 
 **Documentation**:
 P, D, or T for Production, Debugging, or Training
+---
+
+**Name**: residence_type
+
+**ReportStream Internal Name**: residence_type
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 75617-1
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+22232009|Hospital|SNOMED_CT
+22232009|22232009|SNOMED_CT
+2081004|Hospital Ship|SNOMED_CT
+2081004|2081004|SNOMED_CT
+32074000|Long Term Care Hospital|SNOMED_CT
+32074000|32074000|SNOMED_CT
+224929004|Secure Hospital|SNOMED_CT
+224929004|224929004|SNOMED_CT
+42665001|Nursing Home|SNOMED_CT
+42665001|42665001|SNOMED_CT
+30629002|Retirement Home|SNOMED_CT
+30629002|30629002|SNOMED_CT
+74056004|Orphanage|SNOMED_CT
+74056004|74056004|SNOMED_CT
+722173008|Prison-based Care Site|SNOMED_CT
+722173008|Prison Based Care Site|SNOMED_CT
+722173008|722173008|SNOMED_CT
+20078004|Substance Abuse Treatment Center|SNOMED_CT
+20078004|20078004|SNOMED_CT
+257573002|Boarding House|SNOMED_CT
+257573002|257573002|SNOMED_CT
+224683003|Military Accommodation|SNOMED_CT
+224683003|224683003|SNOMED_CT
+284546000|Hospice|SNOMED_CT
+284546000|284546000|SNOMED_CT
+257628001|Hostel|SNOMED_CT
+257628001|257628001|SNOMED_CT
+310207003|Sheltered Housing|SNOMED_CT
+310207003|310207003|SNOMED_CT
+57656006|Penal Institution|SNOMED_CT
+57656006|Prison|SNOMED_CT
+57656006|Correctional Facility|SNOMED_CT
+57656006|Jail|SNOMED_CT
+57656006|County Jail|SNOMED_CT
+57656006|City Jail|SNOMED_CT
+57656006|57656006|SNOMED_CT
+285113009|Religious Institutional Residence|SNOMED_CT
+285113009|285113009|SNOMED_CT
+285141008|Work (environment)|SNOMED_CT
+285141008|Work|SNOMED_CT
+285141008|285141008|SNOMED_CT
+32911000|Homeless|SNOMED_CT
+
+**Documentation**:
+Translate multiple inbound values into Residence Type SNOMED codes.
+---
+
+**Name**: resident_congregate_setting
+
+**ReportStream Internal Name**: resident_congregate_setting
+
+**Type**: CODE
+
+**PII**: No
+
+**Format**: use value found in the Display column
+
+**Default Value**: 
+
+**LOINC Code**: 95421-4
+
+**Cardinality**: [0..1]
+
+**Value Sets**
+
+Code | Display | System
+---- | ------- | ------
+Y|YES|LOCAL
+Y|Y|LOCAL
+N|NO|LOCAL
+N|N|LOCAL
+UNK|Unknown|LOCAL
+UNK|U|LOCAL
+UNK|UNK|LOCAL
+UNK|N/A|LOCAL
+UNK|NA|LOCAL
+UNK|NR|LOCAL
+UNK|NP|LOCAL
+UNK|maybe|LOCAL
+
+**Documentation**:
+Translate multiple inbound Y/N/U AOE values to RS values
 ---
 
 **Name**: specimen_collection_date

--- a/prime-router/metadata/schemas/csv-otc-covid-19.schema
+++ b/prime-router/metadata/schemas/csv-otc-covid-19.schema
@@ -464,6 +464,55 @@ elements:
       csvFields: [{name: illness_onset_date, format: "yyyyMMdd"}]
       nullifyValue: true
 
+    - name: pregnant
+      type: CODE
+      valueSet: sender-automation/pregnant
+      documentation: Translate multiple inbound values into the Pregnancy SNOMED Codes
+      csvFields: [{ name: pregnant, format: $display}]
+      default: ""
+
+    - name: first_test
+      type: CODE
+      valueSet: sender-automation/yesno
+      documentation: Translate multiple inbound Y/N/U AOE values to RS values
+      csvFields: [{ name: first_test, format: $display}]
+      default: ""
+
+    - name: employed_in_healthcare
+      type: CODE
+      valueSet: sender-automation/yesno
+      documentation: Translate multiple inbound Y/N/U AOE values to RS values
+      csvFields: [{ name: employed_in_healthcare, format: $display}]
+      default: ""
+
+    - name: hospitalized
+      type: CODE
+      valueSet: sender-automation/yesno
+      documentation: Translate multiple inbound Y/N/U AOE values to RS values
+      csvFields: [{ name: hospitalized, format: $display}]
+      default: ""
+
+    - name: icu
+      type: CODE
+      valueSet: sender-automation/yesno
+      documentation: Translate multiple inbound Y/N/U AOE values to RS values
+      csvFields: [{ name: icu, format: $display}]
+      default: ""
+
+    - name: resident_congregate_setting
+      type: CODE
+      valueSet: sender-automation/yesno
+      documentation: Translate multiple inbound Y/N/U AOE values to RS values
+      csvFields: [{ name: resident_congregate_setting, format: $display}]
+      default: ""
+
+    - name: residence_type
+      type: CODE
+      valueSet: sender-automation/residence_type
+      documentation: Translate multiple inbound values into Residence Type SNOMED codes.
+      csvFields: [{ name: residence_type, format: $display}]
+      default: ""
+
 ######### These fields are calculated - for filtering purposes
     - name: test_type
     - name: abnormal_flag


### PR DESCRIPTION
This PR adds the remaining covid AOE questions to the csv-otc-covid-19 schema so they are properly handled if received from the sender. They are not required by the schema. Currently only "sympomatic for disease" and "illness onset date" were present as the schema was developed from specs for NIH's "MakeMyTestCount" RADx . 

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. run ./prime data command on test data (attached)
2. ensure that output has expected values for aoe questions that were valued in input
3. run ./prime test or ./gradlew testSmoke locally

## Changes
- added 7 AOE questions to schema as optional.
 - pregnant
 - date of first test
 - employed in healthcare
 - hospitalized
 - icu
 - resident congregate setting
 - residence type

### Testing
- [x ] Tested locally?
- [x ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #8357 

[OTC-COVID-19-SCHEMA-TEST.csv](https://github.com/CDCgov/prime-reportstream/files/10937281/OTC-COVID-19-SCHEMA-TEST.csv)
