### PR TITLE
Fixed get_ssh_list.sh to work on Bash versions prior to v4.

### DIFF
--- a/.environment/sftp/get_ssh_list.sh
+++ b/.environment/sftp/get_ssh_list.sh
@@ -7,7 +7,9 @@ set -e
 # Parse the input
 eval "$(jq -r '@sh "environment=\(.environment)"')"
 
-upper_env=${environment^^}
+# The ^^ case transformation does not work in Bash prior to v4, which is what comes with MacOS by default.
+# upper_env=${environment^^}
+upper_env=$(echo ${environment} | tr '[a-z]' '[A-Z]')
 
 # Query user SFTP SSH keys
 SSH=$(az sshkey list --query "[?resourceGroup=='PRIME-DATA-HUB-$upper_env']" | jq -c '[.[] | select( .name | test("sftp.*-") ).name | (. / "-" | {instance: .[-2], user: .[-1]})]')


### PR DESCRIPTION
Fixed `get_ssh_list.sh` to work on Bash versions prior to v4.




Test Steps:
1. Run Terraform _or_ `get_ssh_list.sh` separately

## Changes
- This PR fixes `get_ssh_list.sh` to work on Bash versions prior to v4. `^^` case transformation does not work in Bash prior to v4, which is what comes with MacOS by default. I.e. this does not work: `upper_env=${environment^^}`


## Checklist

### Testing
- [x] Tested locally?
- [x] DevOps team has been notified if PR requires ops support?

