### PR TITLE
set-default-action-to-deny-for-storage-public-sa

### DIFF
--- a/operations/app/terraform/modules/storage/main.tf
+++ b/operations/app/terraform/modules/storage/main.tf
@@ -185,7 +185,7 @@ resource "azurerm_storage_account" "storage_public" {
   }
 
   network_rules {
-    default_action = "Allow"
+    default_action = "Deny"  # Change the default_action to "Deny"
   }
 
   identity {


### PR DESCRIPTION
This is a quick PR to set the default_action attribute to "Deny" for the network rules of the storage_public Azure Storage