### PR TITLE
9233: increase livdapi and reportstream poll smoketest timeouts

### DIFF
--- a/prime-router/src/main/kotlin/cli/tests/LivdApiTest.kt
+++ b/prime-router/src/main/kotlin/cli/tests/LivdApiTest.kt
@@ -114,7 +114,7 @@ class LivdApiTest : CoolTest() {
      */
     private fun livdApiQuery(testCase: LivdApiTestCase): Pair<Boolean, String?> {
         val (_, response, result) = Fuel.get(testCase.path, testCase.parameters)
-            .timeoutRead(45000)
+            .timeoutRead(75000)
             .responseString()
 
         return if (response.statusCode != testCase.expectedHttpStatus.value()) {

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -638,7 +638,7 @@ abstract class CoolTest {
         totalItems: Int,
         filterOrgName: Boolean = false,
         silent: Boolean = false,
-        maxPollSecs: Int = 360,
+        maxPollSecs: Int = 480,
         pollSleepSecs: Int = 30, // I had this as every 5 secs, but was getting failures.  The queries run unfastly.
         asyncProcessMode: Boolean = false,
         isUniversalPipeline: Boolean = false

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -469,7 +469,7 @@ abstract class CoolTest {
     suspend fun pollForStepResult(
         reportId: ReportId,
         taskAction: TaskAction,
-        maxPollSecs: Int = 360,
+        maxPollSecs: Int = 480,
         pollSleepSecs: Int = 20,
     ): Map<UUID, DetailedSubmissionHistory?> {
         var timeElapsedSecs = 0


### PR DESCRIPTION
This PR increases some of the timeouts in the smoketests as they were occasionally failing.

Test Steps:
n/a

## Changes
- Sets the livdapi timeout in smoke tests to 75000ms
- Sets the polling timeout for testing submissions to 480 seconds

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
