### PR TITLE
12750 remove exception handling from coding extension function

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
@@ -14,7 +14,6 @@ import gov.cdc.prime.router.fhirengine.translation.hl7.utils.CustomContext
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
 import gov.cdc.prime.router.fhirengine.utils.FHIRBundleHelpers.Companion.getChildProperties
 import io.github.linuxforhealth.hl7.data.Hl7RelatedGeneralUtils
-import org.hl7.fhir.exceptions.FHIRException
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.Coding
@@ -67,24 +66,8 @@ private fun lookupCondition(code: Coding, metadata: Metadata): Coding? {
  */
 fun Observation.getCodeSourcesMap(): Map<String, List<Coding>> {
     val toReturn = mutableMapOf<String, List<Coding>>()
-    try {
-        toReturn[ObservationMappingConstants.BUNDLE_CODE_IDENTIFIER] = this.code.coding
-    } catch (error: FHIRException) {
-        if (error.message == null ||
-            !error.message!!.startsWith("Type mismatch: the type CodeableConcept was expected")
-            ) {
-            throw error
-        }
-    }
-    try {
-        toReturn[ObservationMappingConstants.BUNDLE_VALUE_IDENTIFIER] = this.valueCodeableConcept.coding
-    } catch (error: FHIRException) {
-        if (error.message == null ||
-            !error.message!!.startsWith("Type mismatch: the type CodeableConcept was expected")
-            ) {
-            throw error
-        }
-    }
+    toReturn[ObservationMappingConstants.BUNDLE_CODE_IDENTIFIER] = this.code.coding
+    toReturn[ObservationMappingConstants.BUNDLE_VALUE_IDENTIFIER] = this.valueCodeableConcept.coding
     return toReturn
 }
 


### PR DESCRIPTION
This PR removes exception handlers from the coding lookup extension function intended to swallow specific exceptions thrown during testing. There are no other changes.

Test Steps:
1. Ensure all smoke tests pass.

## Changes
- Removed exception handlers from the coding lookup extension function.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

## Linked Issues
- #12750
