### PR TITLE
Added documentation for retrieving unmapped bundles

### DIFF
--- a/prime-router/docs/getting-started/standard-operating-procedures/observation-mapping-table.md
+++ b/prime-router/docs/getting-started/standard-operating-procedures/observation-mapping-table.md
@@ -105,3 +105,28 @@ spreadsheet using its code/OID. The resulting row is then mapped to the appropri
 Either copy the values from the website and map them into the appropriate columns  
 -OR-  
 Sign up for an account, download the CSV, and map the data from it
+
+## Checking for mapping failures
+Use the following query:
+```postgresql
+SELECT detail->>'message' as message, detail->>'fieldMapping' as field, action_log.report_id, report_file.body_url
+    FROM action_log
+    INNER JOIN report_file ON report_file.report_id = action_log.report_id
+    WHERE action_log.detail->>'errorCode' = 'INVALID_MSG_CONDITION_MAPPING'
+    ORDER BY action_log.created_at DESC
+    LIMIT 100;
+```
+
+Output will include the missing code, its origin, and the URL of the source data. Use the azure storage explorer
+or the azure portal to download the file being careful to observe PII precautions. 
+
+### Example output
+
+| message | field | report\_id | body\_url |
+| :--- | :--- | :--- | :--- |
+| Missing mapping for code\(s\): N | observation.valueCodeableConcept.coding.code | 3a947e0f-0832-403d-a9d8-92f9b88557a8 | http://localhost:10000/devstoreaccount1/reports/receive%2Fdevelopment.dev-elims%2FNone-3a947e0f-0832-403d-a9d8-92f9b88557a8-20240102233706.fhir |
+| Missing mapping for code\(s\): Y | observation.valueCodeableConcept.coding.code | 3a947e0f-0832-403d-a9d8-92f9b88557a8 | http://localhost:10000/devstoreaccount1/reports/receive%2Fdevelopment.dev-elims%2FNone-3a947e0f-0832-403d-a9d8-92f9b88557a8-20240102233706.fhir |
+| Missing mapping for code\(s\): N | observation.valueCodeableConcept.coding.code | 3a947e0f-0832-403d-a9d8-92f9b88557a8 | http://localhost:10000/devstoreaccount1/reports/receive%2Fdevelopment.dev-elims%2FNone-3a947e0f-0832-403d-a9d8-92f9b88557a8-20240102233706.fhir |
+| Missing mapping for code\(s\): N | observation.valueCodeableConcept.coding.code | 3a947e0f-0832-403d-a9d8-92f9b88557a8 | http://localhost:10000/devstoreaccount1/reports/receive%2Fdevelopment.dev-elims%2FNone-3a947e0f-0832-403d-a9d8-92f9b88557a8-20240102233706.fhir |
+| Missing mapping for code\(s\): 260415000 | observation.valueCodeableConcept.coding.code | 3a947e0f-0832-403d-a9d8-92f9b88557a8 | http://localhost:10000/devstoreaccount1/reports/receive%2Fdevelopment.dev-elims%2FNone-3a947e0f-0832-403d-a9d8-92f9b88557a8-20240102233706.fhir |
+

--- a/prime-router/docs/getting-started/standard-operating-procedures/observation-mapping-table.md
+++ b/prime-router/docs/getting-started/standard-operating-procedures/observation-mapping-table.md
@@ -109,12 +109,16 @@ Sign up for an account, download the CSV, and map the data from it
 ## Checking for mapping failures
 Use the following query:
 ```postgresql
-SELECT detail->>'message' as message, detail->>'fieldMapping' as field, action_log.report_id, report_file.body_url
-    FROM action_log
-    INNER JOIN report_file ON report_file.report_id = action_log.report_id
-    WHERE action_log.detail->>'errorCode' = 'INVALID_MSG_CONDITION_MAPPING'
-    ORDER BY action_log.created_at DESC
-    LIMIT 100;
+SELECT action_log.created_at,
+       detail ->> 'message'      as message,
+       detail ->> 'fieldMapping' as field,
+       action_log.report_id,
+       report_file.body_url
+FROM action_log
+         INNER JOIN report_file ON report_file.report_id = action_log.report_id
+WHERE action_log.detail ->> 'errorCode' = 'INVALID_MSG_CONDITION_MAPPING'
+ORDER BY action_log.created_at DESC
+LIMIT 100;
 ```
 
 Output will include the missing code, its origin, and the URL of the source data. Use the azure storage explorer


### PR DESCRIPTION
This PR adds documentation that covers retrieving source bundles with unmappable conditions.

Test Steps:
1. Submit `valid.fhir` to the receiver `development.dev-elims` (may have to change topic/format)
   ```zsh
    curl --location 'http://localhost:7071/api/reports' --header 'client: development.dev-elims' --header 'Content-Type:application/fhir+ndjson' --data-binary @/Users/gabriel/dev/focus/prime-reportstream/prime-router/src/test/resources/fhirengine/engine/routing/valid.fhir
   ```
2. Run the query and verify the output matches what is expected

## Changes
- Added SOP for retrieving unmappable conditions

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

### Process
- [x] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?

## Linked Issues
- Fixes #12283