### PR TITLE
Experience: vite preview

### DIFF
--- a/frontend-react/.env.preview
+++ b/frontend-react/.env.preview
@@ -1,0 +1,18 @@
+VITE_TITLE=CDC Prime ReportStream DEV
+VITE_DESCRIPTION=ReportStream Dashboard Application
+VITE_ICON=https://reportstream.cdc.gov/assets/cdc-logo.svg
+
+VITE_BASE_URL=http://localhost:4173
+VITE_BACKEND_URL=http://localhost:4173
+VITE_PUBLIC_URL=
+VITE_OKTA_CLIENTID=0oa2fs6vp3W5MTzjh1d7
+VITE_OKTA_URL=https://hhs-prime.oktapreview.com
+
+VITE_IS_TRAINING_SITE=false
+
+; not sure if these are required
+VITE_CLIENT_ENV=preview
+VITE_ENV=preview
+
+INLINE_RUNTIME_CHUNK=false
+GENERATE_SOURCEMAP=true

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -50,6 +50,7 @@
     "scripts": {
         "clean": "rimraf ./build",
         "start:localdev": "cross-env NODE_ENV=development yarn run start-js",
+        "preview": "cross-env NODE_ENV=preview yarn run build-base && yarn run vite preview",
         "build:demo1": "cross-env NODE_ENV=demo1 yarn build-base",
         "build:demo2": "cross-env NODE_ENV=demo2 yarn build-base",
         "build:demo3": "cross-env NODE_ENV=demo3 yarn build-base",

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -65,6 +65,12 @@ export default defineConfig(async () => {
                 },
             },
         },
+        preview: {
+            headers: {
+                "Content-Security-Policy":
+                    "default-src 'self'; script-src 'self' https://hhs-prime.oktapreview.com https://global.oktacdn.com https://www.google-analytics.com https://*.in.applicationinsights.azure.com https://dap.digitalgov.gov; style-src 'self' 'unsafe-inline' https://global.oktacdn.com https://cdnjs.cloudflare.com; frame-src 'self' https://hhs-prime.oktapreview.com; img-src 'self' https://hhs-prime.oktapreview.com https://reportstream.cdc.gov data: ; connect-src 'self' https://www.google-analytics.com https://*.in.applicationinsights.azure.com https://hhs-prime.oktapreview.com https://reportstream.cdc.gov/api/ https://prime.cdc.gov/api/ https://dap.digitalgov.gov;",
+            },
+        },
         css: {
             preprocessorOptions: {
                 scss: {


### PR DESCRIPTION
Fixes #10715

This PR:
- adds a new `preview` script that builds and runs `vite preview` under the `preview` environment
- adds a new `.env.preview` file
- adds the current CSP header given on the live site to the preview server
  - hhs-prime.okta.com swapped to hhs-prime.oktapreview.com