### PR TITLE
Update design of Resources page

### DIFF
--- a/frontend-react/src/components/Content/MarkdownDirectory.tsx
+++ b/frontend-react/src/components/Content/MarkdownDirectory.tsx
@@ -14,6 +14,8 @@ export abstract class ContentDirectory {
     root: string = "";
     slug: string = "";
     desc: string = "";
+    section: string = "";
+
     setTitle(title: string) {
         this.title = title;
         return this;
@@ -28,6 +30,10 @@ export abstract class ContentDirectory {
     }
     setDescription(description: string) {
         this.desc = description;
+        return this;
+    }
+    setSection(section: string) {
+        this.section = section;
         return this;
     }
 }

--- a/frontend-react/src/components/Content/Templates/IACard.tsx
+++ b/frontend-react/src/components/Content/Templates/IACard.tsx
@@ -4,19 +4,29 @@ import { USNavLink } from "../../USLink";
 /** Takes an array of ContentDirectories and returns a gird list of IACards
  * with navigation links to the directories, and descriptions.
  * @param dirs {ContentDirectory[]} A list of Markdown and Element directories */
-export const IACardList = ({ dirs }: { dirs: ContentDirectory[] }) => {
+export const IACardList = ({
+    dirs,
+    order = [],
+}: {
+    dirs: ContentDirectory[];
+    order?: number[];
+}) => {
     return (
         <ul className="usa-card-group">
             {dirs.map((res, idx) => (
-                <IACard dir={res} key={idx} />
+                <IACard
+                    dir={res}
+                    key={res.slug}
+                    style={{ order: order[idx] }}
+                />
             ))}
         </ul>
     );
 };
 
-const IACard = ({ dir }: { dir: ContentDirectory }) => {
+const IACard = ({ dir, style }: { dir: ContentDirectory; style?: {} }) => {
     return (
-        <li className="usa-card tablet:grid-col-4">
+        <li className="usa-card tablet:grid-col-4" style={style}>
             <div className="usa-card__container">
                 <div className="usa-card__header padding-top-1">
                     <USNavLink className={"usa-link"} href={dir.slug}>

--- a/frontend-react/src/components/Content/Templates/IACardGridTemplate.test.tsx
+++ b/frontend-react/src/components/Content/Templates/IACardGridTemplate.test.tsx
@@ -7,11 +7,8 @@ import {
 } from "../PageGenerationTools";
 import { ContentDirectory, ElementDirectory } from "../MarkdownDirectory";
 
-import {
-    ContentMap,
-    IACardGridProps,
-    IACardGridTemplate,
-} from "./IACardGridTemplate";
+import { IACardGridProps, IACardGridTemplate } from "./IACardGridTemplate";
+import { ContentMap } from "./IAComponentProps";
 
 // Set up page titles
 enum TestDirPages {

--- a/frontend-react/src/components/Content/Templates/IAComponentProps.ts
+++ b/frontend-react/src/components/Content/Templates/IAComponentProps.ts
@@ -1,0 +1,8 @@
+import { IASection } from "../../../content/resources";
+import { ContentDirectory } from "../MarkdownDirectory";
+
+export type ContentMap = Map<string | IASection, ContentDirectory[]>; // Key should be section title
+
+export interface IAComponentProps {
+    directories: ContentDirectory[] | ContentMap;
+}

--- a/frontend-react/src/components/Content/Templates/IASideNavTemplate.tsx
+++ b/frontend-react/src/components/Content/Templates/IASideNavTemplate.tsx
@@ -1,20 +1,24 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 
-import { ContentDirectory, getDirectoryElement } from "../MarkdownDirectory";
+import { getDirectoryElement } from "../MarkdownDirectory";
 
 import GeneratedSideNav from "./GeneratedSideNav";
+import { IAComponentProps } from "./IAComponentProps";
 
-export interface IASideNavProps {
-    directories: ContentDirectory[];
+export interface IASideNavProps extends IAComponentProps {
     rootRedirect?: string;
 }
 
 const IASideNavTemplate = ({ directories, rootRedirect }: IASideNavProps) => {
+    const dirArr =
+        directories instanceof Map
+            ? Array.from(new Set(Array.from(directories.values()).flat()))
+            : directories;
     return (
         <section className="grid-container tablet:margin-top-6 margin-bottom-5">
             <div className="grid-row grid-gap">
                 <section className="tablet:grid-col-4 margin-bottom-6">
-                    <GeneratedSideNav directories={directories} />
+                    <GeneratedSideNav directories={dirArr} />
                 </section>
                 <section className="tablet:grid-col-8 usa-prose rs-documentation">
                     <Routes>
@@ -24,7 +28,7 @@ const IASideNavTemplate = ({ directories, rootRedirect }: IASideNavProps) => {
                                 <Navigate to={rootRedirect || ""} replace />
                             }
                         />
-                        {directories.map((dir, idx) => (
+                        {dirArr.map((dir, idx) => (
                             <Route
                                 key={idx}
                                 path={dir.slug}

--- a/frontend-react/src/components/Content/Templates/IATemplate.tsx
+++ b/frontend-react/src/components/Content/Templates/IATemplate.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { IACardGridTemplate } from "./IACardGridTemplate";
 import IASideNavTemplate from "./IASideNavTemplate";
 import { IAMeta, IARouter } from "./IAMeta";
+import { IAComponentProps } from "./IAComponentProps";
 
 /** Template names! Add the universal template key here whenever
  * you make a new template. */
@@ -11,7 +12,9 @@ export enum TemplateName {
     SIDE_NAV = "side-nav",
 }
 
-export interface IATemplateProps<P> {
+export interface IATemplateProps<
+    P extends IAComponentProps = IAComponentProps
+> {
     pageName: string;
     subtitle: string;
     templateKey: TemplateName;
@@ -27,7 +30,13 @@ export const IATemplate = ({
     templateKey,
     templateProps,
     includeRouter,
-}: IATemplateProps<any>) => {
+}: IATemplateProps) => {
+    const dirArr =
+        templateProps.directories instanceof Map
+            ? Array.from(
+                  new Set(Array.from(templateProps.directories.values()).flat())
+              )
+            : templateProps.directories;
     const template = useMemo(() => {
         switch (templateKey) {
             case TemplateName.CARD_GRID:
@@ -49,10 +58,7 @@ export const IATemplate = ({
              we provide the IARouter component, and use your template as the
              index of this section */}
             {includeRouter && templateProps.directories ? (
-                <IARouter
-                    indexElement={template}
-                    directories={templateProps.directories}
-                />
+                <IARouter indexElement={template} directories={dirArr} />
             ) : (
                 /* When your template has its own routing, we just render the
                  * template */

--- a/frontend-react/src/content/resources/index.ts
+++ b/frontend-react/src/content/resources/index.ts
@@ -19,6 +19,58 @@ import {
     GettingStartedSubmittingDataMd,
 } from "../../pages/resources/markdown-adapters";
 
+export interface IASection {
+    key: string;
+    label: string;
+}
+
+export function directoryArrayToMap(
+    dirs: ElementDirectory[],
+    sections: Record<string, IASection>
+) {
+    const dirMap = new Map();
+    for (const dir of dirs) {
+        const section = sections[dir.section];
+        if (!dirMap.get(section)) {
+            dirMap.set(section, []);
+        }
+
+        const mapArr = dirMap.get(section);
+        dirMap.set(section, [...mapArr, dir]);
+    }
+
+    return dirMap;
+}
+
+export const RESOURCE_INDEX_SECTIONS = {
+    DEFAULT: "",
+    TESTING_FACILITIES: "TESTING_FACILITIES",
+    PUBLIC_HEALTH_DEPARTMENTS: "PUBLIC_HEALTH_DEPARTMENTS",
+} as const;
+
+export type ResourceIndexSections = keyof typeof RESOURCE_INDEX_SECTIONS;
+
+export const resourceIndexSections: Record<
+    (typeof RESOURCE_INDEX_SECTIONS)[ResourceIndexSections],
+    {
+        key: (typeof RESOURCE_INDEX_SECTIONS)[ResourceIndexSections];
+        label: string;
+    }
+> = {
+    [RESOURCE_INDEX_SECTIONS.DEFAULT]: {
+        key: RESOURCE_INDEX_SECTIONS.DEFAULT,
+        label: "",
+    },
+    [RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS]: {
+        key: RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS,
+        label: "For public health departments",
+    },
+    [RESOURCE_INDEX_SECTIONS.TESTING_FACILITIES]: {
+        key: RESOURCE_INDEX_SECTIONS.TESTING_FACILITIES,
+        label: "For testing facilities",
+    },
+};
+
 export enum ResourcesDirectories {
     ACCOUNT_REGISTRATION = "Account registration guide",
     DOWNLOAD_GUIDE = "Manual data download guide",
@@ -80,7 +132,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.ACCOUNT_REGISTRATION
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.GETTING_STARTED_PHD)
         .setSlug(
@@ -98,7 +151,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.GETTING_STARTED_PHD
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.GETTING_STARTED_SUBMITTING_DATA)
         .setSlug(
@@ -116,7 +170,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.GETTING_STARTED_SUBMITTING_DATA
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.TESTING_FACILITIES),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.ELR_CHECKLIST)
         .setSlug(
@@ -132,7 +187,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.ELR_CHECKLIST
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.PROGRAMMERS_GUIDE)
         .setSlug(
@@ -150,7 +206,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.PROGRAMMERS_GUIDE
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.TESTING_FACILITIES),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.DOWNLOAD_GUIDE)
         .setSlug(
@@ -164,7 +221,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.DOWNLOAD_GUIDE
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.REFERRAL_GUIDE)
         .setSlug(
@@ -180,7 +238,8 @@ export const resourcesDirectories = [
                     ResourcesDirectories.REFERRAL_GUIDE
                 )
             )
-        ),
+        )
+        .setSection(RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS),
     new ElementDirectory()
         .setTitle(ResourcesDirectories.SYSTEM)
         .setSlug(ResourcesDirectoryTools.getSlug(ResourcesDirectories.SYSTEM))

--- a/frontend-react/src/pages/resources/Resources.tsx
+++ b/frontend-react/src/pages/resources/Resources.tsx
@@ -2,6 +2,9 @@ import { GridContainer } from "@trussworks/react-uswds";
 
 import { IACardGridProps } from "../../components/Content/Templates/IACardGridTemplate";
 import {
+    directoryArrayToMap,
+    RESOURCE_INDEX_SECTIONS,
+    resourceIndexSections,
     resourcesDirectories,
     ResourcesDirectoryTools,
 } from "../../content/resources";
@@ -18,7 +21,15 @@ const rootProps: IATemplateProps<IACardGridProps> = {
     templateProps: {
         pageName: ResourcesDirectoryTools.title,
         subtitle: ResourcesDirectoryTools.subtitle,
-        directories: resourcesDirectories,
+        directories: directoryArrayToMap(
+            resourcesDirectories,
+            resourceIndexSections
+        ),
+        sectionOrder: [
+            RESOURCE_INDEX_SECTIONS.DEFAULT,
+            RESOURCE_INDEX_SECTIONS.TESTING_FACILITIES,
+            RESOURCE_INDEX_SECTIONS.PUBLIC_HEALTH_DEPARTMENTS,
+        ],
     },
     includeRouter: true,
 };


### PR DESCRIPTION
Closes #8589

This PR updates the resources index page to match the new design in the aforementioned ticket. New programming was added to group directories into sections and to interpret this organizing into existing section component properties. Card list components were updated to sort their directory list by title alphabetically and pass the simple number ordering as props so that it can be applied via the css "order" styling property (as the grid container is flex which allows this). This allows the ordering to be changeable without requiring reordering the dom (thus adhering to keeping how things are displayed relegated to css as much as possible).
