### PR TITLE
replace vault image

### DIFF
--- a/prime-router/docker-compose.yml
+++ b/prime-router/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   # Secrets management
   vault:
-    image: vault
+    image: hashicorp/vault
     cap_add:
       # Allows protected memory
       - IPC_LOCK


### PR DESCRIPTION
This PR updates the build test to use the new repo location for the vault image

Test Steps:
1. Build hub in runner or locally

## Changes
- update vault image

## Linked Issues
- Fixes #10122 
