### PR TITLE
Fix overflow during integer parse of constants

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/utils/ConstantResolver.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/utils/ConstantResolver.kt
@@ -17,6 +17,8 @@ import org.hl7.fhir.r4.model.TypeDetails
 import org.hl7.fhir.r4.model.ValueSet
 import org.hl7.fhir.r4.utils.FHIRPathEngine
 import org.hl7.fhir.r4.utils.FHIRPathUtilityClasses.FunctionDetails
+import java.lang.IllegalArgumentException
+import java.lang.NumberFormatException
 
 /**
  * Context used for resolving [constants] and custom FHIR functions. The class is for us to add our customer function
@@ -166,8 +168,10 @@ class FhirPathCustomResolver(private val customFhirFunctions: FhirPathFunctions?
                     if (it is StringType && StringUtils.isNumeric(it.primitiveValue())) {
                         try {
                             IntegerType(it.primitiveValue())
-                        } catch (e: NumberFormatException) {
-                            it // fallback to string; see https://github.com/CDCgov/prime-reportstream/issues/12609
+                        } catch (e: IllegalArgumentException) {
+                            // fallback to string; see https://github.com/CDCgov/prime-reportstream/issues/12609
+                            if (e.cause !is NumberFormatException) throw e
+                            it
                         }
                     } else {
                         it

--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/utils/ConstantResolver.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/utils/ConstantResolver.kt
@@ -164,7 +164,11 @@ class FhirPathCustomResolver(private val customFhirFunctions: FhirPathFunctions?
                 // Convert string constants that are whole integers to Integer type to facilitate math operations
                 values.map {
                     if (it is StringType && StringUtils.isNumeric(it.primitiveValue())) {
-                        IntegerType(it.primitiveValue())
+                        try {
+                            IntegerType(it.primitiveValue())
+                        } catch (e: NumberFormatException) {
+                            it // fallback to string; see https://github.com/CDCgov/prime-reportstream/issues/12609
+                        }
                     } else {
                         it
                     }

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/utils/ConstantResolverTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/utils/ConstantResolverTests.kt
@@ -136,23 +136,27 @@ class ConstantResolverTests {
     fun `test fhir path resolver multiple values`() {
         val integerValue = 99
         val stringValue = "Ninety-Nine"
+        val giantStringValue = "9999999999999999999"
 
         mockkObject(FhirPathUtils)
         every { FhirPathUtils.evaluate(any(), any(), any(), any()) } returns
-            listOf<Base>(StringType(stringValue), StringType(integerValue.toString()))
+            listOf<Base>(StringType(stringValue), StringType(integerValue.toString()), StringType(giantStringValue))
 
         val constants = sortedMapOf("const1" to "'value1'") // this does not matter but context wants something
         val context = CustomContext.addConstants(constants, CustomContext(Bundle(), Bundle()))
         val result = FhirPathCustomResolver().resolveConstant(context, "const1", false)
         assertThat(result).isNotNull()
         assertThat(result.isNotEmpty())
-        assertThat(result.size == 2)
+        assertThat(result.size == 3)
         assertThat(result[0].isPrimitive).isTrue()
         assertThat(result[0]).isInstanceOf(StringType::class.java)
         assertThat((result[0] as StringType).value).isEqualTo(stringValue)
         assertThat(result[1].isPrimitive).isTrue()
         assertThat(result[1] is IntegerType).isTrue()
         assertThat((result[1] as IntegerType).value).isEqualTo(integerValue)
+        assertThat(result[2].isPrimitive).isTrue()
+        assertThat(result[2]).isInstanceOf(StringType::class.java)
+        assertThat((result[2] as StringType).value).isEqualTo(giantStringValue)
     }
 
     @Test


### PR DESCRIPTION
This PR stops an attempted integer cast that is resulting in an overflow error in production.

Test Steps:
1. Run tests

## Changes
- Do not cast values to Integer in `ConstantResolver.kt`
  - Adjust related tests to expect String

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] ~~Added~~ Modified tests?

## Linked Issues
- Fixes #12609

## To Be Done
- Decide what the path forward is (will we try again to cast? maybe fallback to string?)