### PR TITLE
autoscale alerts removed for staging, but remain in prod

### DIFF
--- a/operations/app/terraform/modules/function_app/autoscale.tf
+++ b/operations/app/terraform/modules/function_app/autoscale.tf
@@ -148,7 +148,7 @@ resource "azurerm_monitor_autoscale_setting" "app_autoscale" {
 
   lifecycle {
     ignore_changes = [
-      notification[0].webhook[0].service_uri
+      notification[0]
     ]
   }
 


### PR DESCRIPTION
This PR ignores removal of pagerduty STAGING alerts for autoscaling.

Test Steps:
1. Change made to reduce non-actionable pagerduty alerts for Staging.

## Changes
- Ignore webhook remove for staging autoscale events

## Checklist

## Linked Issues
- Fixes #12633

