### PR TITLE
Update Terraform Code with 504 FA Alert

### DIFF
--- a/operations/app/terraform/modules/application_insights/alert_response_time.tf
+++ b/operations/app/terraform/modules/application_insights/alert_response_time.tf
@@ -139,31 +139,3 @@ requests
     action_group = [local.action_group_id]
   }
 }
-
-resource "azurerm_monitor_scheduled_query_rules_alert" "http_504-alert" {
-  count = local.alerting_enabled
-
-  name                = "${var.environment}-504-alert"
-  description         = "Raise alert on any 504 responses from the Front Door."
-  location            = var.location
-  resource_group_name = var.resource_group
-  severity            = 1
-  frequency           = 5
-  time_window         = 5
-
-  data_source_id = local.app_insights_id
-
-  query = <<-QUERY
-AzureDiagnostics
-| where ResourceType == 'FRONTDOORS' and httpStatusCode_s == '504'
-  QUERY
-
-  trigger {
-    operator  = "GreaterThanOrEqual"
-    threshold = 1
-  }
-
-  action {
-    action_group = [local.action_group_id]
-  }
-}

--- a/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
+++ b/operations/app/terraform/modules/log_analytics_workspace/alert_rules.tf
@@ -83,3 +83,27 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "functionapp_401errors" {
     threshold = 10
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "functionapp_504errors" {
+  name                = format("%s-alertrule-fa-504errors", var.resource_prefix)
+  location            = var.location
+  resource_group_name = var.resource_group
+
+  action {
+    action_group = [var.action_group_slack_id]
+  }
+  data_source_id = azurerm_log_analytics_workspace.law.id
+  description    = "Found 1 or more 504s errors in FunctionApp logs"
+  enabled        = true
+  query          = <<-EOT
+      AzureDiagnostics
+      | where httpStatusCode_d == 504
+  EOT
+  frequency      = 5
+  time_window    = 5
+
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+}


### PR DESCRIPTION
This pull request (PR) addresses the need to incorporate a 504 FA (Failure Analysis) alert into our Terraform codebase. This alert is crucial for monitoring and responding to potential issues that can lead to service disruptions or performance degradation.

terraform plan&apply work correctly in [staging](https://portal.azure.com/#@cdc.onmicrosoft.com/resource/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledqueryrules/pdhstaging-alertrule-fa-504errors/overview)


```
  # module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_504errors will be created
  + resource "azurerm_monitor_scheduled_query_rules_alert" "functionapp_504errors" {
      + auto_mitigation_enabled = false
      + data_source_id          = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourcegroups/prime-data-hub-staging/providers/microsoft.operationalinsihts/workspaces/pdhstaging-law"
      + description             = "Found 1 or more 504s errors in FunctionApp logs"
      + enabled                 = true
      + frequency               = 5
      + id                      = (known after apply)
      + location                = "eastus"
      + name                    = "pdhstaging-alertrule-fa-504errors"
      + query                   = <<-EOT
            AzureDiagnostics
            | where httpStatusCode_d == 504
        EOT
      + query_type              = "ResultCount"
      + resource_group_name     = "prime-data-hub-staging"
      + time_window             = 5

      + action {
          + action_group           = [
              + "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/microsoft.insights/actionGroups/pdhstaging-ctiongroup-slack",
            ]
          + custom_webhook_payload = (known after apply)
        }

      + trigger {
          + operator  = "GreaterThanOrEqual"
          + threshold = 1
        }
    }

```

```
Plan: 1 to add, 4 to change, 0 to destroy.
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_504errors: Creating...
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.metabase_webapp_alertrule: Modifying... [id=/subscriptions/7d1e3999-6577-4cd5-b296-f58e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-metabase-webapp-alertrule]
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_401errors: Modifying... [id=/subscriptions/7d1e3999-6577-4cd5-b296-f518e58e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-alertrule-fa-401errors]
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_fatal: Modifying... [id=/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e67/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-alertrule-functionapp-fatal]
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_401errors: Modifications complete after 3s [id=/subscriptions/7d1e3999-657-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-alertrule-fa-401errors]
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_fatal: Modifications complete after 3s [id=/subscriptions/7d1e3999-6577-4d5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-alertrule-functionapp-fatal]
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.metabase_webapp_alertrule: Modifications complete after 3s [id=/subscriptions/7d1e399-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-metabase-webapp-alertrule]       
module.log_analytics_workspace.azurerm_monitor_scheduled_query_rules_alert.functionapp_504errors: Creation complete after 5s [id=/subscriptions/7d1e3999-6577-4c5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/scheduledQueryRules/pdhstaging-alertrule-fa-504errors]
╷
│ Warning: Resource targeting is in effect
│
**Apply complete! Resources: 1 added, 3 changed, 0 destroyed.**
```