### PR TITLE
Update MDX loader to ignore md files

### DIFF
--- a/frontend-react/config/webpack.config.js
+++ b/frontend-react/config/webpack.config.js
@@ -561,7 +561,7 @@ module.exports = function (webpackEnv) {
                             ),
                         },
                         {
-                            test: /\.mdx?$/,
+                            test: /\.mdx$/,
                             use: [
                                 {
                                     loader: "@mdx-js/loader",


### PR DESCRIPTION
Fixes #9000

This PR updates the mdx loader config for webpack to target only mdx files and not md so they can be consumed by react-markdown as normal.