### PR TITLE
Feature/7694 trigger pager duty alert metabase webapp

### DIFF
--- a/.github/workflows/alert_cert_expire.yml
+++ b/.github/workflows/alert_cert_expire.yml
@@ -50,6 +50,7 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
       
       - name: Slack Notification
+        if: ${{ steps.format_out.outputs.LIST  != '' }}
         uses: ./.github/actions/notifications
         with:
           method: slack

--- a/operations/app/terraform/modules/application_insights/main.tf
+++ b/operations/app/terraform/modules/application_insights/main.tf
@@ -39,9 +39,8 @@ resource "azurerm_monitor_action_group" "action_group" {
   }
 }
 
-resource "azurerm_monitor_action_group" "action_group_mbhealthcheck" {
-  #count               = local.alerting_enabled
-  name                = "${var.resource_prefix}-actiongroup-mbhealthcheck"
+resource "azurerm_monitor_action_group" "action_group_metabase" {
+  name                = "${var.resource_prefix}-actiongroup-metabase"
   resource_group_name = var.resource_group
   short_name          = "mb-check"
 
@@ -92,4 +91,7 @@ locals {
     try(replace(azurerm_monitor_action_group.action_group_slack.id, "Microsoft.Insights", "microsoft.insights"), "") :
   azurerm_monitor_action_group.action_group_slack.id)
   app_insights_id = replace(azurerm_application_insights.app_insights.id, "Microsoft.Insights", "microsoft.insights")
+  action_group_metabase_id = (local.alerting_enabled == 1 ?
+    try(replace(azurerm_monitor_action_group.action_group_metabase.id, "Microsoft.Insights", "microsoft.insights"), "") :
+  azurerm_monitor_action_group.action_group_metabase.id)
 }

--- a/operations/app/terraform/modules/application_insights/~outputs.tf
+++ b/operations/app/terraform/modules/application_insights/~outputs.tf
@@ -25,3 +25,7 @@ output "metabase_connection_string" {
 output "action_group_slack_id" {
   value = local.action_group_slack_id
 }
+
+output "action_group_metabase_id" {
+  value = local.action_group_metabase_id
+}

--- a/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
@@ -40,7 +40,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "metabase_webapp_alertrul
   description    = "Critical Alert found in Metabase WebApp logs: Service unavailable"
   enabled        = true
   query          = <<-EOT
-      // 2022-03-31: Exclude co-phd.elr-test -- this is a known error per Rick Hood
       AzureDiagnostics
       | where requestUri_s contains "metabase/api/health" and httpStatusCode_d != 200
       | where errorInfo_s == "OriginConnectionRefused"

--- a/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
@@ -26,3 +26,31 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "functionapp_fatal" {
     threshold = 1
   }
 }
+
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "metabase_webapp_alertrule" {
+  name                = format("%s-metabase-webapp-alertrule", var.resource_prefix)
+  location            = var.location
+  resource_group_name = var.resource_group
+
+  action {
+    action_group = [var.action_group_metabase_id]
+  }
+  data_source_id = azurerm_log_analytics_workspace.law.id
+  description    = "Critical Alert found in Metabase WebApp logs: Service unavailable"
+  enabled        = true
+  query          = <<-EOT
+      // 2022-03-31: Exclude co-phd.elr-test -- this is a known error per Rick Hood
+      AzureDiagnostics
+      | where requestUri_s contains "metabase/api/health" and httpStatusCode_d != 200
+      | where errorInfo_s == "OriginConnectionRefused"
+  EOT
+  severity       = 0
+  frequency      = 5
+  time_window    = 5
+
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+}

--- a/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
@@ -53,3 +53,4 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "metabase_webapp_alertrul
     threshold = 1
   }
 }
+

--- a/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
@@ -45,10 +45,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "metabase_webapp_alertrul
       | where requestUri_s contains "metabase/api/health" and httpStatusCode_d != 200
       | where errorInfo_s == "OriginConnectionRefused"
   EOT
-
-  severity    = 0
-  frequency   = 5
-  time_window = 5
+  severity       = 0
+  frequency      = 5
+  time_window    = 5
 
   trigger {
     operator  = "GreaterThanOrEqual"

--- a/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
@@ -45,9 +45,10 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "metabase_webapp_alertrul
       | where requestUri_s contains "metabase/api/health" and httpStatusCode_d != 200
       | where errorInfo_s == "OriginConnectionRefused"
   EOT
-  severity       = 0
-  frequency      = 5
-  time_window    = 5
+
+  severity    = 0
+  frequency   = 5
+  time_window = 5
 
   trigger {
     operator  = "GreaterThanOrEqual"

--- a/operations/app/terraform/modules/log_analytics_workspace/~inputs.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/~inputs.tf
@@ -94,6 +94,11 @@ variable "action_group_slack_id" {
   description = "Slack action group resource id"
 }
 
+variable "action_group_metabase_id" {
+  type        = string
+  description = "Metabase healthcheck action group resource id"
+}
+
 variable "data_factory_id" {
   type        = string
   description = "Data factory resource id"

--- a/operations/app/terraform/vars/demo/main.tf
+++ b/operations/app/terraform/vars/demo/main.tf
@@ -249,13 +249,14 @@ module "log_analytics_workspace" {
   client_config_key_vault_id = module.key_vault.client_config_key_vault_id
   function_app_id            = module.function_app.function_app_id
   //front_door_id                 = module.front_door.front_door_id
-  nat_gateway_id        = module.nat_gateway.nat_gateway_id
-  primary_vnet_id       = module.network.primary_vnet_id
-  replica_vnet_id       = module.network.replica_vnet_id
-  storage_account_id    = module.storage.storage_account_id
-  storage_public_id     = module.storage.storage_public_id
-  storage_partner_id    = module.storage.storage_partner_id
-  action_group_slack_id = module.application_insights.action_group_slack_id
+  nat_gateway_id           = module.nat_gateway.nat_gateway_id
+  primary_vnet_id          = module.network.primary_vnet_id
+  replica_vnet_id          = module.network.replica_vnet_id
+  storage_account_id       = module.storage.storage_account_id
+  storage_public_id        = module.storage.storage_public_id
+  storage_partner_id       = module.storage.storage_partner_id
+  action_group_slack_id    = module.application_insights.action_group_slack_id
+  action_group_metabase_id = module.application_insights.action_group_metabase_id
   //data_factory_id               = module.data_factory.data_factory_id
   //sftp_instance_01_id           = module.sftp.sftp_instance_ids[0]
 }

--- a/operations/app/terraform/vars/prod/main.tf
+++ b/operations/app/terraform/vars/prod/main.tf
@@ -270,6 +270,7 @@ module "log_analytics_workspace" {
   storage_public_id          = module.storage.storage_public_id
   storage_partner_id         = module.storage.storage_partner_id
   action_group_slack_id      = module.application_insights.action_group_slack_id
+  action_group_metabase_id   = module.application_insights.action_group_metabase_id
   data_factory_id            = module.data_factory.data_factory_id
   sftp_instance_01_id        = module.sftp.sftp_instance_ids[0]
 }

--- a/operations/app/terraform/vars/staging/main.tf
+++ b/operations/app/terraform/vars/staging/main.tf
@@ -271,6 +271,7 @@ module "log_analytics_workspace" {
   storage_public_id          = module.storage.storage_public_id
   storage_partner_id         = module.storage.storage_partner_id
   action_group_slack_id      = module.application_insights.action_group_slack_id
+  action_group_metabase_id   = module.application_insights.action_group_metabase_id
   data_factory_id            = module.data_factory.data_factory_id
   sftp_instance_01_id        = module.sftp.sftp_instance_ids[0]
 }

--- a/operations/app/terraform/vars/test/main.tf
+++ b/operations/app/terraform/vars/test/main.tf
@@ -258,6 +258,7 @@ module "log_analytics_workspace" {
   storage_public_id          = module.storage.storage_public_id
   storage_partner_id         = module.storage.storage_partner_id
   action_group_slack_id      = module.application_insights.action_group_slack_id
+  action_group_metabase_id   = module.application_insights.action_group_metabase_id
   data_factory_id            = module.data_factory.data_factory_id
   sftp_instance_01_id        = module.sftp.sftp_instance_ids[0]
 }


### PR DESCRIPTION
This PR is to Set function app to trigger PagerDuty alert if Metabase health check does not give 200](https://github.com/CDCgov/prime-reportstream/issues/7694)

Terraform will perform the following actions:

```
  # module.application_insights.azurerm_monitor_action_group.action_group_metabase will be created
  + resource "azurerm_monitor_action_group" "action_group_metabase" {
      + enabled             = true
      + id                  = (known after apply)
      + name                = "pdhtest-actiongroup-metabase"
      + resource_group_name = "prime-data-hub-test"
      + short_name          = "mb-check"
      + tags                = {
          + "environment" = "test"
        }

      + webhook_receiver {
          + name                    = "PagerDuty-mbhealthcheck"
          + service_uri             = (sensitive)
          + use_common_alert_schema = true
        }
    }

  # module.application_insights.azurerm_monitor_action_group.metabase_healthcheck_AG will be destroyed
  # (because azurerm_monitor_action_group.metabase_healthcheck_AG is not in configuration)
  - resource "azurerm_monitor_action_group" "metabase_healthcheck_AG" {
      - enabled             = true -> null
      - id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.Insights/actionGroups/pdhtest-metabase-healthcheck-AG" -> null
      - name                = "pdhtest-metabase-healthcheck-AG" -> null
      - resource_group_name = "prime-data-hub-test" -> null
      - short_name          = "mb-check" -> null
      - tags                = {
          - "environment" = "test"
        } -> null

      - webhook_receiver {
          - name                    = "PagerDuty-mbhealthcheck" -> null
          - service_uri             = (sensitive) -> null
          - use_common_alert_schema = true -> null
        }
    }

  # module.application_insights.azurerm_monitor_metric_alert.metabase_availability_alert will be destroyed
  # (because azurerm_monitor_metric_alert.metabase_availability_alert is not in configuration)
  - resource "azurerm_monitor_metric_alert" "metabase_availability_alert" {
      - auto_mitigate       = true -> null
      - description         = "Alert triggered when the App Service is unavailable" -> null
      - enabled             = true -> null
      - frequency           = "PT15M" -> null
      - id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.Insights/metricAlerts/pdhtest-metabase-availability-alert" -> null
      - name                = "pdhtest-metabase-availability-alert" -> null
      - resource_group_name = "prime-data-hub-test" -> null
      - scopes              = [
          - "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.Insights/components/pdhtest-metabase-appinsights",
        ] -> null
      - severity            = 0 -> null
      - tags                = {
          - "environment" = "test"
        } -> null
      - window_size         = "PT1H" -> null

      - action {
          - action_group_id    = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.Insights/actionGroups/pdhtest-metabase-healthcheck-AG" -> null
          - webhook_properties = {} -> null
        }

      - criteria {
          - aggregation            = "Average" -> null
          - metric_name            = "availabilityResults/availabilityPercentage" -> null
          - metric_namespace       = "microsoft.insights/components" -> null
          - operator               = "LessThan" -> null
          - skip_metric_validation = false -> null
          - threshold              = 95 -> null
        }
    }

  # module.log_analytics_workspace.azurerm_monitor_diagnostic_setting.diagnostics["postgres_server"] will be created
  + resource "azurerm_monitor_diagnostic_setting" "diagnostics" {
      + id                         = (known after apply)
      + log_analytics_workspace_id = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.OperationalInsights/workspaces/pdhtest-law"
      + name                       = "pdhtest-postgres_server-diag"
      + target_resource_id         = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.DBforPostgreSQL/servers/pdhtest-pgsql"

      + log {
          + category = "PostgreSQLLogs"
          + enabled  = true

          + retention_policy {
              + days    = 60
              + enabled = true
            }
        }
      + log {
          + category = "QueryStoreRuntimeStatistics"
          + enabled  = true

          + retention_policy {
              + days    = 60
              + enabled = true
            }
        }
      + log {
          + category = "QueryStoreWaitStatistics"
          + enabled  = true

          + retention_policy {
              + days    = 60
              + enabled = true
            }
        }

      + metric {
          + category = "AllMetrics"
          + enabled  = true

          + retention_policy {
              + days    = 60
              + enabled = true
            }
        }
    }

  # module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.metabase_webapp_alertrule will be created
  + resource "azurerm_monitor_scheduled_query_rules_alert" "metabase_webapp_alertrule" {
      + auto_mitigation_enabled = false
      + data_source_id          = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-test/providers/Microsoft.OperationalInsights/workspaces/pdhtest-law"
      + description             = "Critical Alert found in Metabase WebApp logs: Service unavailable"
      + enabled                 = true
      + frequency               = 5
      + id                      = (known after apply)
      + location                = "eastus"
      + name                    = "pdhtest-metabase-webapp-alertrule"
      + query                   = <<-EOT
            // 2022-03-31: Exclude co-phd.elr-test -- this is a known error per Rick Hood
            AzureDiagnostics
            | where requestUri_s contains "metabase/api/health" and httpStatusCode_d != 200
            | where errorInfo_s == "OriginConnectionRefused"
        EOT
      + query_type              = "ResultCount"
      + resource_group_name     = "prime-data-hub-test"
      + severity                = 0
      + time_window             = 5

      + action {
          + action_group           = (known after apply)
          + custom_webhook_payload = (known after apply)
        }

      + trigger {
          + operator  = "GreaterThanOrEqual"
          + threshold = 1
        }
    }

Plan: 3 to add, 0 to change, 2 to destroy.
╷
```