### PR TITLE
Sidenav route integration

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -80,7 +80,7 @@
         "lint:eslint:write": "cross-env NODE_ENV=production eslint --fix \"src/**/*.{js,ts,jsx,tsx}\"",
         "yarn:show-outdated-packages": "yarn outdated",
         "run-build-dir": "yarn build:localdev:csp && yarn global add serve && serve -s build",
-        "storybook": "npm-run-all -p watch-scss storybook:start",
+        "storybook": "npm-run-all -p watch-scss \"storybook:start {@}\" --",
         "storybook:start": "start-storybook -p 6006",
         "storybook:build": "build-storybook"
     },
@@ -240,6 +240,7 @@
         "text-table": "^0.2.0",
         "ts-node": "^10.9.1",
         "tslib": "^2.5.0",
+        "type-fest": "^3.8.0",
         "typescript": "^4.9.5",
         "webpack": "^5.78.0",
         "webpack-bundle-analyzer": "^4.7.0",

--- a/frontend-react/src/AppRouter.tsx
+++ b/frontend-react/src/AppRouter.tsx
@@ -1,13 +1,12 @@
 import { useRoutes } from "react-router-dom";
 import { LoginCallback } from "@okta/okta-react";
 import React from "react";
+import { ReadonlyDeep } from "type-fest";
 
 import { TermsOfService } from "./pages/TermsOfService";
 import { About } from "./pages/About";
 import { Login } from "./pages/Login";
 import TermsOfServiceForm from "./pages/tos-sign/TermsOfServiceForm";
-import { Resources } from "./pages/resources/Resources";
-import { ResourcesPage } from "./pages/resources/ResourcesPage";
 import { Product } from "./pages/product/ProductIndex";
 import { Support } from "./pages/support/Support";
 import { UploadWithAuth } from "./pages/Upload";
@@ -31,8 +30,9 @@ import { EditReceiverSettingsWithAuth } from "./components/Admin/EditReceiverSet
 import { AdminRevHistoryWithAuth } from "./pages/admin/AdminRevHistory";
 import { ErrorNoPage } from "./pages/error/legacy-content/ErrorNoPage";
 import { MessageDetailsWithAuth } from "./components/MessageTracker/MessageDetails";
-import { ManagePublicKeyWithAuth } from "./components/ManagePublicKey/ManagePublicKey";
 import FileHandler from "./components/FileHandlers/FileHandler";
+import ResourcesRoute from "./pages/resources/routes";
+import { RSRouteObject } from "./utils/UsefulTypes";
 
 export enum FeatureName {
     DAILY_DATA = "Daily Data",
@@ -49,13 +49,7 @@ export const appRoutes = [
     { path: "/login", element: <Login /> },
     { path: "/login/callback", element: <LoginCallback /> },
     { path: "/sign-tos", element: <TermsOfServiceForm /> },
-    {
-        path: "/resources",
-        children: [
-            { path: "", element: <ResourcesPage /> },
-            { path: "*", element: <Resources /> },
-        ],
-    },
+    ResourcesRoute,
     { path: "/product/*", element: <Product /> },
     { path: "/support/*", element: <Support /> },
     { path: "/file-handler/validate", element: <FileHandler /> },
@@ -115,12 +109,11 @@ export const appRoutes = [
         path: "/admin/revisionhistory/org/:org/settingtype/:settingType",
         element: <AdminRevHistoryWithAuth />,
     },
-    {
-        path: "/resources/manage-public-key",
-        element: <ManagePublicKeyWithAuth />,
-    },
     /* Handles any undefined route */
     { path: "*", element: <ErrorNoPage /> },
-];
+] as const satisfies ReadonlyDeep<RSRouteObject[]>;
 
-export const AppRouter = () => useRoutes(appRoutes);
+export const AppRouter = () => useRoutes(appRoutes as any);
+
+export { ResourcesRoute };
+export * from "./pages/resources/routes";

--- a/frontend-react/src/content/resources/ResourcesIndex.mdx
+++ b/frontend-react/src/content/resources/ResourcesIndex.mdx
@@ -1,6 +1,6 @@
 import { Card, CardHeader, CardBody, CardGroup } from "@trussworks/react-uswds";
 
-<div class="rs-hero__index">
+<div className="rs-hero__index">
     # Resources 
     
     ## Explore guides, tools, and resources to optimize ReportStream

--- a/frontend-react/src/pages/resources/api-programmers-guide/Sidenav.stories.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/Sidenav.stories.tsx
@@ -1,0 +1,10 @@
+import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
+
+import { Sidenav } from "./Sidenav";
+
+export default {
+    title: "pages/resources/API Programmer's Guide Sidenav",
+    component: Sidenav,
+} as ComponentMeta<typeof Sidenav>;
+
+export const Default: ComponentStoryObj<typeof Sidenav> = {};

--- a/frontend-react/src/pages/resources/api-programmers-guide/Sidenav.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/Sidenav.tsx
@@ -1,0 +1,31 @@
+import { SideNav } from "@trussworks/react-uswds";
+import React from "react";
+
+import { createSideNavItem, SideNavRouteItem } from "../../../shared/SideNav";
+
+import {
+    gettingStartedNav,
+    reportStreamApiNav,
+    documentationNav,
+} from "./routes";
+
+export const sidenavItems: SideNavRouteItem[] = [
+    {
+        route: reportStreamApiNav,
+        children: reportStreamApiNav.children.map((c) => ({ route: c })),
+    },
+    {
+        route: gettingStartedNav,
+        children: gettingStartedNav.children.map((c) => ({ route: c })),
+    },
+    {
+        route: documentationNav,
+        children: documentationNav.children.map((c) => ({ route: c })),
+        isActive: true,
+    },
+];
+
+export function Sidenav() {
+    const items = sidenavItems.map((i) => createSideNavItem(i));
+    return <SideNav items={items} />;
+}

--- a/frontend-react/src/pages/resources/api-programmers-guide/routes.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/routes.tsx
@@ -1,0 +1,127 @@
+import { ReadonlyDeep } from "type-fest";
+
+import { RSRouteObject } from "../../../utils/UsefulTypes";
+
+export const reportStreamApiNav = {
+    path: "reportstream-api",
+    title: "ReportStream API",
+    children: [
+        { path: "#onboarding-overview", title: "Onboarding overview" },
+        { path: "#about-our-api", title: "About our API" },
+    ],
+} as const satisfies ReadonlyDeep<RSRouteObject>;
+
+export const gettingStartedNav = {
+    path: "getting-started",
+    title: "Getting started",
+    children: [
+        {
+            path: "#format-and-validate-a-fake-data-file",
+            title: "Format and validate a fake data file",
+        },
+        {
+            path: "#set-up-authentication-and-test-your-api-connection",
+            title: "Set up authentication and test your api connection",
+        },
+        {
+            path: "#test-real-data-in-production",
+            title: "Test real data in production",
+        },
+        {
+            path: "#start-sending-data-in-production",
+            title: "Start sending data in production",
+        },
+    ],
+} as const satisfies ReadonlyDeep<RSRouteObject>;
+
+export const documentationNav = {
+    path: "documentation",
+    title: "Documentation",
+    children: [
+        {
+            path: "data-model",
+            children: [
+                {
+                    path: "#common-errors",
+                    title: "Common errors",
+                },
+                {
+                    path: "#legend",
+                    title: "Legend",
+                },
+                {
+                    path: "#patient-data-elements",
+                    title: "Patient data elements",
+                },
+                {
+                    path: "#order-and-result-data-elements",
+                    title: "Order and result data elements",
+                },
+                {
+                    path: "#specimen-data-elements",
+                    title: "Specimen data elements",
+                },
+                {
+                    path: "#ordering-provider-data-elements",
+                    title: "Ordering provider data elements",
+                },
+                {
+                    path: "#testing-facility-data-elements",
+                    title: "Testing facility data elements",
+                },
+                {
+                    path: "#ask-on-entry",
+                    title: "Ask-On-Entry (AOEs)",
+                },
+                {
+                    path: "#report-and-ordering-facility-elements",
+                    title: "Report and ordering facility elements",
+                },
+            ],
+            title: "Data model",
+        },
+        {
+            path: "responses-from-reportstream",
+            children: [
+                {
+                    path: "#errors-and-warnings",
+                    title: "Errors and warnings",
+                },
+                {
+                    path: "#response-messages",
+                    title: "Response messages",
+                },
+                {
+                    path: "#json-error-responses",
+                    title: "JSON error responses",
+                },
+            ],
+            title: "Responses from ReportStream",
+        },
+        {
+            path: "sample-payloads-and-output",
+            title: "Sample payloads and output",
+            children: [
+                {
+                    path: "#sample-csv-payload-and-output",
+                    title: "Sample CSV payload and output",
+                },
+                {
+                    path: "#sample-hl7-v2.5.1-payload-and-output",
+                    title: "Sample HL7 v2.5.1 payload and output",
+                },
+                {
+                    path: "#example-data-models",
+                    title: "Example data models",
+                },
+            ],
+        },
+    ],
+} as const satisfies ReadonlyDeep<RSRouteObject>;
+
+const routes = {
+    path: "api-programmers-guide",
+    children: [reportStreamApiNav, gettingStartedNav, documentationNav],
+} as const satisfies ReadonlyDeep<RSRouteObject>;
+
+export default routes;

--- a/frontend-react/src/pages/resources/routes.tsx
+++ b/frontend-react/src/pages/resources/routes.tsx
@@ -1,0 +1,35 @@
+import { ReadonlyDeep } from "type-fest";
+import React from "react";
+
+import { lazy } from "../../utils/misc";
+import { RSRouteObject } from "../../utils/UsefulTypes";
+
+import { Resources } from "./Resources";
+import apiProgrammersGuideRoute from "./api-programmers-guide/routes";
+
+const LazyManagePublicKeyPage = lazy(
+    () => import("../../components/ManagePublicKey/ManagePublicKey"),
+    "ManagePublicKeyWithAuth"
+);
+const LazyResourcesPage = lazy(
+    () => import("./ResourcesPage"),
+    "ResourcesPage"
+);
+
+const routes = {
+    path: "/resources",
+    children: [
+        ...(apiProgrammersGuideRoute?.children ?? []),
+        {
+            path: "manage-public-key",
+            element: <LazyManagePublicKeyPage />,
+        },
+        { path: "", element: <LazyResourcesPage /> },
+        { path: "*", element: <Resources /> },
+    ],
+} as const satisfies ReadonlyDeep<RSRouteObject>;
+
+export default routes;
+
+export { apiProgrammersGuideRoute };
+export * from "./api-programmers-guide/routes";

--- a/frontend-react/src/utils/CustomRenderUtils.tsx
+++ b/frontend-react/src/utils/CustomRenderUtils.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
-import { MemoryRouter, useRoutes } from "react-router-dom";
+import { MemoryRouter, RouteObject, useRoutes } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
 import { Fixture, MockResolver } from "@rest-hooks/test";
@@ -34,7 +34,7 @@ interface TestRouterProps {
  */
 const TestRoutes = ({ children }: TestRouterProps) => {
     const routes = useRoutes(
-        appRoutes.map((r) => ({ ...r, element: children }))
+        appRoutes.map((r) => ({ ...r, element: children })) as RouteObject[]
     );
 
     return routes;

--- a/frontend-react/src/utils/UsefulTypes.ts
+++ b/frontend-react/src/utils/UsefulTypes.ts
@@ -1,3 +1,5 @@
+import { RouteObject } from "react-router-dom";
+
 /* Makes everything string-accessible: params["id"]
  * Use generics to limit the value types of this object.
  *
@@ -21,4 +23,9 @@ export class SimpleError {
     constructor(message: string) {
         this.message = message;
     }
+}
+
+export interface RSRouteObject extends RouteObject {
+    title?: string;
+    children?: RSRouteObject[];
 }

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -17459,6 +17459,11 @@ type-fest@^3.0.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.6.1.tgz#cf8025edeebfd6cf48de73573a5e1423350b9993"
   integrity sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==
 
+type-fest@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.8.0.tgz#ce80d1ca7c7d11c5540560999cbd410cb5b3a385"
+  integrity sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
Fixes #9198

This PR:
- Creates route inheritance inside the pages/resources directory
- Adds a new lazy helper to allow for lazy-loading components that are not the default export
- Uses lazy loading on some resources routes
- Enhances the RouteObjects to RSRouteObjects to allow for custom properties
- Defines api programmer's guide routes with title properties
- Adds new helpers for sidenav item creation
- Creates a Sidenav component for use in api programmer's guide pages that uses routes