### PR TITLE
Attempt to fix failing smoke test

### DIFF
--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -489,8 +489,7 @@ abstract class CoolTest {
                 }
                 timeElapsedSecs += pollSleepSecs
                 queryResult = queryForStepResults(reportId, taskAction)
-                @Suppress("SENSELESS_COMPARISON")
-                if (queryResult != null)
+                if (queryResult.isNotEmpty())
                     break
             }
         }


### PR DESCRIPTION
This PR attempts to fix an issue causing smoke tests to fail on the staging environment.

Test Steps:
1. Run smoke tests and check for failures.

## Changes
- Alter logic to allow the test to wait for query results longer

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?
