### PR TITLE
Add tests to schema config reader and adjust tests for merging schema…

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchema.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchema.kt
@@ -105,6 +105,8 @@ abstract class ConfigSchema<T : ConfigSchemaElement>(
                 this.elements.add(childElement)
             }
         }
+        this.constants.putAll(childSchema.constants)
+        this.name = childSchema.name
     }
 
     /**

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReaderTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReaderTests.kt
@@ -210,13 +210,15 @@ class ConfigSchemaReaderTests {
             )
         }.isFailure().messageContains("Schema circular dependency")
 
-        assertThat(
-            ConfigSchemaReader.fromFile(
-                "ORU_R01_extends",
-                "src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06",
-                schemaClass = ConverterSchema::class.java,
-            ).isValid()
-        ).isTrue()
+        val schema = ConfigSchemaReader.fromFile(
+            "ORU_R01_extends",
+            "src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06",
+            schemaClass = ConverterSchema::class.java,
+        )
+        assertThat(schema.isValid()).isTrue()
+        assertThat(schema.constants["baseConstant"]).isEqualTo("baseValue")
+        assertThat(schema.constants["lowLevelConstant"]).isEqualTo("lowLevelValue")
+        assertThat(schema.name).isEqualTo("ORU_R01_extends")
     }
 
     @Test

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReaderTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReaderTests.kt
@@ -218,6 +218,7 @@ class ConfigSchemaReaderTests {
         assertThat(schema.isValid()).isTrue()
         assertThat(schema.constants["baseConstant"]).isEqualTo("baseValue")
         assertThat(schema.constants["lowLevelConstant"]).isEqualTo("lowLevelValue")
+        assertThat(schema.constants["overriddenConstant"]).isEqualTo("overriddenValue")
         assertThat(schema.name).isEqualTo("ORU_R01_extends")
     }
 

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/fhirTransform/FhirTransformSchemaTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/fhirTransform/FhirTransformSchemaTests.kt
@@ -257,32 +257,48 @@ class FhirTransformSchemaTests {
 
     @Test
     fun `test merge of schemas`() {
-        val childSchema = FhirTransformSchema(
+        val referencedSchema = FhirTransformSchema(
             elements = mutableListOf(
                 FhirTransformSchemaElement("child1"),
                 FhirTransformSchemaElement("child2"),
                 FhirTransformSchemaElement("child3")
-            )
+            ),
+            constants = sortedMapOf(Pair("K3", "refV3"), Pair("K5", "refV5")),
         )
-        val schema = FhirTransformSchema(
+        referencedSchema.name = "referencedSchema"
+
+        val baseSchema = FhirTransformSchema(
             elements = mutableListOf(
                 FhirTransformSchemaElement("parent1"),
                 FhirTransformSchemaElement("parent2"),
                 FhirTransformSchemaElement("parent3"),
-                FhirTransformSchemaElement("schemaElement", schema = "childSchema", schemaRef = childSchema)
-            )
+                FhirTransformSchemaElement("schemaElement", schema = "childSchema", schemaRef = referencedSchema)
+            ),
+            constants = sortedMapOf(Pair("K1", "baseV1"), Pair("K2", "baseV2"), Pair("K3", "baseV3")),
         )
+        baseSchema.name = "baseSchema"
 
-        val extendedSchema = FhirTransformSchema(
+        val parentSchema = FhirTransformSchema(constants = sortedMapOf(Pair("K2", "parentV2")))
+        parentSchema.name = "parentSchema"
+
+        val schema = FhirTransformSchema(
             elements = mutableListOf(
-                FhirTransformSchemaElement("parent1"),
+                FhirTransformSchemaElement("parent1", required = true),
                 FhirTransformSchemaElement("child2", condition = "condition1"),
-                FhirTransformSchemaElement("newElement1"),
-            )
+                FhirTransformSchemaElement("newElement"),
+            ),
+            constants = sortedMapOf(Pair("K1", "testV1"), Pair("K4", "testV4")),
         )
+        schema.name = "testSchema"
 
-        schema.merge(extendedSchema)
-        assertThat(childSchema.elements[1].condition).isEqualTo(extendedSchema.elements[1].condition)
-        assertThat(schema.elements.last().name).isEqualTo(extendedSchema.elements[2].name)
+        baseSchema.merge(parentSchema).merge(schema)
+        assertThat((baseSchema.elements[0]).required).isEqualTo((schema.elements[0]).required)
+        assertThat(referencedSchema.elements[1].condition).isEqualTo(schema.elements[1].condition)
+        assertThat(baseSchema.elements.last().name).isEqualTo(schema.elements[2].name)
+        assertThat(baseSchema.name).isEqualTo("testSchema")
+        assertThat(baseSchema.constants["K1"]).isEqualTo("testV1")
+        assertThat(baseSchema.constants["K2"]).isEqualTo("parentV2")
+        assertThat(baseSchema.constants["K3"]).isEqualTo("baseV3")
+        assertThat(baseSchema.constants["K4"]).isEqualTo("testV4")
     }
 }

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/fhirTransform/FhirTransformSchemaTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/schema/fhirTransform/FhirTransformSchemaTests.kt
@@ -234,6 +234,13 @@ class FhirTransformSchemaTests {
     }
 
     @Test
+    fun `test merge of schema with unnamed element`() {
+        val schemaA = FhirTransformSchema(elements = mutableListOf((FhirTransformSchemaElement())))
+        val schemaB = FhirTransformSchema(elements = mutableListOf((FhirTransformSchemaElement())))
+        assertThat { schemaA.merge(schemaB) }.isFailure()
+    }
+
+    @Test
     fun `test find element`() {
         val childSchema = FhirTransformSchema(
             elements = mutableListOf(

--- a/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01.yml
+++ b/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01.yml
@@ -1,6 +1,7 @@
 hl7Class: ca.uhn.hl7v2.model.v251.message.ORU_R01
 constants:
   baseConstant: "baseValue"
+  overriddenConstant: "defaultValue"
 elements:
   - name: message-headers
     condition: >

--- a/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01.yml
+++ b/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01.yml
@@ -1,4 +1,6 @@
 hl7Class: ca.uhn.hl7v2.model.v251.message.ORU_R01
+constants:
+  baseConstant: "baseValue"
 elements:
   - name: message-headers
     condition: >

--- a/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01_extends.yml
+++ b/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01_extends.yml
@@ -1,5 +1,7 @@
 hl7Class: ca.uhn.hl7v2.model.v251.message.ORU_R01
 extends: ORU_R01
+constants:
+  lowLevelConstant: "lowLevelValue"
 elements:
   - name: patient-information
     resource: Bundle.entry.resource.ofType(Patient)

--- a/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01_extends.yml
+++ b/prime-router/src/test/resources/fhirengine/translation/hl7/schema/schema-read-test-06/ORU_R01_extends.yml
@@ -2,6 +2,7 @@ hl7Class: ca.uhn.hl7v2.model.v251.message.ORU_R01
 extends: ORU_R01
 constants:
   lowLevelConstant: "lowLevelValue"
+  overriddenConstant: "overriddenValue"
 elements:
   - name: patient-information
     resource: Bundle.entry.resource.ofType(Patient)


### PR DESCRIPTION
This PR adds a missing piece of the merge between two schemas. Previously, the merge would pull child schema elements into the parent schema, either by adding them straight in, or by merging them into an element within the parent schema, but the name of the resulting merged schema would still reflect the base schema and the constants from the child schema would be ignored. A couple lines of code was enough to fix that behavior.

As part of this, I adjust the unit tests to make sure we're checking the constants and the name of a schema post-merge.

Test Steps:

- Run fhirdata --input-file src/testIntegration/resources/datatests/FHIR_to_HL7/sample_SR_1_20230302-0001.fhir -s <some schema>.yml --output-format HL7 --output-file src/testIntegration/resources/datatests/FHIR_to_HL7/sample_SR_1_20230302-0001.hl7 using a yml file that extends another yml file with constants defined at the top level of both and using those constants as part of the conversion.
- Observe the results to see that the constant values from both the child schema and the parent schema were used.

or

- Run test `test read from file with extends`

## Changes
- Edit the `merge` function in `ConfigSchema.kt` to allow merging of two schemas' `constants` and `name` values
- Add to `ConfigSchemaReaderTests.kt` `ConverterSchemaTests.kt` and `FhirTransformSchemaTests.kt` to exercise new code and to more closely verify behavior of inherited constants/names.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

## Linked Issues
- Addresses #8723
