### PR TITLE
12352 - removed activeMembership.service check since not all receiver have a service defined i.e."default"

### DIFF
--- a/frontend-react/src/hooks/network/DataDashboard/UseReceiverDeliveries.ts
+++ b/frontend-react/src/hooks/network/DataDashboard/UseReceiverDeliveries.ts
@@ -96,7 +96,7 @@ export default function useReceiverDeliveries(serviceName?: string) {
             filterManager,
         ],
         queryFn: memoizedDataFetch,
-        enabled: !!activeMembership?.parsedName && !!activeMembership.service,
+        enabled: !!activeMembership?.parsedName,
     });
 
     return { data, filterManager, isLoading };

--- a/frontend-react/yarn.lock
+++ b/frontend-react/yarn.lock
@@ -7024,9 +7024,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001538, caniuse-lite@npm:^1.0.30001541":
-  version: 1.0.30001562
-  resolution: "caniuse-lite@npm:1.0.30001562"
-  checksum: 414ed45ae47a432607be1c9588bd478440acb033e46ede74c97501bfdb9ba4b1615e221d3ce7c7be55e1e0834725fd1ce5bf5e037bb9dd384c8e85b5e83dc6d1
+  version: 1.0.30001563
+  resolution: "caniuse-lite@npm:1.0.30001563"
+  checksum: c90a1e6efc72fc73ad4a756011242211406883b36dde3a01726e7246281dcbceaf78e1ee61d1298624c4a69cf81c12b41e8d2a2f1b7c89ed84c9333026a0bfbd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR ...

Fixes the issue where the Data dashboard will not load if the reciever does not have a service defined in their active membership

Test Steps:
1. Log into RS as a receiver i.e. Alaska
2. Navigate to Data dashboard

## Changes
- removed the activeMembership.service enabled check when calling the endpoint.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


## Linked Issues
- Fixes #12352 
