### PR TITLE
Catch translation errors in UP and record in action log

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRTranslator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRTranslator.kt
@@ -18,9 +18,6 @@ import gov.cdc.prime.router.azure.QueueAccess
 import gov.cdc.prime.router.azure.db.Tables
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.fhirengine.translation.hl7.FhirToHl7Converter
-import gov.cdc.prime.router.fhirengine.translation.hl7.HL7ConversionException
-import gov.cdc.prime.router.fhirengine.translation.hl7.RequiredElementException
-import gov.cdc.prime.router.fhirengine.translation.hl7.SchemaException
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
 import gov.cdc.prime.router.fhirengine.utils.FHIRBundleHelpers.deleteResource
 import gov.cdc.prime.router.fhirengine.utils.FHIRBundleHelpers.getResourceReferences
@@ -105,19 +102,8 @@ class FHIRTranslator(
                         null
                     )
                 } catch (e: Exception) { // handle translation errors
-                    when (e) {
-                        is SchemaException,
-                        is HL7ConversionException,
-                        is RequiredElementException -> {
-                            logger.warn(e)
-                            actionLogger.error(InvalidReportMessage(e.message ?: ""))
-                            return@forEach
-                        }
-                        else -> {
-                            logger.error(e)
-                            actionLogger.error(InvalidReportMessage(e.message ?: ""))
-                        }
-                    }
+                    logger.error(e)
+                    actionLogger.error(InvalidReportMessage(e.message ?: ""))
                 }
             }
         }

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRTranslator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRTranslator.kt
@@ -18,6 +18,9 @@ import gov.cdc.prime.router.azure.QueueAccess
 import gov.cdc.prime.router.azure.db.Tables
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.fhirengine.translation.hl7.FhirToHl7Converter
+import gov.cdc.prime.router.fhirengine.translation.hl7.HL7ConversionException
+import gov.cdc.prime.router.fhirengine.translation.hl7.RequiredElementException
+import gov.cdc.prime.router.fhirengine.translation.hl7.SchemaException
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
 import gov.cdc.prime.router.fhirengine.utils.FHIRBundleHelpers.deleteResource
 import gov.cdc.prime.router.fhirengine.utils.FHIRBundleHelpers.getResourceReferences
@@ -55,21 +58,21 @@ class FHIRTranslator(
         actionHistory: ActionHistory
     ) {
         logger.trace("Translating FHIR file for receivers.")
-        try {
-            // pull fhir document and parse FHIR document
-            val bundle = FhirTranscoder.decode(message.downloadContent())
+        // pull fhir document and parse FHIR document
+        val bundle = FhirTranscoder.decode(message.downloadContent())
 
-            // track input report
-            actionHistory.trackExistingInputReport(message.reportId)
+        // track input report
+        actionHistory.trackExistingInputReport(message.reportId)
 
-            val provenance = bundle.entry.first { it.resource.resourceType.name == "Provenance" }.resource as Provenance
-            val receiverEndpoints = provenance.target.map { it.resource }.filterIsInstance<Endpoint>()
+        val provenance = bundle.entry.first { it.resource.resourceType.name == "Provenance" }.resource as Provenance
+        val receiverEndpoints = provenance.target.map { it.resource }.filterIsInstance<Endpoint>()
 
-            receiverEndpoints.forEach { receiverEndpoint ->
-                val receiverName = receiverEndpoint.identifier[0].value
-                val receiver = settings.findReceiver(receiverName)
-                // We only process receivers that are active and for this pipeline.
-                if (receiver != null && receiver.topic == Topic.FULL_ELR) {
+        receiverEndpoints.forEach { receiverEndpoint ->
+            val receiverName = receiverEndpoint.identifier[0].value
+            val receiver = settings.findReceiver(receiverName)
+            // We only process receivers that are active and for this pipeline.
+            if (receiver != null && receiver.topic == Topic.FULL_ELR) {
+                try {
                     val updatedBundle = removeUnwantedConditions(bundle, receiverEndpoint)
                     val hl7Message = getHL7MessageFromBundle(updatedBundle, receiver)
                     val bodyBytes = hl7Message.encode().toByteArray()
@@ -101,11 +104,22 @@ class FHIRTranslator(
                         finishedField = Tables.TASK.TRANSLATED_AT,
                         null
                     )
+                } catch (e: Exception) { // handle translation errors
+                    when (e) {
+                        is SchemaException,
+                        is HL7ConversionException,
+                        is RequiredElementException -> {
+                            logger.warn(e)
+                            actionLogger.error(InvalidReportMessage(e.message ?: ""))
+                            return@forEach
+                        }
+                        else -> {
+                            logger.error(e)
+                            actionLogger.error(InvalidReportMessage(e.message ?: ""))
+                        }
+                    }
                 }
             }
-        } catch (e: IllegalArgumentException) {
-            logger.error(e)
-            actionLogger.error(InvalidReportMessage(e.message ?: ""))
         }
     }
 
@@ -126,7 +140,7 @@ class FHIRTranslator(
     }
 
     /**
-     * Turn a fhir [bundle] into an hl7 message formatter for the [receiver] specified.
+     * Turn a fhir [bundle] into a hl7 message formatter for the [receiver] specified.
      * @return HL7 Message in the format required by the receiver
      */
     internal fun getHL7MessageFromBundle(bundle: Bundle, receiver: Receiver): ca.uhn.hl7v2.model.Message {

--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/schema/ConfigSchemaReader.kt
@@ -84,7 +84,7 @@ object ConfigSchemaReader : Logging {
         schemaClass: Class<out ConfigSchema<out ConfigSchemaElement>> = ConverterSchema::class.java
     ): ConfigSchema<*> {
         val file = File(folder, "$schemaName.yml")
-        if (!file.canRead()) throw Exception("Cannot read ${file.absolutePath}")
+        if (!file.canRead()) throw SchemaException("Cannot read ${file.absolutePath}")
         val rawSchema = try {
             readOneYamlSchema(file.inputStream(), schemaClass)
         } catch (e: Exception) {

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirTranslatorTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirTranslatorTests.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import ca.uhn.hl7v2.util.Terser
+import gov.cdc.prime.router.ActionLogDetail
 import gov.cdc.prime.router.ActionLogger
 import gov.cdc.prime.router.CustomerStatus
 import gov.cdc.prime.router.DeepOrganization
@@ -381,6 +382,61 @@ class FhirTranslatorTests {
             engine.removeUnwantedConditions(any(), any())
         }
     }
+
+    @Test
+    fun `test full elr translation hl7 translation exception`() {
+        mockkObject(BlobAccess)
+
+        val badSchemaOrganization = DeepOrganization(
+            "co-phd",
+            "test",
+            Organization.Jurisdiction.FEDERAL,
+            receivers = listOf(
+                Receiver(
+                    "full-elr-hl7",
+                    "co-phd",
+                    Topic.FULL_ELR,
+                    CustomerStatus.ACTIVE,
+                    "THIS_PATH_IS_BAD"
+                )
+            )
+        )
+
+        // set up
+        val settings = FileSettings().loadOrganizations(badSchemaOrganization)
+        val one = Schema(name = "None", topic = Topic.FULL_ELR, elements = emptyList())
+        val metadata = Metadata(schema = one)
+        val actionHistory = mockk<ActionHistory>()
+        val actionLogger = mockk<ActionLogger>()
+
+        val message = spyk(RawSubmission(UUID.randomUUID(), "http://blob.url", "test", "test-sender"))
+
+        val bodyFormat = Report.Format.FHIR
+        val bodyUrl = "http://anyblob.com"
+
+        every { actionLogger.hasErrors() } returns false
+        every { actionLogger.error(any<ActionLogDetail>()) } returns Unit
+        every { actionLogger.error(any<List<ActionLogDetail>>()) } returns Unit
+        every { message.downloadContent() }
+            .returns(File("src/test/resources/fhirengine/engine/valid_data_with_extensions.fhir").readText())
+        every { BlobAccess.Companion.uploadBlob(any(), any()) } returns "test"
+        every { accessSpy.insertTask(any(), bodyFormat.toString(), bodyUrl, any()) }.returns(Unit)
+        every { actionHistory.trackCreatedReport(any(), any(), any()) }.returns(Unit)
+        every { actionHistory.trackExistingInputReport(any()) }.returns(Unit)
+        every { queueMock.sendMessage(any(), any()) }
+            .returns(Unit)
+
+        val engine = spyk(makeFhirEngine(metadata, settings, TaskAction.translate) as FHIRTranslator)
+
+        // act
+        engine.doWork(message, actionLogger, actionHistory)
+
+        // assert
+        verify(exactly = 1) {
+            actionLogger.error(any<ActionLogDetail>())
+        }
+    }
+
     @Test
     fun `Test removing some filtered observations from a DiagnosticReport`() {
         val settings = FileSettings().loadOrganizations(oneOrganization)


### PR DESCRIPTION
Handles and records errors that can happen in the translation step of the UP.

Test Steps:
1. See/Run new test case that was added.

## Changes
- If a translation error occurs, record it and go on to next sender instead of just giving up alltogether

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes 8830
- Fixes 8810
