### PR TITLE
missing demo env slack_email data

### DIFF
--- a/operations/app/terraform/vars/demo/README.md
+++ b/operations/app/terraform/vars/demo/README.md
@@ -1,0 +1,13 @@
+### Specify environment & Terraform path
+```bash
+env=demo2
+path='operations/app/terraform/vars/demo'
+
+terraform -chdir=$path init \
+-reconfigure \
+-var-file=$env/env.tfvars.json \
+-backend-config=$env/env.tfbackend
+
+terraform -chdir=$path plan \
+-var-file=$env/env.tfvars.json 
+```

--- a/operations/app/terraform/vars/demo/data.tf
+++ b/operations/app/terraform/vars/demo/data.tf
@@ -76,3 +76,8 @@ data "azurerm_key_vault_key" "pdh-2048-key" {
 resource "random_id" "init" {
   byte_length = 2
 }
+
+data "azurerm_key_vault_secret" "slack_email_address" {
+  name         = "slack-email"
+  key_vault_id = data.azurerm_key_vault.tf-secrets.id
+}


### PR DESCRIPTION
This PR adds missing slack_email data to demo env Terraform

## Linked Issues
- Fixes [#9327](https://github.com/CDCgov/prime-reportstream/issues/9327)
