### PR TITLE
Pin log4j version to 2.22.0

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -819,9 +819,9 @@ dependencies {
         exclude(group = "com.azure", module = "azure-core")
         exclude(group = "com.azure", module = "azure-core-http-netty")
     }
-    implementation("org.apache.logging.log4j:log4j-api:[2.17.1,)")
-    implementation("org.apache.logging.log4j:log4j-core:[2.17.1,)")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:[2.17.1,)")
+    implementation("org.apache.logging.log4j:log4j-api:2.22.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.22.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.22.0")
     implementation("org.apache.logging.log4j:log4j-api-kotlin:1.3.0")
     implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.9.2")
     implementation("tech.tablesaw:tablesaw-core:0.43.1")


### PR DESCRIPTION
This PR fixes the log4j dependency so that it's pinned to a specific version.

Test Steps:
CI is enough

## Changes
- Fixes the dependency declaration for log4j so it's pinned to 2.22.0

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to
