### PR TITLE
Experience-8170: Update validate endpoint to return 200 for strictly validation errors

### DIFF
--- a/prime-router/docs/api/validate.yml
+++ b/prime-router/docs/api/validate.yml
@@ -17,7 +17,7 @@ paths:
     post:
       tags:
         - validate
-      summary: Validate a message using client information
+      summary: Validate a message using client information. Validation errors and warnings are reported in the response json.
       parameters:
         - in: header
           name: client

--- a/prime-router/src/main/kotlin/azure/ValidateFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ValidateFunction.kt
@@ -108,11 +108,10 @@ class ValidateFunction(
                     validatedRequest.routeTo,
                     allowDuplicates,
                 )
-                // return OK status, report validation was successful
                 HttpStatus.OK
             } catch (e: ActionError) {
                 actionHistory.trackLogs(e.details)
-                HttpStatus.BAD_REQUEST
+                HttpStatus.OK
             } catch (e: IllegalArgumentException) {
                 actionHistory.trackLogs(
                     ActionLog(InvalidReportMessage(e.message ?: "Invalid request."), type = ActionLogLevel.error)
@@ -162,7 +161,7 @@ class ValidateFunction(
         }
 
         // set status for validation response
-        submission.overallStatus = if (httpStatus == HttpStatus.BAD_REQUEST)
+        submission.overallStatus = if (httpStatus == HttpStatus.BAD_REQUEST || submission.errorCount > 0)
             DetailedSubmissionHistory.Status.ERROR
         else
             DetailedSubmissionHistory.Status.VALID


### PR DESCRIPTION
This changeset updates the validation endpoint to still return 200 if there are only validation errors.  We should still continue to return 4xx/5xx for _real_ errors, but catching validation errors is unexceptional logic for the validator -- that's working as expected.

Test Steps:
1. Submit a file with only errors to the /validate endpoint, expect:
    - 200 response code is received
    - `overallStatus` to equal `Error`
    - `errors` to be populated with expected errors
    - `warnings` to be empty

2. Submit a file with only warnings to the /validate endpoint, expect:
    - 200 response code is received
    - `overallStatus` to equal `Valid`
    - `errors` to be empty
    - `warnings` to be populated with expected warnings

3. Submit a file with both errors and warnings to the /validate endpoint, expect:
    - 200 response code is received
    - `overallStatus` to equal `Error`
    - `errors` to be populated with expected errors
    - `warnings` to be populated with expected warnings

Example Postman request with only errors (1 above):
<img width="1324" alt="Screenshot 2023-03-30 at 10 30 00" src="https://user-images.githubusercontent.com/2421042/228869399-14403087-0680-4211-b961-080c3eee726b.png">

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
<strike>- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? </strike>
- [x] Added tests?

## Linked Issues
- Fixes #8170 