### PR TITLE
set-default-action-to-deny-for-sftp-sa

### DIFF
--- a/operations/app/terraform/modules/sftp/storage.tf
+++ b/operations/app/terraform/modules/sftp/storage.tf
@@ -8,7 +8,7 @@ resource "azurerm_storage_account" "sftp" {
   min_tls_version          = "TLS1_2"
 
   network_rules {
-    default_action = "Allow"
+    default_action = "Deny"  # Change the default_action to "Deny"
     bypass         = ["AzureServices"]
 
     ip_rules = var.terraform_caller_ip_address

--- a/operations/app/terraform/modules/sftp/storage.tf
+++ b/operations/app/terraform/modules/sftp/storage.tf
@@ -8,7 +8,7 @@ resource "azurerm_storage_account" "sftp" {
   min_tls_version          = "TLS1_2"
 
   network_rules {
-    default_action = "Deny"  # Change the default_action to "Deny"
+    default_action = "Deny" # Change the default_action to "Deny"
     bypass         = ["AzureServices"]
 
     ip_rules = var.terraform_caller_ip_address


### PR DESCRIPTION
This is a quick PR to set the default_action attribute to "Deny" for the network rules of the sftp Azure Storage 