### PR TITLE
 Clean up githook precommit hook script #11009.

### DIFF
--- a/.environment/frontend/run-frontend.sh
+++ b/.environment/frontend/run-frontend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 isModified=0
+set -o pipefail
 
 function modified_check() {
     MODIFIED_COUNT=$(git status --porcelain | grep "frontend-react/" | wc -l | xargs)

--- a/.environment/terraform-fmt/run-terraform-fmt.sh
+++ b/.environment/terraform-fmt/run-terraform-fmt.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-
+set -o pipefail
 function checkExec() {
     terraform version &>/dev/null
 
-    if [ $? -eq 0 ]; 
+    if [ $? -eq 0 ];
     then
        echo "Great! $(Terraform version | head -1) is istalled"
-       echo -e "\033[32mNow runing Terraform format Check...\033[m" 
+       echo -e "\033[32mNow runing Terraform format Check...\033[m"
     else
        echo -e "\033[31mError: Terraform executable is missing.\033[m"
        echo -e "Please follow https://www.terraform.io/downloads.html for the installation steps"


### PR DESCRIPTION
Added `set -o pipefail` to the pre-commit scripts where pipelines are used.

Test Steps:
1. Run `./.environment/pre-commit.runner.sh`

## Changes
- Added `set -o pipefail` to the pre-commit scripts where pipelines are used.

## Checklist

### Testing
- [x] Tested locally?

## Linked Issues
- Fixes #11009

