### PR TITLE
Bump flyway and flyway-core to 9.21.1

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -31,7 +31,7 @@ import java.util.Properties
 
 plugins {
     kotlin("jvm") version "1.8.22"
-    id("org.flywaydb.flyway") version "8.5.13"
+    id("org.flywaydb.flyway") version "9.21.1"
     id("nu.studer.jooq") version "7.1.1"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("com.microsoft.azure.azurefunctions") version "1.11.1"
@@ -834,7 +834,7 @@ dependencies {
     implementation("commons-io:commons-io:2.13.0")
     implementation("org.postgresql:postgresql:42.6.0")
     implementation("com.zaxxer:HikariCP:5.0.1")
-    implementation("org.flywaydb:flyway-core:9.7.0")
+    implementation("org.flywaydb:flyway-core:9.21.1")
     implementation("org.commonmark:commonmark:0.21.0")
     implementation("com.google.guava:guava:32.1.1-jre")
     implementation("com.helger.as2:as2-lib:5.1.1")

--- a/prime-router/gradle.properties
+++ b/prime-router/gradle.properties
@@ -1,3 +1,4 @@
 # Set the character encoding when running from Gradle.
 # This affects the unit tests and runs of the primeCLI from Gradle.
 org.gradle.jvmargs=-Dfile.encoding=UTF8 -Xmx2048M
+flyway.postgresql.transactional.lock=false

--- a/prime-router/gradle.properties
+++ b/prime-router/gradle.properties
@@ -1,4 +1,6 @@
 # Set the character encoding when running from Gradle.
 # This affects the unit tests and runs of the primeCLI from Gradle.
 org.gradle.jvmargs=-Dfile.encoding=UTF8 -Xmx2048M
+# This setting makes flyway fall back to session locks as concurrent index creation cannot be done
+# within a transaction. This setting is needed as of flyway 9.19.4.
 flyway.postgresql.transactional.lock=false

--- a/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
+++ b/prime-router/src/main/kotlin/azure/DatabaseAccess.kt
@@ -1415,9 +1415,8 @@ class DatabaseAccess(private val create: DSLContext) : Logging {
             config.maxLifetime = 180000
             val dataSource = HikariDataSource(config)
 
-            // This is a current issue in flyway https://github.com/flyway/flyway/issues/3508
-            // This setting makes flyway fall back to session locks
-            // This is fixed in flyway 9.19.4
+            // This setting makes flyway fall back to session locks as concurrent index creation cannot be done
+            // within a transaction. This setting is needed as of flyway 9.19.4.
             val flyway = Flyway.configure().configuration(mapOf(Pair("flyway.postgresql.transactional.lock", "false")))
                 .dataSource(dataSource).load()
             if (isFlywayMigrationOK) {


### PR DESCRIPTION
This PR bumps flyway and flyway-core to 9.21.1 and makes a change to Gradle properties to support new configuration options.

Building on #10512, the configuration changes to set flyway to use session locks has already been added to the code, but at the time the flyway 9.8.3 and 9.9.0 updates were previously tested in RS there was [an issue with flyway](https://github.com/flyway/flyway/issues/3682) not obeying the configuration flag. This has since been corrected upstream as of flyway 9.19.4.

Test Steps:
1. Ensure all smoke tests pass.

## Changes
- Bumps flyway and flyway-core to 9.21.1.
- Change Gradle properties to configure flyway to run without transactional locks.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Linked Issues
- #10865
- Supercedes #9090 and #10650.

## To Be Done
- #10526