### PR TITLE
Experience/12446/date string bug

### DIFF
--- a/frontend-react/src/components/DataDashboard/DataDashboardTable/DataDashboardTable.tsx
+++ b/frontend-react/src/components/DataDashboard/DataDashboardTable/DataDashboardTable.tsx
@@ -122,7 +122,7 @@ function DashboardFilterAndTable({
                     handleSetActive={handleSetActive}
                 />
                 <TableFilters
-                    startDateLabel="From: (mm/dd/yyy)"
+                    startDateLabel="From: (mm/dd/yyyy)"
                     endDateLabel="To: (mm/dd/yyyy)"
                     filterManager={filterManager}
                     onFilterClick={({

--- a/frontend-react/src/components/DataDashboard/FacilitiesProviders/FacilitiesProvidersTable.tsx
+++ b/frontend-react/src/components/DataDashboard/FacilitiesProviders/FacilitiesProvidersTable.tsx
@@ -124,7 +124,7 @@ function FacilitiesProvidersFilterAndTable({
                         handleSetActive={handleSetActive}
                     />
                     <TableFilters
-                        startDateLabel="From: (mm/dd/yyy)"
+                        startDateLabel="From: (mm/dd/yyyy)"
                         endDateLabel="To: (mm/dd/yyyy)"
                         filterManager={filterManager}
                         onFilterClick={({

--- a/frontend-react/src/components/DataDashboard/FacilityProviderSubmitterDetails/FacilityProviderSubmitterTable.tsx
+++ b/frontend-react/src/components/DataDashboard/FacilityProviderSubmitterDetails/FacilityProviderSubmitterTable.tsx
@@ -100,7 +100,7 @@ function FacilityProviderSubmitterTable(
             <section id="facilities">
                 <h2>Your available reports including {props.senderTypeName}</h2>
                 <TableFilters
-                    startDateLabel="From: (mm/dd/yyy)"
+                    startDateLabel="From: (mm/dd/yyyy)"
                     endDateLabel="To: (mm/dd/yyyy)"
                     filterManager={filterManager}
                     onFilterClick={({

--- a/frontend-react/src/components/DataDashboard/ReportDetails/ReportDetailsTable.tsx
+++ b/frontend-react/src/components/DataDashboard/ReportDetails/ReportDetailsTable.tsx
@@ -49,7 +49,7 @@ function ReportDetailsTable(props: ReportDetailsTableProps) {
             <section id="facilities">
                 <h2>Facilities & Providers included in this report</h2>
                 <TableFilters
-                    startDateLabel="From: (mm/dd/yyy)"
+                    startDateLabel="From: (mm/dd/yyyy)"
                     endDateLabel="To: (mm/dd/yyyy)"
                     filterManager={filterManager}
                     onFilterClick={({

--- a/prime-router/docs/onboarding-users/senders.md
+++ b/prime-router/docs/onboarding-users/senders.md
@@ -63,6 +63,30 @@ The schema provides additional transforms required so that the senders data can 
 
 Note: When creating a transform, please reference [Changing/Updating Sender/Receiver Transforms](../getting-started/standard-operating-procedures/changing-transforms.md) for guidance.
 
+### Authenticating to ReportStream’s REST API
+**Note: This is legacy authentication and should not be used for onboarding new users**
+
+Shared secret key authorization
+
+Prior to connecting to the endpoint, you’ll need a public/private keypair. There are many ways to do this. The steps below show how to create a key pair using `openssl`.
+
+EC
+```
+openssl ecparam -genkey -name secp384r1 -noout -out my-es-keypair.pem
+openssl ec -in my-es-keypair.pem -pubout -out  my-es-public-key.pem
+```
+
+RSA
+```
+openssl genrsa -out my-rsa-keypair.pem 2048
+openssl rsa -in my-rsa-keypair.pem -outform PEM -pubout -out my-rsa-public-key.pem
+```
+
+Send the public key to the ReportStream team using [our public key tool](/manage-public-key).
+Note: you’ll need to login to use that feature. If you do not have a login contact ReportStream support at [reportstream@cdc.gov](mailto:reportstream@cdc.gov). ReportStream will associate the key with your configuration within ReportStream.
+
+You only need to do this step once, not every time you submit reports. If you need to change your keys at any time, contact ReportStream support.
+
 ## Testing
 
 ### Note


### PR DESCRIPTION
This PR ...

Fixes date test that read 'yyy' to 'yyyy'

Test Steps:
1. Log into RS
2. Navigate to Daily Data and see updated label
3. Navigate to Data Dashboard and see updated label
4. Navigate to Facility and Providers page and see updated label
5. Navigate to Report Details page and see updated label

## Changes
![Screenshot 2023-12-21 at 11 27 58 AM](https://github.com/CDCgov/prime-reportstream/assets/102491809/4b503dbc-c1f8-48ca-8b6d-f5636db84f7e)
![Screenshot 2023-12-21 at 11 28 04 AM](https://github.com/CDCgov/prime-reportstream/assets/102491809/cf8215cf-443b-4494-93e0-4b366ce1f188)


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


## Linked Issues
- Fixes #12446 
