### PR TITLE
Remove Homepage Testimonials

### DIFF
--- a/frontend-react/src/shared/LiveMap/LiveMap.tsx
+++ b/frontend-react/src/shared/LiveMap/LiveMap.tsx
@@ -2,7 +2,6 @@ import { Link } from "@trussworks/react-uswds";
 
 import usamapsvg from "../../content/usa_w_territories.svg";
 import { USLink } from "../../components/USLink";
-import { Citation } from "../Citation/Citation";
 
 import styles from "./LiveMap.module.scss";
 
@@ -15,7 +14,6 @@ export const LiveMap = ({
     title,
     summary,
     subTitle,
-    citation,
     ...props
 }: LiveMapProps) => {
     return (
@@ -64,15 +62,6 @@ export const LiveMap = ({
                     See all partners
                 </Link>
             </div>
-            {citation?.map((citation, citationIndex) => {
-                return (
-                    <Citation
-                        data-testid="citation"
-                        key={citationIndex}
-                        {...citation}
-                    />
-                );
-            })}
         </section>
     );
 };


### PR DESCRIPTION
Remove testimonials on homepage based on this Slack comment: 

<img width="840" alt="Screenshot 2023-08-30 at 3 18 08 PM" src="https://github.com/CDCgov/prime-reportstream/assets/516877/f0cf8c71-7941-4db9-8d35-5ccd74f787e7">


**Note:** leaving the content itself as-is since we may use it in the future.

Screenshot:

<img width="698" alt="Screenshot 2023-08-30 at 3 16 35 PM" src="https://github.com/CDCgov/prime-reportstream/assets/516877/969e1c17-e6f5-4ac1-8708-f4d0791f25de">
