### PR TITLE
Experience-9235: Fix storybook command

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -81,6 +81,7 @@
         "yarn:show-outdated-packages": "yarn outdated",
         "run-build-dir": "yarn build:localdev:csp && yarn global add serve && serve -s build",
         "storybook": "npm-run-all -p watch-scss storybook:start",
+        "storybook:start": "start-storybook -p 6006",
         "build-storybook": "npm-run-all -p compile-scss-prod && build-storybook"
     },
     "browserslist": {


### PR DESCRIPTION
In https://github.com/CDCgov/prime-reportstream/pull/9019, we removed the `storybook:start` command, but it was being used for the base `storybook` command.  This changeset just restores the command so everything works again.