### PR TITLE
Adding logging to track the duration of downloading a blob in the bat…

### DIFF
--- a/prime-router/src/main/kotlin/azure/BatchFunction.kt
+++ b/prime-router/src/main/kotlin/azure/BatchFunction.kt
@@ -12,6 +12,7 @@ import gov.cdc.prime.router.fhirengine.utils.HL7MessageHelpers
 import org.apache.logging.log4j.kotlin.Logging
 import org.jooq.Configuration
 import java.time.OffsetDateTime
+import java.util.Calendar
 
 const val batch = "batch"
 const val defaultBatchSize = 100
@@ -138,6 +139,7 @@ class BatchFunction(
                             receiver.format.isSingleItemFormat -> inReports // don't merge, when we are about to split
                             receiver.timing?.operation == Receiver.BatchOperation.MERGE ->
                                 listOf(Report.merge(inReports))
+
                             else -> inReports
                         }
                         val outReports = if (receiver.format.isSingleItemFormat)
@@ -192,7 +194,7 @@ class BatchFunction(
                 actionHistory.trackExistingInputReport(it.task.reportId)
 
                 // download message
-                val bodyBytes = BlobAccess.downloadBlob(it.task.bodyUrl)
+                val bodyBytes = downloadBlobWithMetrics(it)
 
                 // get a Report from the message
                 val (report, sendEvent, blobInfo) = Report.generateReportAndUploadBlob(
@@ -223,7 +225,7 @@ class BatchFunction(
                 actionHistory.trackExistingInputReport(it.task.reportId)
 
                 // download message
-                val bodyBytes = BlobAccess.downloadBlob(it.task.bodyUrl)
+                val bodyBytes = downloadBlobWithMetrics(it)
                 String(bodyBytes)
             }
 
@@ -254,5 +256,13 @@ class BatchFunction(
                 txn
             )
         }
+    }
+
+    private fun downloadBlobWithMetrics(it: WorkflowEngine.Header): ByteArray {
+        val startDownloadTime = Calendar.getInstance().timeInMillis
+        val bodyBytes = BlobAccess.downloadBlob(it.task.bodyUrl)
+        val endDownloadTime = Calendar.getInstance().timeInMillis
+        logger.info("Batch Download Time: " + (endDownloadTime - startDownloadTime))
+        return bodyBytes
     }
 }


### PR DESCRIPTION
…ch function

This PR adds logging around the blob store in the batch function. A second part of this ticket will be actually adding the query to Azure once this is deployed so that I have logs to work with. 

Test Steps:
1. I guess you can send a message through the pipeline and make sure you see the logs?

## Changes
- Added logging around downloading the blob in the batch function


## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?