### PR TITLE
Feature/delete untaged container images from acr

### DIFF
--- a/.github/workflows/cleanup_old_images.yaml
+++ b/.github/workflows/cleanup_old_images.yaml
@@ -75,6 +75,7 @@ jobs:
         # resulting in an orphaned (or "dangling") image. 
         # The previously pushed image's manifest--and its layer data--remains in the registry.
         # They still need to be removed
+        
       - name: List image manifests in Test env
         id: list-test-untaged-images
         run: |

--- a/.github/workflows/cleanup_old_images.yaml
+++ b/.github/workflows/cleanup_old_images.yaml
@@ -1,10 +1,7 @@
 name: Cleanup old images in Test & Staging ACRs
 on:
-  push:
-    branches:
-      - feature/delete-untaged-container-images-from-ACR
-  # schedule:
-  #   - cron: "0 0 * * *" # Runs daily at midnight UTC
+  schedule:
+    - cron: "0 0 * * *" # Runs daily at midnight UTC
 
 
 jobs:
@@ -75,7 +72,7 @@ jobs:
         # resulting in an orphaned (or "dangling") image. 
         # The previously pushed image's manifest--and its layer data--remains in the registry.
         # They still need to be removed
-        
+
       - name: List image manifests in Test env
         id: list-test-untaged-images
         run: |

--- a/.github/workflows/cleanup_old_images.yaml
+++ b/.github/workflows/cleanup_old_images.yaml
@@ -75,14 +75,36 @@ jobs:
         # resulting in an orphaned (or "dangling") image. 
         # The previously pushed image's manifest--and its layer data--remains in the registry.
         # They still need to be removed
+      - name: List image manifests in Test env
+        id: list-test-untaged-images
+        run: |
+          az acr login --name pdhtestcontainerregistry
+          az acr repository show-manifests --name pdhtestcontainerregistry --repository pdhtest --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -4 > test-untaged-images.txt
 
-      - name: List untagged images in Staging env
+      - name: Delete image manifest in test env
+        env:
+          TEST_UNTAGED_FILE: test-untaged-images.txt  
+        run: |
+          if [ -e "$TEST_UNTAGED_FILE" ]; then
+            while IFS= read -r manifest_id; do
+                az acr repository delete --name pdhtestcontainerregistry --image pdhtest@$manifest_id --yes
+                if [ $? -eq 0 ]; then
+                    echo "Deleted image: pdhtest:$manifest_id"
+                else
+                    echo "Failed to delete image: pdhtest:$manifest_id"
+                fi
+            done < "$TEST_UNTAGED_FILE"
+              else
+                echo "File not found: $TEST_UNTAGED_FILE"
+          fi
+
+      - name: List image manifests in Staging env
         id: list-stg-untaged-images
         run: |
           az acr login --name pdhstagingcontainerregistry
-          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -3 > stg-untaged-images.txt
+          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -4 > stg-untaged-images.txt
 
-      - name: Delete untagged images in Staging env
+      - name: Delete image manifest in Staging env
         env:
           STG_UNTAGED_FILE: stg-untaged-images.txt  
         run: |

--- a/.github/workflows/cleanup_old_images.yaml
+++ b/.github/workflows/cleanup_old_images.yaml
@@ -80,7 +80,7 @@ jobs:
         id: list-stg-untaged-images
         run: |
           az acr login --name pdhstagingcontainerregistry
-          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -10 > stg-untaged-images.txt
+          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -20 > stg-untaged-images.txt
 
       - name: Delete untagged images in Staging env
         env:

--- a/.github/workflows/cleanup_old_images.yaml
+++ b/.github/workflows/cleanup_old_images.yaml
@@ -1,7 +1,10 @@
 name: Cleanup old images in Test & Staging ACRs
 on:
-  schedule:
-    - cron: "0 0 * * *" # Runs daily at midnight UTC
+  push:
+    branches:
+      - feature/delete-untaged-container-images-from-ACR
+  # schedule:
+  #   - cron: "0 0 * * *" # Runs daily at midnight UTC
 
 
 jobs:
@@ -20,51 +23,78 @@ jobs:
           user-key: ${{ secrets.USER_KEY }}
           sp-creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
 
-      - name: List test repository images
-        id: list-test-images
-        run: |
-          az acr login --name pdhtestcontainerregistry
-          az acr repository show-tags --name pdhtestcontainerregistry --repository pdhtest --orderby time_asc --output table | head -n -2 > test-images.txt
-          sed -i '1,2d' test-images.txt
+      # - name: List test repository images
+      #   id: list-test-images
+      #   run: |
+      #     az acr login --name pdhtestcontainerregistry
+      #     az acr repository show-tags --name pdhtestcontainerregistry --repository pdhtest --orderby time_asc --output table | head -n -2 > test-images.txt
+      #     sed -i '1,2d' test-images.txt
 
-      - name: Delete old images in TEST env
-        env:
-          IMAGE_FILE: test-images.txt  
-        run: |
-          if [ -e "$IMAGE_FILE" ]; then
-            while IFS= read -r image_id; do
-                az acr repository delete --name pdhtestcontainerregistry --image pdhtest:$image_id --yes
-                if [ $? -eq 0 ]; then
-                    echo "Deleted image: pdhtestcontainerregistry:$image_id"
-                else
-                    echo "Failed to delete image: pdhtestcontainerregistry:$image_id"
-                fi
-            done < "$IMAGE_FILE"
-              else
-                echo "File not found: $IMAGE_FILE"
-          fi
+      # - name: Delete old images in TEST env
+      #   env:
+      #     IMAGE_FILE: test-images.txt  
+      #   run: |
+      #     if [ -e "$IMAGE_FILE" ]; then
+      #       while IFS= read -r image_id; do
+      #           az acr repository delete --name pdhtestcontainerregistry --image pdhtest:$image_id --yes
+      #           if [ $? -eq 0 ]; then
+      #               echo "Deleted image: pdhtestcontainerregistry:$image_id"
+      #           else
+      #               echo "Failed to delete image: pdhtestcontainerregistry:$image_id"
+      #           fi
+      #       done < "$IMAGE_FILE"
+      #         else
+      #           echo "File not found: $IMAGE_FILE"
+      #     fi
 
-      - name: List staging repository images
-        id: list-stg-images
+      # - name: List staging repository images
+      #   id: list-stg-images
+      #   run: |
+      #     az acr login --name pdhstagingcontainerregistry
+      #     az acr repository show-tags --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output table | head -n -2 > stg-images.txt
+      #     sed -i '1,2d' stg-images.txt
+
+      # - name: Delete old images in Staging env
+      #   env:
+      #     STG_FILE: stg-images.txt  
+      #   run: |
+      #     if [ -e "$STG_FILE" ]; then
+      #       while IFS= read -r image_id; do
+      #           az acr repository delete --name pdhstagingcontainerregistry --image pdhstaging:$image_id --yes
+      #           if [ $? -eq 0 ]; then
+      #               echo "Deleted image: pdhstagingcontainerregistry:$image_id"
+      #           else
+      #               echo "Failed to delete image: pdhstagingcontainerregistry:$image_id"
+      #           fi
+      #       done < "$STG_FILE"
+      #         else
+      #           echo "File not found: $STG_FILE"
+      #     fi
+
+        # Pushing a modified image using an existing tag untags the previously pushed image, 
+        # resulting in an orphaned (or "dangling") image. 
+        # The previously pushed image's manifest--and its layer data--remains in the registry.
+        # They still need to be removed
+
+      - name: List staging repository untaged images
+        id: list-stg-untaged-images
         run: |
           az acr login --name pdhstagingcontainerregistry
-          az acr repository show-tags --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output table | head -n -2 > stg-images.txt
-          sed -i '1,2d' stg-images.txt
-          cat stg-images.txt
+          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -10 > stg-untaged-images.txt
 
-      - name: Delete old images in Staging env
+      - name: Delete untagged images in Staging env
         env:
-          STG_FILE: stg-images.txt  
+          STG_UNTAGED_FILE: stg-untaged-images.txt  
         run: |
-          if [ -e "$STG_FILE" ]; then
-            while IFS= read -r image_id; do
-                az acr repository delete --name pdhstagingcontainerregistry --image pdhstaging:$image_id --yes
+          if [ -e "$STG_UNTAGED_FILE" ]; then
+            while IFS= read -r manifest_id; do
+                az acr repository delete --name pdhstagingcontainerregistry --image pdhstaging@$manifest_id --yes
                 if [ $? -eq 0 ]; then
-                    echo "Deleted image: pdhstagingcontainerregistry:$image_id"
+                    echo "Deleted image: pdhstagingcontainerregistry:$manifest_id"
                 else
-                    echo "Failed to delete image: pdhstagingcontainerregistry:$image_id"
+                    echo "Failed to delete image: pdhstagingcontainerregistry:$manifest_id"
                 fi
-            done < "$STG_FILE"
+            done < "$STG_UNTAGED_FILE"
               else
-                echo "File not found: $STG_FILE"
+                echo "File not found: $STG_UNTAGED_FILE"
           fi

--- a/.github/workflows/cleanup_old_images.yaml
+++ b/.github/workflows/cleanup_old_images.yaml
@@ -23,64 +23,64 @@ jobs:
           user-key: ${{ secrets.USER_KEY }}
           sp-creds: ${{ secrets.SERVICE_PRINCIPAL_CREDS }}
 
-      # - name: List test repository images
-      #   id: list-test-images
-      #   run: |
-      #     az acr login --name pdhtestcontainerregistry
-      #     az acr repository show-tags --name pdhtestcontainerregistry --repository pdhtest --orderby time_asc --output table | head -n -2 > test-images.txt
-      #     sed -i '1,2d' test-images.txt
+      - name: List test repository images
+        id: list-test-images
+        run: |
+          az acr login --name pdhtestcontainerregistry
+          az acr repository show-tags --name pdhtestcontainerregistry --repository pdhtest --orderby time_asc --output table | head -n -2 > test-images.txt
+          sed -i '1,2d' test-images.txt
 
-      # - name: Delete old images in TEST env
-      #   env:
-      #     IMAGE_FILE: test-images.txt  
-      #   run: |
-      #     if [ -e "$IMAGE_FILE" ]; then
-      #       while IFS= read -r image_id; do
-      #           az acr repository delete --name pdhtestcontainerregistry --image pdhtest:$image_id --yes
-      #           if [ $? -eq 0 ]; then
-      #               echo "Deleted image: pdhtestcontainerregistry:$image_id"
-      #           else
-      #               echo "Failed to delete image: pdhtestcontainerregistry:$image_id"
-      #           fi
-      #       done < "$IMAGE_FILE"
-      #         else
-      #           echo "File not found: $IMAGE_FILE"
-      #     fi
+      - name: Delete old images in TEST env
+        env:
+          IMAGE_FILE: test-images.txt  
+        run: |
+          if [ -e "$IMAGE_FILE" ]; then
+            while IFS= read -r image_id; do
+                az acr repository delete --name pdhtestcontainerregistry --image pdhtest:$image_id --yes
+                if [ $? -eq 0 ]; then
+                    echo "Deleted image: pdhtestcontainerregistry:$image_id"
+                else
+                    echo "Failed to delete image: pdhtestcontainerregistry:$image_id"
+                fi
+            done < "$IMAGE_FILE"
+              else
+                echo "File not found: $IMAGE_FILE"
+          fi
 
-      # - name: List staging repository images
-      #   id: list-stg-images
-      #   run: |
-      #     az acr login --name pdhstagingcontainerregistry
-      #     az acr repository show-tags --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output table | head -n -2 > stg-images.txt
-      #     sed -i '1,2d' stg-images.txt
+      - name: List staging repository images
+        id: list-stg-images
+        run: |
+          az acr login --name pdhstagingcontainerregistry
+          az acr repository show-tags --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output table | head -n -2 > stg-images.txt
+          sed -i '1,2d' stg-images.txt
 
-      # - name: Delete old images in Staging env
-      #   env:
-      #     STG_FILE: stg-images.txt  
-      #   run: |
-      #     if [ -e "$STG_FILE" ]; then
-      #       while IFS= read -r image_id; do
-      #           az acr repository delete --name pdhstagingcontainerregistry --image pdhstaging:$image_id --yes
-      #           if [ $? -eq 0 ]; then
-      #               echo "Deleted image: pdhstagingcontainerregistry:$image_id"
-      #           else
-      #               echo "Failed to delete image: pdhstagingcontainerregistry:$image_id"
-      #           fi
-      #       done < "$STG_FILE"
-      #         else
-      #           echo "File not found: $STG_FILE"
-      #     fi
+      - name: Delete old images in Staging env
+        env:
+          STG_FILE: stg-images.txt  
+        run: |
+          if [ -e "$STG_FILE" ]; then
+            while IFS= read -r image_id; do
+                az acr repository delete --name pdhstagingcontainerregistry --image pdhstaging:$image_id --yes
+                if [ $? -eq 0 ]; then
+                    echo "Deleted image: pdhstagingcontainerregistry:$image_id"
+                else
+                    echo "Failed to delete image: pdhstagingcontainerregistry:$image_id"
+                fi
+            done < "$STG_FILE"
+              else
+                echo "File not found: $STG_FILE"
+          fi
 
         # Pushing a modified image using an existing tag untags the previously pushed image, 
         # resulting in an orphaned (or "dangling") image. 
         # The previously pushed image's manifest--and its layer data--remains in the registry.
         # They still need to be removed
 
-      - name: List staging repository untaged images
+      - name: List untagged images in Staging env
         id: list-stg-untaged-images
         run: |
           az acr login --name pdhstagingcontainerregistry
-          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -20 > stg-untaged-images.txt
+          az acr repository show-manifests --name pdhstagingcontainerregistry --repository pdhstaging --orderby time_asc --output tsv --query "[*].{Digest:digest}" | head -n -3 > stg-untaged-images.txt
 
       - name: Delete untagged images in Staging env
         env:


### PR DESCRIPTION
This PR addresses the need to remove unlabeled container images that are currently stored in our Azure Container Registry (ACR). Unlabeled images can accumulate over time, consuming unnecessary storage and making it harder to manage our container registry effectively. This PR aims to clean up the ACR by removing these untagged images, resulting in better cost control, security, and overall registry efficiency.