### PR TITLE
8981: mock JwkSet companion rather than System.get

### DIFF
--- a/prime-router/src/test/kotlin/azure/ApiKeysFunctionsTest.kt
+++ b/prime-router/src/test/kotlin/azure/ApiKeysFunctionsTest.kt
@@ -11,6 +11,7 @@ import gov.cdc.prime.router.common.JacksonMapperUtilities
 import gov.cdc.prime.router.tokens.AuthenticatedClaims
 import gov.cdc.prime.router.tokens.AuthenticationType
 import gov.cdc.prime.router.tokens.Jwk
+import gov.cdc.prime.router.tokens.JwkSet
 import gov.cdc.prime.router.tokens.oktaSystemAdminGroup
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
@@ -18,8 +19,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
+import io.mockk.unmockkObject
 import org.bouncycastle.util.io.pem.PemObject
 import org.bouncycastle.util.io.pem.PemWriter
 import org.json.JSONObject
@@ -173,8 +173,8 @@ class ApiKeysFunctionsTest {
 
         @Test
         fun `Test successfully removes the oldest key and adds the new one when over the limit`() {
-            mockkStatic(System::class)
-            every { System.getenv("MAX_NUM_KEY_PER_SCOPE") } returns "2"
+            mockkObject(JwkSet.Companion)
+            every { JwkSet.Companion.getMaximumNumberOfKeysPerScope() } returns 2
             settings.organizationStore.put(
                 organization.name,
                 organization.makeCopyWithNewScopeAndJwk(wildcardReportScope, jwk2)
@@ -204,7 +204,7 @@ class ApiKeysFunctionsTest {
                         .toSet()
                 ).isEqualTo(setOf(jwk3.toRSAPublicKey(), jwk.toRSAPublicKey()))
             }
-            unmockkStatic(System::class)
+            unmockkObject(JwkSet.Companion)
         }
 
         @Test


### PR DESCRIPTION
This PR updates a test case to not mock System

Test Steps:
1. Run the tests

## Changes
- Mocks `JwkSet.Companion` rather than System for testing the JwkSet key limit

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #8981 

## To Be Done


## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
