### PR TITLE
Bump jacoco from 0.8.8 to 0.8.9

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -106,7 +106,7 @@ defaultTasks("package")
 val ktorVersion = "2.2.4"
 val kotlinVersion = "1.8.0"
 val jacksonVersion = "2.14.1"
-jacoco.toolVersion = "0.8.8"
+jacoco.toolVersion = "0.8.9"
 
 // Set the compiler JVM target
 java {


### PR DESCRIPTION
This PR updates `JaCoCo` from 0.8.8 to 0.8.9. This adds support for JDK 19 and 20.

This PR does *not* change the project to use JDK 19. See also #8206 

Changelog: https://www.jacoco.org/jacoco/trunk/doc/changes.html

Test Steps:
1. Build the branch using JDK 17 or 18 and verify it is successful.
2. Verify the Github build is successful.

## Changes
- Update `JaCoCo` from 0.8.8 to 0.8.9.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?
