### PR TITLE
Route Resource Page Link to the new API Programmer's Guide

### DIFF
--- a/frontend-react/src/AppRouter.tsx
+++ b/frontend-react/src/AppRouter.tsx
@@ -103,47 +103,66 @@ export const appRoutes: RouteObject[] = [
                 path: "/resources",
                 children: [
                     {
-                        path: "documentation",
+                        path: "api",
                         children: [
                             {
                                 path: "",
-                                element: <DocumentationPage />,
                                 index: true,
-                                handle: {
-                                    isContentPage: true,
-                                },
-                            },
-                            { path: "data-model", element: <DataModelPage /> },
-                            {
-                                path: "responses-from-reportstream",
-                                element: <ResponsesFromReportStreamPage />,
+                                element: <ReportStreamAPIPage />,
                                 handle: {
                                     isContentPage: true,
                                 },
                             },
                             {
-                                path: "sample-payloads-and-output",
-                                element: <SamplePayloadsAndOutputPage />,
+                                path: "getting-started",
+                                element: <GettingStartedPage />,
                                 handle: {
                                     isContentPage: true,
                                 },
+                            },
+                            {
+                                path: "documentation",
+                                children: [
+                                    {
+                                        path: "",
+                                        element: <DocumentationPage />,
+                                        index: true,
+                                        handle: {
+                                            isContentPage: true,
+                                        },
+                                    },
+                                    {
+                                        path: "data-model",
+                                        element: <DataModelPage />,
+                                        handle: {
+                                            isContentPage: true,
+                                        },
+                                    },
+                                    {
+                                        path: "responses-from-reportstream",
+                                        element: (
+                                            <ResponsesFromReportStreamPage />
+                                        ),
+                                        handle: {
+                                            isContentPage: true,
+                                        },
+                                    },
+                                    {
+                                        path: "sample-payloads-and-output",
+                                        element: (
+                                            <SamplePayloadsAndOutputPage />
+                                        ),
+                                        handle: {
+                                            isContentPage: true,
+                                        },
+                                    },
+                                ],
                             },
                         ],
                     },
                     {
                         path: "manage-public-key",
                         element: <ManagePublicKeyWithAuth />,
-                    },
-                    {
-                        path: "reportstream-api",
-                        element: <ReportStreamAPIPage />,
-                    },
-                    {
-                        path: "getting-started",
-                        element: <GettingStartedPage />,
-                        handle: {
-                            isContentPage: true,
-                        },
                     },
                     {
                         path: "",

--- a/frontend-react/src/content/resources/api-programmers-guide/Sidenav.mdx
+++ b/frontend-react/src/content/resources/api-programmers-guide/Sidenav.mdx
@@ -3,37 +3,37 @@ import { USNavLink } from "../../../components/USLink"
 import SideNavItem from "../../../shared/SideNavItem"
 
 <SideNav items={[
-    <SideNavItem href="/resources/reportstream-api" items={[
-        <USNavLink href="/resources/reportstream-api#onboarding-overview">Onboarding overview</USNavLink>,
-        <USNavLink href="/resources/reportstream-api#about-our-api">About our API</USNavLink>,
+    <SideNavItem href="/resources/api" items={[
+        <USNavLink href="/resources/api#onboarding-overview">Onboarding overview</USNavLink>,
+        <USNavLink href="/resources/api#about-our-api">About our API</USNavLink>,
     ]}>ReportStream API</SideNavItem>,
-    <SideNavItem href="/resources/getting-started" items={[
-        <USNavLink href="/resources/getting-started#format-and-validate-a-fake-data-file">Format and validate a fake data file</USNavLink>,
-        <USNavLink href="/resources/getting-started#set-up-authentication-and-test-your-api-connection">Set up authentication and test your api connection</USNavLink>,
-        <USNavLink href="/resources/getting-started#test-real-data-in-production">Test real data in production</USNavLink>,
-        <USNavLink href="/resources/getting-started#start-sending-data-in-production">Start sending data in production</USNavLink>,
+    <SideNavItem href="/resources/api/getting-started" items={[
+        <USNavLink href="/resources/api/getting-started#format-and-validate-a-fake-data-file">Format and validate a fake data file</USNavLink>,
+        <USNavLink href="/resources/api/getting-started#set-up-authentication-and-test-your-api-connection">Set up authentication and test your api connection</USNavLink>,
+        <USNavLink href="/resources/api/getting-started#test-real-data-in-production">Test real data in production</USNavLink>,
+        <USNavLink href="/resources/api/getting-started#start-sending-data-in-production">Start sending data in production</USNavLink>,
     ]}>Getting started</SideNavItem>,
-    <SideNavItem isActive={true} href="/resources/documentation" items={[
-        <SideNavItem href="/resources/documentation/data-model" items={[
-            <USNavLink href="/resources/documentation/data-model#common-errors">Common errors</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#legend">Legend</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#patient-data-elements">Patient data elements</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#order-and-result-data-elements">Order and result data elements</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#specimen-data-elements">Specimen data elements</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#ordering-provider-data-elements">Ordering provider data elements</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#testing-facility-data-elements">Testing facility data elements</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#ask-on-entry">Ask-On-Entry (AOEs)</USNavLink>,
-            <USNavLink href="/resources/documentation/data-model#report-and-ordering-facility-elements">Report and ordering facility elements</USNavLink>,
+    <SideNavItem isActive={true} href="/resources/api/documentation" items={[
+        <SideNavItem href="/resources/api/documentation/data-model" items={[
+            <USNavLink href="/resources/api/documentation/data-model#common-errors">Common errors</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#legend">Legend</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#patient-data-elements">Patient data elements</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#order-and-result-data-elements">Order and result data elements</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#specimen-data-elements">Specimen data elements</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#ordering-provider-data-elements">Ordering provider data elements</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#testing-facility-data-elements">Testing facility data elements</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#ask-on-entry">Ask-On-Entry (AOEs)</USNavLink>,
+            <USNavLink href="/resources/api/documentation/data-model#report-and-ordering-facility-elements">Report and ordering facility elements</USNavLink>,
         ]}>Data model</SideNavItem>,
-            <SideNavItem href="/resources/documentation/responses-from-reportstream" items={[
-                    <USNavLink href="/resources/documentation/responses-from-reportstream#errors-and-warnings">Errors and warnings</USNavLink>,
-                    <USNavLink href="/resources/documentation/responses-from-reportstream#response-messages">Response messages</USNavLink>,
-                    <USNavLink href="/resources/documentation/responses-from-reportstream#json-error-responses">JSON error responses</USNavLink>,
+            <SideNavItem href="/resources/api/documentation/responses-from-reportstream" items={[
+                    <USNavLink href="/resources/api/documentation/responses-from-reportstream#errors-and-warnings">Errors and warnings</USNavLink>,
+                    <USNavLink href="/resources/api/documentation/responses-from-reportstream#response-messages">Response messages</USNavLink>,
+                    <USNavLink href="/resources/api/documentation/responses-from-reportstream#json-error-responses">JSON error responses</USNavLink>,
             ]}>Responses from ReportStream</SideNavItem>,
-            <SideNavItem href="/resources/documentation/sample-payloads-and-output" items={[
-                    <USNavLink href="/resources/documentation/sample-payloads-and-output#sample-csv-payload-and-output">Sample CSV payload and output</USNavLink>,
-                    <USNavLink href="/resources/documentation/sample-payloads-and-output#sample-hl7-v2.5.1-payload-and-output">Sample HL7 v2.5.1 payload and output</USNavLink>,
-                    <USNavLink href="/resources/documentation/sample-payloads-and-output#example-data-models">Example data models</USNavLink>,
+            <SideNavItem href="/resources/api/documentation/sample-payloads-and-output" items={[
+                    <USNavLink href="/resources/api/documentation/sample-payloads-and-output#sample-csv-payload-and-output">Sample CSV payload and output</USNavLink>,
+                    <USNavLink href="/resources/api/documentation/sample-payloads-and-output#sample-hl7-v2.5.1-payload-and-output">Sample HL7 v2.5.1 payload and output</USNavLink>,
+                    <USNavLink href="/resources/api/documentation/sample-payloads-and-output#example-data-models">Example data models</USNavLink>,
             ]}>Sample payloads and output</SideNavItem>,
     ]}>Documentation</SideNavItem>,
 ]}>

--- a/frontend-react/src/content/resources/api-programmers-guide/getting-started/GettingStarted.mdx
+++ b/frontend-react/src/content/resources/api-programmers-guide/getting-started/GettingStarted.mdx
@@ -15,7 +15,7 @@ You can also use a program like Postman to test submissions.
 
 <h2 className="rs-numbered">Format and validate a fake data file</h2>
 
-To prepare your file for testing, review our [data models](/resources/documentation/data-model) and set up a sample file with fake data (artificially created, non-PII data).
+To prepare your file for testing, review our [data models](documentation/data-model) and set up a sample file with fake data (artificially created, non-PII data).
 We have [fake data you can use](https://reportstream.cdc.gov/assets/csv/ReportStream-StandardCSV-ExampleData-20220509.csv), if needed.
 
 <CardGroup>

--- a/frontend-react/src/pages/resources/api-programmers-guide/documentation/DataModel.stories.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/documentation/DataModel.stories.tsx
@@ -14,7 +14,7 @@ import { MarkdownLayout } from "../../../../components/Content/MarkdownLayout";
 import DataModelPage from "./DataModel";
 
 export default {
-    title: "pages/resources/documentation/DataModel",
+    title: "pages/resources/api/documentation/DataModel",
     component: DataModelPage,
 } as ComponentMeta<typeof DataModelPage>;
 

--- a/frontend-react/src/pages/resources/api-programmers-guide/documentation/Documentation.stories.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/documentation/Documentation.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 import DocumentationPage from "./Documentation";
 
 export default {
-    title: "pages/resources/documentation/Documentation",
+    title: "pages/resources/api/documentation/Documentation",
     component: DocumentationPage,
 } as ComponentMeta<typeof DocumentationPage>;
 

--- a/frontend-react/src/pages/resources/api-programmers-guide/documentation/ResponsesFromReportStream.stories.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/documentation/ResponsesFromReportStream.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 import ResponsesFromReportStream from "./ResponsesFromReportStream";
 
 export default {
-    title: "pages/resources/documentation/ResponsesFromReportStream",
+    title: "pages/resources/api/documentation/ResponsesFromReportStream",
     component: ResponsesFromReportStream,
 } as ComponentMeta<typeof ResponsesFromReportStream>;
 

--- a/frontend-react/src/pages/resources/api-programmers-guide/documentation/SamplePayloadsAndOutput.stories.tsx
+++ b/frontend-react/src/pages/resources/api-programmers-guide/documentation/SamplePayloadsAndOutput.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 import SamplePayloadsAndOutput from "./SamplePayloadsAndOutput";
 
 export default {
-    title: "pages/resources/documentation/SamplePayloadsAndOutput",
+    title: "pages/resources/api/documentation/SamplePayloadsAndOutput",
     component: SamplePayloadsAndOutput,
 } as ComponentMeta<typeof SamplePayloadsAndOutput>;
 


### PR DESCRIPTION
Fixes #9613

This PR updates the api programmer's guide url structure to be pages under /resources/api.
