### PR TITLE
Include typescript-eslint in typescript group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -147,6 +147,7 @@ updates:
           - "typescript"
           - "tslib"
           - "ts-node"
+          - "@typescript-eslint*"
       react:
         patterns:
           - "react"


### PR DESCRIPTION
This PR fixes `@typescript-eslint` so that it is grouped inside the typescript group.
