### PR TITLE
13073 fix last mile failures api

### DIFF
--- a/prime-router/src/main/resources/db/migration/V67__update_list_send_failure.sql
+++ b/prime-router/src/main/resources/db/migration/V67__update_list_send_failure.sql
@@ -1,0 +1,90 @@
+/*
+* The Flyway tool applies this migration to create the database.
+*
+* Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+* use VARCHAR(63) for names in organization and schema
+*
+* Copy a version of this comment into the next migration
+*
+*/
+
+/*
+    This is the "Last Mile" failures query.
+    See https://github.com/CDCgov/prime-reportstream/issues/5771 ,
+        https://github.com/CDCgov/prime-reportstream/issues/9649 ,
+        https://github.com/CDCgov/prime-reportstream/issues/13073
+ */
+DROP FUNCTION IF EXISTS list_send_failures;
+CREATE OR REPLACE FUNCTION list_send_failures(days_to_show_param INT)
+    RETURNS TABLE
+            (
+                action_id            BIGINT,
+                report_id            UUID,
+                receiver             TEXT,
+                file_name            TEXT,
+                failed_at           TIMESTAMP WITH TIME ZONE,
+                action_params        varchar(2048),
+                action_result        TEXT,
+                body_url             varchar(2048),
+                report_file_receiver TEXT
+            )
+    LANGUAGE plpgsql
+AS
+$$
+
+BEGIN
+    RETURN QUERY
+        WITH send_failures as
+                 (select a.action_id
+                       , (a.action_params::jsonb->>'reportId')::uuid
+                         as "report_id"
+                       , a.created_at as "failed_at"
+                       , a.action_params
+                       , a.action_result
+                       , case
+                             when strpos(a.action_result, 'unrecoverable exception') > 0 and
+                                  strpos(a.action_result, 'host=') > 0
+                                 then trim(split_part(
+                                     split_part(a.action_result, 'host=', 2), ',', 1))
+                             when strpos(a.action_result, 'unrecoverable exception') > 0 and
+                                  strpos(a.action_result, 'database:') > 0
+                                 then trim(split_part(
+                                     split_part(a.action_result, 'database:', 2), 'Event:', 1))
+                             when strpos(a.action_result, 'AS2') > 0
+                                 then trim(split_part(
+                                     split_part(a.action_result, 'orgService =', 2),
+                                     ');', 1))
+                            when strpos(a.action_result, 'orgService = ') > 0
+                                 then trim(split_part(
+                                     split_part(a.action_result, 'orgService =', 2),
+                                     '),', 1))
+                             when strpos(a.action_result, 'gaen') > 0
+                                 then 'wa-phd.gaen'
+                             when strpos(a.action_result, 'gaen') = 0 and
+                                  strpos(a.action_result, 'Send Error report for: ') >
+                                  0
+                                 then trim(split_part(
+                                     split_part(a.action_result, 'Send Error report for: ', 2),
+                                     'to', 2))
+                             else 'Cannot parse error message'
+                         end
+                         as "receiver"
+                  from action a
+                  where a.created_at >= current_date - days_to_show_param
+                    and a.action_name = 'send_error')
+        select sf.action_id
+             , sf.report_id
+             , sf.receiver
+             , split_part(rf.body_url, '%2F', 3)
+            as "file_name"
+             , sf.failed_at
+             , sf.action_params
+             , sf.action_result
+             , rf.body_url
+             , rf.receiving_org || '.' || rf.receiving_org_svc
+            as "report_file_receiver"
+        FROM report_file rf
+                 join send_failures sf on rf.report_id = sf.report_id
+        ORDER BY sf.failed_at desc;
+END;
+$$;


### PR DESCRIPTION
This PR corrects an issue with the Last Mile Failures API.

A known caveat with this change is that send failures that predate the message format change will now return an error. In production, the last instance of a send error using the deprecated message format occurred on December 6, 2023.

Test Steps:
1. Create the test data:
```
INSERT INTO public.action(
	action_name, action_params, action_result, created_at, receiving_org, receiving_org_svc)
	VALUES ('send_error', '{"type":"report","eventAction":"SEND","emptyBatch":false,"reportId":"d0e999c6-d819-41f1-bf08-083f0e8e091c","at":""}', '"FAILED Sftp upload of inputReportId d0e999c6-d819-41f1-bf08-083f0e8e091c to SFTPTransportType(host=sftp, port=22, filePath=./upload, credentialName=DEFAULT-SFTP-PPK) (orgService = ignore.HL7_BATCH_PPK), Exception: Unable to find SFTP credentials for DEFAULT-SFTP-PPK connectionId(DEFAULT-SFTP-PPK), All retries failed.  Manual Intervention Required.  Send Error report for: d0e999c6-d819-41f1-bf08-083f0e8e091c to ignore.HL7_BATCH_PPK"', now(), 'ignore', 'HL7_BATCH_PPK');
	
INSERT INTO public.report_file(
	report_id, action_id, next_action, receiving_org, receiving_org_svc, schema_name, schema_topic, body_url, body_format, item_count, created_at)
	SELECT 'd0e999c6-d819-41f1-bf08-083f0e8e091c' report_id, action_id, 'send' next_action, 'ignore' receiving_org, 'HL7_BATCH_PPK' receiving_org_svc, 'az/az-covid-19-hl7' schema_name, 'covid-19' schema_topic, 'http://localhost:10000/devstoreaccount1/reports/ready%2Fignore.HL7_BATCH_PPK%2Faz-covid-19-hl7-d0e999c6-d819-41f1-bf08-083f0e8e091c-20231010154400.hl7' body_url, 'HL7_BATCH' body_format, 5 item_count, now() created_at FROM action WHERE action_result LIKE '%d0e999c6-d819-41f1-bf08-083f0e8e091c%';
```
2. Run ``SELECT * FROM list_send_failures(15)`` and observe an error.
3. Apply the migration from this PR and run the statement again. Observe data is returned.

## Changes
- Updated the stored procedure used by the Last Mile Failures API call to process the new action parameters message format.

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

## Linked Issues
- #13073

## To Be Done
- #13115