### PR TITLE
Fix filter for ignore.etor-ti receiver

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -228,7 +228,9 @@
       organizationName: ignore
       topic: etor-ti
       customerStatus: active
-      jurisdictionalFilter: [ "(%performerState.exists() and %performerState = 'IG') or (%patientState.exists() and %patientState = 'IG')" ]
+      jurisdictionalFilter:
+        - "(%performerState.exists() and %performerState = 'IG') or (%patientState.exists() and %patientState = 'IG')"
+        - "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       timing:
         operation: MERGE
         numberPerDay: 1440 # Every minute


### PR DESCRIPTION
This PR Fixes an issue where ORM messages would get routed to Ignore.ETOR-TI receiver and would fail translation

Test Steps:
1. run `./prime multiple-settings set --input /Users/arnej/Projects/prime-reportstream/prime-router/settings/organizations.yml `
2. Configure and run "Send HL7v2 Message" from the Postman collection: 
[CDC.postman_collection.json.zip](https://github.com/CDCgov/prime-reportstream/files/12432257/CDC.postman_collection.json.zip)
3. Verify no translation error occurs and Ignore.ETOR-TI was not a receiver
