### PR TITLE
add missing sendgrid argument for demo envs

### DIFF
--- a/operations/app/terraform/modules/init/key_vault.tf
+++ b/operations/app/terraform/modules/init/key_vault.tf
@@ -19,6 +19,10 @@ locals {
     cyberark-ip-ingress = {
       secret = "158.111.21.0/24,158.111.123.0/25",
       vault  = azurerm_key_vault.init["keyvault"]
+    },
+    sendgrid-password = {
+      secret = "changeIT!",
+      vault  = azurerm_key_vault.init["appconfig"]
     }
   }
   keys = {

--- a/operations/app/terraform/vars/demo/data.tf
+++ b/operations/app/terraform/vars/demo/data.tf
@@ -10,6 +10,15 @@ data "azurerm_key_vault" "app_config" {
   ]
 }
 
+data "azurerm_key_vault_secret" "sendgrid_password" {
+  name         = "sendgrid-password"
+  key_vault_id = data.azurerm_key_vault.app_config.id
+
+  depends_on = [
+    module.init
+  ]
+}
+
 data "azurerm_key_vault_secret" "postgres_user" {
   name         = "functionapp-postgres-user"
   key_vault_id = data.azurerm_key_vault.app_config.id

--- a/operations/app/terraform/vars/demo/main.tf
+++ b/operations/app/terraform/vars/demo/main.tf
@@ -227,6 +227,7 @@ module "metabase" {
   postgres_server_name   = module.database.postgres_server_name
   postgres_user          = data.azurerm_key_vault_secret.postgres_user.value
   postgres_pass          = data.azurerm_key_vault_secret.postgres_pass.value
+  sendgrid_password      = data.azurerm_key_vault_secret.sendgrid_password.value
   subnets                = module.network.subnets
 }
 


### PR DESCRIPTION
This PR fixes error caused by a missing argument for demo environments.

Test Steps:
1. Deploy a demo environment

## Changes
- Added sendgrid pass argument

## Linked Issues
- Fixes #11536 

