### PR TITLE
12347 - Removed the Example Data Models from API Guide

### DIFF
--- a/frontend-react/src/content/developer-resources/reportstream-api/documentation/SamplePayloadsAndOutput.mdx
+++ b/frontend-react/src/content/developer-resources/reportstream-api/documentation/SamplePayloadsAndOutput.mdx
@@ -11,7 +11,7 @@ import site from "../../../site.json";
 
 <LayoutMain>
 # Sample payloads and output
-<p className="text-base">Last updated: 5/26/23</p>
+<p className="text-base">Last updated: 1/4/24</p>
 
 ***
 
@@ -84,10 +84,4 @@ Response
   "warnings": [ ]
 }
 ```
-
-## Example data models
-* [COVID-19 data matching HHS Guidance](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/schema_documentation/direct-direct-covid-19.md)
-* [A simple schema meant for testing and demos](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/schema_documentation/sample-phd1-sample.md)
-* [A complex real-life schema used by our sister project, SimpleReport, for submitting COVID-19 data](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md)
-* [Other examples of COVID-19 schemas](https://github.com/CDCgov/prime-reportstream/tree/master/prime-router/docs/schema_documentation)
 </LayoutMain>


### PR DESCRIPTION
This PR ...

Removed the Example Data Models from API Guide

Test Steps:
1. Go to RS
2. Click on the Developers tab
3. Click on the API guide
4. Click on Sample payloads and output
5. Notice the section has been removed

## Changes
![Screenshot 2024-01-04 at 10 30 59 AM](https://github.com/CDCgov/prime-reportstream/assets/102491809/0e605876-5c5f-4baf-9c2c-e5b1e0b5faa1)

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?


## Linked Issues
- Fixes #12347 
