### PR TITLE
update auto scale alert name to include Autoscaling event in the name

### DIFF
--- a/operations/app/terraform/modules/function_app/autoscale.tf
+++ b/operations/app/terraform/modules/function_app/autoscale.tf
@@ -1,6 +1,6 @@
 resource "azurerm_monitor_autoscale_setting" "app_autoscale" {
   count               = 1
-  name                = "${var.resource_prefix}-appautoscale"
+  name                = "Autoscaling event - ${var.resource_prefix}-appautoscale"
   resource_group_name = var.resource_group
   location            = var.location
   target_resource_id  = var.app_service_plan


### PR DESCRIPTION
This PR is to update the Autoscale setting name for the function app from ${var.resource_prefix}-appautoscale to Autoscalingevent - ${var.resource_prefix}-appautoscale

below is the terraform plan output from staging environment for "terraform plan -target=module.function_app"


  _# module.function_app.azurerm_monitor_autoscale_setting.app_autoscale[0] must be replaced
-/+ resource "azurerm_monitor_autoscale_setting" "app_autoscale" {
      ~ id                  = "/subscriptions/7d1e3999-6577-4cd5-b296-f518e5c8e677/resourceGroups/prime-data-hub-staging/providers/Microsoft.Insights/autoscaleSettings/pdhstaging-appautoscale" -> (known after apply)
      ~ name                = "pdhstaging-appautoscale" -> "Autoscaling event - pdhstaging-appautoscale" # forces replacement
      - tags                = {} -> null
        # (4 unchanged attributes hidden)

      ~ notification {

          ~ webhook {
              - properties  = {} -> null
                # (1 unchanged attribute hidden)
            }
            # (1 unchanged block hidden)
        }

      ~ profile {
          ~ name = "Autoscaling event - ScaleOnHighLoad" -> "ScaleOnHighLoad"


          ~ rule {
              ~ metric_trigger {
                  - divide_by_instance_count = false -> null
                    # (8 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }
          ~ rule {
              ~ metric_trigger {
                  - divide_by_instance_count = false -> null
                    # (8 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }
          ~ rule {
              ~ metric_trigger {
                  - divide_by_instance_count = false -> null
                    # (8 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }
          ~ rule {
              ~ metric_trigger {
                  - divide_by_instance_count = false -> null
                    # (8 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }
          ~ rule {
              ~ metric_trigger {
                  - divide_by_instance_count = false -> null
                    # (8 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }
          ~ rule {
              ~ metric_trigger {
                  - divide_by_instance_count = false -> null
                    # (8 unchanged attributes hidden)
                }

                # (1 unchanged block hidden)
            }
            # (1 unchanged block hidden)
        }

      - timeouts {}
    }

  # module.function_app.null_resource.admin_function_app_publish must be replaced
-/+ resource "null_resource" "admin_function_app_publish" {
      ~ id       = "5506869246962560558" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "input_json"           = "70ffda023fa296cfcd18901232820867" -> "b6a1fe01d4b7349e8decbd9f4642c1f5"
          ~ "publish_code_command" = <<-EOT
                      az functionapp deployment source config-zip --resource-group prime-data-hub-staging --name pdhstaging-admin-functionapp --src function-app-admin.zip --build-remote false --timeout 600
            EOT
        }
    }

Plan: 2 to add, 2 to change, 2 to destroy._
