### PR TITLE
changing sonarcloud master scan to only run manually

### DIFF
--- a/.github/workflows/sonarcloud_master.yml
+++ b/.github/workflows/sonarcloud_master.yml
@@ -2,11 +2,6 @@ name: SonarCloud Master
 
 on: 
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    paths:
-      - "prime-router/**"
 
 env:
   # These are for CI and not credentials of any system


### PR DESCRIPTION
Changes the trigger for the sonarcloud_master job to only run when triggered manually.