### PR TITLE
Bump jacoco from 0.8.9 to 0.8.10

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -109,7 +109,7 @@ val ktorVersion = "2.3.2"
 val kotlinVersion = "1.9.10"
 val jacksonVersion = "2.15.2"
 
-jacoco.toolVersion = "0.8.9"
+jacoco.toolVersion = "0.8.10"
 
 // Set the compiler JVM target
 java {


### PR DESCRIPTION
This PR updates `JaCoCo` from 0.8.9 to 0.8.10. This addresses a regression introduced in 0.8.9.

Changelog: https://www.jacoco.org/jacoco/trunk/doc/changes.html

Test Steps:
1. Verify the build is successful.

## Changes
- Update `JaCoCo` from 0.8.9 to 0.8.10.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?
