### PR TITLE
Fix tests for ktor upgrade

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -61,7 +61,7 @@ val javaVersion = when (appJvmTarget) {
     "21" -> JavaVersion.VERSION_21
     else -> JavaVersion.VERSION_17
 }
-val ktorVersion = "2.3.2"
+val ktorVersion = "2.3.6"
 val kotlinVersion by System.getProperties()
 val jacksonVersion = "2.15.3"
 jacoco.toolVersion = "0.8.10"

--- a/prime-router/src/testIntegration/kotlin/transport/RESTTransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/RESTTransportIntegrationTests.kt
@@ -33,8 +33,7 @@ import io.ktor.util.Attributes
 import io.ktor.util.InternalAPI
 import io.ktor.util.date.GMTDate
 import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.bits.Memory
-import io.ktor.utils.io.core.Input
+import io.ktor.utils.io.core.ByteReadPacket
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -240,13 +239,7 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
         val call = mockk<HttpClientCall> {
             every { client } returns mockk {}
             coEvery { body(io.ktor.util.reflect.typeInfo<String>()) } returns "Rest Transport Test Call Body"
-            coEvery { bodyNullable(io.ktor.util.reflect.typeInfo<Input>()) } returns object : Input() {
-                override fun closeSource() {}
-
-                override fun fill(destination: Memory, offset: Int, length: Int): Int {
-                    return 0
-                }
-            }
+            coEvery { bodyNullable(io.ktor.util.reflect.typeInfo<ByteReadPacket>()) } returns ByteReadPacket.Empty
             every { coroutineContext } returns EmptyCoroutineContext
             every { attributes } returns Attributes()
             every { request } returns object : HttpRequest {


### PR DESCRIPTION
This PR fixes test failures in `RESTTransportIntegrationTests.kt` caused by an upgraded version of ktor. The underlying cause was a mock implementing an abstract class that had been deprecated (`io.ktor.utils.io.core.Input`). I switched to the new concrete class `io.ktor.utils.io.core.ByteReadPacket`, eliminating the need for anonymous declaration. The removed behaviors are the same in the new class, and the provided companion final `Empty` was used for the mock.

I also searched for usages of Input throughout the project (both by symbol and text).

Test Steps:
1. Run integration tests

## Changes
- Adjust parameter and return type in the `getHttpResponse` mocks of `RESTTransportIntegrationTests.kt`
- Clean up unneeded imports

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] ~~Added~~ Adjusted tests?

## Linked Issues
- Fixes #12226 
- Fixes #12159