### PR TITLE
Dependency review update to run only on PRs

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -6,10 +6,6 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
 on: 
-  push:
-    branches: 
-     - master
-     - production
   pull_request:
     branches: 
      - master


### PR DESCRIPTION
This PR is to make the Dependency review action to run only on Pull requests, Currently it is set to run on pushes to master and production branches and causing failures while running the action as both a base ref and head ref must be provided, either via the `base_ref`/`head_ref` config options