### PR TITLE
add .bin files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ operations/app/src/environments/configurations/dev.*
 !operations/app/src/**/.terraform.lock.hcl
 terraform-fmt.log
 **.tfstate
+**.bin
 
 # Hashicorp Vault Secrets
 prime-router/.vault/env/**


### PR DESCRIPTION
This PR ...

adds **/.bin to .gitignore

** Testing **
```
prime-reportstream % touch test.bin
prime-reportstream % git status
On branch devops/jmp/gitignore
Your branch is up to date with 'origin/devops/jmp/gitignore'.

nothing to commit, working tree clean
```