### PR TITLE
Allow org.*.user scopes access to read settings

### DIFF
--- a/prime-router/src/main/kotlin/azure/ApiKeysFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/ApiKeysFunctions.kt
@@ -221,7 +221,7 @@ class ApiKeysFunctions(private val settingsFacade: SettingsFacade = SettingsFaca
         useNewApiResponse: Boolean = false
     ): HttpResponseMessage {
         val claims = AuthenticatedClaims.authenticate(request)
-        if (claims == null || !claims.authorized(setOf(PRIME_ADMIN_PATTERN, "$orgName.*.admin"))) {
+        if (claims == null || !claims.authorized(setOf(PRIME_ADMIN_PATTERN, "$orgName.*.admin"), request)) {
             logger.warn("User '${claims?.userName}' FAILED authorized for endpoint ${request.uri}")
             return HttpUtilities.unauthorizedResponse(request, authenticationFailure)
         }
@@ -487,7 +487,7 @@ class ApiKeysFunctions(private val settingsFacade: SettingsFacade = SettingsFaca
         @BindingName(PARAM_NAME_KID) kidStr: String? = null
     ): HttpResponseMessage {
         val claims = AuthenticatedClaims.authenticate(request)
-        if (claims == null || !claims.authorized(setOf(PRIME_ADMIN_PATTERN, "$orgName.*.admin"))) {
+        if (claims == null || !claims.authorized(setOf(PRIME_ADMIN_PATTERN, "$orgName.*.admin"), request)) {
             logger.warn("User '${claims?.userName}' FAILED authorized for endpoint ${request.uri}")
             return HttpUtilities.unauthorizedResponse(request, authenticationFailure)
         }
@@ -639,7 +639,7 @@ class ApiKeysFunctions(private val settingsFacade: SettingsFacade = SettingsFaca
         @PathParam(PARAM_NAME_KID) @BindingName(PARAM_NAME_KID) kid: String
     ): HttpResponseMessage {
         val claims = AuthenticatedClaims.authenticate(request)
-        if (claims == null || !claims.authorized(setOf(PRIME_ADMIN_PATTERN, "$orgName.*.admin"))) {
+        if (claims == null || !claims.authorized(setOf(PRIME_ADMIN_PATTERN, "$orgName.*.admin"), request)) {
             logger.warn("User '${claims?.userName}' FAILED authorized for endpoint ${request.uri}")
             return HttpUtilities.unauthorizedResponse(request, authenticationFailure)
         }

--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -160,7 +160,7 @@ class CheckFunction : Logging {
     ): HttpResponseMessage {
         val claims = AuthenticatedClaims.authenticate(request)
 
-        if (claims == null || !claims.authorized(setOf("*.*.primeadmin", "$orgName.*.admin"))) {
+        if (claims == null || !claims.authorized(setOf("*.*.primeadmin", "$orgName.*.admin"), request)) {
             logger.warn("User '${claims?.userName}' FAILED authorized for endpoint ${request.uri}")
             return HttpUtilities.unauthorizedResponse(request, authenticationFailure)
         }

--- a/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
+++ b/prime-router/src/main/kotlin/azure/HistoryFunctions.kt
@@ -185,7 +185,7 @@ class GetReports :
         ) request: HttpRequestMessage<String?>
     ): HttpResponseMessage {
         val claims = AuthenticatedClaims.authenticate(request)
-        if (claims == null || !claims.authorized(setOf("*.*.primeadmin"))) {
+        if (claims == null || !claims.authorized(setOf("*.*.primeadmin"), request)) {
             logger.warn("User '${claims?.userName}' FAILED authorized for endpoint ${request.uri}")
             return HttpUtilities.unauthorizedResponse(request, authenticationFailure)
         }

--- a/prime-router/src/main/kotlin/cli/tests/AuthTests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/AuthTests.kt
@@ -83,7 +83,8 @@ class OktaAuthTests : CoolTest() {
                 OktaCommand.fetchAccessToken(environment.oktaApp)
                     ?: CommandUtilities.abort(
                         "Cannot run test $testName. Invalid access token. " +
-                            "Run ./prime login to fetch/refresh a PrimeAdmin access token for the $environment environment."
+                            "Run ./prime login to fetch/refresh a PrimeAdmin access token " +
+                            "for the $environment environment."
                     )
             }
         }

--- a/prime-router/src/main/kotlin/cli/tests/SettingsTest.kt
+++ b/prime-router/src/main/kotlin/cli/tests/SettingsTest.kt
@@ -102,8 +102,8 @@ class SettingsTest : CoolTest() {
                 HttpStatus.SC_OK -> Unit
                 else ->
                     return bad(settingErrorMessage + "Failed Dummy organization - ${responseDel.responseMessage}.")
-                }
             }
+        }
 
         /**
          * CREATE the dummy organization

--- a/prime-router/src/main/kotlin/history/azure/DeliveryFunction.kt
+++ b/prime-router/src/main/kotlin/history/azure/DeliveryFunction.kt
@@ -261,7 +261,7 @@ class DeliveryFunction(
         @BindingName("reportId") reportId: UUID
     ): HttpResponseMessage {
         val claims = AuthenticatedClaims.authenticate(request)
-        if (claims == null || !claims.authorized(setOf("*.*.primeadmin"))) {
+        if (claims == null || !claims.authorized(setOf("*.*.primeadmin"), request)) {
             logger.warn("User '${claims?.userName}' FAILED authorized for endpoint ${request.uri}")
             return HttpUtilities.unauthorizedResponse(request, authenticationFailure)
         }

--- a/prime-router/src/main/kotlin/tokens/Scope.kt
+++ b/prime-router/src/main/kotlin/tokens/Scope.kt
@@ -1,6 +1,7 @@
 package gov.cdc.prime.router.tokens
 
 import gov.cdc.prime.router.Organization
+import io.ktor.util.toLowerCasePreservingASCIIRules
 import org.apache.logging.log4j.kotlin.Logging
 
 /**
@@ -126,7 +127,9 @@ class Scope {
          * @return the (possibly empty) intersection of the two sets.  Empty Set == not authorized for anything.
          */
         internal fun authorizedScopes(userScopes: Set<String>, requiredScopes: Set<String>): Set<String> {
-            return userScopes.filter { it.isNotBlank() }.intersect(requiredScopes.filter { it.isNotBlank() }.toSet())
+            return userScopes.map(String::toLowerCasePreservingASCIIRules).filter { it.isNotBlank() }.intersect(
+                requiredScopes.map(String::toLowerCasePreservingASCIIRules).filter { it.isNotBlank() }.toSet()
+            )
         }
 
         /**

--- a/prime-router/src/test/kotlin/tokens/Server2ServerAuthenticationTests.kt
+++ b/prime-router/src/test/kotlin/tokens/Server2ServerAuthenticationTests.kt
@@ -22,6 +22,7 @@ import io.jsonwebtoken.io.Encoders
 import io.jsonwebtoken.security.Keys
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkConstructor
@@ -213,7 +214,7 @@ class Server2ServerAuthenticationTests {
         val claims = server2ServerAuthentication.authenticate(token.accessToken, rslookup)
         // if claims is non-null then the sender's accessToken is valid.
         assertNotNull(claims)
-        if (! claims.authorized(setOf("*.*.primeadmin")))
+        if (! claims.authorized(setOf("*.*.primeadmin"), mockk()))
             error("Authorization failed")
         // if claims is non-null then the sender's accessToken is valid.
         assertEquals(token.expiresAtSeconds, claims.jwtClaims["exp"])
@@ -267,7 +268,7 @@ class Server2ServerAuthenticationTests {
         // if claims is non-null then the sender's accessToken is valid.
         assertNotNull(claims)
 
-        if (! claims.authorized(setOf("simple_report.*.report")))
+        if (! claims.authorized(setOf("simple_report.*.report"), mockk()))
             error("Authorization failed")
         assertEquals(accessToken.expiresAtSeconds, claims.jwtClaims["exp"])
         assertEquals("simple_report.*.report", claims.jwtClaims["scope"])
@@ -428,7 +429,7 @@ class Server2ServerAuthenticationTests {
         val accessToken = server2ServerAuthentication.createAccessToken("a.b.report", rslookup)
         val claims = server2ServerAuthentication.authenticate(accessToken.accessToken, rslookup)
         assertNotNull(claims)
-        if (! claims.authorized(setOf("a.b.report")))
+        if (! claims.authorized(setOf("a.b.report"), mockk()))
             error("Claims not authorized")
         assertEquals(accessToken.expiresAtSeconds, claims.jwtClaims["exp"])
         assertTrue(claims.scopes.contains("a.b.report"))


### PR DESCRIPTION
This PR suggest a minor refactor of how we do authorization and authentication, partially to improve the architecture, and partially to fix a defect introduced by #10478 where a normal user is not able to access the Daily Data page because this PR makes it so only Prime Admins can. I hope to facilitate a discussion with these changes and come to a consensus on a path forward.

Test Steps Okta:
1. Create a normal level account in staging Okta (this is what local dev uses) and assign to flexion org (I used my CDC email)
2. log in with the normal account and go to daily data, see that it loads

Test Steps Server-Server:
1. Do Okta setup outline above
2. Set up server-server auth with scope of "flexion.*.user" for flexion org and try to hit the same endpoint Daily Data does

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
