### PR TITLE
update terraform code with 504 FA alert

### DIFF
--- a/operations/app/terraform/modules/application_insights/alert_response_time.tf
+++ b/operations/app/terraform/modules/application_insights/alert_response_time.tf
@@ -139,3 +139,31 @@ requests
     action_group = [local.action_group_id]
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "http_504-alert" {
+  count = local.alerting_enabled
+
+  name                = "${var.environment}-504-alert"
+  description         = "Raise alert on any 504 responses from the Front Door."
+  location            = var.location
+  resource_group_name = var.resource_group
+  severity            = 1
+  frequency           = 5
+  time_window         = 5
+
+  data_source_id = local.app_insights_id
+
+  query = <<-QUERY
+AzureDiagnostics
+| where ResourceType == 'FRONTDOORS' and httpStatusCode_s == '504'
+  QUERY
+
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+
+  action {
+    action_group = [local.action_group_id]
+  }
+}


### PR DESCRIPTION
This PR is to Configure pdhprod-504-alert via Terraform code

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  ```
# module.database.azurerm_postgresql_server.postgres_server has changed
  ~ resource "azurerm_postgresql_server" "postgres_server" {
        id                                = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.DBforPostgreSQL/servers/pdhprod-pgsql"
        name                              = "pdhprod-pgsql"
      ~ sku_name                          = "GP_Gen5_16" -> "MO_Gen5_32"
      ~ storage_mb                        = 342016 -> 1048576
        tags                              = {
            "environment" = "prod"
        }
        # (14 unchanged attributes hidden)


      ~ storage_profile {
          ~ storage_mb            = 342016 -> 1048576
            # (3 unchanged attributes hidden)
        }


        # (3 unchanged blocks hidden)
    }

  # module.log_analytics_workspace.azurerm_log_analytics_workspace.law has changed
  ~ resource "azurerm_log_analytics_workspace" "law" {
        id                         = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.OperationalInsights/workspaces/pdhprod-law"
        name                       = "pdhprod-law"
      ~ retention_in_days          = 30 -> 730
        tags                       = {
            "environment" = "prod"
        }
        # (9 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include       
actions to undo or respond to these changes.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # module.application_insights.azurerm_application_insights_web_test.metabase_test will be created
  + resource "azurerm_application_insights_web_test" "metabase_test" {
      + application_insights_id = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/components/pdhprod-appinsights"
      + configuration           = <<-EOT
            <WebTest Name="" Id="" Enabled="True" CssProjectStructure="" CssIteration="" Timeout="60" WorkItemIds="" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010" Description="" CredentialUserName="" CredentialPassword="" PreAuthenticate="True" Proxy="default" StopOnError="False" RecordedResultFile="" ResultsLocale="">
                  <Items>
                    <Request Method="GET" Version="1.1" Url="https://prod.prime.cdc.gov/metabase/api/health" ThinkTime="0" Timeout="60" ParseDependentRequests="False" FollowRedirects="True" RecordResult="True" Cache="False" ResponseTimeGoal="0" Encoding="utf-8" ExpectedHttpStatusCode="200" ExpectedResponseUrl="" 
ReportingName="" IgnoreHttpStatusCode="False"/>
                  </Items>
                </WebTest>
        EOT
      + enabled                 = true
      + frequency               = 300
      + geo_locations           = [
          + "us-va-ash-azr",
          + "us-ca-sjc-azr",
          + "us-fl-mia-edge",
        ]
      + id                      = (known after apply)
      + kind                    = "ping"
      + location                = "eastus"
      + name                    = "pdhprod-metabase-health-check"
      + resource_group_name     = "prime-data-hub-prod"
      + retry_enabled           = true
      + synthetic_monitor_id    = (known after apply)
      + tags                    = {
          + "environment"
                = "prod"
          + "hidden-link:/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/components/pdhprod-appinsights" = "Resource"
        }
      + timeout                 = 60
    }

  # module.application_insights.azurerm_monitor_action_group.action_group_businesshours[0] will be destroyed
  # (because azurerm_monitor_action_group.action_group_businesshours is not in configuration)
  - resource "azurerm_monitor_action_group" "action_group_businesshours" {
      - enabled             = true -> null
      - id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/actionGroups/pdhprod-actiongroup-businesshours" -> null
      - name                = "pdhprod-actiongroup-businesshours" -> null
      - resource_group_name = "prime-data-hub-prod" -> null
      - short_name          = "PD Day Hours" -> null
      - tags                = {
          - "environment" = "prod"
        } -> null

      - timeouts {}

      - webhook_receiver {
          - name                    = "PagerDuty Business Hours" -> null
          - service_uri             = (sensitive) -> null
          - use_common_alert_schema = true -> null
        }
    }

  # module.application_insights.azurerm_monitor_action_group.action_group_metabase will be created
  + resource "azurerm_monitor_action_group" "action_group_metabase" {
      + enabled             = true
      + id                  = (known after apply)
      + name                = "pdhprod-actiongroup-metabase"
      + resource_group_name = "prime-data-hub-prod"
      + short_name          = "mb-check"
      + tags                = {
          + "environment" = "prod"
        }

      + webhook_receiver {
          + name                    = "PagerDuty-mbhealthcheck"
          + service_uri             = (sensitive)
          + use_common_alert_schema = true
        }
    }

  # module.application_insights.azurerm_monitor_action_group.action_group_slack will be created
  + resource "azurerm_monitor_action_group" "action_group_slack" {
      + enabled             = true
      + id                  = (known after apply)
      + name                = "pdhprod-actiongroup-slack"
      + resource_group_name = "prime-data-hub-prod"
      + short_name          = "Slack-AG"
      + tags                = {
          + "environment" = "prod"
        }

      + email_receiver {
          + email_address = (sensitive)
          + name          = "slack-notification"
        }
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.db_query_duration[0] will be updated in-place
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration" {
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/scheduledQueryRules/prod-db-query-duration"
        name                    = "prod-db-query-duration"
      ~ query                   = <<-EOT
            dependencies
            | where timestamp >= ago(5m) and name has "SQL:" and duration >= 10000
        EOT
        tags                    = {}
        # (12 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.db_query_duration_over_time_window[0] will be updated in-place
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "db_query_duration_over_time_window" {
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/scheduledQueryRules/prod-db-query-duration-over-time-window"
        name                    = "prod-db-query-duration-over-time-window"
      ~ query                   = <<-EOT
            dependencies
            | where timestamp >= ago(5m) and name has "SQL:" and duration > 1250
        EOT
        tags                    = {}
        # (12 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.http_2xx_failed_requests[0] will be updated in-place
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "http_2xx_failed_requests" {
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/scheduledQueryRules/prod-api-2xx-failed-requests"
        name                    = "prod-api-2xx-failed-requests"
      ~ query                   = <<-EOT
            requests
            | where toint(resultCode) between (200 .. 299) and success == false and timestamp >= ago(5m)
        EOT
        tags                    = {}
        # (12 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.http_4xx_errors[0] will be updated in-place
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "http_4xx_errors" {
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/scheduledQueryRules/prod-api-4xx-errors"
        name                    = "prod-api-4xx-errors"
      ~ query                   = <<-EOT
            requests
            | where toint(resultCode) >= 400 and toint(resultCode) < 500 and toint(resultCode) != 401 and timestamp >= ago(5m)
        EOT
        tags                    = {}
        # (12 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.http_504-alert[0] will be created
  + resource "azurerm_monitor_scheduled_query_rules_alert" "http_504-alert" {
      + auto_mitigation_enabled = false
      + data_source_id          = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/microsoft.insights/components/pdhprod-appinsights"
      + description             = "Raise alert on any 504 responses from the Front Door."
      + enabled                 = true
      + frequency               = 5
      + id                      = (known after apply)
      + location                = "eastus"
      + name                    = "prod-504-alert"
      + query                   = <<-EOT
            AzureDiagnostics
            | where ResourceType == 'FRONTDOORS' and httpStatusCode_s == '504'
        EOT
      + query_type              = "ResultCount"
      + resource_group_name     = "prime-data-hub-prod"
      + severity                = 1
      + time_window             = 5

      + action {
          + action_group           = [
              + "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/microsoft.insights/actionGroups/pdhprod-actiongroup",
            ]
          + custom_webhook_payload = (known after apply)
        }

      + trigger {
          + operator  = "GreaterThanOrEqual"
          + threshold = 1
        }
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.http_5xx_errors[0] will be updated in-place
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "http_5xx_errors" {
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/scheduledQueryRules/prod-api-5xx-errors"
        name                    = "prod-api-5xx-errors"
      ~ query                   = <<-EOT
            requests
            | where toint(resultCode) >= 500 and timestamp >= ago(5m)
        EOT
        tags                    = {}
        # (12 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

  # module.application_insights.azurerm_monitor_scheduled_query_rules_alert.http_response_time[0] will be updated in-place
  ~ resource "azurerm_monitor_scheduled_query_rules_alert" "http_response_time" {
        id                      = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-prod/providers/Microsoft.Insights/scheduledQueryRules/prod-api-http-response"
        name                    = "prod-api-http-response"
      ~ query                   = <<-EOT
            requests
            | summarize AggregatedValue = (percentile(duration, 50)) by bin(timestamp, 5m)
        EOT
        tags                    = {}
        # (12 unchanged attributes hidden)



        # (3 unchanged blocks hidden)
    }

Plan: 4 to add, 6 to change, 1 to destroy.
```