### PR TITLE
Fixed Flexion REST Alive Check rebased

### DIFF
--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -16,7 +16,6 @@ import gov.cdc.prime.router.SFTPTransportType
 import gov.cdc.prime.router.azure.db.enums.SettingType
 import gov.cdc.prime.router.common.BaseEngine
 import gov.cdc.prime.router.common.JacksonMapperUtilities
-import gov.cdc.prime.router.credentials.RestCredential
 import gov.cdc.prime.router.tokens.AuthenticatedClaims
 import gov.cdc.prime.router.tokens.authenticationFailure
 import gov.cdc.prime.router.transport.RESTTransport
@@ -348,10 +347,7 @@ class CheckFunction : Logging {
             val reportId = UUID.randomUUID().toString()
             // REST transport throws exception with error method to handle fails
             // get the username/password to authenticate with OAuth, fail throws exception
-            val credential: RestCredential = theRESTTransport.getCredential(restTransportType.authType, receiver)
-
-            // get the TLS/SSL cert in a JKS if needed, NY uses a specific one, fail throws exception
-            val jksCredential = restTransportType.tlsKeystore?.let { theRESTTransport.lookupJksCredentials(it) }
+            val (credential, jksCredential) = theRESTTransport.getCredential(restTransportType, receiver)
 
             responseBody.add("Attempting to authenticate at: ${restTransportType.authTokenUrl}")
             val aLogger: Logger = Logger.getLogger(this.toString())

--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -348,11 +348,7 @@ class CheckFunction : Logging {
             val reportId = UUID.randomUUID().toString()
             // REST transport throws exception with error method to handle fails
             // get the username/password to authenticate with OAuth, fail throws exception
-            val credential: RestCredential = if (restTransportType.authType == "two-legged") {
-                theRESTTransport.lookupTwoLeggedCredential(receiver)
-            } else {
-                theRESTTransport.lookupDefaultCredential(receiver)
-            }
+            val credential: RestCredential = theRESTTransport.getCredential(restTransportType.authType, receiver)
 
             // get the TLS/SSL cert in a JKS if needed, NY uses a specific one, fail throws exception
             val jksCredential = restTransportType.tlsKeystore?.let { theRESTTransport.lookupJksCredentials(it) }

--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -348,7 +348,11 @@ class CheckFunction : Logging {
             val reportId = UUID.randomUUID().toString()
             // REST transport throws exception with error method to handle fails
             // get the username/password to authenticate with OAuth, fail throws exception
-            val credential: RestCredential = theRESTTransport.lookupDefaultCredential(receiver)
+            val credential: RestCredential = if (restTransportType.authType == "two-legged") {
+                theRESTTransport.lookupTwoLeggedCredential(receiver)
+            } else {
+                theRESTTransport.lookupDefaultCredential(receiver)
+            }
 
             // get the TLS/SSL cert in a JKS if needed, NY uses a specific one, fail throws exception
             val jksCredential = restTransportType.tlsKeystore?.let { theRESTTransport.lookupJksCredentials(it) }

--- a/prime-router/src/main/kotlin/transport/RESTTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RESTTransport.kt
@@ -92,11 +92,7 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
         // get the file name, or create one from the report ID, NY requires a file name in the POST
         val fileName = header.reportFile.externalName ?: "$reportId.hl7"
         // get the username/password to authenticate with OAuth
-        val credential: RestCredential = if (restTransportInfo.authType == "two-legged") {
-            lookupTwoLeggedCredential(receiver)
-        } else {
-            lookupDefaultCredential(receiver)
-        }
+        val credential: RestCredential = getCredential(restTransportInfo.authType, receiver)
         // get the TLS/SSL cert in a JKS if needed, NY uses a specific one
         val jksCredential = restTransportInfo.tlsKeystore?.let { lookupJksCredentials(it) }
 
@@ -199,6 +195,19 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
                     RetryToken.allItems
                 }
             }
+        }
+    }
+
+    /**
+     * Get credential either two-legged or default.
+     * @param transportType the transport type of two-legged or default
+     * @param receiver the receiver setting
+     */
+    fun getCredential(transportType: String?, receiver: Receiver): RestCredential {
+        return if (transportType == "two-legged") {
+            lookupTwoLeggedCredential(receiver)
+        } else {
+            lookupDefaultCredential(receiver)
         }
     }
 

--- a/prime-router/src/main/kotlin/transport/RESTTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RESTTransport.kt
@@ -92,9 +92,9 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
         // get the file name, or create one from the report ID, NY requires a file name in the POST
         val fileName = header.reportFile.externalName ?: "$reportId.hl7"
         // get the username/password to authenticate with OAuth
-        val credential: RestCredential = getCredential(restTransportInfo.authType, receiver)
+        val (credential, jksCredential) = getCredential(restTransportInfo, receiver)
         // get the TLS/SSL cert in a JKS if needed, NY uses a specific one
-        val jksCredential = restTransportInfo.tlsKeystore?.let { lookupJksCredentials(it) }
+//        val jksCredential = restTransportInfo.tlsKeystore?.let { lookupJksCredentials(it) }
 
         return try {
             // run our call to the endpoint in a blocking fashion
@@ -203,12 +203,16 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
      * @param transportType the transport type of two-legged or default
      * @param receiver the receiver setting
      */
-    fun getCredential(transportType: String?, receiver: Receiver): RestCredential {
-        return if (transportType == "two-legged") {
+    fun getCredential(transport: RESTTransportType, receiver: Receiver): Pair<RestCredential, UserJksCredential?> {
+        val credential: RestCredential = if (transport.authType == "two-legged") {
             lookupTwoLeggedCredential(receiver)
         } else {
             lookupDefaultCredential(receiver)
         }
+
+        val jksCredential: UserJksCredential? = transport.tlsKeystore?.let { lookupJksCredentials(it) }
+
+        return Pair(credential, jksCredential)
     }
 
     /**


### PR DESCRIPTION
This PR This PR fixed the alive checking function for flexion REST endpoint.

Test Steps:
1.) Setup flexion in the localhost.
2.) Run curl command below
curl "http://localhost:7071/api/check?sftpcheck=flexion.etor-service-receiver"
3.) Output screenshot:
![image](https://github.com/CDCgov/prime-reportstream/assets/20068283/6c5701a7-4f52-4287-9c80-e203f2c1756d)

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
