### PR TITLE
Added missing OKTA variable references in function_app module in DEMO env

### DIFF
--- a/operations/app/terraform/vars/demo/main.tf
+++ b/operations/app/terraform/vars/demo/main.tf
@@ -151,6 +151,10 @@ module "function_app" {
   ai_connection_string              = module.application_insights.connection_string
   okta_base_url                     = local.init.okta_base_url
   okta_redirect_url                 = local.init.okta_redirect_url
+  OKTA_authKey                      = local.init.OKTA_authKey
+  OKTA_clientId                     = local.init.OKTA_clientId
+  fn_OKTA_clientId                  = local.init.fn_OKTA_clientId
+  OKTA_scope                        = local.init.OKTA_scope
   terraform_caller_ip_address       = local.network.terraform_caller_ip_address
   use_cdc_managed_vnet              = local.network.use_cdc_managed_vnet
   primary_access_key                = module.storage.sa_primary_access_key


### PR DESCRIPTION
Added missing OKTA variable references in the `function_app `module in DEMO environment.

Test Steps:
1. `terraform plan -var-file=$env/env.tfvars.json` should now pass. 

### Testing
- [x] Tested locally?

