### PR TITLE
Up the smoke test polling timeout to 10 min

### DIFF
--- a/prime-router/src/main/kotlin/cli/tests/BasicTests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/BasicTests.kt
@@ -402,7 +402,7 @@ class Merge : CoolTest() {
         receivers: List<Receiver>,
         itemsPerReport: Int,
         silent: Boolean = false,
-        maxPollSecs: Int = 600,
+        maxPollSecs: Int = 860,
         pollSleepSecs: Int = 20,
     ): Boolean {
         var timeElapsedSecs = 0

--- a/prime-router/src/main/kotlin/cli/tests/BasicTests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/BasicTests.kt
@@ -402,7 +402,7 @@ class Merge : CoolTest() {
         receivers: List<Receiver>,
         itemsPerReport: Int,
         silent: Boolean = false,
-        maxPollSecs: Int = 180,
+        maxPollSecs: Int = 600,
         pollSleepSecs: Int = 20,
     ): Boolean {
         var timeElapsedSecs = 0

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -469,7 +469,7 @@ abstract class CoolTest {
     suspend fun pollForStepResult(
         reportId: ReportId,
         taskAction: TaskAction,
-        maxPollSecs: Int = 480,
+        maxPollSecs: Int = 600,
         pollSleepSecs: Int = 20,
     ): Map<UUID, DetailedSubmissionHistory?> {
         var timeElapsedSecs = 0
@@ -660,7 +660,7 @@ abstract class CoolTest {
         totalItems: Int,
         filterOrgName: Boolean = false,
         silent: Boolean = false,
-        maxPollSecs: Int = 480,
+        maxPollSecs: Int = 600,
         pollSleepSecs: Int = 30, // I had this as every 5 secs, but was getting failures.  The queries run unfastly.
         asyncProcessMode: Boolean = false,
         isUniversalPipeline: Boolean = false

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -660,7 +660,7 @@ abstract class CoolTest {
         totalItems: Int,
         filterOrgName: Boolean = false,
         silent: Boolean = false,
-        maxPollSecs: Int = 600,
+        maxPollSecs: Int = 720,
         pollSleepSecs: Int = 30, // I had this as every 5 secs, but was getting failures.  The queries run unfastly.
         asyncProcessMode: Boolean = false,
         isUniversalPipeline: Boolean = false

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -660,7 +660,7 @@ abstract class CoolTest {
         totalItems: Int,
         filterOrgName: Boolean = false,
         silent: Boolean = false,
-        maxPollSecs: Int = 720,
+        maxPollSecs: Int = 860,
         pollSleepSecs: Int = 30, // I had this as every 5 secs, but was getting failures.  The queries run unfastly.
         asyncProcessMode: Boolean = false,
         isUniversalPipeline: Boolean = false

--- a/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
+++ b/prime-router/src/main/kotlin/cli/tests/TestReportStream.kt
@@ -469,7 +469,7 @@ abstract class CoolTest {
     suspend fun pollForStepResult(
         reportId: ReportId,
         taskAction: TaskAction,
-        maxPollSecs: Int = 600,
+        maxPollSecs: Int = 860,
         pollSleepSecs: Int = 20,
     ): Map<UUID, DetailedSubmissionHistory?> {
         var timeElapsedSecs = 0


### PR DESCRIPTION
This PR increases the the timeout for the smoke test

Test Steps:
1. Run the smoketest

## Changes
- Increases the timeout for the smoketest to ten minutes

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues


## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #10289 

## Specific Security-related subjects a reviewer should pay specific attention to
