### PR TITLE
8991: use correct name for putSetting and add test for api-key persist failure

### DIFF
--- a/prime-router/src/main/kotlin/azure/ApiKeysFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/ApiKeysFunctions.kt
@@ -8,7 +8,6 @@ import com.microsoft.azure.functions.annotation.BindingName
 import com.microsoft.azure.functions.annotation.FunctionName
 import com.microsoft.azure.functions.annotation.HttpTrigger
 import gov.cdc.prime.router.Organization
-import gov.cdc.prime.router.azure.db.enums.SettingType
 import gov.cdc.prime.router.common.BaseEngine
 import gov.cdc.prime.router.common.JacksonMapperUtilities
 import gov.cdc.prime.router.tokens.AuthenticatedClaims
@@ -85,15 +84,18 @@ class ApiKeysFunctions(private val settingsFacade: SettingsFacade = SettingsFaca
 
             val updatedKeys = JwkSet.addKeyToScope(organization.keys, scope, jwk)
 
-            settingsFacade.putSetting(
-                SettingType.ORGANIZATION.name,
+            val (result, error) = settingsFacade.putSetting(
+                organization.name,
                 JacksonMapperUtilities.defaultMapper.writeValueAsString(Organization(organization, updatedKeys)),
                 claims,
-                OrganizationAPI::class.java,
-                organization.name
+                OrganizationAPI::class.java
             )
 
-            return HttpUtilities.okJSONResponse(request, ApiKeysResponse(orgName, updatedKeys))
+            return if (result == SettingsFacade.AccessResult.SUCCESS) {
+                HttpUtilities.okJSONResponse(request, ApiKeysResponse(orgName, updatedKeys))
+            } else {
+                HttpUtilities.bad(request, error)
+            }
         } catch (e: Exception) {
             return HttpUtilities.bad(request, "Unable to parse public key: ${e.localizedMessage}")
         }

--- a/prime-router/src/test/kotlin/azure/ApiKeysFunctionsTest.kt
+++ b/prime-router/src/test/kotlin/azure/ApiKeysFunctionsTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
+import assertk.assertions.isNull
 import com.microsoft.azure.functions.HttpStatus
 import gov.cdc.prime.router.Organization
 import gov.cdc.prime.router.common.BaseEngine
@@ -95,11 +96,10 @@ class ApiKeysFunctionsTest {
         every { SettingsFacade.common } returns facade
         every {
             facade.putSetting<OrganizationAPI>(
-                any<String>(),
+                organization.name,
                 any<String>(),
                 any<AuthenticatedClaims>(),
-                any(),
-                any()
+                OrganizationAPI::class.java,
             )
         } answers {
             val organizationAPI =
@@ -372,6 +372,31 @@ class ApiKeysFunctionsTest {
 
             val response = ApiKeysFunctions().post(httpRequestMessage, organization.name)
             assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED)
+        }
+
+        @Test
+        fun `Test returns the error if one is encountered persisting the key`() {
+            settings.organizationStore.put(organization.name, organization)
+            val httpRequestMessage = MockHttpRequestMessage(encodedPubKey)
+            httpRequestMessage.queryParameters["scope"] = wildcardReportScope
+            httpRequestMessage.queryParameters["kid"] = organization.name
+
+            val jwt = mapOf("organization" to listOf(oktaSystemAdminGroup), "sub" to "test@cdc.gov")
+            val claims = AuthenticatedClaims(jwt, AuthenticationType.Okta)
+
+            mockkObject(AuthenticatedClaims)
+            every { AuthenticatedClaims.Companion.authenticate(any()) } returns claims
+            every { facade.putSetting(organization.name, any(), claims, OrganizationAPI::class.java) } returns Pair(
+                SettingsFacade.AccessResult.BAD_REQUEST,
+                "Payload and path name do not match"
+            )
+
+            val response = ApiKeysFunctions().post(httpRequestMessage, organization.name)
+            assertThat(response.status).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(response.body).isEqualTo("Payload and path name do not match")
+
+            val updatedOrg = settings.organizationStore.get(organization.name)
+            assertThat(updatedOrg?.keys).isNull()
         }
     }
 


### PR DESCRIPTION
This PR fixes the bug where the api key is not persisted via the POST endpoint due to a typo in the `putSetting` call

Test Steps:
1. Add an api key
```sh
curl --location 'http://localhost:7071/api/settings/organizations/simple_report/public-keys?scope=simple_report.*.report&kid=simple_report' \
--header 'Authorization: Bearer dummy' \
--header 'Content-Type: text/plain' \
--data '-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu/iNl3p3b0G4a5AbhycX
0gnzszqSjMP7NJygno4UfF8HA+jLKqKXbG93ywyvbau+Rm1J7wbVb5hYWx3jvXt2
7LfQea1XgMF67O2Xo7bJ7U5NSceVVrtAA/IIq5sqolrxcVQ5LbGkuVqVTKwMtgs2
pe+sj6GcgdjhRnxLCN0Ex4xB7RtsieIvqwqEi4ds+sbLAs9fHMumcGzvyDLQpNGW
avOMqpXM1WqNauzOn4mgECu4BJuHPu7gXIPAkrVwLRF0LcSs7Js37uWtg04FxTz8
6sv0kYwqYXDJNcrCd+3S5cbQTGvdLAbUvvZ3vassfrxbQGFKJEt51iiHW7U/CaX8
ewIDAQAB
-----END PUBLIC KEY-----'
```
2. Verify the key was persisted
```sh
curl --location 'http://localhost:7071/api/settings/organizations/simple_report/public-keys' \
--header 'Authorization: Bearer dummy' 
``` 

## Changes
- Updates the POST public key function to invoke putSetting correctly
- Adds a new test that verifies when putSetting fails that the endpoint returns a BAD_REQUEST

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #8991

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
