### PR TITLE
add AR to map

### DIFF
--- a/frontend-react/src/content/about/our-network.mdx
+++ b/frontend-react/src/content/about/our-network.mdx
@@ -37,6 +37,7 @@ ReportStream has established connections to report public health data for each o
 <div className="rs-column-3">
 - Alabama
 - Alaska
+- Arkansas
 - Arizona
 - California
 - Colorado

--- a/frontend-react/src/content/live.json
+++ b/frontend-react/src/content/live.json
@@ -10,6 +10,10 @@
         },
         {
             "status": "Live",
+            "state": "Arkansas"
+        },
+        {
+            "status": "Live",
             "state": "Arizona"
         },
         {

--- a/frontend-react/src/content/usa_w_territories.svg
+++ b/frontend-react/src/content/usa_w_territories.svg
@@ -12,7 +12,7 @@
     /* Individual states and territories can be colored as follows: */
     .ak, /* Alaska */
     .al, /* Alabama */
-    /* .ar, Arkansas */
+    .ar, /* Arkansas */
     /* .as, American Samoa */
     .az, /* Arizona */
     .ca, /* California */


### PR DESCRIPTION
This PR adds [AR] to the "where we're live" map and list  

## Changes 

[include screenshot image of the circled state/territory that needs to be added to the map] 
![AR Map Circled](https://github.com/CDCgov/prime-reportstream/assets/109554461/7b006bfa-a484-4271-8038-3de1abccdc66)

[include screenshot image of the circled state/territory that needs to be added to the text list] 

 ## Linked Issue 

- #12438  

## Checklist 

### Testing 

- [X] Tested locally? 

- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container? 
