### PR TITLE
[SPIKE] Org/Status not being cleared after logging out of site

### DIFF
--- a/frontend-react/src/utils/UserUtils.ts
+++ b/frontend-react/src/utils/UserUtils.ts
@@ -6,12 +6,17 @@ export enum SessionEvent {
 }
 
 async function logout(): Promise<void> {
+    /*
+     * Clear localstorage BEFORE okta signout as
+     * the okta process will prevent logic after
+     * from running
+     */
+    localStorage.clear();
     try {
         await OKTA_AUTH.signOut();
     } catch (e) {
         console.trace(e);
     }
-    localStorage.clear();
 }
 
 export { logout };


### PR DESCRIPTION
Fixes #9609

This PR changes the order of operations on logout so that localstorage is cleared BEFORE initiating the okta library's signOut function. This ensures that the okta library doesn't prevent the clearage.
