### PR TITLE
Remove pipeline label from Platform User Story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-user-story.md
+++ b/.github/ISSUE_TEMPLATE/platform-user-story.md
@@ -2,7 +2,7 @@
 name: Platform User Story
 about: Platform team's User Story issue template
 title: User Story Title
-labels: pipeline, platform
+labels: platform
 assignees: ''
 
 ---


### PR DESCRIPTION
This PR removes the pipeline label from being automatically added when the Platform User Story issue template is used.

## Changes
- Remove pipeline label from default labels in Platform User Story template
