### PR TITLE
12905: update segment extensions

### DIFF
--- a/prime-router/metadata/fhir_mapping/hl7/codesystem/ExtensionUrlMapping.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/codesystem/ExtensionUrlMapping.yml
@@ -281,6 +281,7 @@
 # NK1 -> RelatedPerson
 - id: "nk1-related-person"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person"
+# TODO: evaluate if this should get collapsed into the nk1-related-person extension
 - id: "nk1-15-administrative-sex"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex"
 

--- a/prime-router/metadata/fhir_mapping/hl7/codesystem/ExtensionUrlMapping.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/codesystem/ExtensionUrlMapping.yml
@@ -75,32 +75,8 @@
 # message character set
 - id: "character-set"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set"
-
-# TODO: collapse into one extension
-- id: "msh-7-datetime-of-message"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message"
-- id: "msh-13-sequence-number"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-13-sequence-number"
-- id: "msh-14-continuation-pointer"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-14-continuation-pointer"
-# message accept acknowledgement type
-- id: "msh-15-accept-acknowledgement-type"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type"
-# source application acknowledgement type
-- id: "msh-16-application-acknowledgement-type"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type"
-- id: "msh-19-principal-language-of-message"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message"
-- id: "msh-20-alternate-character-set-handling-scheme"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-20-alternate-character-set-handling-scheme"
-# source message profile ID
-- id: "msh21-source-message-profile-id"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id"
-- id: "msh-24-hd-extension"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-24-hd-extension"
-- id: "msh-25-hd-extension"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-25-hd-extension"
-# TODO end
+- id: "msh-message-header"
+  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header"
 
 # SFT
 # software binary identifier
@@ -207,14 +183,6 @@
 # Filler assigned identifier
 - id: "filler-assigned-identifier"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/filler-assigned-identifier"
-# Check Digit
-# TODO: replace with HL7 version
-- id: "check-digit"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/check-digit"
-# Check Digit Scheme
-# TODO: replace with HL7 version
-- id: "check-digit-scheme"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/check-digit-scheme"
 # TODO: likely can get collapsed with always capturing the universal-id in an extension
 # Unknown Universal ID Type
 - id: "universal-id-unknown-type"
@@ -229,8 +197,6 @@
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id"
 - id: "location-physical-type-poc"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/location-physical-type-poc"
-
-
 
 # CE/CWE -> Coding
 # Coding system
@@ -289,8 +255,6 @@
 - id: "bodySiteModifier"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/bodySiteModifier"
 
-
-
 # XTN -> ContactPoint
 - id: xtn-contact-point
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point"
@@ -315,13 +279,10 @@
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner"
 
 # NK1 -> RelatedPerson
-# TODO: collapse
-- id: "nk1-13-organization-name"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-13-organization-name"
+- id: "nk1-related-person"
+  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person"
 - id: "nk1-15-administrative-sex"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex"
-- id: "nk1-16-birth-date"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-16-birth-date"
 
 # XPN -> HumanName
 - id: "xpn-human-name"
@@ -373,14 +334,6 @@
 
 
 # PV1/PV2 -> Encounter
-# PV1 Extension
-# TODO rename
-- id: "pv1-encounter"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter"
-# PV2 Extension
-# TODO rename
-- id: "pv2-encounter"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-encounter"
 - id: "admission-level-of-care"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care"
 - id: "publicity-code"
@@ -393,14 +346,21 @@
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date"
 - id: "visit-user-code"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code"
-- id: "pv1-2-patient-class"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class"
 - id: "temporary-location"
   url: "https://hl7.org/fhir/StructureDefinition/temporary-location"
-- id: "pv2-visit-description"
-  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description"
 - id: "episode-of-care-name"
   url: "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name"
+# PV1 Extension
+- id: "pv1-patient-visit"
+  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit"
+# PV2 Extension
+- id: "pv2-patient-visit-additional-information"
+  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information"
+# TODO: how to handle these; they're not in the extension and used to extend primitives in the mapping
+- id: "pv1-2-patient-class"
+  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class"
+- id: "pv2-visit-description"
+  url: "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description"
 
 # NTE -> Annotation
 # Source of comment

--- a/prime-router/metadata/fhir_mapping/hl7/datatypes/ED/EDExtension.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/datatypes/ED/EDExtension.yml
@@ -40,7 +40,7 @@ extension:
     - expressionType: nested
       vars:
         ed5: STRING, ED.5
-      condition: $ed5 NOT_EQUALS Base64
+      condition: $ed5 NOT_NULL
       expressionsMap:
         url:
           type: STRING

--- a/prime-router/metadata/fhir_mapping/hl7/segments/MSH/MSHExtension.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/segments/MSH/MSHExtension.yml
@@ -1,0 +1,140 @@
+url:
+  type: SYSTEM_URL
+  value: msh-message-header
+
+extension:
+  expressionType: nested
+  generateList: true
+  expressions:
+    - expressionType: nested
+      vars:
+        msh7: MSH.7
+      condition: $msh7 NOT_NULL
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.7
+        valueString:
+          type: STRING
+          expressionType: HL7Spec
+          valueOf: MSH.7
+    - expressionType: nested
+      vars:
+        msh13: MSH.13
+      condition: $msh13 NOT_NULL
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.13
+        valueString:
+          type: STRING
+          expressionType: HL7Spec
+          valueOf: MSH.13
+    - expressionType: nested
+      vars:
+        msh14: MSH.14
+      condition: $msh14 NOT_NULL
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.14
+        valueString:
+          type: STRING
+          expressionType: HL7Spec
+          valueOf: MSH.14
+    - condition: $msh15 NOT_NULL
+      expressionType: nested
+      vars:
+        msh15: MSH.15
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.15
+        valueString:
+          valueOf: MSH.15
+          expressionType: HL7Spec
+          type: STRING
+    - condition: $msh16 NOT_NULL
+      expressionType: nested
+      vars:
+        msh16: MSH.16
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.16
+        valueString:
+          type: STRING
+          valueOf: MSH.16
+          expressionType: HL7Spec
+    - vars:
+        msh19: STRING_ALL, MSH.19
+      condition: $msh19 NOT_NULL
+      expressionType: nested
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.19
+        valueCodeableConcept:
+          expressionType: resource
+          valueOf: datatypes/CWE/CodeableConcept
+          specs: MSH.19
+    - vars:
+        msh20: MSH.20
+      condition: $msh20 NOT_NULL
+      expressionType: nested
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.20
+        valueString:
+          type: STRING
+          expressionType: HL7Spec
+          valueOf: MSH.20
+    - expressionType: nested
+      vars:
+        $msh21: STRING_ALL, MSH.21
+      condition: $msh21 NOT_NULL
+      generateList: true
+      specs: MSH.21 *
+      expressionsMap:
+        url:
+          type: STRING
+          value: MSH.21
+        valueIdentifier:
+          valueOf: datatypes/EI/Identifier
+          expressionType: resource
+    - vars:
+        msh3: STRING_ALL, MSH.3
+        msh24: STRING_ALL, MSH.24
+      constants:
+        extensionUrl: MSH.24
+        isStringUrl: true
+      condition: $msh3 NOT_NULL && $msh24 NOT_NULL
+      expressionType: resource
+      valueOf: datatypes/HD/ExtensionHD
+      specs: MSH.24
+    - vars:
+        msh5: STRING_ALL, MSH.5
+        msh25: STRING_ALL, MSH.25
+      constants:
+        extensionUrl: MSH.25
+        isStringUrl: true
+      condition: $msh5 EQUALS $msh25
+      expressionType: resource
+      valueOf: datatypes/HD/ExtensionHD
+      specs: MSH.25
+
+# TODO there is a bug in the library where if these are included in
+# expressions array above only one value is generated
+#extension_1:
+#  expressionType: nested
+#  generateList: true
+#  specs: MSH.21
+#  expressionsMap:
+#    url:
+#      type: SYSTEM_URL
+#      value: msh21-source-message-profile-id
+#    valueIdentifier:
+#      generateList: true
+#      valueOf: datatype/Identifier_SystemID
+#      expressionType: resource

--- a/prime-router/metadata/fhir_mapping/hl7/segments/MSH/MessageHeader.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/segments/MSH/MessageHeader.yml
@@ -131,138 +131,23 @@ extension_messageHeader:
           type: STRING
           valueOf: MSH.2
           expressionType: HL7Spec
-    - expressionType: nested
-      vars:
-        msh7: MSH.7
-      condition: $msh7 NOT_NULL
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-7-datetime-of-message
-        valueString:
-          type: STRING
-          expressionType: HL7Spec
-          valueOf: MSH.7
-    - expressionType: nested
-      vars:
-        msh13: MSH.13
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-13-sequence-number
-        valueString:
-          type: STRING
-          expressionType: HL7Spec
-          valueOf: MSH.13
-    - expressionType: nested
-      vars:
-        msh14: MSH.14
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-14-continuation-pointer
-        valueString:
-          type: STRING
-          expressionType: HL7Spec
-          valueOf: MSH.14
-    - condition: $msh15 NOT_NULL
+    - condition: $msh18 NOT_NULL
       expressionType: nested
       vars:
-        msh15: MSH.15
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-15-accept-acknowledgement-type
-        valueString:
-          valueOf: MSH.15
-          expressionType: HL7Spec
-          type: STRING
-    - condition: $msh16 NOT_NULL
-      expressionType: nested
-      vars:
-        msh16: MSH.16
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-16-application-acknowledgement-type
-        valueString:
-          type: STRING
-          valueOf: MSH.16
-          expressionType: HL7Spec
-    - vars:
-        msh19: STRING_ALL, MSH.19
-      condition: $msh19 NOT_NULL
-      expressionType: nested
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-19-principal-language-of-message
-        valueCodeableConcept:
-          expressionType: resource
-          valueOf: datatypes/CWE/CodeableConcept
-          specs: MSH.19
-    - vars:
-        msh20: MSH.20
-      condition: $msh20 NOT_NULL
-      expressionType: nested
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: msh-20-alternate-character-set-handling-scheme
-        valueString:
-          type: STRING
-          expressionType: HL7Spec
-          valueOf: MSH.20
-    - vars:
-        msh3: STRING_ALL, MSH.3
-        msh24: STRING_ALL, MSH.24
-      constants:
-        extensionUrl: msh-24-hd-extension
-      condition: $msh3 NOT_NULL && $msh24 NOT_NULL
-      expressionType: resource
-      valueOf: datatypes/HD/ExtensionHD
-      specs: MSH.24
-    - vars:
-        msh5: STRING_ALL, MSH.5
-        msh25: STRING_ALL, MSH.25
-      constants:
-        extensionUrl: msh-25-hd-extension
-      condition: $msh5 EQUALS $msh25
-      expressionType: resource
-      valueOf: datatypes/HD/ExtensionHD
-      specs: MSH.25
-
-# TODO there is a bug in the library where if these are included in
-# expressions array above only one value is generated
-extension_1:
-  expressionType: nested
-  generateList: true
-  specs: MSH.21
-  expressionsMap:
-    url:
-      type: SYSTEM_URL
-      value: msh21-source-message-profile-id
-    valueIdentifier:
+        msh18: STRING_ALL, MSH.18
+      specs: MSH.18 *
       generateList: true
-      valueOf: datatype/Identifier_SystemID
-      expressionType: resource
-
-extension_2:
-  condition: $msh18 NOT_NULL
-  expressionType: nested
-  generateList: true
-  vars:
-    msh18: STRING_ALL, MSH.18
-  specs: MSH.18
-  expressionsMap:
-    url:
-      type: SYSTEM_URL
-      value: character-set
-    valueString:
-      generateList: true
-      type: STRING
-      valueOf: $BASE_VALUE
-      expressionType: HL7Spec
+      expressionsMap:
+        url:
+          type: SYSTEM_URL
+          value: character-set
+        valueString:
+          generateList: true
+          type: STRING
+          valueOf: $BASE_VALUE
+          expressionType: HL7Spec
+    - expressionType: resource
+      valueOf: segments/MSH/MSHExtension
 
 responsible:
   vars:

--- a/prime-router/metadata/fhir_mapping/hl7/segments/NK1/NK1Extension.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/segments/NK1/NK1Extension.yml
@@ -1,0 +1,29 @@
+url:
+  type: SYSTEM_URL
+  value: nk1-related-person
+
+extension:
+  generateList: true
+  expressionType: nested
+  expressions:
+    - expressionType: nested
+      generateList: true
+      condition: $nk1-13 NOT_NULL
+      specs: NK1.13 *
+      expressionsMap:
+        url:
+          type: STRING
+          value: NK1.13
+        valueReference:
+          valueOf: datatypes/XON/Organization
+          expressionType: reference
+    - expressionType: nested
+      condition: $nk1-16 NOT_NULL
+      expressionsMap:
+        url:
+          type: STRING
+          value: NK1.16
+        valueString:
+          type: STRING
+          valueOf: NK1.16
+          expressionType: HL7Spec

--- a/prime-router/metadata/fhir_mapping/hl7/segments/NK1/RelatedPerson.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/segments/NK1/RelatedPerson.yml
@@ -292,24 +292,5 @@ extension:
           valueOf: hl7v2Name
         valueString:
           valueOf: 'NK1'
-    - expressionType: nested
-      generateList: true
-      condition: $nk1-13 NOT_NULL
-      specs: NK1.13 *
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: nk1-13-organization-name
-        valueReference:
-          valueOf: datatypes/XON/Organization
-          expressionType: reference
-    - expressionType: nested
-      condition: $nk1-16 NOT_NULL
-      expressionsMap:
-        url:
-          type: SYSTEM_URL
-          value: nk1-16-birth-date
-        valueString:
-          type: STRING
-          valueOf: NK1.16
-          expressionType: HL7Spec
+    - expressionType: resource
+      valueOf: segments/NK1/NK1Extension

--- a/prime-router/metadata/fhir_mapping/hl7/segments/PV1/PV1Extension.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/segments/PV1/PV1Extension.yml
@@ -1,6 +1,6 @@
 url:
   type: SYSTEM_URL
-  value: pv1-encounter
+  value: pv1-patient-visit
 
 extension:
   expressionType: nested

--- a/prime-router/metadata/fhir_mapping/hl7/segments/PV1/PV2Extension.yml
+++ b/prime-router/metadata/fhir_mapping/hl7/segments/PV1/PV2Extension.yml
@@ -1,6 +1,6 @@
 url:
   type: SYSTEM_URL
-  value: pv2-encounter
+  value: pv2-patient-visit-additional-information
 
 extension:
   expressionType: nested

--- a/prime-router/metadata/fhir_transforms/senders/Flexion/TILabOrder.yml
+++ b/prime-router/metadata/fhir_transforms/senders/Flexion/TILabOrder.yml
@@ -2,8 +2,8 @@
 elements:
   - name: message-date-time
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message").value.exists().not()'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message").value[x]'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.7").value.exists().not()'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.7").value[x]'
     value:
       - Bundle.entry.resource.ofType(Provenance).recorded.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time").value
       - Bundle.entry.resource.ofType(Provenance).recorded

--- a/prime-router/metadata/fhir_transforms/senders/SimpleReport/simple-report-sender-transform.yml
+++ b/prime-router/metadata/fhir_transforms/senders/SimpleReport/simple-report-sender-transform.yml
@@ -27,8 +27,8 @@ elements:
 
   - name: message-date-time
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message").value.exists().not()'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message").value[x]'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.7").value.exists().not()'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.7").value[x]'
     value:
       - Bundle.entry.resource.ofType(Provenance).recorded.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time").value
       - Bundle.entry.resource.ofType(Provenance).recorded

--- a/prime-router/metadata/fhir_transforms/senders/original-pipeline-transforms.yml
+++ b/prime-router/metadata/fhir_transforms/senders/original-pipeline-transforms.yml
@@ -55,15 +55,15 @@ elements:
     value: [ '%resource.collection.collected + 6 seconds' ]
 
   - name: msh-15-accept-acknowledgement-type
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type").value.exists().not()'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.15").value.exists().not()'
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type").value[x]'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.15").value[x]'
     value: [ '"NE"' ]
 
   - name: msh-16-application-acknowledgement-type
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type").value.exists().not()'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.16").value.exists().not()'
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type").value[x]'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.16").value[x]'
     value: [ '"NE"' ]
 
   - name: msh-18-character-set
@@ -75,44 +75,50 @@ elements:
   - name: msh-19-principal-language-of-message
     condition: true
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message").valueCodeableConcept.coding.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding").value[x]'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.19").valueCodeableConcept.coding.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding").value[x]'
     value: [ '"coding"' ]
 
   - name: msh-19-principal-language-of-message-coding
     condition: true
-    resource: 'Bundle.entry.resource.ofType(MessageHeader).extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message").value.coding.where(extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding").value = "coding")'
+    resource: 'Bundle.entry.resource.ofType(MessageHeader).extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.19").value.coding.where(extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding").value = "coding")'
     bundleProperty: '%resource.code'
     value: [ '"ENG"' ]
 
   - name: msh-19-principal-language-of-message-display
     condition: true
-    resource: 'Bundle.entry.resource.ofType(MessageHeader).extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message").value.coding.where(extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding").value = "coding")'
+    resource: 'Bundle.entry.resource.ofType(MessageHeader).extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.19").value.coding.where(extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding").value = "coding")'
     bundleProperty: '%resource.display'
     value: [ '"English"' ]
 
   - name: msh-19-principal-language-of-message-coding-system
     condition: true
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message").value.coding.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system").value[x]'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.19").value.coding.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system").value[x]'
     value: [ '"ISO"' ]
 
   - name: msh-21-1-message-profile-identifier
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.value.exists().not()'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.value.exists().not()'
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").valueIdentifier.value'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").valueIdentifier.value'
     value: [ '"PHLabReport-NoAck"' ]
 
   - name: msh-21-2-message-profile-identifier-namespace-id
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id").value.exists().not() and %resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.system.getId().exists().not() and %resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.system.exists().not()'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority").extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id").value.exists().not() and %resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.system.getId().exists().not() and %resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.system.exists().not()'
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id").value[x]'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority").extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id").value[x]'
     value: [ '"ELR_Receiver"' ]
 
   - name: msh-21-3-message-profile-identifier-universal-id
-    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id").value.getId().exists().not()'
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority").extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id").value.getId().exists().not()'
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'
-    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id").value[x]'
-    value: [ '"urn:oid:2.16.840.1.113883.9.11"' ]
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority").extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id").value[x]'
+    value: [ '"2.16.840.1.113883.9.11"' ]
+
+  - name: msh-21-3-message-profile-identifier-universal-id-type
+    condition: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority").extension("https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type").value.getId().exists().not()'
+    resource: 'Bundle.entry.resource.ofType(MessageHeader)'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header").extension("MSH.21").value.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority").extension("https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type").value[x]'
+    value: [ '"ISO"' ]
 
   - name: sft-2-software-version
     resource: 'Bundle.entry.resource.ofType(MessageHeader)'

--- a/prime-router/metadata/hl7_mapping/resources/Encounter/PV1.yml
+++ b/prime-router/metadata/hl7_mapping/resources/Encounter/PV1.yml
@@ -156,5 +156,5 @@ elements:
       cxField: '%{hl7PV1Field}-54'
 
   - name: pv1-extension-values
-    resource: '%resource.extension(%`rsext-pv1-encounter`)'
+    resource: '%resource.extension(%`rsext-pv1-patient-visit`)'
     schema: ./PV1Extension

--- a/prime-router/metadata/hl7_mapping/resources/Encounter/PV2.yml
+++ b/prime-router/metadata/hl7_mapping/resources/Encounter/PV2.yml
@@ -79,5 +79,5 @@ elements:
       cweField: '%{hl7PV2Field}-40'
 
   - name: pv2-extension-values
-    resource: '%resource.extension(%`rsext-pv2-encounter`)'
+    resource: '%resource.extension(%`rsext-pv2-patient-visit-additional-information`)'
     schema: ./PV2Extension

--- a/prime-router/metadata/hl7_mapping/resources/MessageHeader/MSH.yml
+++ b/prime-router/metadata/hl7_mapping/resources/MessageHeader/MSH.yml
@@ -30,11 +30,6 @@ elements:
     constants:
       hl7HDField: 'MSH-6'
 
-  - name: message-date-time
-    value:
-      - '%resource.extension(%`rsext-msh-7-datetime-of-message`).value'
-    hl7Spec: [ MSH-7 ]
-
   - name: security
     value: [ '%resource.meta.security.code' ]
     hl7Spec: [ MSH-8-1 ]
@@ -61,22 +56,6 @@ elements:
     value: [ '"2.5.1"' ]
     hl7Spec: [ MSH-12 ]
 
-  - name: continuation-pointer
-    value: [ '%resource.extension(%`rsext-msh-13-sequence-number`).value' ]
-    hl7Spec: [ MSH-13 ]
-
-  - name: continuation-pointer
-    value: [ '%resource.extension(%`rsext-msh-14-continuation-pointer`).value' ]
-    hl7Spec: [ MSH-14 ]
-
-  - name: accept-acknowledgement-type
-    value: [ '%resource.extension(%`rsext-msh-15-accept-acknowledgement-type`).value' ]
-    hl7Spec: [ MSH-15 ]
-
-  - name: app-acknowledgement-type
-    value: [ '%resource.extension(%`rsext-msh-16-application-acknowledgement-type`).value' ]
-    hl7Spec: [ MSH-16 ]
-
   - name: country-code
     value: [ '%resource.sender.resolve().address.country' ]
     hl7Spec: [ MSH-17 ]
@@ -85,24 +64,6 @@ elements:
     resource: '%resource.extension(%`rsext-character-set`).value'
     resourceIndex: characterSetIndex
     schema: extensionCharacterSetList/ID
-
-  - name: principal-lanuage-of-message
-    resource: '%resource.extension(%`rsext-msh-19-principal-language-of-message`).value'
-    schema: ../../datatypes/codeableConcept/CWE
-    constants:
-      cweField: 'MSH-19'
-
-  - name: alternate-character-set
-    value: [ '%resource.extension(%`rsext-msh-20-alternate-character-set-handling-scheme`).value' ]
-    hl7Spec: [ MSH-20 ]
-
-  - name: message-profile-identifier
-    resource: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id").value'
-    condition: '%resource.exists()'
-    constants:
-      entityIdFieldPath: 'MSH-21(%{entityIdIndex})'
-    schema: ../../common/datatype/ei-entity-identifier
-    resourceIndex: entityIdIndex
 
   - name: responsible
     resource: '%resource.responsible.resolve()'
@@ -124,21 +85,13 @@ elements:
     constants:
       hl7HDField: 'MSH-24'
 
-  - name: sending-network-address-from-extension
-    resource: '%resource.extension(%`rsext-msh-24-hd-extension`)'
-    schema: ../../datatypes/extensionHD/HD
-    constants:
-      hl7HDField: 'MSH-24'
-
   - name: receiving-network-address
     resource: '%resource.destination.where(extension(%`rsext-hl7-use`).value = "receiving-network-address")'
     schema: Destination/HD
     constants:
       hl7HDField: 'MSH-25'
 
-  - name: receiving-network-address-duplicates-receiving-application
-    resource: '%resource.extension(%`rsext-msh-25-hd-extension`)'
-    schema: ../../datatypes/extensionHD/HD
-    constants:
-      hl7HDField: 'MSH-25'
+  - name: msh-extension-values
+    resource: '%resource.extension(%`rsext-msh-message-header`)'
+    schema: ./MSHExtension
 

--- a/prime-router/metadata/hl7_mapping/resources/MessageHeader/MSHExtension.yml
+++ b/prime-router/metadata/hl7_mapping/resources/MessageHeader/MSHExtension.yml
@@ -1,0 +1,51 @@
+elements:
+
+  - name: message-date-time
+    value:
+      - '%resource.extension("MSH.7").value'
+    hl7Spec: [ MSH-7 ]
+
+  - name: msh-13-continuation-pointer
+    value: [ '%resource.extension("MSH.13").value' ]
+    hl7Spec: [ MSH-13 ]
+
+  - name: continuation-pointer
+    value: [ '%resource.extension("MSH.14").value' ]
+    hl7Spec: [ MSH-14 ]
+
+  - name: accept-acknowledgement-type
+    value: [ '%resource.extension("MSH.15").value' ]
+    hl7Spec: [ MSH-15 ]
+
+  - name: app-acknowledgement-type
+    value: [ '%resource.extension("MSH.16").value' ]
+    hl7Spec: [ MSH-16 ]
+
+  - name: msh-19-principal-lanuage-of-message
+    resource: '%resource.extension("MSH.19").value'
+    schema: ../../datatypes/codeableConcept/CWE
+    constants:
+      cweField: 'MSH-19'
+
+  - name: msh-20-alternate-character-set
+    value: [ '%resource.extension("MSH.20").value' ]
+    hl7Spec: [ MSH-20 ]
+
+  - name: msh-21-message-profile-identifier
+    resource: '%resource.extension("MSH.21").value'
+    constants:
+      eiFieldPath: 'MSH-21(%{entityIdIndex})'
+    schema: ../../datatypes/identifier-extension/EI
+    resourceIndex: entityIdIndex
+
+  - name: sending-network-address-from-extension
+    resource: '%resource.extension("MSH.24")'
+    schema: ../../datatypes/extensionHD/HD
+    constants:
+      hl7HDField: 'MSH-24'
+
+  - name: msh-25-receiving-network-address-duplicates-receiving-application
+    resource: '%resource.extension("MSH.25")'
+    schema: ../../datatypes/extensionHD/HD
+    constants:
+      hl7HDField: 'MSH-25'

--- a/prime-router/metadata/hl7_mapping/resources/RelatedPerson/NK1.yml
+++ b/prime-router/metadata/hl7_mapping/resources/RelatedPerson/NK1.yml
@@ -64,24 +64,11 @@ elements:
     constants:
       cxField: '%{hl7NK1FieldPath}-12'
 
-  - name: organization-name
-    resource: '%resource.extension(%`rsext-nk1-13-organization-name`).value.resolve()'
-    resourceIndex: xonIndex
-    constants:
-      hl7XONField: '%{hl7NK1FieldPath}-13(%{xonIndex})'
-    schema: ../Organization/XON
-
   - name: administrative-sex
     resource: '%resource.gender.extension(%`rsext-nk1-15-administrative-sex`).value'
     constants:
       cweField: '%{hl7NK1FieldPath}-15'
     schema: ../../datatypes/codeableConcept/CWE
-
-  - name: birth-date
-    resource: '%resource.extension(%`rsext-nk1-16-birth-date`).value'
-    constants:
-      dtmFieldPath: '%{hl7NK1FieldPath}-16'
-    schema: ../../datatypes/dateTime/DTMorDT
 
   - name: primary-language
     resource: '%resource.communication.language'
@@ -136,3 +123,7 @@ elements:
     constants:
       hl7TelecomField: '%{hl7NK1FieldPath}-41'
     resourceIndex: telecomIndex
+
+  - name: nk1-extension-values
+    resource: '%resource.extension(%`rsext-nk1-related-person`)'
+    schema: ./NK1Extension

--- a/prime-router/metadata/hl7_mapping/resources/RelatedPerson/NK1Extension.yml
+++ b/prime-router/metadata/hl7_mapping/resources/RelatedPerson/NK1Extension.yml
@@ -1,0 +1,14 @@
+elements:
+
+  - name: nk1-13-organization-name
+    resource: '%resource.extension("NK1.13").value.resolve()'
+    resourceIndex: xonIndex
+    constants:
+      hl7XONField: '%{hl7NK1FieldPath}-13(%{xonIndex})'
+    schema: ../Organization/XON
+
+  - name: nk1-16-birth-date
+    resource: '%resource.extension("NK1.16").value'
+    constants:
+      dtmFieldPath: '%{hl7NK1FieldPath}-16'
+    schema: ../../datatypes/dateTime/DTMorDT

--- a/prime-router/src/testIntegration/resources/datatests/FHIR_to_HL7/sample_OML_20230831-0001.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/FHIR_to_HL7/sample_OML_20230831-0001.fhir
@@ -38,36 +38,59 @@
         },
         "extension" : [
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-            "valueString" : "AL"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-            "valueString" : "AL"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.82"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.16",
+                "valueString" : "AL"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "AL"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.82"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_PRU_COMPONENT"
                 }
-              ],
-              "value" : "LAB_PRU_COMPONENT"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_TO_COMPONENT"
                 }
-              ],
-              "value" : "LAB_TO_COMPONENT"
-            }
+              }
+            ]
           }
         ],
         "eventCoding" : {

--- a/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_orm_20230809-001-with-enrichment.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_orm_20230809-001-with-enrichment.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706650171252111000.275055d0-ccdf-4ac1-a353-6762072386a7",
+  "id" : "1706820764498719000.a882d7e2-caa1-43d0-8363-b92857c171ba",
   "meta" : {
-    "lastUpdated" : "2024-01-30T16:29:31.258-05:00"
+    "lastUpdated" : "2024-02-01T15:52:44.504-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -26,52 +26,84 @@
         },
         "extension" : [
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230506052916-0500"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-            "valueString" : "AL"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-            "valueString" : "AL"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.82"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230506052916-0500"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "AL"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "AL"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.82"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_PRU_COMPONENT"
                 }
-              ],
-              "value" : "LAB_PRU_COMPONENT"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_TO_COMPONENT"
                 }
-              ],
-              "value" : "LAB_TO_COMPONENT"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_THREE_COMPONENT"
                 }
-              ],
-              "value" : "LAB_THREE_COMPONENT"
-            }
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -97,12 +129,12 @@
             ],
             "name" : "NATUS",
             "receiver" : {
-              "reference" : "Organization/1706650171317452000.879da08c-57a0-43fb-a83f-748cd35e3fee"
+              "reference" : "Organization/1706820764566609000.03eda0de-e2f4-4876-b119-b5b6f567ed45"
             }
           }
         ],
         "sender" : {
-          "reference" : "Organization/1706650171320944000.7222ea01-7d5e-4a24-914b-4d230463d72c"
+          "reference" : "Organization/1706820764542890000.0bca22ea-ed34-4e54-86b2-e3c255975115"
         },
         "source" : {
           "extension" : [
@@ -130,10 +162,45 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650171317452000.879da08c-57a0-43fb-a83f-748cd35e3fee",
+      "fullUrl" : "Organization/1706820764542890000.0bca22ea-ed34-4e54-86b2-e3c255975115",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650171317452000.879da08c-57a0-43fb-a83f-748cd35e3fee",
+        "id" : "1706820764542890000.0bca22ea-ed34-4e54-86b2-e3c255975115",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Centracare"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "DNS"
+                }
+              ]
+            },
+            "value" : "centracare.com"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706820764566609000.03eda0de-e2f4-4876-b119-b5b6f567ed45",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706820764566609000.03eda0de-e2f4-4876-b119-b5b6f567ed45",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
@@ -172,45 +239,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650171320944000.7222ea01-7d5e-4a24-914b-4d230463d72c",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706650171320944000.7222ea01-7d5e-4a24-914b-4d230463d72c",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Centracare"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "DNS"
-                }
-              ]
-            },
-            "value" : "centracare.com"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706650171603843000.baf42ac6-8070-42d9-b047-a1853118b1ae",
+      "fullUrl" : "Patient/1706820764907431000.edf434e0-278b-4245-8570-55b96a47b5c1",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706650171603843000.baf42ac6-8070-42d9-b047-a1853118b1ae",
+        "id" : "1706820764907431000.edf434e0-278b-4245-8570-55b96a47b5c1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -270,7 +302,7 @@
             },
             "value" : "11102779",
             "assigner" : {
-              "reference" : "Organization/1706650171584788000.62760b8e-3102-4ec9-ad8c-3bcce4d36895"
+              "reference" : "Organization/1706820764884080000.7ee11556-9487-443a-adaf-825a53298ef8"
             }
           }
         ],
@@ -383,7 +415,7 @@
         "link" : [
           {
             "other" : {
-              "reference" : "RelatedPerson/1706650171596355000.0b6b0d8e-3bc8-47c0-9e31-c58b936e2b18"
+              "reference" : "RelatedPerson/1706820764897147000.5b41ffec-2031-4acb-8150-aa19070b4524"
             },
             "type" : "seealso"
           }
@@ -391,10 +423,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650171584788000.62760b8e-3102-4ec9-ad8c-3bcce4d36895",
+      "fullUrl" : "Organization/1706820764884080000.7ee11556-9487-443a-adaf-825a53298ef8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650171584788000.62760b8e-3102-4ec9-ad8c-3bcce4d36895",
+        "id" : "1706820764884080000.7ee11556-9487-443a-adaf-825a53298ef8",
         "identifier" : [
           {
             "extension" : [
@@ -409,10 +441,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706650171596355000.0b6b0d8e-3bc8-47c0-9e31-c58b936e2b18",
+      "fullUrl" : "RelatedPerson/1706820764897147000.5b41ffec-2031-4acb-8150-aa19070b4524",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706650171596355000.0b6b0d8e-3bc8-47c0-9e31-c58b936e2b18",
+        "id" : "1706820764897147000.5b41ffec-2031-4acb-8150-aa19070b4524",
         "identifier" : [
           {
             "extension" : [
@@ -431,10 +463,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706650171614184000.9dd57f0b-b586-44a3-ae6e-1a79fe813817",
+      "fullUrl" : "ServiceRequest/1706820764919934000.0dd86790-cf4d-4f50-8d7b-2abec2737969",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706650171614184000.9dd57f0b-b586-44a3-ae6e-1a79fe813817",
+        "id" : "1706820764919934000.0dd86790-cf4d-4f50-8d7b-2abec2737969",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -513,7 +545,7 @@
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706650171603843000.baf42ac6-8070-42d9-b047-a1853118b1ae"
+          "reference" : "Patient/1706820764907431000.edf434e0-278b-4245-8570-55b96a47b5c1"
         },
         "authoredOn" : "2023-05-06T05:29:13-05:00",
         "_authoredOn" : {
@@ -525,15 +557,15 @@
           ]
         },
         "requester" : {
-          "reference" : "PractitionerRole/1706650171608874000.ee3d6fef-4b86-4ee7-b903-13f9ed2dd28d"
+          "reference" : "PractitionerRole/1706820764913210000.4f7ce448-4b9a-4ca6-a115-f8f485211194"
         }
       }
     },
     {
-      "fullUrl" : "Organization/1706650171609177000.824fa5c3-b1a8-49ea-b116-0fd1f12e764e",
+      "fullUrl" : "Organization/1706820764913550000.8b9bf46e-f290-4984-ab14-8539edb70666",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650171609177000.824fa5c3-b1a8-49ea-b116-0fd1f12e764e",
+        "id" : "1706820764913550000.8b9bf46e-f290-4984-ab14-8539edb70666",
         "identifier" : [
           {
             "extension" : [
@@ -548,10 +580,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706650171610275000.c6151cff-04f4-44a2-895a-26ea1855bfbc",
+      "fullUrl" : "Practitioner/1706820764914985000.947d7e9a-4a39-4add-8387-6938356a112a",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706650171610275000.c6151cff-04f4-44a2-895a-26ea1855bfbc",
+        "id" : "1706820764914985000.947d7e9a-4a39-4add-8387-6938356a112a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -603,7 +635,7 @@
             },
             "value" : "1265136360",
             "assigner" : {
-              "reference" : "Organization/1706650171609177000.824fa5c3-b1a8-49ea-b116-0fd1f12e764e"
+              "reference" : "Organization/1706820764913550000.8b9bf46e-f290-4984-ab14-8539edb70666"
             }
           }
         ],
@@ -619,10 +651,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650171611672000.2a21d350-01a4-4ded-a119-71a263782602",
+      "fullUrl" : "Organization/1706820764916570000.e29f5a86-bcd1-4579-8a50-56a06af4eb54",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650171611672000.2a21d350-01a4-4ded-a119-71a263782602",
+        "id" : "1706820764916570000.e29f5a86-bcd1-4579-8a50-56a06af4eb54",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -692,23 +724,23 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706650171608874000.ee3d6fef-4b86-4ee7-b903-13f9ed2dd28d",
+      "fullUrl" : "PractitionerRole/1706820764913210000.4f7ce448-4b9a-4ca6-a115-f8f485211194",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706650171608874000.ee3d6fef-4b86-4ee7-b903-13f9ed2dd28d",
+        "id" : "1706820764913210000.4f7ce448-4b9a-4ca6-a115-f8f485211194",
         "practitioner" : {
-          "reference" : "Practitioner/1706650171610275000.c6151cff-04f4-44a2-895a-26ea1855bfbc"
+          "reference" : "Practitioner/1706820764914985000.947d7e9a-4a39-4add-8387-6938356a112a"
         },
         "organization" : {
-          "reference" : "Organization/1706650171611672000.2a21d350-01a4-4ded-a119-71a263782602"
+          "reference" : "Organization/1706820764916570000.e29f5a86-bcd1-4579-8a50-56a06af4eb54"
         }
       }
     },
     {
-      "fullUrl" : "Specimen/1706650171787410000.51aebbd6-23a4-4977-8e7f-c0ddd072836a",
+      "fullUrl" : "Specimen/1706820765127570000.b36e05ae-7c52-422b-a20c-17cfc15c1647",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706650171787410000.51aebbd6-23a4-4977-8e7f-c0ddd072836a"
+        "id" : "1706820765127570000.b36e05ae-7c52-422b-a20c-17cfc15c1647"
       }
     }
   ]

--- a/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_orm_20230809-001.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/HL7_to_FHIR/sample_orm_20230809-001.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706650144186081000.baf5d360-48d1-46bd-b685-4a18e6363383",
+  "id" : "1706820799053352000.63fc1cb0-9ca8-4cab-8157-04c8690a7011",
   "meta" : {
-    "lastUpdated" : "2024-01-30T16:29:04.193-05:00"
+    "lastUpdated" : "2024-02-01T15:53:19.059-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -26,52 +26,84 @@
         },
         "extension" : [
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230506052916-0500"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-            "valueString" : "AL"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-            "valueString" : "AL"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.82"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230506052916-0500"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "AL"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "AL"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.82"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_PRU_COMPONENT"
                 }
-              ],
-              "value" : "LAB_PRU_COMPONENT"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_TO_COMPONENT"
                 }
-              ],
-              "value" : "LAB_TO_COMPONENT"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_THREE_COMPONENT"
                 }
-              ],
-              "value" : "LAB_THREE_COMPONENT"
-            }
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -97,12 +129,12 @@
             ],
             "name" : "NATUS",
             "receiver" : {
-              "reference" : "Organization/1706650144256492000.b530ff09-b6de-4543-b624-77969f4f2fc0"
+              "reference" : "Organization/1706820799122922000.47bd5f75-3574-4319-a24e-270ff5e859de"
             }
           }
         ],
         "sender" : {
-          "reference" : "Organization/1706650144260387000.91c032d7-f6a7-4c38-80bd-40830dfe4d8f"
+          "reference" : "Organization/1706820799097911000.8586dddb-2389-402a-b4b6-e399b17e952a"
         },
         "source" : {
           "extension" : [
@@ -128,10 +160,45 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650144256492000.b530ff09-b6de-4543-b624-77969f4f2fc0",
+      "fullUrl" : "Organization/1706820799097911000.8586dddb-2389-402a-b4b6-e399b17e952a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650144256492000.b530ff09-b6de-4543-b624-77969f4f2fc0",
+        "id" : "1706820799097911000.8586dddb-2389-402a-b4b6-e399b17e952a",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Centracare"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "DNS"
+                }
+              ]
+            },
+            "value" : "centracare.com"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706820799122922000.47bd5f75-3574-4319-a24e-270ff5e859de",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706820799122922000.47bd5f75-3574-4319-a24e-270ff5e859de",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
@@ -170,45 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650144260387000.91c032d7-f6a7-4c38-80bd-40830dfe4d8f",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706650144260387000.91c032d7-f6a7-4c38-80bd-40830dfe4d8f",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Centracare"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "DNS"
-                }
-              ]
-            },
-            "value" : "centracare.com"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706650144573968000.d181310d-fafe-4f99-865f-8a1688279834",
+      "fullUrl" : "Patient/1706820799456070000.97798610-c2af-46b8-8259-8dbcdd1dc91b",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706650144573968000.d181310d-fafe-4f99-865f-8a1688279834",
+        "id" : "1706820799456070000.97798610-c2af-46b8-8259-8dbcdd1dc91b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -268,7 +300,7 @@
             },
             "value" : "11102779",
             "assigner" : {
-              "reference" : "Organization/1706650144552010000.64349976-3960-4ba9-b321-c25bb3b00cb9"
+              "reference" : "Organization/1706820799436548000.a0d9d5ec-e2c6-4fab-af23-dc589a4ea3dd"
             }
           }
         ],
@@ -381,7 +413,7 @@
         "link" : [
           {
             "other" : {
-              "reference" : "RelatedPerson/1706650144565871000.41ee1cbb-2ae5-4b98-a948-95f23e857eb9"
+              "reference" : "RelatedPerson/1706820799448412000.245681f8-34bc-496a-a261-181aabbd39d8"
             },
             "type" : "seealso"
           }
@@ -389,10 +421,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650144552010000.64349976-3960-4ba9-b321-c25bb3b00cb9",
+      "fullUrl" : "Organization/1706820799436548000.a0d9d5ec-e2c6-4fab-af23-dc589a4ea3dd",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650144552010000.64349976-3960-4ba9-b321-c25bb3b00cb9",
+        "id" : "1706820799436548000.a0d9d5ec-e2c6-4fab-af23-dc589a4ea3dd",
         "identifier" : [
           {
             "extension" : [
@@ -407,10 +439,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706650144565871000.41ee1cbb-2ae5-4b98-a948-95f23e857eb9",
+      "fullUrl" : "RelatedPerson/1706820799448412000.245681f8-34bc-496a-a261-181aabbd39d8",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706650144565871000.41ee1cbb-2ae5-4b98-a948-95f23e857eb9",
+        "id" : "1706820799448412000.245681f8-34bc-496a-a261-181aabbd39d8",
         "identifier" : [
           {
             "extension" : [
@@ -429,10 +461,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706650144586062000.7006deff-96de-4bfe-b9d5-d46d53c6f3d3",
+      "fullUrl" : "ServiceRequest/1706820799466585000.bf4124bc-9eac-4ec8-ab8e-748eeed6c00f",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706650144586062000.7006deff-96de-4bfe-b9d5-d46d53c6f3d3",
+        "id" : "1706820799466585000.bf4124bc-9eac-4ec8-ab8e-748eeed6c00f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -511,7 +543,7 @@
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706650144573968000.d181310d-fafe-4f99-865f-8a1688279834"
+          "reference" : "Patient/1706820799456070000.97798610-c2af-46b8-8259-8dbcdd1dc91b"
         },
         "authoredOn" : "2023-05-06T05:29:13-05:00",
         "_authoredOn" : {
@@ -523,15 +555,15 @@
           ]
         },
         "requester" : {
-          "reference" : "PractitionerRole/1706650144580038000.dd4b19fc-167b-40d5-a961-b68835b483e2"
+          "reference" : "PractitionerRole/1706820799461039000.de5a192f-0b57-4be6-b892-cc117b96325d"
         }
       }
     },
     {
-      "fullUrl" : "Organization/1706650144580405000.bfec6c23-f9c8-401a-8918-ee7675f9f1fd",
+      "fullUrl" : "Organization/1706820799461355000.0f66ab13-11ae-4f5a-95bb-53ccc7f79d6e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650144580405000.bfec6c23-f9c8-401a-8918-ee7675f9f1fd",
+        "id" : "1706820799461355000.0f66ab13-11ae-4f5a-95bb-53ccc7f79d6e",
         "identifier" : [
           {
             "extension" : [
@@ -546,10 +578,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706650144581670000.7b47fc81-a748-4a42-9d52-52de6b365ce3",
+      "fullUrl" : "Practitioner/1706820799462557000.2b54b59d-b16c-4e7e-a5f9-5849b21be3e0",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706650144581670000.7b47fc81-a748-4a42-9d52-52de6b365ce3",
+        "id" : "1706820799462557000.2b54b59d-b16c-4e7e-a5f9-5849b21be3e0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -601,7 +633,7 @@
             },
             "value" : "1265136360",
             "assigner" : {
-              "reference" : "Organization/1706650144580405000.bfec6c23-f9c8-401a-8918-ee7675f9f1fd"
+              "reference" : "Organization/1706820799461355000.0f66ab13-11ae-4f5a-95bb-53ccc7f79d6e"
             }
           }
         ],
@@ -617,10 +649,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706650144582895000.6d7c8fd7-b829-4a26-b5bb-dd6881acc365",
+      "fullUrl" : "Organization/1706820799463752000.31ac57bb-1f46-4063-891d-3a2aed483ebf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706650144582895000.6d7c8fd7-b829-4a26-b5bb-dd6881acc365",
+        "id" : "1706820799463752000.31ac57bb-1f46-4063-891d-3a2aed483ebf",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -690,23 +722,23 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706650144580038000.dd4b19fc-167b-40d5-a961-b68835b483e2",
+      "fullUrl" : "PractitionerRole/1706820799461039000.de5a192f-0b57-4be6-b892-cc117b96325d",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706650144580038000.dd4b19fc-167b-40d5-a961-b68835b483e2",
+        "id" : "1706820799461039000.de5a192f-0b57-4be6-b892-cc117b96325d",
         "practitioner" : {
-          "reference" : "Practitioner/1706650144581670000.7b47fc81-a748-4a42-9d52-52de6b365ce3"
+          "reference" : "Practitioner/1706820799462557000.2b54b59d-b16c-4e7e-a5f9-5849b21be3e0"
         },
         "organization" : {
-          "reference" : "Organization/1706650144582895000.6d7c8fd7-b829-4a26-b5bb-dd6881acc365"
+          "reference" : "Organization/1706820799463752000.31ac57bb-1f46-4063-891d-3a2aed483ebf"
         }
       }
     },
     {
-      "fullUrl" : "Specimen/1706650144777145000.08c22da9-b35d-4151-9a7b-3730c30d82a3",
+      "fullUrl" : "Specimen/1706820799644261000.bfcd3774-1c40-4802-9992-d2b60ad7b6f0",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706650144777145000.08c22da9-b35d-4151-9a7b-3730c30d82a3"
+        "id" : "1706820799644261000.bfcd3774-1c40-4802-9992-d2b60ad7b6f0"
       }
     }
   ]

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cnn/cnn-to-Practitioner.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cnn/cnn-to-Practitioner.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706633867610786000.790a9ea1-8ed2-4441-957f-cc64718bb247",
+  "id" : "1706812112856970000.399b6226-3037-41c7-85c3-6743e6872fac",
   "meta" : {
-    "lastUpdated" : "2024-01-30T11:57:47.617-05:00"
+    "lastUpdated" : "2024-02-01T13:28:32.863-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706633867677833000.bc6aa66d-0460-456d-b38d-6f6678010277"
+          "reference" : "Organization/1706812112910383000.ffcb6a06-4af3-4fc6-ba24-20604e3f5729"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706633867677833000.bc6aa66d-0460-456d-b38d-6f6678010277",
+      "fullUrl" : "Organization/1706812112910383000.ffcb6a06-4af3-4fc6-ba24-20604e3f5729",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706633867677833000.bc6aa66d-0460-456d-b38d-6f6678010277",
+        "id" : "1706812112910383000.ffcb6a06-4af3-4fc6-ba24-20604e3f5729",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706633867986417000.59066d88-a8ef-43c6-a38c-3e4a964cabae",
+      "fullUrl" : "Provenance/1706812113288236000.50bb461a-aa0b-4025-ac9e-df339b97d7de",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706633867986417000.59066d88-a8ef-43c6-a38c-3e4a964cabae",
+        "id" : "1706812113288236000.50bb461a-aa0b-4025-ac9e-df339b97d7de",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706633868172608000.6b42d511-1984-433a-90a9-a4181f7394da"
+            "reference" : "DiagnosticReport/1706812113494959000.48642e2b-ce92-4859-8e7b-fd5d95eacd9a"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706633867994567000.a758b6b2-75c7-47ee-b459-e7b5a00e3c4e",
+      "fullUrl" : "Provenance/1706812113296049000.5c4fcadc-d5bd-4007-b5d2-9d41c90afef8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706633867994567000.a758b6b2-75c7-47ee-b459-e7b5a00e3c4e",
-        "recorded" : "2024-01-30T11:57:47Z",
+        "id" : "1706812113296049000.5c4fcadc-d5bd-4007-b5d2-9d41c90afef8",
+        "recorded" : "2024-02-01T13:28:33Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706633867993847000.f649f100-7eca-4fa3-8f9b-57038535a30f"
+              "reference" : "Organization/1706812113295618000.00438fbf-4c66-4465-8e67-446e8c384c1f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706633867993847000.f649f100-7eca-4fa3-8f9b-57038535a30f",
+      "fullUrl" : "Organization/1706812113295618000.00438fbf-4c66-4465-8e67-446e8c384c1f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706633867993847000.f649f100-7eca-4fa3-8f9b-57038535a30f",
+        "id" : "1706812113295618000.00438fbf-4c66-4465-8e67-446e8c384c1f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706633868008795000.e471a14b-a60f-45dd-abda-a0ef006baad1",
+      "fullUrl" : "ServiceRequest/1706812113313885000.6b81d2a4-a641-42f7-ae72-f181a3094000",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706633868008795000.e471a14b-a60f-45dd-abda-a0ef006baad1",
+        "id" : "1706812113313885000.6b81d2a4-a641-42f7-ae72-f181a3094000",
         "status" : "unknown",
         "code" : {
           "extension" : [
@@ -175,13 +180,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706633868172608000.6b42d511-1984-433a-90a9-a4181f7394da",
+      "fullUrl" : "DiagnosticReport/1706812113494959000.48642e2b-ce92-4859-8e7b-fd5d95eacd9a",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706633868172608000.6b42d511-1984-433a-90a9-a4181f7394da",
+        "id" : "1706812113494959000.48642e2b-ce92-4859-8e7b-fd5d95eacd9a",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706633868008795000.e471a14b-a60f-45dd-abda-a0ef006baad1"
+            "reference" : "ServiceRequest/1706812113313885000.6b81d2a4-a641-42f7-ae72-f181a3094000"
           }
         ],
         "status" : "final",
@@ -212,16 +217,16 @@
         },
         "resultsInterpreter" : [
           {
-            "reference" : "PractitionerRole/1706633868171916000.3e46ae6e-191f-467f-b46b-8c526068483e"
+            "reference" : "PractitionerRole/1706812113494034000.858f3eac-58b1-478b-843a-57bde7961711"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706633868171239000.80030b68-5d46-45fa-bf85-59fd3d8b2586",
+      "fullUrl" : "Practitioner/1706812113493106000.ef7988c5-e639-4ceb-8baa-b56cd5a01734",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706633868171239000.80030b68-5d46-45fa-bf85-59fd3d8b2586",
+        "id" : "1706812113493106000.ef7988c5-e639-4ceb-8baa-b56cd5a01734",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -288,12 +293,12 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706633868171916000.3e46ae6e-191f-467f-b46b-8c526068483e",
+      "fullUrl" : "PractitionerRole/1706812113494034000.858f3eac-58b1-478b-843a-57bde7961711",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706633868171916000.3e46ae6e-191f-467f-b46b-8c526068483e",
+        "id" : "1706812113494034000.858f3eac-58b1-478b-843a-57bde7961711",
         "practitioner" : {
-          "reference" : "Practitioner/1706633868171239000.80030b68-5d46-45fa-bf85-59fd3d8b2586"
+          "reference" : "Practitioner/1706812113493106000.ef7988c5-e639-4ceb-8baa-b56cd5a01734"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cq/quantity/cq_29_null.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cq/quantity/cq_29_null.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310191933733000.c587b845-3eb3-4e75-a7dd-2152a1307c98",
+  "id" : "1706812592529802000.4407d51d-4498-43be-99f2-924f31ed0c27",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:03:11.948-06:00"
+    "lastUpdated" : "2024-02-01T13:36:32.538-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310192347469000.445dc175-e1d0-4bff-8845-7919b50d8ec9",
+      "fullUrl" : "Provenance/1706812592973247000.6967d373-3952-4d7f-9002-84a53467abb3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310192347469000.445dc175-e1d0-4bff-8845-7919b50d8ec9",
+        "id" : "1706812592973247000.6967d373-3952-4d7f-9002-84a53467abb3",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310192528986000.c97b6d20-c2d0-443c-a7f8-f3a8f59fee77"
+            "reference" : "DiagnosticReport/1706812593196554000.1876ec55-4911-483f-8a45-a080a82cc50b"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310192355244000.0ff81dac-7a00-4d0d-871d-03c1bf2818e9",
+      "fullUrl" : "Provenance/1706812592984592000.601d2b4b-6b6b-4471-9d2b-e4334ffdf02b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310192355244000.0ff81dac-7a00-4d0d-871d-03c1bf2818e9",
-        "recorded" : "2024-01-26T17:03:12Z",
+        "id" : "1706812592984592000.601d2b4b-6b6b-4471-9d2b-e4334ffdf02b",
+        "recorded" : "2024-02-01T13:36:32Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310192354692000.be290f25-55a1-4541-933f-daf22923703a"
+              "reference" : "Organization/1706812592984059000.7ca39e0b-3459-499c-9956-16aae2c6189a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310192354692000.be290f25-55a1-4541-933f-daf22923703a",
+      "fullUrl" : "Organization/1706812592984059000.7ca39e0b-3459-499c-9956-16aae2c6189a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310192354692000.be290f25-55a1-4541-933f-daf22923703a",
+        "id" : "1706812592984059000.7ca39e0b-3459-499c-9956-16aae2c6189a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310192369229000.9c83cda4-1aca-48dd-9fc7-7f5cac2ae2ee",
+      "fullUrl" : "Patient/1706812593006756000.f359a28b-172b-4406-9a95-06d6c6bbc851",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310192369229000.9c83cda4-1aca-48dd-9fc7-7f5cac2ae2ee"
+        "id" : "1706812593006756000.f359a28b-172b-4406-9a95-06d6c6bbc851"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310192369773000.2754da16-8400-4873-a6b1-27dc909bcc6f",
+      "fullUrl" : "Provenance/1706812593007756000.9fea21d1-5ae9-4416-b577-f05ec14809cf",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310192369773000.2754da16-8400-4873-a6b1-27dc909bcc6f",
+        "id" : "1706812593007756000.9fea21d1-5ae9-4416-b577-f05ec14809cf",
         "target" : [
           {
-            "reference" : "Patient/1706310192369229000.9c83cda4-1aca-48dd-9fc7-7f5cac2ae2ee"
+            "reference" : "Patient/1706812593006756000.f359a28b-172b-4406-9a95-06d6c6bbc851"
           }
         ],
-        "recorded" : "2024-01-26T17:03:12Z",
+        "recorded" : "2024-02-01T13:36:33Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310192373188000.657add46-9be7-44cf-8c69-3994cdadb43c",
+      "fullUrl" : "Specimen/1706812593012482000.d5d60aaa-6ad5-48b2-b3e5-f94c33a1ecf2",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310192373188000.657add46-9be7-44cf-8c69-3994cdadb43c",
+        "id" : "1706812593012482000.d5d60aaa-6ad5-48b2-b3e5-f94c33a1ecf2",
         "collection" : {
           "quantity" : {
             "extension" : [
@@ -205,10 +210,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310192525519000.66fd1b93-e720-4090-a26a-c2e00ca172ab",
+      "fullUrl" : "ServiceRequest/1706812593193717000.254325c9-5282-44c4-8830-7356b7d881a1",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310192525519000.66fd1b93-e720-4090-a26a-c2e00ca172ab",
+        "id" : "1706812593193717000.254325c9-5282-44c4-8830-7356b7d881a1",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -224,18 +229,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310192369229000.9c83cda4-1aca-48dd-9fc7-7f5cac2ae2ee"
+          "reference" : "Patient/1706812593006756000.f359a28b-172b-4406-9a95-06d6c6bbc851"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310192528986000.c97b6d20-c2d0-443c-a7f8-f3a8f59fee77",
+      "fullUrl" : "DiagnosticReport/1706812593196554000.1876ec55-4911-483f-8a45-a080a82cc50b",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310192528986000.c97b6d20-c2d0-443c-a7f8-f3a8f59fee77",
+        "id" : "1706812593196554000.1876ec55-4911-483f-8a45-a080a82cc50b",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310192525519000.66fd1b93-e720-4090-a26a-c2e00ca172ab"
+            "reference" : "ServiceRequest/1706812593193717000.254325c9-5282-44c4-8830-7356b7d881a1"
           }
         ],
         "status" : "final",
@@ -253,11 +258,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310192369229000.9c83cda4-1aca-48dd-9fc7-7f5cac2ae2ee"
+          "reference" : "Patient/1706812593006756000.f359a28b-172b-4406-9a95-06d6c6bbc851"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310192373188000.657add46-9be7-44cf-8c69-3994cdadb43c"
+            "reference" : "Specimen/1706812593012482000.d5d60aaa-6ad5-48b2-b3e5-f94c33a1ecf2"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cq/quantity/cq_all_fields.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cq/quantity/cq_all_fields.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310200938194000.32ad5d7f-fe77-4d5c-bb3b-e67b20e99b0d",
+  "id" : "1706812603217565000.1d8055c1-d5e2-4a0f-bd92-0977521005f3",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:03:20.952-06:00"
+    "lastUpdated" : "2024-02-01T13:36:43.224-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310201332506000.b55e82f8-d0b8-49da-9c26-8d4b2bbd8baa",
+      "fullUrl" : "Provenance/1706812603583744000.2802d293-fa93-4d2b-8629-faa28537b818",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310201332506000.b55e82f8-d0b8-49da-9c26-8d4b2bbd8baa",
+        "id" : "1706812603583744000.2802d293-fa93-4d2b-8629-faa28537b818",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310201533664000.30b9d444-868b-424d-98d9-033633c93dae"
+            "reference" : "DiagnosticReport/1706812603771561000.c0151623-ee3f-416c-baea-3488442bc952"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310201339680000.8cb73c5d-2bf9-4c2c-8df6-cf9d273c6d85",
+      "fullUrl" : "Provenance/1706812603591251000.3816c846-0c30-47d9-9547-e616d9c41287",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310201339680000.8cb73c5d-2bf9-4c2c-8df6-cf9d273c6d85",
-        "recorded" : "2024-01-26T17:03:21Z",
+        "id" : "1706812603591251000.3816c846-0c30-47d9-9547-e616d9c41287",
+        "recorded" : "2024-02-01T13:36:43Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310201339273000.9d570776-4e26-4e4c-bd2d-38a328456c01"
+              "reference" : "Organization/1706812603590604000.502f0a02-674b-437d-8eae-12060993cc68"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310201339273000.9d570776-4e26-4e4c-bd2d-38a328456c01",
+      "fullUrl" : "Organization/1706812603590604000.502f0a02-674b-437d-8eae-12060993cc68",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310201339273000.9d570776-4e26-4e4c-bd2d-38a328456c01",
+        "id" : "1706812603590604000.502f0a02-674b-437d-8eae-12060993cc68",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310201355556000.23146691-c715-4ad9-8708-4cac6ee730c8",
+      "fullUrl" : "Patient/1706812603605091000.a139f02c-e76e-4806-bac6-b40c8adfc33c",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310201355556000.23146691-c715-4ad9-8708-4cac6ee730c8"
+        "id" : "1706812603605091000.a139f02c-e76e-4806-bac6-b40c8adfc33c"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310201356169000.5faf6cd0-8c2a-420f-a19a-ced697e7abaf",
+      "fullUrl" : "Provenance/1706812603605646000.f0995cae-d922-4cf7-91ab-bafad78b4edd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310201356169000.5faf6cd0-8c2a-420f-a19a-ced697e7abaf",
+        "id" : "1706812603605646000.f0995cae-d922-4cf7-91ab-bafad78b4edd",
         "target" : [
           {
-            "reference" : "Patient/1706310201355556000.23146691-c715-4ad9-8708-4cac6ee730c8"
+            "reference" : "Patient/1706812603605091000.a139f02c-e76e-4806-bac6-b40c8adfc33c"
           }
         ],
-        "recorded" : "2024-01-26T17:03:21Z",
+        "recorded" : "2024-02-01T13:36:43Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310201360852000.ba43d7a0-f178-4ab6-a640-2bbe21bee146",
+      "fullUrl" : "Specimen/1706812603609126000.4ffe2909-ad66-48eb-a77a-dde2bed6f206",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310201360852000.ba43d7a0-f178-4ab6-a640-2bbe21bee146",
+        "id" : "1706812603609126000.4ffe2909-ad66-48eb-a77a-dde2bed6f206",
         "collection" : {
           "quantity" : {
             "extension" : [
@@ -206,10 +211,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310201530220000.770303ee-8946-4154-b605-4afce7a91824",
+      "fullUrl" : "ServiceRequest/1706812603769208000.e8718d65-8448-4299-bfba-3ed194064367",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310201530220000.770303ee-8946-4154-b605-4afce7a91824",
+        "id" : "1706812603769208000.e8718d65-8448-4299-bfba-3ed194064367",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -225,18 +230,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310201355556000.23146691-c715-4ad9-8708-4cac6ee730c8"
+          "reference" : "Patient/1706812603605091000.a139f02c-e76e-4806-bac6-b40c8adfc33c"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310201533664000.30b9d444-868b-424d-98d9-033633c93dae",
+      "fullUrl" : "DiagnosticReport/1706812603771561000.c0151623-ee3f-416c-baea-3488442bc952",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310201533664000.30b9d444-868b-424d-98d9-033633c93dae",
+        "id" : "1706812603771561000.c0151623-ee3f-416c-baea-3488442bc952",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310201530220000.770303ee-8946-4154-b605-4afce7a91824"
+            "reference" : "ServiceRequest/1706812603769208000.e8718d65-8448-4299-bfba-3ed194064367"
           }
         ],
         "status" : "final",
@@ -254,11 +259,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310201355556000.23146691-c715-4ad9-8708-4cac6ee730c8"
+          "reference" : "Patient/1706812603605091000.a139f02c-e76e-4806-bac6-b40c8adfc33c"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310201360852000.ba43d7a0-f178-4ab6-a640-2bbe21bee146"
+            "reference" : "Specimen/1706812603609126000.4ffe2909-ad66-48eb-a77a-dde2bed6f206"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-10-test-value-cwe7.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-10-test-value-cwe7.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310211814541000.71bcac5b-8f8d-48a7-a904-5fb9d3e06e33",
+  "id" : "1706812796222912000.862508be-729a-43d6-9069-919d527159c1",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:03:31.828-06:00"
+    "lastUpdated" : "2024-02-01T13:39:56.230-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310211902274000.ba14020a-f70a-497e-8063-a7d7b0d6bb5d"
+          "reference" : "Organization/1706812796275140000.bdddbdf7-f78f-4292-8519-9c809a9528f8"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310211902274000.ba14020a-f70a-497e-8063-a7d7b0d6bb5d",
+      "fullUrl" : "Organization/1706812796275140000.bdddbdf7-f78f-4292-8519-9c809a9528f8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310211902274000.ba14020a-f70a-497e-8063-a7d7b0d6bb5d",
+        "id" : "1706812796275140000.bdddbdf7-f78f-4292-8519-9c809a9528f8",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310212216475000.af70817c-7b11-4c12-885f-6a9a11a3d09c",
+      "fullUrl" : "Provenance/1706812796605365000.a5ff1a43-3889-4faf-837e-875d9a2f764e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310212216475000.af70817c-7b11-4c12-885f-6a9a11a3d09c",
+        "id" : "1706812796605365000.a5ff1a43-3889-4faf-837e-875d9a2f764e",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310212396212000.6d15f930-1fba-47eb-82fd-577e4ad23940"
+            "reference" : "DiagnosticReport/1706812796790619000.c6f0f49d-113a-4d8b-ae48-f9f3fdd98dd6"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310212226730000.114b435e-5077-4fe8-9377-fa2f5acac39f",
+      "fullUrl" : "Provenance/1706812796611476000.5e13bbbd-0604-44a2-ab82-381b6e0c5e18",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310212226730000.114b435e-5077-4fe8-9377-fa2f5acac39f",
-        "recorded" : "2024-01-26T17:03:32Z",
+        "id" : "1706812796611476000.5e13bbbd-0604-44a2-ab82-381b6e0c5e18",
+        "recorded" : "2024-02-01T13:39:56Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310212226284000.10aeed15-5397-4d1c-a505-5c178b3f3a2f"
+              "reference" : "Organization/1706812796611039000.38babb7e-3f3d-47e2-a6e3-97ecb927fa9a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310212226284000.10aeed15-5397-4d1c-a505-5c178b3f3a2f",
+      "fullUrl" : "Organization/1706812796611039000.38babb7e-3f3d-47e2-a6e3-97ecb927fa9a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310212226284000.10aeed15-5397-4d1c-a505-5c178b3f3a2f",
+        "id" : "1706812796611039000.38babb7e-3f3d-47e2-a6e3-97ecb927fa9a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310212243371000.d129579b-656b-475e-ac1a-1c9a373029da",
+      "fullUrl" : "Patient/1706812796625026000.cc1e25cf-5d7b-4009-9f8d-59bf5dfcaaad",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310212243371000.d129579b-656b-475e-ac1a-1c9a373029da"
+        "id" : "1706812796625026000.cc1e25cf-5d7b-4009-9f8d-59bf5dfcaaad"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310212244982000.29943cec-9cde-42c4-9fba-ea70239d29c0",
+      "fullUrl" : "Provenance/1706812796625587000.cb37a647-6ecc-419e-98e3-7d91ad1e32c0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310212244982000.29943cec-9cde-42c4-9fba-ea70239d29c0",
+        "id" : "1706812796625587000.cb37a647-6ecc-419e-98e3-7d91ad1e32c0",
         "target" : [
           {
-            "reference" : "Patient/1706310212243371000.d129579b-656b-475e-ac1a-1c9a373029da"
+            "reference" : "Patient/1706812796625026000.cc1e25cf-5d7b-4009-9f8d-59bf5dfcaaad"
           }
         ],
-        "recorded" : "2024-01-26T17:03:32Z",
+        "recorded" : "2024-02-01T13:39:56Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310212247195000.69fefb90-3eec-4daf-9cc1-8f2f8ca74fa4",
+      "fullUrl" : "Specimen/1706812796627297000.688f72d0-b381-410a-8bbe-ce6597eefcba",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310212247195000.69fefb90-3eec-4daf-9cc1-8f2f8ca74fa4",
+        "id" : "1706812796627297000.688f72d0-b381-410a-8bbe-ce6597eefcba",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310212393224000.f9024d2b-f7c6-4553-a531-672ab0001b8b",
+      "fullUrl" : "ServiceRequest/1706812796788125000.e159de0e-2617-4d8b-9a66-d614316d0179",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310212393224000.f9024d2b-f7c6-4553-a531-672ab0001b8b",
+        "id" : "1706812796788125000.e159de0e-2617-4d8b-9a66-d614316d0179",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310212243371000.d129579b-656b-475e-ac1a-1c9a373029da"
+          "reference" : "Patient/1706812796625026000.cc1e25cf-5d7b-4009-9f8d-59bf5dfcaaad"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310212396212000.6d15f930-1fba-47eb-82fd-577e4ad23940",
+      "fullUrl" : "DiagnosticReport/1706812796790619000.c6f0f49d-113a-4d8b-ae48-f9f3fdd98dd6",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310212396212000.6d15f930-1fba-47eb-82fd-577e4ad23940",
+        "id" : "1706812796790619000.c6f0f49d-113a-4d8b-ae48-f9f3fdd98dd6",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310212393224000.f9024d2b-f7c6-4553-a531-672ab0001b8b"
+            "reference" : "ServiceRequest/1706812796788125000.e159de0e-2617-4d8b-9a66-d614316d0179"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310212243371000.d129579b-656b-475e-ac1a-1c9a373029da"
+          "reference" : "Patient/1706812796625026000.cc1e25cf-5d7b-4009-9f8d-59bf5dfcaaad"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310212247195000.69fefb90-3eec-4daf-9cc1-8f2f8ca74fa4"
+            "reference" : "Specimen/1706812796627297000.688f72d0-b381-410a-8bbe-ce6597eefcba"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-11-test-value-cwe8.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-11-test-value-cwe8.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310220702135000.51396242-0479-4613-9ca9-a5dc5f61136d",
+  "id" : "1706812806560145000.deeb91e7-6d2b-4180-9072-14080234dd0e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:03:40.718-06:00"
+    "lastUpdated" : "2024-02-01T13:40:06.566-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310220805692000.d0d16742-8243-46fa-a9bb-eceb69999f12"
+          "reference" : "Organization/1706812806611520000.19acd56f-4d1f-445e-a5fb-876f9f11fd07"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310220805692000.d0d16742-8243-46fa-a9bb-eceb69999f12",
+      "fullUrl" : "Organization/1706812806611520000.19acd56f-4d1f-445e-a5fb-876f9f11fd07",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310220805692000.d0d16742-8243-46fa-a9bb-eceb69999f12",
+        "id" : "1706812806611520000.19acd56f-4d1f-445e-a5fb-876f9f11fd07",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310221120849000.c6a88147-5867-4cab-ae43-9821e1fb713a",
+      "fullUrl" : "Provenance/1706812806964214000.ec4560b8-69cd-4fbf-9a62-c865520a971a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310221120849000.c6a88147-5867-4cab-ae43-9821e1fb713a",
+        "id" : "1706812806964214000.ec4560b8-69cd-4fbf-9a62-c865520a971a",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310221302093000.23a87cb7-e4e0-4d3d-972f-5641106fded4"
+            "reference" : "DiagnosticReport/1706812807167935000.9111d958-8e96-4c66-a6de-ebc5944ef358"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310221128467000.0e112e80-7269-48bf-839f-3fa60842cdc6",
+      "fullUrl" : "Provenance/1706812806972127000.57dafeab-c731-4d74-94ea-91a239ff6c0d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310221128467000.0e112e80-7269-48bf-839f-3fa60842cdc6",
-        "recorded" : "2024-01-26T17:03:41Z",
+        "id" : "1706812806972127000.57dafeab-c731-4d74-94ea-91a239ff6c0d",
+        "recorded" : "2024-02-01T13:40:06Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310221128038000.ff543a02-23bf-4076-a310-959891167529"
+              "reference" : "Organization/1706812806971718000.07dd14a4-3ebf-4809-937b-ad7c2d370c93"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310221128038000.ff543a02-23bf-4076-a310-959891167529",
+      "fullUrl" : "Organization/1706812806971718000.07dd14a4-3ebf-4809-937b-ad7c2d370c93",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310221128038000.ff543a02-23bf-4076-a310-959891167529",
+        "id" : "1706812806971718000.07dd14a4-3ebf-4809-937b-ad7c2d370c93",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310221143430000.468a0ae8-9ca8-450e-ae60-b3da7a9ae711",
+      "fullUrl" : "Patient/1706812806990015000.af354fa7-3cce-4cb3-a1e7-65bb8d0bffda",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310221143430000.468a0ae8-9ca8-450e-ae60-b3da7a9ae711"
+        "id" : "1706812806990015000.af354fa7-3cce-4cb3-a1e7-65bb8d0bffda"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310221145150000.43db0b0a-c868-4588-8ee3-cc717fcc49d8",
+      "fullUrl" : "Provenance/1706812806990992000.b344410c-86cb-4e6a-afbf-2192537bf3ad",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310221145150000.43db0b0a-c868-4588-8ee3-cc717fcc49d8",
+        "id" : "1706812806990992000.b344410c-86cb-4e6a-afbf-2192537bf3ad",
         "target" : [
           {
-            "reference" : "Patient/1706310221143430000.468a0ae8-9ca8-450e-ae60-b3da7a9ae711"
+            "reference" : "Patient/1706812806990015000.af354fa7-3cce-4cb3-a1e7-65bb8d0bffda"
           }
         ],
-        "recorded" : "2024-01-26T17:03:41Z",
+        "recorded" : "2024-02-01T13:40:06Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310221147435000.2e4abec4-fcfb-4e15-b2e2-b81a00608479",
+      "fullUrl" : "Specimen/1706812806993183000.67008227-e590-4264-a671-63959cdb61d4",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310221147435000.2e4abec4-fcfb-4e15-b2e2-b81a00608479",
+        "id" : "1706812806993183000.67008227-e590-4264-a671-63959cdb61d4",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310221298589000.0ac92b19-ca32-4336-ba8f-ca28b36b7376",
+      "fullUrl" : "ServiceRequest/1706812807164002000.5f8966be-c68f-4553-adc1-85df5da9a755",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310221298589000.0ac92b19-ca32-4336-ba8f-ca28b36b7376",
+        "id" : "1706812807164002000.5f8966be-c68f-4553-adc1-85df5da9a755",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310221143430000.468a0ae8-9ca8-450e-ae60-b3da7a9ae711"
+          "reference" : "Patient/1706812806990015000.af354fa7-3cce-4cb3-a1e7-65bb8d0bffda"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310221302093000.23a87cb7-e4e0-4d3d-972f-5641106fded4",
+      "fullUrl" : "DiagnosticReport/1706812807167935000.9111d958-8e96-4c66-a6de-ebc5944ef358",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310221302093000.23a87cb7-e4e0-4d3d-972f-5641106fded4",
+        "id" : "1706812807167935000.9111d958-8e96-4c66-a6de-ebc5944ef358",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310221298589000.0ac92b19-ca32-4336-ba8f-ca28b36b7376"
+            "reference" : "ServiceRequest/1706812807164002000.5f8966be-c68f-4553-adc1-85df5da9a755"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310221143430000.468a0ae8-9ca8-450e-ae60-b3da7a9ae711"
+          "reference" : "Patient/1706812806990015000.af354fa7-3cce-4cb3-a1e7-65bb8d0bffda"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310221147435000.2e4abec4-fcfb-4e15-b2e2-b81a00608479"
+            "reference" : "Specimen/1706812806993183000.67008227-e590-4264-a671-63959cdb61d4"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-12-test-value-cwe9.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-12-test-value-cwe9.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310229688136000.ec2e5b93-c0f0-4c61-8bb7-d6f613a8e482",
+  "id" : "1706812817040312000.344a87f5-33b0-4775-a7fc-cef122f748ae",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:03:49.702-06:00"
+    "lastUpdated" : "2024-02-01T13:40:17.048-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310229772262000.e4989e66-9d3a-47ac-8ec2-52406c90ffca"
+          "reference" : "Organization/1706812817090000000.d92c72bd-a961-488b-8cde-e9eb17e8c55a"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310229772262000.e4989e66-9d3a-47ac-8ec2-52406c90ffca",
+      "fullUrl" : "Organization/1706812817090000000.d92c72bd-a961-488b-8cde-e9eb17e8c55a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310229772262000.e4989e66-9d3a-47ac-8ec2-52406c90ffca",
+        "id" : "1706812817090000000.d92c72bd-a961-488b-8cde-e9eb17e8c55a",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310230105740000.68015725-ba1c-4161-b30a-422a3b7e4401",
+      "fullUrl" : "Provenance/1706812817429484000.6452b0d5-ff56-4814-9d36-61d4f87bd274",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310230105740000.68015725-ba1c-4161-b30a-422a3b7e4401",
+        "id" : "1706812817429484000.6452b0d5-ff56-4814-9d36-61d4f87bd274",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310230305603000.a29f3907-3133-406f-9afe-868229d854f6"
+            "reference" : "DiagnosticReport/1706812817638459000.6e680735-6301-4bda-b847-c20817383649"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310230114027000.dbcc1a5c-9cf6-4259-9e51-e007a271e2c5",
+      "fullUrl" : "Provenance/1706812817438342000.c29ed5a7-c4b2-4bad-802e-79f2691aeb59",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310230114027000.dbcc1a5c-9cf6-4259-9e51-e007a271e2c5",
-        "recorded" : "2024-01-26T17:03:50Z",
+        "id" : "1706812817438342000.c29ed5a7-c4b2-4bad-802e-79f2691aeb59",
+        "recorded" : "2024-02-01T13:40:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310230113583000.ab91c4c3-85e1-4f7f-9535-2eab96962eb4"
+              "reference" : "Organization/1706812817437733000.98cc39c7-9398-474c-8f7d-f07b80a46b51"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310230113583000.ab91c4c3-85e1-4f7f-9535-2eab96962eb4",
+      "fullUrl" : "Organization/1706812817437733000.98cc39c7-9398-474c-8f7d-f07b80a46b51",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310230113583000.ab91c4c3-85e1-4f7f-9535-2eab96962eb4",
+        "id" : "1706812817437733000.98cc39c7-9398-474c-8f7d-f07b80a46b51",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310230131395000.ab9c2f6e-7478-434d-8052-a2e60d7831f9",
+      "fullUrl" : "Patient/1706812817455644000.b120ff77-4a30-4fb7-9f78-22e05a3806ea",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310230131395000.ab9c2f6e-7478-434d-8052-a2e60d7831f9"
+        "id" : "1706812817455644000.b120ff77-4a30-4fb7-9f78-22e05a3806ea"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310230132559000.d218e71e-8960-4378-a211-c2055f782277",
+      "fullUrl" : "Provenance/1706812817456706000.ac7e7c4a-b739-4ebf-8bfb-19fb0be4287b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310230132559000.d218e71e-8960-4378-a211-c2055f782277",
+        "id" : "1706812817456706000.ac7e7c4a-b739-4ebf-8bfb-19fb0be4287b",
         "target" : [
           {
-            "reference" : "Patient/1706310230131395000.ab9c2f6e-7478-434d-8052-a2e60d7831f9"
+            "reference" : "Patient/1706812817455644000.b120ff77-4a30-4fb7-9f78-22e05a3806ea"
           }
         ],
-        "recorded" : "2024-01-26T17:03:50Z",
+        "recorded" : "2024-02-01T13:40:17Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310230135697000.6a2fe18e-f85d-4c4b-8838-ee21792f4d08",
+      "fullUrl" : "Specimen/1706812817458697000.b01d3d8c-34fe-4573-a704-8d9cb248c800",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310230135697000.6a2fe18e-f85d-4c4b-8838-ee21792f4d08",
+        "id" : "1706812817458697000.b01d3d8c-34fe-4573-a704-8d9cb248c800",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310230299854000.0a860b78-ff55-4c6e-8855-44c0f49062a4",
+      "fullUrl" : "ServiceRequest/1706812817635671000.09cc180f-2f40-4e81-9865-bbe6611acea7",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310230299854000.0a860b78-ff55-4c6e-8855-44c0f49062a4",
+        "id" : "1706812817635671000.09cc180f-2f40-4e81-9865-bbe6611acea7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310230131395000.ab9c2f6e-7478-434d-8052-a2e60d7831f9"
+          "reference" : "Patient/1706812817455644000.b120ff77-4a30-4fb7-9f78-22e05a3806ea"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310230305603000.a29f3907-3133-406f-9afe-868229d854f6",
+      "fullUrl" : "DiagnosticReport/1706812817638459000.6e680735-6301-4bda-b847-c20817383649",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310230305603000.a29f3907-3133-406f-9afe-868229d854f6",
+        "id" : "1706812817638459000.6e680735-6301-4bda-b847-c20817383649",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310230299854000.0a860b78-ff55-4c6e-8855-44c0f49062a4"
+            "reference" : "ServiceRequest/1706812817635671000.09cc180f-2f40-4e81-9865-bbe6611acea7"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310230131395000.ab9c2f6e-7478-434d-8052-a2e60d7831f9"
+          "reference" : "Patient/1706812817455644000.b120ff77-4a30-4fb7-9f78-22e05a3806ea"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310230135697000.6a2fe18e-f85d-4c4b-8838-ee21792f4d08"
+            "reference" : "Specimen/1706812817458697000.b01d3d8c-34fe-4573-a704-8d9cb248c800"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-4-test-value-cwe1.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-4-test-value-cwe1.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310238968579000.2901bba0-9f9e-49d2-82c7-8cef1a3cc86e",
+  "id" : "1706812827106568000.f7c74146-b546-4112-b4d4-cc528eefaad4",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:03:58.983-06:00"
+    "lastUpdated" : "2024-02-01T13:40:27.113-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310239060854000.d619c61b-36cd-4e7c-b98f-996c989250df"
+          "reference" : "Organization/1706812827166670000.3d717156-5672-4bb6-8615-0ee8d78a57f6"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310239060854000.d619c61b-36cd-4e7c-b98f-996c989250df",
+      "fullUrl" : "Organization/1706812827166670000.3d717156-5672-4bb6-8615-0ee8d78a57f6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310239060854000.d619c61b-36cd-4e7c-b98f-996c989250df",
+        "id" : "1706812827166670000.3d717156-5672-4bb6-8615-0ee8d78a57f6",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310239376693000.723c4abe-c6b7-425c-aab6-eff731323379",
+      "fullUrl" : "Provenance/1706812827620615000.fc4ed88a-ac4e-4767-af4e-cedf4092a6ca",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310239376693000.723c4abe-c6b7-425c-aab6-eff731323379",
+        "id" : "1706812827620615000.fc4ed88a-ac4e-4767-af4e-cedf4092a6ca",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310239549940000.8d468399-71c8-4840-84e0-f08d98975dc6"
+            "reference" : "DiagnosticReport/1706812827808070000.dea15c7e-a97f-4182-b958-c43f7d1a036b"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310239386439000.6479a1b2-b397-4aa8-bbf1-69442e0b45ab",
+      "fullUrl" : "Provenance/1706812827628289000.7d6a57dd-d793-4bd1-af16-8a226aaa48fd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310239386439000.6479a1b2-b397-4aa8-bbf1-69442e0b45ab",
-        "recorded" : "2024-01-26T17:03:59Z",
+        "id" : "1706812827628289000.7d6a57dd-d793-4bd1-af16-8a226aaa48fd",
+        "recorded" : "2024-02-01T13:40:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310239385895000.54c74760-2062-4879-b888-ff5eeea9cfa5"
+              "reference" : "Organization/1706812827627782000.dcb1314b-a0b9-4a05-91ad-b4995d401597"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310239385895000.54c74760-2062-4879-b888-ff5eeea9cfa5",
+      "fullUrl" : "Organization/1706812827627782000.dcb1314b-a0b9-4a05-91ad-b4995d401597",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310239385895000.54c74760-2062-4879-b888-ff5eeea9cfa5",
+        "id" : "1706812827627782000.dcb1314b-a0b9-4a05-91ad-b4995d401597",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310239399316000.1f6378c0-c1d6-428b-b7f4-6ee7260f2407",
+      "fullUrl" : "Patient/1706812827646463000.b9424a81-4cf1-4594-973b-e8c126725c02",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310239399316000.1f6378c0-c1d6-428b-b7f4-6ee7260f2407"
+        "id" : "1706812827646463000.b9424a81-4cf1-4594-973b-e8c126725c02"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310239399901000.cfa5603e-b139-40ba-9588-99738528335f",
+      "fullUrl" : "Provenance/1706812827647313000.e9122faa-c096-4740-8acd-f679a9ac8893",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310239399901000.cfa5603e-b139-40ba-9588-99738528335f",
+        "id" : "1706812827647313000.e9122faa-c096-4740-8acd-f679a9ac8893",
         "target" : [
           {
-            "reference" : "Patient/1706310239399316000.1f6378c0-c1d6-428b-b7f4-6ee7260f2407"
+            "reference" : "Patient/1706812827646463000.b9424a81-4cf1-4594-973b-e8c126725c02"
           }
         ],
-        "recorded" : "2024-01-26T17:03:59Z",
+        "recorded" : "2024-02-01T13:40:27Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310239402350000.957e3ea6-b867-4d33-9ae8-09ce83af59e8",
+      "fullUrl" : "Specimen/1706812827649466000.490ac6d4-5a91-4db1-92cf-a26dc8d08668",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310239402350000.957e3ea6-b867-4d33-9ae8-09ce83af59e8",
+        "id" : "1706812827649466000.490ac6d4-5a91-4db1-92cf-a26dc8d08668",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310239546007000.9f896c12-7e44-4490-9e06-79e14a7e1f1b",
+      "fullUrl" : "ServiceRequest/1706812827804990000.56e3b463-68d0-411d-9518-39f1269930ea",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310239546007000.9f896c12-7e44-4490-9e06-79e14a7e1f1b",
+        "id" : "1706812827804990000.56e3b463-68d0-411d-9518-39f1269930ea",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310239399316000.1f6378c0-c1d6-428b-b7f4-6ee7260f2407"
+          "reference" : "Patient/1706812827646463000.b9424a81-4cf1-4594-973b-e8c126725c02"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310239549940000.8d468399-71c8-4840-84e0-f08d98975dc6",
+      "fullUrl" : "DiagnosticReport/1706812827808070000.dea15c7e-a97f-4182-b958-c43f7d1a036b",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310239549940000.8d468399-71c8-4840-84e0-f08d98975dc6",
+        "id" : "1706812827808070000.dea15c7e-a97f-4182-b958-c43f7d1a036b",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310239546007000.9f896c12-7e44-4490-9e06-79e14a7e1f1b"
+            "reference" : "ServiceRequest/1706812827804990000.56e3b463-68d0-411d-9518-39f1269930ea"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310239399316000.1f6378c0-c1d6-428b-b7f4-6ee7260f2407"
+          "reference" : "Patient/1706812827646463000.b9424a81-4cf1-4594-973b-e8c126725c02"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310239402350000.957e3ea6-b867-4d33-9ae8-09ce83af59e8"
+            "reference" : "Specimen/1706812827649466000.490ac6d4-5a91-4db1-92cf-a26dc8d08668"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-5-test-value-cwe2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-5-test-value-cwe2.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310248103063000.60ce4161-d7e3-4664-82f2-7a45f2745cfa",
+  "id" : "1706812837168446000.bd813b59-6472-4822-8c88-c374c7942ecf",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:04:08.119-06:00"
+    "lastUpdated" : "2024-02-01T13:40:37.174-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310248193496000.0c7b1b21-0169-47b5-b178-ffd4b5522004"
+          "reference" : "Organization/1706812837219865000.5d2b13dc-45a1-4bd6-b107-55c03b00f669"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310248193496000.0c7b1b21-0169-47b5-b178-ffd4b5522004",
+      "fullUrl" : "Organization/1706812837219865000.5d2b13dc-45a1-4bd6-b107-55c03b00f669",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310248193496000.0c7b1b21-0169-47b5-b178-ffd4b5522004",
+        "id" : "1706812837219865000.5d2b13dc-45a1-4bd6-b107-55c03b00f669",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310248506146000.7b7c7941-963f-41cd-9147-1fc4d35ebf4e",
+      "fullUrl" : "Provenance/1706812837555563000.d41e9dfe-f55b-42df-9b6f-f1d4c929537f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310248506146000.7b7c7941-963f-41cd-9147-1fc4d35ebf4e",
+        "id" : "1706812837555563000.d41e9dfe-f55b-42df-9b6f-f1d4c929537f",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310248685301000.c9357bc7-c4cd-4bae-bf40-d2799a0a6524"
+            "reference" : "DiagnosticReport/1706812837741608000.3bbac3ce-53ee-4f7a-8750-42ca0d733e08"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310248513460000.a97a5965-78ed-4b94-968a-ae29eb74c3f2",
+      "fullUrl" : "Provenance/1706812837563281000.c9adf315-517a-4c28-99c8-7ea2d62429ce",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310248513460000.a97a5965-78ed-4b94-968a-ae29eb74c3f2",
-        "recorded" : "2024-01-26T17:04:08Z",
+        "id" : "1706812837563281000.c9adf315-517a-4c28-99c8-7ea2d62429ce",
+        "recorded" : "2024-02-01T13:40:37Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310248512940000.2f4d95ec-4e87-431b-985a-5fb1f69f3bdc"
+              "reference" : "Organization/1706812837562837000.2788b961-f409-455b-9b07-2a3a27845daa"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310248512940000.2f4d95ec-4e87-431b-985a-5fb1f69f3bdc",
+      "fullUrl" : "Organization/1706812837562837000.2788b961-f409-455b-9b07-2a3a27845daa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310248512940000.2f4d95ec-4e87-431b-985a-5fb1f69f3bdc",
+        "id" : "1706812837562837000.2788b961-f409-455b-9b07-2a3a27845daa",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310248527703000.ab4bcfbd-3da1-4978-8c5f-65860e14f09b",
+      "fullUrl" : "Patient/1706812837578454000.dc55e6eb-3cff-460c-a59d-1bff7d5ee277",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310248527703000.ab4bcfbd-3da1-4978-8c5f-65860e14f09b"
+        "id" : "1706812837578454000.dc55e6eb-3cff-460c-a59d-1bff7d5ee277"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310248528348000.2e10330c-14f5-4c66-940b-99330589f7af",
+      "fullUrl" : "Provenance/1706812837579121000.b55ef3a8-e761-4b96-b7df-7575b7844fb7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310248528348000.2e10330c-14f5-4c66-940b-99330589f7af",
+        "id" : "1706812837579121000.b55ef3a8-e761-4b96-b7df-7575b7844fb7",
         "target" : [
           {
-            "reference" : "Patient/1706310248527703000.ab4bcfbd-3da1-4978-8c5f-65860e14f09b"
+            "reference" : "Patient/1706812837578454000.dc55e6eb-3cff-460c-a59d-1bff7d5ee277"
           }
         ],
-        "recorded" : "2024-01-26T17:04:08Z",
+        "recorded" : "2024-02-01T13:40:37Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310248530094000.d7df7abc-00e7-4e28-b9be-0a5fe068771b",
+      "fullUrl" : "Specimen/1706812837580867000.bc81fddd-2470-40ca-8919-fd8ec5ce4681",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310248530094000.d7df7abc-00e7-4e28-b9be-0a5fe068771b",
+        "id" : "1706812837580867000.bc81fddd-2470-40ca-8919-fd8ec5ce4681",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310248682144000.cda57787-6a37-46eb-beed-1df7fa15e984",
+      "fullUrl" : "ServiceRequest/1706812837738261000.ea13c200-a828-4be2-ba2c-420849d49e18",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310248682144000.cda57787-6a37-46eb-beed-1df7fa15e984",
+        "id" : "1706812837738261000.ea13c200-a828-4be2-ba2c-420849d49e18",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310248527703000.ab4bcfbd-3da1-4978-8c5f-65860e14f09b"
+          "reference" : "Patient/1706812837578454000.dc55e6eb-3cff-460c-a59d-1bff7d5ee277"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310248685301000.c9357bc7-c4cd-4bae-bf40-d2799a0a6524",
+      "fullUrl" : "DiagnosticReport/1706812837741608000.3bbac3ce-53ee-4f7a-8750-42ca0d733e08",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310248685301000.c9357bc7-c4cd-4bae-bf40-d2799a0a6524",
+        "id" : "1706812837741608000.3bbac3ce-53ee-4f7a-8750-42ca0d733e08",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310248682144000.cda57787-6a37-46eb-beed-1df7fa15e984"
+            "reference" : "ServiceRequest/1706812837738261000.ea13c200-a828-4be2-ba2c-420849d49e18"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310248527703000.ab4bcfbd-3da1-4978-8c5f-65860e14f09b"
+          "reference" : "Patient/1706812837578454000.dc55e6eb-3cff-460c-a59d-1bff7d5ee277"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310248530094000.d7df7abc-00e7-4e28-b9be-0a5fe068771b"
+            "reference" : "Specimen/1706812837580867000.bc81fddd-2470-40ca-8919-fd8ec5ce4681"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-6-test-value-cwe3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-6-test-value-cwe3.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310257065650000.74e5af25-0a1f-447c-bd8c-f849b018a2ef",
+  "id" : "1706812847637809000.4bff3a32-ba33-4abf-99aa-85cb2d6dab3a",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:04:17.080-06:00"
+    "lastUpdated" : "2024-02-01T13:40:47.644-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310257156215000.399bafa1-526a-463f-93d3-b9045e654913"
+          "reference" : "Organization/1706812847688154000.fca0c703-dfcd-4e5a-ac53-9f2825e3ca51"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310257156215000.399bafa1-526a-463f-93d3-b9045e654913",
+      "fullUrl" : "Organization/1706812847688154000.fca0c703-dfcd-4e5a-ac53-9f2825e3ca51",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310257156215000.399bafa1-526a-463f-93d3-b9045e654913",
+        "id" : "1706812847688154000.fca0c703-dfcd-4e5a-ac53-9f2825e3ca51",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310257471180000.86b90b58-74b6-45f5-a05f-6a65f4027c9a",
+      "fullUrl" : "Provenance/1706812848028765000.af58ae36-836b-4da4-b1b3-a0dbf5c07fde",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310257471180000.86b90b58-74b6-45f5-a05f-6a65f4027c9a",
+        "id" : "1706812848028765000.af58ae36-836b-4da4-b1b3-a0dbf5c07fde",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310257661284000.ccc6a4f1-9f74-40e5-8cd6-3987d45590ca"
+            "reference" : "DiagnosticReport/1706812848238459000.180ea4e0-e111-4f7b-8151-068c68dd94cf"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310257480137000.5634ad19-78df-4397-9e9e-3207f5b87879",
+      "fullUrl" : "Provenance/1706812848036572000.eab89b53-a0ea-4267-8567-dc3959f9784a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310257480137000.5634ad19-78df-4397-9e9e-3207f5b87879",
-        "recorded" : "2024-01-26T17:04:17Z",
+        "id" : "1706812848036572000.eab89b53-a0ea-4267-8567-dc3959f9784a",
+        "recorded" : "2024-02-01T13:40:48Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310257479708000.57a7f277-a121-44e7-af39-18d7fde8dbd8"
+              "reference" : "Organization/1706812848035116000.a39af2aa-af99-4912-89e7-556b2cd1cca8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310257479708000.57a7f277-a121-44e7-af39-18d7fde8dbd8",
+      "fullUrl" : "Organization/1706812848035116000.a39af2aa-af99-4912-89e7-556b2cd1cca8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310257479708000.57a7f277-a121-44e7-af39-18d7fde8dbd8",
+        "id" : "1706812848035116000.a39af2aa-af99-4912-89e7-556b2cd1cca8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310257494051000.d7de0df6-81cc-4831-8605-49a89d22ed2a",
+      "fullUrl" : "Patient/1706812848050506000.70cd7852-ba0e-4efa-8a3b-f55bbd878dea",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310257494051000.d7de0df6-81cc-4831-8605-49a89d22ed2a"
+        "id" : "1706812848050506000.70cd7852-ba0e-4efa-8a3b-f55bbd878dea"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310257494778000.833264c4-1078-417b-bc15-56f187f2be1e",
+      "fullUrl" : "Provenance/1706812848051107000.9f7e8d36-e905-48db-9535-0ca091e39a7c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310257494778000.833264c4-1078-417b-bc15-56f187f2be1e",
+        "id" : "1706812848051107000.9f7e8d36-e905-48db-9535-0ca091e39a7c",
         "target" : [
           {
-            "reference" : "Patient/1706310257494051000.d7de0df6-81cc-4831-8605-49a89d22ed2a"
+            "reference" : "Patient/1706812848050506000.70cd7852-ba0e-4efa-8a3b-f55bbd878dea"
           }
         ],
-        "recorded" : "2024-01-26T17:04:17Z",
+        "recorded" : "2024-02-01T13:40:48Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310257496899000.2039ec57-e4c0-4290-a3c6-b5c1963fcbc8",
+      "fullUrl" : "Specimen/1706812848053275000.3e7214b8-13d6-4a26-8e0b-6b375be83f22",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310257496899000.2039ec57-e4c0-4290-a3c6-b5c1963fcbc8",
+        "id" : "1706812848053275000.3e7214b8-13d6-4a26-8e0b-6b375be83f22",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310257658020000.1bba61d6-d76c-4fdf-8f41-cb9dc8d1d1ac",
+      "fullUrl" : "ServiceRequest/1706812848234806000.ddddd311-e323-4b3f-ad1a-23efbb5fb342",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310257658020000.1bba61d6-d76c-4fdf-8f41-cb9dc8d1d1ac",
+        "id" : "1706812848234806000.ddddd311-e323-4b3f-ad1a-23efbb5fb342",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310257494051000.d7de0df6-81cc-4831-8605-49a89d22ed2a"
+          "reference" : "Patient/1706812848050506000.70cd7852-ba0e-4efa-8a3b-f55bbd878dea"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310257661284000.ccc6a4f1-9f74-40e5-8cd6-3987d45590ca",
+      "fullUrl" : "DiagnosticReport/1706812848238459000.180ea4e0-e111-4f7b-8151-068c68dd94cf",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310257661284000.ccc6a4f1-9f74-40e5-8cd6-3987d45590ca",
+        "id" : "1706812848238459000.180ea4e0-e111-4f7b-8151-068c68dd94cf",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310257658020000.1bba61d6-d76c-4fdf-8f41-cb9dc8d1d1ac"
+            "reference" : "ServiceRequest/1706812848234806000.ddddd311-e323-4b3f-ad1a-23efbb5fb342"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310257494051000.d7de0df6-81cc-4831-8605-49a89d22ed2a"
+          "reference" : "Patient/1706812848050506000.70cd7852-ba0e-4efa-8a3b-f55bbd878dea"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310257496899000.2039ec57-e4c0-4290-a3c6-b5c1963fcbc8"
+            "reference" : "Specimen/1706812848053275000.3e7214b8-13d6-4a26-8e0b-6b375be83f22"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-7-test-value-cwe4.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-7-test-value-cwe4.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310266193909000.fcb545ee-4b25-41a7-ac3f-761d47a02c84",
+  "id" : "1706812857755776000.c1460cbf-a18f-4407-883e-5384360bf41b",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:04:26.209-06:00"
+    "lastUpdated" : "2024-02-01T13:40:57.765-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310266289424000.32e3e27f-baae-41e5-9a7b-c07e7f46ee79"
+          "reference" : "Organization/1706812857804718000.d83506f7-40d6-4059-b6c2-d9012b0e7834"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310266289424000.32e3e27f-baae-41e5-9a7b-c07e7f46ee79",
+      "fullUrl" : "Organization/1706812857804718000.d83506f7-40d6-4059-b6c2-d9012b0e7834",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310266289424000.32e3e27f-baae-41e5-9a7b-c07e7f46ee79",
+        "id" : "1706812857804718000.d83506f7-40d6-4059-b6c2-d9012b0e7834",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310266594043000.10d674d1-ff13-430e-be3f-eb825c15c660",
+      "fullUrl" : "Provenance/1706812858133767000.b7709b63-38d0-42ed-94af-79a5eac8d63e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310266594043000.10d674d1-ff13-430e-be3f-eb825c15c660",
+        "id" : "1706812858133767000.b7709b63-38d0-42ed-94af-79a5eac8d63e",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310266761704000.2a2169df-3702-4ace-9cf5-b92267b9d4df"
+            "reference" : "DiagnosticReport/1706812858324392000.5fa6cd6a-87a7-4f2c-9402-0d4797d4d1fa"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310266601466000.1553b38c-19a6-4c47-8de0-1b60f6c23203",
+      "fullUrl" : "Provenance/1706812858141774000.282b3fb9-2cc2-4be7-b180-5857648c4d21",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310266601466000.1553b38c-19a6-4c47-8de0-1b60f6c23203",
-        "recorded" : "2024-01-26T17:04:26Z",
+        "id" : "1706812858141774000.282b3fb9-2cc2-4be7-b180-5857648c4d21",
+        "recorded" : "2024-02-01T13:40:58Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310266600246000.6ea820dd-8461-48d9-9a5d-2e6ac4b5c296"
+              "reference" : "Organization/1706812858141307000.3eba69b8-ddf2-4063-9167-34ce94a0d7ea"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310266600246000.6ea820dd-8461-48d9-9a5d-2e6ac4b5c296",
+      "fullUrl" : "Organization/1706812858141307000.3eba69b8-ddf2-4063-9167-34ce94a0d7ea",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310266600246000.6ea820dd-8461-48d9-9a5d-2e6ac4b5c296",
+        "id" : "1706812858141307000.3eba69b8-ddf2-4063-9167-34ce94a0d7ea",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310266613559000.b8d309ca-5691-48f3-a50b-4a43b8b818d6",
+      "fullUrl" : "Patient/1706812858160269000.649c6030-0409-4498-94cd-0e27832114ae",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310266613559000.b8d309ca-5691-48f3-a50b-4a43b8b818d6"
+        "id" : "1706812858160269000.649c6030-0409-4498-94cd-0e27832114ae"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310266614153000.8080934e-df05-452d-8b82-81a6ad649463",
+      "fullUrl" : "Provenance/1706812858161298000.8619dd39-5654-4736-ab6c-a0a6fb6e63b3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310266614153000.8080934e-df05-452d-8b82-81a6ad649463",
+        "id" : "1706812858161298000.8619dd39-5654-4736-ab6c-a0a6fb6e63b3",
         "target" : [
           {
-            "reference" : "Patient/1706310266613559000.b8d309ca-5691-48f3-a50b-4a43b8b818d6"
+            "reference" : "Patient/1706812858160269000.649c6030-0409-4498-94cd-0e27832114ae"
           }
         ],
-        "recorded" : "2024-01-26T17:04:26Z",
+        "recorded" : "2024-02-01T13:40:58Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310266615846000.bc0deb2f-f5a0-4d35-8c3d-3406a9e6a612",
+      "fullUrl" : "Specimen/1706812858163369000.2837c7cc-c40f-407f-8856-4bab45aef4e0",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310266615846000.bc0deb2f-f5a0-4d35-8c3d-3406a9e6a612",
+        "id" : "1706812858163369000.2837c7cc-c40f-407f-8856-4bab45aef4e0",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310266759060000.7bb6dff3-e804-4e1a-b94f-3eae1211f667",
+      "fullUrl" : "ServiceRequest/1706812858320855000.05f97997-c38b-4a1a-9835-826f46df6bb0",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310266759060000.7bb6dff3-e804-4e1a-b94f-3eae1211f667",
+        "id" : "1706812858320855000.05f97997-c38b-4a1a-9835-826f46df6bb0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310266613559000.b8d309ca-5691-48f3-a50b-4a43b8b818d6"
+          "reference" : "Patient/1706812858160269000.649c6030-0409-4498-94cd-0e27832114ae"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310266761704000.2a2169df-3702-4ace-9cf5-b92267b9d4df",
+      "fullUrl" : "DiagnosticReport/1706812858324392000.5fa6cd6a-87a7-4f2c-9402-0d4797d4d1fa",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310266761704000.2a2169df-3702-4ace-9cf5-b92267b9d4df",
+        "id" : "1706812858324392000.5fa6cd6a-87a7-4f2c-9402-0d4797d4d1fa",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310266759060000.7bb6dff3-e804-4e1a-b94f-3eae1211f667"
+            "reference" : "ServiceRequest/1706812858320855000.05f97997-c38b-4a1a-9835-826f46df6bb0"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310266613559000.b8d309ca-5691-48f3-a50b-4a43b8b818d6"
+          "reference" : "Patient/1706812858160269000.649c6030-0409-4498-94cd-0e27832114ae"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310266615846000.bc0deb2f-f5a0-4d35-8c3d-3406a9e6a612"
+            "reference" : "Specimen/1706812858163369000.2837c7cc-c40f-407f-8856-4bab45aef4e0"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-8-test-value-cwe5.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-8-test-value-cwe5.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310275397254000.e44f0909-40ad-4eec-841d-49bfd2b69987",
+  "id" : "1706812867475204000.a71bb419-4ed9-417d-9356-dac1bc8bdc73",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:04:35.411-06:00"
+    "lastUpdated" : "2024-02-01T13:41:07.481-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310275487934000.0deaadfd-274e-4904-8110-99d452c6c788"
+          "reference" : "Organization/1706812867527599000.55a2dea8-f69c-4c14-8298-76dce27ec31f"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310275487934000.0deaadfd-274e-4904-8110-99d452c6c788",
+      "fullUrl" : "Organization/1706812867527599000.55a2dea8-f69c-4c14-8298-76dce27ec31f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310275487934000.0deaadfd-274e-4904-8110-99d452c6c788",
+        "id" : "1706812867527599000.55a2dea8-f69c-4c14-8298-76dce27ec31f",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310275796125000.72c850f9-54c1-4a12-9a58-093aedb335da",
+      "fullUrl" : "Provenance/1706812867874697000.3895b6f5-3af5-483a-8b54-a7c69733ed19",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310275796125000.72c850f9-54c1-4a12-9a58-093aedb335da",
+        "id" : "1706812867874697000.3895b6f5-3af5-483a-8b54-a7c69733ed19",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310275974640000.9b063220-2335-4552-8061-e88c306804a8"
+            "reference" : "DiagnosticReport/1706812868059040000.8f58a83b-1ca3-4ae6-aa91-aad4c2942c55"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310275803416000.e541b8a6-da7d-4d4f-b855-11f59b706be1",
+      "fullUrl" : "Provenance/1706812867882797000.801e8eb0-49a5-4e2e-8f3a-9f810b7fa62c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310275803416000.e541b8a6-da7d-4d4f-b855-11f59b706be1",
-        "recorded" : "2024-01-26T17:04:35Z",
+        "id" : "1706812867882797000.801e8eb0-49a5-4e2e-8f3a-9f810b7fa62c",
+        "recorded" : "2024-02-01T13:41:07Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310275802633000.044a0d87-30d4-466f-a4dc-db2461d62adf"
+              "reference" : "Organization/1706812867882344000.2003a282-1f0b-40ae-b447-871794405266"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310275802633000.044a0d87-30d4-466f-a4dc-db2461d62adf",
+      "fullUrl" : "Organization/1706812867882344000.2003a282-1f0b-40ae-b447-871794405266",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310275802633000.044a0d87-30d4-466f-a4dc-db2461d62adf",
+        "id" : "1706812867882344000.2003a282-1f0b-40ae-b447-871794405266",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310275816225000.6df06714-2b99-4def-8943-a0ed2d1d14b1",
+      "fullUrl" : "Patient/1706812867896452000.18b048b0-a0af-4022-aed7-a321db507387",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310275816225000.6df06714-2b99-4def-8943-a0ed2d1d14b1"
+        "id" : "1706812867896452000.18b048b0-a0af-4022-aed7-a321db507387"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310275816904000.188e834d-382c-4ebc-ba3f-50f37a650c1b",
+      "fullUrl" : "Provenance/1706812867897262000.3d76e11d-9a12-4b4c-b0e6-d939eea7b084",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310275816904000.188e834d-382c-4ebc-ba3f-50f37a650c1b",
+        "id" : "1706812867897262000.3d76e11d-9a12-4b4c-b0e6-d939eea7b084",
         "target" : [
           {
-            "reference" : "Patient/1706310275816225000.6df06714-2b99-4def-8943-a0ed2d1d14b1"
+            "reference" : "Patient/1706812867896452000.18b048b0-a0af-4022-aed7-a321db507387"
           }
         ],
-        "recorded" : "2024-01-26T17:04:35Z",
+        "recorded" : "2024-02-01T13:41:07Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310275818900000.85b5e60b-2caf-4681-92b0-8aa21a3970ff",
+      "fullUrl" : "Specimen/1706812867899221000.f217259d-3128-462f-9b41-8cc5f810feac",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310275818900000.85b5e60b-2caf-4681-92b0-8aa21a3970ff",
+        "id" : "1706812867899221000.f217259d-3128-462f-9b41-8cc5f810feac",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310275971807000.a37b6a6a-fe83-4635-9681-f856485dd2ed",
+      "fullUrl" : "ServiceRequest/1706812868056495000.4b32c4ef-0707-4513-85b3-b951cfd5c9a0",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310275971807000.a37b6a6a-fe83-4635-9681-f856485dd2ed",
+        "id" : "1706812868056495000.4b32c4ef-0707-4513-85b3-b951cfd5c9a0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310275816225000.6df06714-2b99-4def-8943-a0ed2d1d14b1"
+          "reference" : "Patient/1706812867896452000.18b048b0-a0af-4022-aed7-a321db507387"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310275974640000.9b063220-2335-4552-8061-e88c306804a8",
+      "fullUrl" : "DiagnosticReport/1706812868059040000.8f58a83b-1ca3-4ae6-aa91-aad4c2942c55",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310275974640000.9b063220-2335-4552-8061-e88c306804a8",
+        "id" : "1706812868059040000.8f58a83b-1ca3-4ae6-aa91-aad4c2942c55",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310275971807000.a37b6a6a-fe83-4635-9681-f856485dd2ed"
+            "reference" : "ServiceRequest/1706812868056495000.4b32c4ef-0707-4513-85b3-b951cfd5c9a0"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310275816225000.6df06714-2b99-4def-8943-a0ed2d1d14b1"
+          "reference" : "Patient/1706812867896452000.18b048b0-a0af-4022-aed7-a321db507387"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310275818900000.85b5e60b-2caf-4681-92b0-8aa21a3970ff"
+            "reference" : "Specimen/1706812867899221000.f217259d-3128-462f-9b41-8cc5f810feac"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-9-test-value-cwe6.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/annotation/cwe-9-test-value-cwe6.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310284380843000.18afe094-db7d-43a8-9cb0-0eb6e8a6fca5",
+  "id" : "1706812877143815000.5ecf8387-0bd3-4b0f-83fb-0324e84d8ac0",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:04:44.394-06:00"
+    "lastUpdated" : "2024-02-01T13:41:17.150-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310284469938000.ad153a1b-84bb-4a50-ad3c-6b112a72b897"
+          "reference" : "Organization/1706812877193204000.69d346c9-95df-4ae6-9252-fb4cf11de4fe"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310284469938000.ad153a1b-84bb-4a50-ad3c-6b112a72b897",
+      "fullUrl" : "Organization/1706812877193204000.69d346c9-95df-4ae6-9252-fb4cf11de4fe",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310284469938000.ad153a1b-84bb-4a50-ad3c-6b112a72b897",
+        "id" : "1706812877193204000.69d346c9-95df-4ae6-9252-fb4cf11de4fe",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310284791730000.2ee2d5b2-8c25-4108-b785-e4ebea8f1696",
+      "fullUrl" : "Provenance/1706812877524377000.ac651711-8d4c-4134-9b7f-266d821218ce",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310284791730000.2ee2d5b2-8c25-4108-b785-e4ebea8f1696",
+        "id" : "1706812877524377000.ac651711-8d4c-4134-9b7f-266d821218ce",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310284976944000.b4f6fae7-d2d6-4432-b300-d4a52b8938ef"
+            "reference" : "DiagnosticReport/1706812877716718000.9db9a52e-2f61-4679-9ba5-13f94519db7f"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310284799423000.212ae25b-eda1-4cb0-9840-204b26a2e7e5",
+      "fullUrl" : "Provenance/1706812877531526000.41ad75ba-ec3e-4101-9308-c5fd0d575c40",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310284799423000.212ae25b-eda1-4cb0-9840-204b26a2e7e5",
-        "recorded" : "2024-01-26T17:04:44Z",
+        "id" : "1706812877531526000.41ad75ba-ec3e-4101-9308-c5fd0d575c40",
+        "recorded" : "2024-02-01T13:41:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310284799051000.ad0c16f5-24f1-4ec7-be61-840477240c32"
+              "reference" : "Organization/1706812877531042000.737beccb-7758-41dd-9029-bf4ace938df4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310284799051000.ad0c16f5-24f1-4ec7-be61-840477240c32",
+      "fullUrl" : "Organization/1706812877531042000.737beccb-7758-41dd-9029-bf4ace938df4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310284799051000.ad0c16f5-24f1-4ec7-be61-840477240c32",
+        "id" : "1706812877531042000.737beccb-7758-41dd-9029-bf4ace938df4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310284813105000.992bc597-0bc4-4315-acbe-df130bc5d884",
+      "fullUrl" : "Patient/1706812877545118000.05cd01d7-65d4-4691-b333-afe28ae48a7b",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310284813105000.992bc597-0bc4-4315-acbe-df130bc5d884"
+        "id" : "1706812877545118000.05cd01d7-65d4-4691-b333-afe28ae48a7b"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310284813698000.941f4d61-2384-4d81-b024-0d40b05d5f21",
+      "fullUrl" : "Provenance/1706812877546000000.c3170d0d-bd5b-4cba-ba58-f520506e195a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310284813698000.941f4d61-2384-4d81-b024-0d40b05d5f21",
+        "id" : "1706812877546000000.c3170d0d-bd5b-4cba-ba58-f520506e195a",
         "target" : [
           {
-            "reference" : "Patient/1706310284813105000.992bc597-0bc4-4315-acbe-df130bc5d884"
+            "reference" : "Patient/1706812877545118000.05cd01d7-65d4-4691-b333-afe28ae48a7b"
           }
         ],
-        "recorded" : "2024-01-26T17:04:44Z",
+        "recorded" : "2024-02-01T13:41:17Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310284816060000.eeda6529-780e-4438-8b18-01becedd3896",
+      "fullUrl" : "Specimen/1706812877547870000.25df7f7d-df6e-448f-b05f-4f4a80bea41d",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310284816060000.eeda6529-780e-4438-8b18-01becedd3896",
+        "id" : "1706812877547870000.25df7f7d-df6e-448f-b05f-4f4a80bea41d",
         "note" : [
           {
             "extension" : [
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310284973350000.5f1eeb87-4477-43a8-8154-1a26532e5b18",
+      "fullUrl" : "ServiceRequest/1706812877713693000.da21d24a-aec2-4f64-ae3b-b7b0662f786c",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310284973350000.5f1eeb87-4477-43a8-8154-1a26532e5b18",
+        "id" : "1706812877713693000.da21d24a-aec2-4f64-ae3b-b7b0662f786c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -230,18 +235,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310284813105000.992bc597-0bc4-4315-acbe-df130bc5d884"
+          "reference" : "Patient/1706812877545118000.05cd01d7-65d4-4691-b333-afe28ae48a7b"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310284976944000.b4f6fae7-d2d6-4432-b300-d4a52b8938ef",
+      "fullUrl" : "DiagnosticReport/1706812877716718000.9db9a52e-2f61-4679-9ba5-13f94519db7f",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310284976944000.b4f6fae7-d2d6-4432-b300-d4a52b8938ef",
+        "id" : "1706812877716718000.9db9a52e-2f61-4679-9ba5-13f94519db7f",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310284973350000.5f1eeb87-4477-43a8-8154-1a26532e5b18"
+            "reference" : "ServiceRequest/1706812877713693000.da21d24a-aec2-4f64-ae3b-b7b0662f786c"
           }
         ],
         "status" : "final",
@@ -259,11 +264,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310284813105000.992bc597-0bc4-4315-acbe-df130bc5d884"
+          "reference" : "Patient/1706812877545118000.05cd01d7-65d4-4691-b333-afe28ae48a7b"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310284816060000.eeda6529-780e-4438-8b18-01becedd3896"
+            "reference" : "Specimen/1706812877547870000.25df7f7d-df6e-448f-b05f-4f4a80bea41d"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-10-test-value-cwe8.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-10-test-value-cwe8.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310295009296000.28b9e651-dd49-480b-bf15-e89124e91533",
+  "id" : "1706812889954155000.8f5e969b-7c5c-41bb-9e6f-fbc834298e89",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:04:55.023-06:00"
+    "lastUpdated" : "2024-02-01T13:41:29.961-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310295122751000.1d576b78-670c-4d68-90b1-ae6737b37623"
+          "reference" : "Organization/1706812890016946000.ba26b009-8f80-4b31-9196-10c3e5a0ff52"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310295122751000.1d576b78-670c-4d68-90b1-ae6737b37623",
+      "fullUrl" : "Organization/1706812890016946000.ba26b009-8f80-4b31-9196-10c3e5a0ff52",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310295122751000.1d576b78-670c-4d68-90b1-ae6737b37623",
+        "id" : "1706812890016946000.ba26b009-8f80-4b31-9196-10c3e5a0ff52",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310295470126000.d3888a15-81b1-4fbc-9604-295a43fec919",
+      "fullUrl" : "Provenance/1706812890400918000.efece4a2-198e-4485-9dfc-93f59e4a2200",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310295470126000.d3888a15-81b1-4fbc-9604-295a43fec919",
+        "id" : "1706812890400918000.efece4a2-198e-4485-9dfc-93f59e4a2200",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310295478528000.9e9030fd-4a8b-45b4-b5a1-c1c1256492f8",
+      "fullUrl" : "Provenance/1706812890409886000.243bcd08-9410-4263-8116-cbdf727f0af6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310295478528000.9e9030fd-4a8b-45b4-b5a1-c1c1256492f8",
-        "recorded" : "2024-01-26T17:04:55Z",
+        "id" : "1706812890409886000.243bcd08-9410-4263-8116-cbdf727f0af6",
+        "recorded" : "2024-02-01T13:41:30Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310295478064000.f759fcd7-e0ca-4af1-b160-9c2a2c0a0a3e"
+              "reference" : "Organization/1706812890409324000.73c2cfbc-a0c3-4408-9c90-8aa96b3574ae"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310295478064000.f759fcd7-e0ca-4af1-b160-9c2a2c0a0a3e",
+      "fullUrl" : "Organization/1706812890409324000.73c2cfbc-a0c3-4408-9c90-8aa96b3574ae",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310295478064000.f759fcd7-e0ca-4af1-b160-9c2a2c0a0a3e",
+        "id" : "1706812890409324000.73c2cfbc-a0c3-4408-9c90-8aa96b3574ae",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310295502026000.80812d11-59a3-49d9-a92d-ba9f95cbe6c3",
+      "fullUrl" : "Patient/1706812890426426000.e9d1c9a5-b080-4b9c-8c67-37ea177f63ca",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310295502026000.80812d11-59a3-49d9-a92d-ba9f95cbe6c3",
+        "id" : "1706812890426426000.e9d1c9a5-b080-4b9c-8c67-37ea177f63ca",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310295503742000.7359530d-d373-4745-965c-2485790e60fa",
+      "fullUrl" : "Provenance/1706812890427224000.68224c1d-99c4-4416-b5c1-0743fef7b7ff",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310295503742000.7359530d-d373-4745-965c-2485790e60fa",
+        "id" : "1706812890427224000.68224c1d-99c4-4416-b5c1-0743fef7b7ff",
         "target" : [
           {
-            "reference" : "Patient/1706310295502026000.80812d11-59a3-49d9-a92d-ba9f95cbe6c3"
+            "reference" : "Patient/1706812890426426000.e9d1c9a5-b080-4b9c-8c67-37ea177f63ca"
           }
         ],
-        "recorded" : "2024-01-26T17:04:55Z",
+        "recorded" : "2024-02-01T13:41:30Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-11-test-value-cwe9.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-11-test-value-cwe9.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310303696962000.59d97a79-4d57-4c77-8397-678d277a3361",
+  "id" : "1706812899766637000.398b757e-729e-4300-9654-d7d0670f343e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:03.715-06:00"
+    "lastUpdated" : "2024-02-01T13:41:39.773-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310303795047000.ec5bd47a-7000-4066-b6f5-a95395466f56"
+          "reference" : "Organization/1706812899817907000.b6336b03-380b-49ec-84e0-36a71af155ee"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310303795047000.ec5bd47a-7000-4066-b6f5-a95395466f56",
+      "fullUrl" : "Organization/1706812899817907000.b6336b03-380b-49ec-84e0-36a71af155ee",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310303795047000.ec5bd47a-7000-4066-b6f5-a95395466f56",
+        "id" : "1706812899817907000.b6336b03-380b-49ec-84e0-36a71af155ee",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310304107804000.9bbd5e27-ba9e-408e-bfac-e253a032ec38",
+      "fullUrl" : "Provenance/1706812900234659000.adcc6978-e1ac-45ab-9892-dd0364479947",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310304107804000.9bbd5e27-ba9e-408e-bfac-e253a032ec38",
+        "id" : "1706812900234659000.adcc6978-e1ac-45ab-9892-dd0364479947",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310304115668000.78bb9a2f-5b5d-47a8-b4b6-df39cda1bf3d",
+      "fullUrl" : "Provenance/1706812900242205000.33ef2d90-32bf-4414-bbc6-28bcb4a3665a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310304115668000.78bb9a2f-5b5d-47a8-b4b6-df39cda1bf3d",
-        "recorded" : "2024-01-26T17:05:04Z",
+        "id" : "1706812900242205000.33ef2d90-32bf-4414-bbc6-28bcb4a3665a",
+        "recorded" : "2024-02-01T13:41:40Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310304115223000.633faff5-5b3e-4f79-b46b-f9dee5c651e3"
+              "reference" : "Organization/1706812900241732000.0565f26b-3127-494f-9405-e01238b49f2b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310304115223000.633faff5-5b3e-4f79-b46b-f9dee5c651e3",
+      "fullUrl" : "Organization/1706812900241732000.0565f26b-3127-494f-9405-e01238b49f2b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310304115223000.633faff5-5b3e-4f79-b46b-f9dee5c651e3",
+        "id" : "1706812900241732000.0565f26b-3127-494f-9405-e01238b49f2b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310304132276000.97bda1e3-3d63-44bf-b8a6-7c080c18902a",
+      "fullUrl" : "Patient/1706812900258711000.c3d628f5-93ff-403a-82bc-7d28388d99c5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310304132276000.97bda1e3-3d63-44bf-b8a6-7c080c18902a",
+        "id" : "1706812900258711000.c3d628f5-93ff-403a-82bc-7d28388d99c5",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -165,16 +170,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310304133191000.bd2d7c2b-fae3-4eb7-add2-2414e75f8cb5",
+      "fullUrl" : "Provenance/1706812900259596000.e5324cba-d8db-4990-b018-901c88a3c6ec",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310304133191000.bd2d7c2b-fae3-4eb7-add2-2414e75f8cb5",
+        "id" : "1706812900259596000.e5324cba-d8db-4990-b018-901c88a3c6ec",
         "target" : [
           {
-            "reference" : "Patient/1706310304132276000.97bda1e3-3d63-44bf-b8a6-7c080c18902a"
+            "reference" : "Patient/1706812900258711000.c3d628f5-93ff-403a-82bc-7d28388d99c5"
           }
         ],
-        "recorded" : "2024-01-26T17:05:04Z",
+        "recorded" : "2024-02-01T13:41:40Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-12-test-value-cwe10.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-12-test-value-cwe10.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310312771763000.b970e727-fb38-406c-88b7-212b8d824911",
+  "id" : "1706812910567943000.676ccccc-f86e-4936-a8ce-8e71ef11a304",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:12.795-06:00"
+    "lastUpdated" : "2024-02-01T13:41:50.603-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310312925201000.3444091f-7f52-4527-9f35-0be51dd41293"
+          "reference" : "Organization/1706812910653741000.e1ce8045-ecb0-4f2a-96d1-4b3e81897e83"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310312925201000.3444091f-7f52-4527-9f35-0be51dd41293",
+      "fullUrl" : "Organization/1706812910653741000.e1ce8045-ecb0-4f2a-96d1-4b3e81897e83",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310312925201000.3444091f-7f52-4527-9f35-0be51dd41293",
+        "id" : "1706812910653741000.e1ce8045-ecb0-4f2a-96d1-4b3e81897e83",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310313337174000.1a944008-f97f-4e14-9f25-8edeacd02886",
+      "fullUrl" : "Provenance/1706812911169043000.b55371a0-c97f-43b6-bbc3-66d0acd905e5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310313337174000.1a944008-f97f-4e14-9f25-8edeacd02886",
+        "id" : "1706812911169043000.b55371a0-c97f-43b6-bbc3-66d0acd905e5",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310313352921000.74025c4c-9586-4d8e-8499-b96ea810a83a",
+      "fullUrl" : "Provenance/1706812911177673000.8634540f-43c9-493c-8305-7215f19455d3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310313352921000.74025c4c-9586-4d8e-8499-b96ea810a83a",
-        "recorded" : "2024-01-26T17:05:13Z",
+        "id" : "1706812911177673000.8634540f-43c9-493c-8305-7215f19455d3",
+        "recorded" : "2024-02-01T13:41:51Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310313351785000.c99eece5-dc29-4197-b304-c2fad0002059"
+              "reference" : "Organization/1706812911176901000.83f00433-c1d2-47a6-9161-daab81606745"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310313351785000.c99eece5-dc29-4197-b304-c2fad0002059",
+      "fullUrl" : "Organization/1706812911176901000.83f00433-c1d2-47a6-9161-daab81606745",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310313351785000.c99eece5-dc29-4197-b304-c2fad0002059",
+        "id" : "1706812911176901000.83f00433-c1d2-47a6-9161-daab81606745",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310313374645000.b2c322a0-2bde-4fee-8fda-cfbec67d4713",
+      "fullUrl" : "Patient/1706812911197792000.44b8465d-b32b-436d-9250-1813d442dd66",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310313374645000.b2c322a0-2bde-4fee-8fda-cfbec67d4713",
+        "id" : "1706812911197792000.44b8465d-b32b-436d-9250-1813d442dd66",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310313376794000.5fa92b3c-5928-4b7c-88cf-2c9fd9613314",
+      "fullUrl" : "Provenance/1706812911199143000.f158f98f-a1c0-44e9-9df4-199f55252e1b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310313376794000.5fa92b3c-5928-4b7c-88cf-2c9fd9613314",
+        "id" : "1706812911199143000.f158f98f-a1c0-44e9-9df4-199f55252e1b",
         "target" : [
           {
-            "reference" : "Patient/1706310313374645000.b2c322a0-2bde-4fee-8fda-cfbec67d4713"
+            "reference" : "Patient/1706812911197792000.44b8465d-b32b-436d-9250-1813d442dd66"
           }
         ],
-        "recorded" : "2024-01-26T17:05:13Z",
+        "recorded" : "2024-02-01T13:41:51Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-13-test-value-cwe11.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-13-test-value-cwe11.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310322671482000.f5d46ac3-9bc4-42e6-9e25-3f295b4e541f",
+  "id" : "1706812920496097000.2fac2c9b-df13-494a-ba32-b3a2834cdd0b",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:22.685-06:00"
+    "lastUpdated" : "2024-02-01T13:42:00.503-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310322760396000.0feb9300-b89e-49c9-bf26-aac77ac52f60"
+          "reference" : "Organization/1706812920548690000.c0cbac94-c83e-41ee-82b4-e2a0640b2841"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310322760396000.0feb9300-b89e-49c9-bf26-aac77ac52f60",
+      "fullUrl" : "Organization/1706812920548690000.c0cbac94-c83e-41ee-82b4-e2a0640b2841",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310322760396000.0feb9300-b89e-49c9-bf26-aac77ac52f60",
+        "id" : "1706812920548690000.c0cbac94-c83e-41ee-82b4-e2a0640b2841",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310323087072000.796b2bfc-780b-4b32-8e64-78467b7ca5f8",
+      "fullUrl" : "Provenance/1706812920880168000.8ab2ca24-9761-4d1e-905d-95492c4a6231",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310323087072000.796b2bfc-780b-4b32-8e64-78467b7ca5f8",
+        "id" : "1706812920880168000.8ab2ca24-9761-4d1e-905d-95492c4a6231",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310323094788000.c0347c66-aef3-4ec5-b40b-2dc6b98801bc",
+      "fullUrl" : "Provenance/1706812920887040000.9c2f4dd0-48eb-4fdb-9652-ca4a460b3840",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310323094788000.c0347c66-aef3-4ec5-b40b-2dc6b98801bc",
-        "recorded" : "2024-01-26T17:05:23Z",
+        "id" : "1706812920887040000.9c2f4dd0-48eb-4fdb-9652-ca4a460b3840",
+        "recorded" : "2024-02-01T13:42:00Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310323094365000.a7b133be-a3e5-4559-8e3c-3ec481dfb243"
+              "reference" : "Organization/1706812920886584000.df9c735f-a827-46cb-b602-664563e1c09b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310323094365000.a7b133be-a3e5-4559-8e3c-3ec481dfb243",
+      "fullUrl" : "Organization/1706812920886584000.df9c735f-a827-46cb-b602-664563e1c09b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310323094365000.a7b133be-a3e5-4559-8e3c-3ec481dfb243",
+        "id" : "1706812920886584000.df9c735f-a827-46cb-b602-664563e1c09b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310323110328000.63472a71-b4c9-43b6-8067-5eb5db5fd680",
+      "fullUrl" : "Patient/1706812920901675000.77409f1c-af87-49db-aa68-9e3d3bad3fe5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310323110328000.63472a71-b4c9-43b6-8067-5eb5db5fd680",
+        "id" : "1706812920901675000.77409f1c-af87-49db-aa68-9e3d3bad3fe5",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310323111145000.2aa4f6bc-aa49-4afc-a43a-d270eab6796c",
+      "fullUrl" : "Provenance/1706812920902386000.6ae992fa-ef55-4114-841f-a0f8f34d0e48",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310323111145000.2aa4f6bc-aa49-4afc-a43a-d270eab6796c",
+        "id" : "1706812920902386000.6ae992fa-ef55-4114-841f-a0f8f34d0e48",
         "target" : [
           {
-            "reference" : "Patient/1706310323110328000.63472a71-b4c9-43b6-8067-5eb5db5fd680"
+            "reference" : "Patient/1706812920901675000.77409f1c-af87-49db-aa68-9e3d3bad3fe5"
           }
         ],
-        "recorded" : "2024-01-26T17:05:23Z",
+        "recorded" : "2024-02-01T13:42:00Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-14-test-value-cwe12.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-14-test-value-cwe12.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310331264034000.5322b53e-29e1-4321-9e77-bd9359134388",
+  "id" : "1706812929714535000.e3bba3c8-b098-45b1-9ab4-68d921521822",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:31.278-06:00"
+    "lastUpdated" : "2024-02-01T13:42:09.720-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310331364058000.38f68ee3-ae58-423b-b20e-1dd847a72011"
+          "reference" : "Organization/1706812929760718000.0bc8ef78-3383-4aed-ba94-bba72e012994"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310331364058000.38f68ee3-ae58-423b-b20e-1dd847a72011",
+      "fullUrl" : "Organization/1706812929760718000.0bc8ef78-3383-4aed-ba94-bba72e012994",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310331364058000.38f68ee3-ae58-423b-b20e-1dd847a72011",
+        "id" : "1706812929760718000.0bc8ef78-3383-4aed-ba94-bba72e012994",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310331688261000.5d5381e4-d5ef-4efa-8363-adccabbba61c",
+      "fullUrl" : "Provenance/1706812930096189000.71bbd75c-3b0f-447a-979b-6c0b1c81cc98",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310331688261000.5d5381e4-d5ef-4efa-8363-adccabbba61c",
+        "id" : "1706812930096189000.71bbd75c-3b0f-447a-979b-6c0b1c81cc98",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310331696389000.d3978e01-baf6-49d4-a0e1-342a50d50983",
+      "fullUrl" : "Provenance/1706812930104183000.d2f73bea-a773-4135-ad89-a4c9ce2cadb1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310331696389000.d3978e01-baf6-49d4-a0e1-342a50d50983",
-        "recorded" : "2024-01-26T17:05:31Z",
+        "id" : "1706812930104183000.d2f73bea-a773-4135-ad89-a4c9ce2cadb1",
+        "recorded" : "2024-02-01T13:42:10Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310331695564000.54bfd752-13f2-468a-a08a-9e291393d0e6"
+              "reference" : "Organization/1706812930103746000.4d1fe7ac-4c07-4387-b729-7e2b9e002006"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310331695564000.54bfd752-13f2-468a-a08a-9e291393d0e6",
+      "fullUrl" : "Organization/1706812930103746000.4d1fe7ac-4c07-4387-b729-7e2b9e002006",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310331695564000.54bfd752-13f2-468a-a08a-9e291393d0e6",
+        "id" : "1706812930103746000.4d1fe7ac-4c07-4387-b729-7e2b9e002006",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310331711313000.aba8ad7e-3104-4647-9074-e11c2e41a5a9",
+      "fullUrl" : "Patient/1706812930119897000.f28a90d9-f801-45ff-b54e-3648d2ca8a0a",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310331711313000.aba8ad7e-3104-4647-9074-e11c2e41a5a9",
+        "id" : "1706812930119897000.f28a90d9-f801-45ff-b54e-3648d2ca8a0a",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -179,16 +184,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310331712117000.f3e92b07-0ca3-48f3-a520-15c2884f801d",
+      "fullUrl" : "Provenance/1706812930120821000.83bca142-6741-49e9-a6dc-528d49f5b2a1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310331712117000.f3e92b07-0ca3-48f3-a520-15c2884f801d",
+        "id" : "1706812930120821000.83bca142-6741-49e9-a6dc-528d49f5b2a1",
         "target" : [
           {
-            "reference" : "Patient/1706310331711313000.aba8ad7e-3104-4647-9074-e11c2e41a5a9"
+            "reference" : "Patient/1706812930119897000.f28a90d9-f801-45ff-b54e-3648d2ca8a0a"
           }
         ],
-        "recorded" : "2024-01-26T17:05:31Z",
+        "recorded" : "2024-02-01T13:42:10Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-15-test-value-cwe13.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-15-test-value-cwe13.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310339766521000.aa4bb59e-7062-4bfc-87ea-d3c1c9ffc1ea",
+  "id" : "1706812939967881000.57d96a54-76f5-4604-9b08-2350e112ebbc",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:39.780-06:00"
+    "lastUpdated" : "2024-02-01T13:42:19.974-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310339851561000.f24bab59-2cb2-4cde-900a-70de5d09fa0d"
+          "reference" : "Organization/1706812940017064000.db4684f2-196c-4286-9d1b-e874f51aa743"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310339851561000.f24bab59-2cb2-4cde-900a-70de5d09fa0d",
+      "fullUrl" : "Organization/1706812940017064000.db4684f2-196c-4286-9d1b-e874f51aa743",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310339851561000.f24bab59-2cb2-4cde-900a-70de5d09fa0d",
+        "id" : "1706812940017064000.db4684f2-196c-4286-9d1b-e874f51aa743",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310340174790000.8d1f6709-720c-4b33-8d6d-c51e55d2dfa7",
+      "fullUrl" : "Provenance/1706812940345519000.84777516-668b-4ca5-8f65-e6875150abdb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310340174790000.8d1f6709-720c-4b33-8d6d-c51e55d2dfa7",
+        "id" : "1706812940345519000.84777516-668b-4ca5-8f65-e6875150abdb",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310340183646000.da52cbb0-00e4-442c-9d2e-66ff7c01f9fb",
+      "fullUrl" : "Provenance/1706812940353210000.37da0009-a1a8-4e1a-a59d-71be4efa07c8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310340183646000.da52cbb0-00e4-442c-9d2e-66ff7c01f9fb",
-        "recorded" : "2024-01-26T17:05:40Z",
+        "id" : "1706812940353210000.37da0009-a1a8-4e1a-a59d-71be4efa07c8",
+        "recorded" : "2024-02-01T13:42:20Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310340182929000.70e6dedb-927d-403f-8d41-f7a4e17146e8"
+              "reference" : "Organization/1706812940352805000.d9561736-cb93-4a6b-b862-ef1c445b9911"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310340182929000.70e6dedb-927d-403f-8d41-f7a4e17146e8",
+      "fullUrl" : "Organization/1706812940352805000.d9561736-cb93-4a6b-b862-ef1c445b9911",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310340182929000.70e6dedb-927d-403f-8d41-f7a4e17146e8",
+        "id" : "1706812940352805000.d9561736-cb93-4a6b-b862-ef1c445b9911",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310340199444000.e1e6d618-f030-4cbb-9bc4-a4a237a5b818",
+      "fullUrl" : "Patient/1706812940370345000.0d0dc8dc-625d-4f5c-ad0c-9cdafe07d2d9",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310340199444000.e1e6d618-f030-4cbb-9bc4-a4a237a5b818",
+        "id" : "1706812940370345000.0d0dc8dc-625d-4f5c-ad0c-9cdafe07d2d9",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310340200499000.62b39011-d0f4-4c50-9066-d9d5f1d03a92",
+      "fullUrl" : "Provenance/1706812940371186000.d52a5ff6-8189-413e-99a3-faed644b35c7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310340200499000.62b39011-d0f4-4c50-9066-d9d5f1d03a92",
+        "id" : "1706812940371186000.d52a5ff6-8189-413e-99a3-faed644b35c7",
         "target" : [
           {
-            "reference" : "Patient/1706310340199444000.e1e6d618-f030-4cbb-9bc4-a4a237a5b818"
+            "reference" : "Patient/1706812940370345000.0d0dc8dc-625d-4f5c-ad0c-9cdafe07d2d9"
           }
         ],
-        "recorded" : "2024-01-26T17:05:40Z",
+        "recorded" : "2024-02-01T13:42:20Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-16-test-value-cwe14.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-16-test-value-cwe14.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310348439152000.83d44b49-7bfc-4eb0-9186-e2a96a955a56",
+  "id" : "1706812949006902000.57a082c4-acac-4e7f-9484-9c2fe5f35a75",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:48.452-06:00"
+    "lastUpdated" : "2024-02-01T13:42:29.012-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310348532595000.7991af02-fed9-40e0-9108-e637f3c5d3d5"
+          "reference" : "Organization/1706812949058429000.9f9bc9df-8bcd-493b-a629-d5806fc7361a"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310348532595000.7991af02-fed9-40e0-9108-e637f3c5d3d5",
+      "fullUrl" : "Organization/1706812949058429000.9f9bc9df-8bcd-493b-a629-d5806fc7361a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310348532595000.7991af02-fed9-40e0-9108-e637f3c5d3d5",
+        "id" : "1706812949058429000.9f9bc9df-8bcd-493b-a629-d5806fc7361a",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310348864723000.5e28a5a4-c09f-4255-977d-73669411483d",
+      "fullUrl" : "Provenance/1706812949389246000.9350395e-8214-4c79-b57b-097e28f099cb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310348864723000.5e28a5a4-c09f-4255-977d-73669411483d",
+        "id" : "1706812949389246000.9350395e-8214-4c79-b57b-097e28f099cb",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310348873381000.464531b8-670a-4aff-a156-18dc7c114b77",
+      "fullUrl" : "Provenance/1706812949396137000.01e710d1-8d53-4170-9c4b-67e41c118a25",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310348873381000.464531b8-670a-4aff-a156-18dc7c114b77",
-        "recorded" : "2024-01-26T17:05:48Z",
+        "id" : "1706812949396137000.01e710d1-8d53-4170-9c4b-67e41c118a25",
+        "recorded" : "2024-02-01T13:42:29Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310348872974000.884baecd-de17-4313-a622-988b3b6061ce"
+              "reference" : "Organization/1706812949395611000.22cd5c39-0d31-471c-9faa-f9b223bafead"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310348872974000.884baecd-de17-4313-a622-988b3b6061ce",
+      "fullUrl" : "Organization/1706812949395611000.22cd5c39-0d31-471c-9faa-f9b223bafead",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310348872974000.884baecd-de17-4313-a622-988b3b6061ce",
+        "id" : "1706812949395611000.22cd5c39-0d31-471c-9faa-f9b223bafead",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310348888344000.b7190e0a-3555-4fb7-828f-4ec59a54ef79",
+      "fullUrl" : "Patient/1706812949411927000.5b1962bf-b76e-4199-b5fc-4525f13328da",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310348888344000.b7190e0a-3555-4fb7-828f-4ec59a54ef79",
+        "id" : "1706812949411927000.5b1962bf-b76e-4199-b5fc-4525f13328da",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -168,16 +173,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310348889035000.831b6c40-64cc-40e8-8d8c-25674a3c3051",
+      "fullUrl" : "Provenance/1706812949412653000.647e443f-5b96-4b82-80d8-8d7f13663575",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310348889035000.831b6c40-64cc-40e8-8d8c-25674a3c3051",
+        "id" : "1706812949412653000.647e443f-5b96-4b82-80d8-8d7f13663575",
         "target" : [
           {
-            "reference" : "Patient/1706310348888344000.b7190e0a-3555-4fb7-828f-4ec59a54ef79"
+            "reference" : "Patient/1706812949411927000.5b1962bf-b76e-4199-b5fc-4525f13328da"
           }
         ],
-        "recorded" : "2024-01-26T17:05:48Z",
+        "recorded" : "2024-02-01T13:42:29Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-3-test-value-cwe1.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-3-test-value-cwe1.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310357091193000.28cfc1e5-b8d7-4220-a6bd-8b00b6b96d9f",
+  "id" : "1706812958334873000.3d54da9c-1407-483a-a82d-98ed3daa2207",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:05:57.106-06:00"
+    "lastUpdated" : "2024-02-01T13:42:38.341-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310357187128000.8d7dee67-12c1-4f32-a3fe-206288515340"
+          "reference" : "Organization/1706812958381877000.4cfd15bb-89f5-4f34-8db1-c2e4045782c8"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310357187128000.8d7dee67-12c1-4f32-a3fe-206288515340",
+      "fullUrl" : "Organization/1706812958381877000.4cfd15bb-89f5-4f34-8db1-c2e4045782c8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310357187128000.8d7dee67-12c1-4f32-a3fe-206288515340",
+        "id" : "1706812958381877000.4cfd15bb-89f5-4f34-8db1-c2e4045782c8",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310357497690000.531f4878-7b80-4ed5-a7ca-429e1c54dcd3",
+      "fullUrl" : "Provenance/1706812958719031000.3056c321-5067-444e-a0a4-7e42ee8d1667",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310357497690000.531f4878-7b80-4ed5-a7ca-429e1c54dcd3",
+        "id" : "1706812958719031000.3056c321-5067-444e-a0a4-7e42ee8d1667",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310357504622000.8ecb81c4-0a4e-4a09-a0fc-9b6a290d0e81",
+      "fullUrl" : "Provenance/1706812958730259000.33af6773-5521-4672-9c4a-cc6e4789c59a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310357504622000.8ecb81c4-0a4e-4a09-a0fc-9b6a290d0e81",
-        "recorded" : "2024-01-26T17:05:57Z",
+        "id" : "1706812958730259000.33af6773-5521-4672-9c4a-cc6e4789c59a",
+        "recorded" : "2024-02-01T13:42:38Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310357504248000.c4aecf07-0d74-4aa5-a4cd-7167c14f1c72"
+              "reference" : "Organization/1706812958729844000.b3eea650-01ff-49b1-a7b7-7bb45e037d4c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310357504248000.c4aecf07-0d74-4aa5-a4cd-7167c14f1c72",
+      "fullUrl" : "Organization/1706812958729844000.b3eea650-01ff-49b1-a7b7-7bb45e037d4c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310357504248000.c4aecf07-0d74-4aa5-a4cd-7167c14f1c72",
+        "id" : "1706812958729844000.b3eea650-01ff-49b1-a7b7-7bb45e037d4c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310357519687000.1eb13802-9c3e-41aa-bf71-d0bf2ab49585",
+      "fullUrl" : "Patient/1706812958745413000.4665129f-48bb-4d23-bb9c-8f5808d721af",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310357519687000.1eb13802-9c3e-41aa-bf71-d0bf2ab49585",
+        "id" : "1706812958745413000.4665129f-48bb-4d23-bb9c-8f5808d721af",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310357520749000.b73dddc9-8aad-46fd-9aaf-90b68e2e8fca",
+      "fullUrl" : "Provenance/1706812958746166000.a58efebc-6e43-45f2-ae94-3f3c6b753b5f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310357520749000.b73dddc9-8aad-46fd-9aaf-90b68e2e8fca",
+        "id" : "1706812958746166000.a58efebc-6e43-45f2-ae94-3f3c6b753b5f",
         "target" : [
           {
-            "reference" : "Patient/1706310357519687000.1eb13802-9c3e-41aa-bf71-d0bf2ab49585"
+            "reference" : "Patient/1706812958745413000.4665129f-48bb-4d23-bb9c-8f5808d721af"
           }
         ],
-        "recorded" : "2024-01-26T17:05:57Z",
+        "recorded" : "2024-02-01T13:42:38Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-4-test-value-cwe2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-4-test-value-cwe2.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310365672229000.f31213ef-fa95-4287-80d2-99d6b4bf78f6",
+  "id" : "1706812967681160000.c421312f-1d4c-45ca-8927-bd170775f50e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:06:05.687-06:00"
+    "lastUpdated" : "2024-02-01T13:42:47.686-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310365764686000.094efc08-5223-413a-b527-d92b6cccc98a"
+          "reference" : "Organization/1706812967732980000.c531316a-d68b-4cf1-a295-9a79d03ece46"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310365764686000.094efc08-5223-413a-b527-d92b6cccc98a",
+      "fullUrl" : "Organization/1706812967732980000.c531316a-d68b-4cf1-a295-9a79d03ece46",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310365764686000.094efc08-5223-413a-b527-d92b6cccc98a",
+        "id" : "1706812967732980000.c531316a-d68b-4cf1-a295-9a79d03ece46",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310366083036000.ee61830c-2bbc-459e-b069-b505e170eeaa",
+      "fullUrl" : "Provenance/1706812968094262000.e9f8b50d-665b-4efc-861c-ddc76ba48a17",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310366083036000.ee61830c-2bbc-459e-b069-b505e170eeaa",
+        "id" : "1706812968094262000.e9f8b50d-665b-4efc-861c-ddc76ba48a17",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310366090762000.eee4066b-ead4-43e4-9322-fc3b72720b6d",
+      "fullUrl" : "Provenance/1706812968101159000.25eed898-67ae-42af-b612-9cf8a547aac8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310366090762000.eee4066b-ead4-43e4-9322-fc3b72720b6d",
-        "recorded" : "2024-01-26T17:06:06Z",
+        "id" : "1706812968101159000.25eed898-67ae-42af-b612-9cf8a547aac8",
+        "recorded" : "2024-02-01T13:42:48Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310366089586000.ea11749c-6405-4b90-8b80-b07d323807c8"
+              "reference" : "Organization/1706812968100748000.ffd25e1a-867d-4c8c-8ed1-a14f3d2b67df"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310366089586000.ea11749c-6405-4b90-8b80-b07d323807c8",
+      "fullUrl" : "Organization/1706812968100748000.ffd25e1a-867d-4c8c-8ed1-a14f3d2b67df",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310366089586000.ea11749c-6405-4b90-8b80-b07d323807c8",
+        "id" : "1706812968100748000.ffd25e1a-867d-4c8c-8ed1-a14f3d2b67df",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310366105420000.ec28a85f-435a-468d-86eb-6aabf5809f1f",
+      "fullUrl" : "Patient/1706812968117398000.5b1cce35-94e3-4202-8659-049e664fd48e",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310366105420000.ec28a85f-435a-468d-86eb-6aabf5809f1f",
+        "id" : "1706812968117398000.5b1cce35-94e3-4202-8659-049e664fd48e",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310366106224000.fda9ac42-e56c-43f8-a398-3b63ca141546",
+      "fullUrl" : "Provenance/1706812968118302000.aac16d2d-383e-4218-8807-3dded87b0be4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310366106224000.fda9ac42-e56c-43f8-a398-3b63ca141546",
+        "id" : "1706812968118302000.aac16d2d-383e-4218-8807-3dded87b0be4",
         "target" : [
           {
-            "reference" : "Patient/1706310366105420000.ec28a85f-435a-468d-86eb-6aabf5809f1f"
+            "reference" : "Patient/1706812968117398000.5b1cce35-94e3-4202-8659-049e664fd48e"
           }
         ],
-        "recorded" : "2024-01-26T17:06:06Z",
+        "recorded" : "2024-02-01T13:42:48Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-5-test-value-cwe3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-5-test-value-cwe3.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310374297830000.37af68b8-93ec-4ecf-aa4b-912546912070",
+  "id" : "1706812977442240000.395d5852-7f4a-40d4-9402-4bfcce715d3f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:06:14.315-06:00"
+    "lastUpdated" : "2024-02-01T13:42:57.449-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310374425073000.adaac345-2e62-40fd-868c-e31905c313e8"
+          "reference" : "Organization/1706812977491312000.852fbc24-9905-4d25-8c21-9289cc3bccdc"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310374425073000.adaac345-2e62-40fd-868c-e31905c313e8",
+      "fullUrl" : "Organization/1706812977491312000.852fbc24-9905-4d25-8c21-9289cc3bccdc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310374425073000.adaac345-2e62-40fd-868c-e31905c313e8",
+        "id" : "1706812977491312000.852fbc24-9905-4d25-8c21-9289cc3bccdc",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310374750886000.f5ce7ffa-5ad8-451a-9ea0-8f0a6d2d3416",
+      "fullUrl" : "Provenance/1706812977847789000.0d75ecb9-4a1e-4b3e-8731-610fb7433ddc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310374750886000.f5ce7ffa-5ad8-451a-9ea0-8f0a6d2d3416",
+        "id" : "1706812977847789000.0d75ecb9-4a1e-4b3e-8731-610fb7433ddc",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310374757905000.2c016494-f32a-4698-8024-e5e241cc375d",
+      "fullUrl" : "Provenance/1706812977855927000.0bd2660a-20d7-43b8-8d15-284b15208a11",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310374757905000.2c016494-f32a-4698-8024-e5e241cc375d",
-        "recorded" : "2024-01-26T17:06:14Z",
+        "id" : "1706812977855927000.0bd2660a-20d7-43b8-8d15-284b15208a11",
+        "recorded" : "2024-02-01T13:42:57Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310374757498000.748833c6-9ea6-476a-830c-0dd33cb4f1ca"
+              "reference" : "Organization/1706812977855280000.b1db3772-45b0-4313-a8aa-6f75676fc60e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310374757498000.748833c6-9ea6-476a-830c-0dd33cb4f1ca",
+      "fullUrl" : "Organization/1706812977855280000.b1db3772-45b0-4313-a8aa-6f75676fc60e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310374757498000.748833c6-9ea6-476a-830c-0dd33cb4f1ca",
+        "id" : "1706812977855280000.b1db3772-45b0-4313-a8aa-6f75676fc60e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310374771387000.0117078e-71da-4bfd-830c-d1c9ab075e22",
+      "fullUrl" : "Patient/1706812977875824000.0cca9110-638b-404e-baaa-edbd5a6de336",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310374771387000.0117078e-71da-4bfd-830c-d1c9ab075e22",
+        "id" : "1706812977875824000.0cca9110-638b-404e-baaa-edbd5a6de336",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -179,16 +184,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310374772462000.516744cb-82c5-456b-a611-8b5a11261aad",
+      "fullUrl" : "Provenance/1706812977876626000.6375a5e1-f7c7-4308-b5b8-55e176450f36",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310374772462000.516744cb-82c5-456b-a611-8b5a11261aad",
+        "id" : "1706812977876626000.6375a5e1-f7c7-4308-b5b8-55e176450f36",
         "target" : [
           {
-            "reference" : "Patient/1706310374771387000.0117078e-71da-4bfd-830c-d1c9ab075e22"
+            "reference" : "Patient/1706812977875824000.0cca9110-638b-404e-baaa-edbd5a6de336"
           }
         ],
-        "recorded" : "2024-01-26T17:06:14Z",
+        "recorded" : "2024-02-01T13:42:57Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-6-test-value-cwe4.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-6-test-value-cwe4.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310383291927000.dd68122f-d01d-4356-b2a4-f91b0f4c752d",
+  "id" : "1706812986718971000.9e095362-cc0b-437b-9f47-c68cf98aa1f0",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:06:23.307-06:00"
+    "lastUpdated" : "2024-02-01T13:43:06.726-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310383390922000.810be01d-f57e-4472-ae4d-8e480708f6c6"
+          "reference" : "Organization/1706812986771138000.d30829f2-f727-4a4a-af80-a018963e9dae"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310383390922000.810be01d-f57e-4472-ae4d-8e480708f6c6",
+      "fullUrl" : "Organization/1706812986771138000.d30829f2-f727-4a4a-af80-a018963e9dae",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310383390922000.810be01d-f57e-4472-ae4d-8e480708f6c6",
+        "id" : "1706812986771138000.d30829f2-f727-4a4a-af80-a018963e9dae",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310383693409000.0aeba0b8-6cf3-43a0-8659-8db791c99731",
+      "fullUrl" : "Provenance/1706812987108064000.cda5c21e-351a-428d-838c-b59050f47bcf",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310383693409000.0aeba0b8-6cf3-43a0-8659-8db791c99731",
+        "id" : "1706812987108064000.cda5c21e-351a-428d-838c-b59050f47bcf",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310383701401000.7093bbdf-5dd5-4451-a03e-7ff19ae0a81a",
+      "fullUrl" : "Provenance/1706812987115569000.0a5186ad-b6da-4a9e-9dd0-d8a45903951c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310383701401000.7093bbdf-5dd5-4451-a03e-7ff19ae0a81a",
-        "recorded" : "2024-01-26T17:06:23Z",
+        "id" : "1706812987115569000.0a5186ad-b6da-4a9e-9dd0-d8a45903951c",
+        "recorded" : "2024-02-01T13:43:07Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310383700973000.67afee18-31a6-4793-9e8d-41077f274005"
+              "reference" : "Organization/1706812987115041000.88a2bb57-0c11-46bb-91c0-f06b729dcadc"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310383700973000.67afee18-31a6-4793-9e8d-41077f274005",
+      "fullUrl" : "Organization/1706812987115041000.88a2bb57-0c11-46bb-91c0-f06b729dcadc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310383700973000.67afee18-31a6-4793-9e8d-41077f274005",
+        "id" : "1706812987115041000.88a2bb57-0c11-46bb-91c0-f06b729dcadc",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310383716260000.f48864b1-c1dc-4009-9cce-bf04c449d41b",
+      "fullUrl" : "Patient/1706812987130025000.79629655-bd9c-4d47-bbe5-875dfb6e57a1",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310383716260000.f48864b1-c1dc-4009-9cce-bf04c449d41b",
+        "id" : "1706812987130025000.79629655-bd9c-4d47-bbe5-875dfb6e57a1",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310383717024000.8bc7e0a0-217f-4990-9b74-4636d14fd751",
+      "fullUrl" : "Provenance/1706812987130724000.589c4428-2da3-4c12-b6dc-ee5be8f214c0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310383717024000.8bc7e0a0-217f-4990-9b74-4636d14fd751",
+        "id" : "1706812987130724000.589c4428-2da3-4c12-b6dc-ee5be8f214c0",
         "target" : [
           {
-            "reference" : "Patient/1706310383716260000.f48864b1-c1dc-4009-9cce-bf04c449d41b"
+            "reference" : "Patient/1706812987130025000.79629655-bd9c-4d47-bbe5-875dfb6e57a1"
           }
         ],
-        "recorded" : "2024-01-26T17:06:23Z",
+        "recorded" : "2024-02-01T13:43:07Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-7-test-value-cwe5.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-7-test-value-cwe5.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310392172387000.0e7ca2a3-b2fb-48ad-9a13-3228497edbae",
+  "id" : "1706812996224377000.19b6b7d2-6599-49d1-b0bc-2bc81e8c632c",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:06:32.187-06:00"
+    "lastUpdated" : "2024-02-01T13:43:16.231-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310392262340000.6de8ed3c-0113-4544-960f-f1580d33d3ef"
+          "reference" : "Organization/1706812996275309000.ee9b0d90-e747-49bf-9e0c-be854104e995"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310392262340000.6de8ed3c-0113-4544-960f-f1580d33d3ef",
+      "fullUrl" : "Organization/1706812996275309000.ee9b0d90-e747-49bf-9e0c-be854104e995",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310392262340000.6de8ed3c-0113-4544-960f-f1580d33d3ef",
+        "id" : "1706812996275309000.ee9b0d90-e747-49bf-9e0c-be854104e995",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310392564197000.3f3d4462-a00c-410a-ada1-e7fce5cfcfdf",
+      "fullUrl" : "Provenance/1706812996619727000.22da942c-b21e-48e5-94e9-407d52acf171",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310392564197000.3f3d4462-a00c-410a-ada1-e7fce5cfcfdf",
+        "id" : "1706812996619727000.22da942c-b21e-48e5-94e9-407d52acf171",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310392571296000.5fe49fde-3dcb-4251-92ee-13932ced1198",
+      "fullUrl" : "Provenance/1706812996626732000.196d95e5-20c6-46d2-aa87-530a9cfb8c92",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310392571296000.5fe49fde-3dcb-4251-92ee-13932ced1198",
-        "recorded" : "2024-01-26T17:06:32Z",
+        "id" : "1706812996626732000.196d95e5-20c6-46d2-aa87-530a9cfb8c92",
+        "recorded" : "2024-02-01T13:43:16Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310392570292000.3c5c00ad-18d0-4dd8-a678-b3f7541c3680"
+              "reference" : "Organization/1706812996626292000.72bd9a14-2d9e-4789-9af9-2dad74c786fe"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310392570292000.3c5c00ad-18d0-4dd8-a678-b3f7541c3680",
+      "fullUrl" : "Organization/1706812996626292000.72bd9a14-2d9e-4789-9af9-2dad74c786fe",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310392570292000.3c5c00ad-18d0-4dd8-a678-b3f7541c3680",
+        "id" : "1706812996626292000.72bd9a14-2d9e-4789-9af9-2dad74c786fe",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310392586681000.17705881-9976-46d6-ace0-f04565df0947",
+      "fullUrl" : "Patient/1706812996644158000.34951c00-dbb8-41f9-918e-b134290561d0",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310392586681000.17705881-9976-46d6-ace0-f04565df0947",
+        "id" : "1706812996644158000.34951c00-dbb8-41f9-918e-b134290561d0",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310392587426000.fc8b9c94-e316-495f-b9ca-d0ea207414a1",
+      "fullUrl" : "Provenance/1706812996645053000.debecc6c-4cd7-4abc-ac9b-a9bade4db64d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310392587426000.fc8b9c94-e316-495f-b9ca-d0ea207414a1",
+        "id" : "1706812996645053000.debecc6c-4cd7-4abc-ac9b-a9bade4db64d",
         "target" : [
           {
-            "reference" : "Patient/1706310392586681000.17705881-9976-46d6-ace0-f04565df0947"
+            "reference" : "Patient/1706812996644158000.34951c00-dbb8-41f9-918e-b134290561d0"
           }
         ],
-        "recorded" : "2024-01-26T17:06:32Z",
+        "recorded" : "2024-02-01T13:43:16Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-8-test-value-cwe6.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-8-test-value-cwe6.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310400634466000.7e92fbaf-37a4-4a70-9c87-ca37b88d33f2",
+  "id" : "1706813006319836000.71c4d378-d953-4ee1-b133-2c4d016e54c3",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:06:40.648-06:00"
+    "lastUpdated" : "2024-02-01T13:43:26.325-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310400725081000.02caf873-9a1a-4e73-9923-590180a6bb87"
+          "reference" : "Organization/1706813006369007000.760bf8c4-56b1-4fc4-806d-58ae192367c5"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310400725081000.02caf873-9a1a-4e73-9923-590180a6bb87",
+      "fullUrl" : "Organization/1706813006369007000.760bf8c4-56b1-4fc4-806d-58ae192367c5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310400725081000.02caf873-9a1a-4e73-9923-590180a6bb87",
+        "id" : "1706813006369007000.760bf8c4-56b1-4fc4-806d-58ae192367c5",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310401034105000.f370dfe9-8965-48de-9b29-db2991fec9d1",
+      "fullUrl" : "Provenance/1706813006703013000.1ef6d98a-69ec-42bb-8082-0d1cc1bf5cdc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310401034105000.f370dfe9-8965-48de-9b29-db2991fec9d1",
+        "id" : "1706813006703013000.1ef6d98a-69ec-42bb-8082-0d1cc1bf5cdc",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310401041821000.74c48750-a51f-4ab1-bf6e-a0b666ee3fd0",
+      "fullUrl" : "Provenance/1706813006710709000.05abead7-2851-40ba-a5ca-f6582a62dbb1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310401041821000.74c48750-a51f-4ab1-bf6e-a0b666ee3fd0",
-        "recorded" : "2024-01-26T17:06:41Z",
+        "id" : "1706813006710709000.05abead7-2851-40ba-a5ca-f6582a62dbb1",
+        "recorded" : "2024-02-01T13:43:26Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310401041300000.0eb5fcf2-86b6-408e-a89e-3befe885674f"
+              "reference" : "Organization/1706813006709607000.e4eb47b7-7df9-4c49-81e5-146f88e3ae5c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310401041300000.0eb5fcf2-86b6-408e-a89e-3befe885674f",
+      "fullUrl" : "Organization/1706813006709607000.e4eb47b7-7df9-4c49-81e5-146f88e3ae5c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310401041300000.0eb5fcf2-86b6-408e-a89e-3befe885674f",
+        "id" : "1706813006709607000.e4eb47b7-7df9-4c49-81e5-146f88e3ae5c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310401058578000.7da0d9d2-df34-404f-9b93-75042473a66c",
+      "fullUrl" : "Patient/1706813006727595000.ed9d0a12-6bd4-4d43-895b-65726d816186",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310401058578000.7da0d9d2-df34-404f-9b93-75042473a66c",
+        "id" : "1706813006727595000.ed9d0a12-6bd4-4d43-895b-65726d816186",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -179,16 +184,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310401059408000.954e678f-f49b-44d1-90ca-0843349aa1fa",
+      "fullUrl" : "Provenance/1706813006728624000.2cc07978-b6fe-4cb4-b168-dc99af67d77a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310401059408000.954e678f-f49b-44d1-90ca-0843349aa1fa",
+        "id" : "1706813006728624000.2cc07978-b6fe-4cb4-b168-dc99af67d77a",
         "target" : [
           {
-            "reference" : "Patient/1706310401058578000.7da0d9d2-df34-404f-9b93-75042473a66c"
+            "reference" : "Patient/1706813006727595000.ed9d0a12-6bd4-4d43-895b-65726d816186"
           }
         ],
-        "recorded" : "2024-01-26T17:06:41Z",
+        "recorded" : "2024-02-01T13:43:26Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-9-test-value-cwe7.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/codeable-concept/cwe-9-test-value-cwe7.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310409102678000.99e9f254-136c-400d-bcd5-e976152e4dbe",
+  "id" : "1706813016455154000.9b50ddb5-a308-4b1a-8dd5-e9def5ed19b0",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:06:49.116-06:00"
+    "lastUpdated" : "2024-02-01T13:43:36.463-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310409187505000.2b789c51-03cd-4276-a802-a5ec139bc33f"
+          "reference" : "Organization/1706813016516525000.c86af131-07f2-488e-9a08-0bf5e9201a82"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310409187505000.2b789c51-03cd-4276-a802-a5ec139bc33f",
+      "fullUrl" : "Organization/1706813016516525000.c86af131-07f2-488e-9a08-0bf5e9201a82",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310409187505000.2b789c51-03cd-4276-a802-a5ec139bc33f",
+        "id" : "1706813016516525000.c86af131-07f2-488e-9a08-0bf5e9201a82",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310409518383000.b4e05428-a57b-4ab8-ba42-22a263647f74",
+      "fullUrl" : "Provenance/1706813016886307000.0e526cff-8921-4ca3-989b-a77e7eaf66e7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310409518383000.b4e05428-a57b-4ab8-ba42-22a263647f74",
+        "id" : "1706813016886307000.0e526cff-8921-4ca3-989b-a77e7eaf66e7",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310409526996000.b14f1c9d-f6ed-4035-a698-f5d7f8bb61a8",
+      "fullUrl" : "Provenance/1706813016896756000.54a609d0-f754-4cba-9ba6-889e23b89612",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310409526996000.b14f1c9d-f6ed-4035-a698-f5d7f8bb61a8",
-        "recorded" : "2024-01-26T17:06:49Z",
+        "id" : "1706813016896756000.54a609d0-f754-4cba-9ba6-889e23b89612",
+        "recorded" : "2024-02-01T13:43:36Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310409525625000.b56a7bc0-5199-4d43-92cf-a4f4419587e7"
+              "reference" : "Organization/1706813016896258000.1f891150-3bf4-45aa-9eba-e8d9165c5a18"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310409525625000.b56a7bc0-5199-4d43-92cf-a4f4419587e7",
+      "fullUrl" : "Organization/1706813016896258000.1f891150-3bf4-45aa-9eba-e8d9165c5a18",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310409525625000.b56a7bc0-5199-4d43-92cf-a4f4419587e7",
+        "id" : "1706813016896258000.1f891150-3bf4-45aa-9eba-e8d9165c5a18",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310409542602000.04168919-b485-4b39-b770-ac2811418db3",
+      "fullUrl" : "Patient/1706813016914703000.abc449ba-bb50-4168-84e0-288aa06fec96",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310409542602000.04168919-b485-4b39-b770-ac2811418db3",
+        "id" : "1706813016914703000.abc449ba-bb50-4168-84e0-288aa06fec96",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310409543614000.65421b61-6cf9-4e5b-aae3-fb0af8d7295e",
+      "fullUrl" : "Provenance/1706813016915610000.1afa60d7-f741-45d3-809e-1a81fc6c9c52",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310409543614000.65421b61-6cf9-4e5b-aae3-fb0af8d7295e",
+        "id" : "1706813016915610000.1afa60d7-f741-45d3-809e-1a81fc6c9c52",
         "target" : [
           {
-            "reference" : "Patient/1706310409542602000.04168919-b485-4b39-b770-ac2811418db3"
+            "reference" : "Patient/1706813016914703000.abc449ba-bb50-4168-84e0-288aa06fec96"
           }
         ],
-        "recorded" : "2024-01-26T17:06:49Z",
+        "recorded" : "2024-02-01T13:43:36Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/quantity/cwe-quantity.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cwe/quantity/cwe-quantity.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310420442730000.3d987086-6c58-48e1-82e6-9f2df98ef849",
+  "id" : "1706813029013851000.148a1035-c4f5-46a9-ae04-ed5566aa3b10",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:00.460-06:00"
+    "lastUpdated" : "2024-02-01T13:43:49.020-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310420538572000.bfd2f368-7a8c-492c-89a9-928f5b52758f"
+          "reference" : "Organization/1706813029066018000.f6342a03-8a49-4401-993f-f1da4f76e7cf"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310420538572000.bfd2f368-7a8c-492c-89a9-928f5b52758f",
+      "fullUrl" : "Organization/1706813029066018000.f6342a03-8a49-4401-993f-f1da4f76e7cf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310420538572000.bfd2f368-7a8c-492c-89a9-928f5b52758f",
+        "id" : "1706813029066018000.f6342a03-8a49-4401-993f-f1da4f76e7cf",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310420852444000.aada83d0-ff16-4a4e-bdff-cc5e31115150",
+      "fullUrl" : "Provenance/1706813029424435000.bd802f57-4d14-4320-917a-a38fb637eb89",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310420852444000.aada83d0-ff16-4a4e-bdff-cc5e31115150",
+        "id" : "1706813029424435000.bd802f57-4d14-4320-917a-a38fb637eb89",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310421033160000.408abcd2-36e4-4ced-8d47-97290e9f1a58"
+            "reference" : "DiagnosticReport/1706813029609994000.b11cb33c-f446-4b46-ac98-7fb34287b692"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310420860668000.3676ce1c-9bbc-406e-b5a2-00c9c39cd4ac",
+      "fullUrl" : "Provenance/1706813029433236000.919abe5d-e2a3-4174-9383-d91fa1b3271c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310420860668000.3676ce1c-9bbc-406e-b5a2-00c9c39cd4ac",
-        "recorded" : "2024-01-26T17:07:00Z",
+        "id" : "1706813029433236000.919abe5d-e2a3-4174-9383-d91fa1b3271c",
+        "recorded" : "2024-02-01T13:43:49Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310420860051000.80748ea5-6b0a-4f04-8525-2ef8f25d6f35"
+              "reference" : "Organization/1706813029432613000.152cc43b-87ec-4dda-8a63-f3d5b3177d2b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310420860051000.80748ea5-6b0a-4f04-8525-2ef8f25d6f35",
+      "fullUrl" : "Organization/1706813029432613000.152cc43b-87ec-4dda-8a63-f3d5b3177d2b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310420860051000.80748ea5-6b0a-4f04-8525-2ef8f25d6f35",
+        "id" : "1706813029432613000.152cc43b-87ec-4dda-8a63-f3d5b3177d2b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706310420872395000.86168072-51b5-42bc-beb4-241292689267",
+      "fullUrl" : "Observation/1706813029446997000.e11ec9ca-12ec-4fa6-a118-bfe326d4e52c",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706310420872395000.86168072-51b5-42bc-beb4-241292689267",
+        "id" : "1706813029446997000.e11ec9ca-12ec-4fa6-a118-bfe326d4e52c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -224,10 +229,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310421030240000.100b2cd0-fd5f-4f92-b9a3-b4185814037e",
+      "fullUrl" : "ServiceRequest/1706813029607726000.fc07712b-b1b4-4604-95bb-b8768b8482ab",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310421030240000.100b2cd0-fd5f-4f92-b9a3-b4185814037e",
+        "id" : "1706813029607726000.fc07712b-b1b4-4604-95bb-b8768b8482ab",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -251,13 +256,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310421033160000.408abcd2-36e4-4ced-8d47-97290e9f1a58",
+      "fullUrl" : "DiagnosticReport/1706813029609994000.b11cb33c-f446-4b46-ac98-7fb34287b692",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310421033160000.408abcd2-36e4-4ced-8d47-97290e9f1a58",
+        "id" : "1706813029609994000.b11cb33c-f446-4b46-ac98-7fb34287b692",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310421030240000.100b2cd0-fd5f-4f92-b9a3-b4185814037e"
+            "reference" : "ServiceRequest/1706813029607726000.fc07712b-b1b4-4604-95bb-b8768b8482ab"
           }
         ],
         "status" : "final",
@@ -282,7 +287,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706310420872395000.86168072-51b5-42bc-beb4-241292689267"
+            "reference" : "Observation/1706813029446997000.e11ec9ca-12ec-4fa6-a118-bfe326d4e52c"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-5.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-5.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310429246076000.44f97ae8-1676-4d2e-8c77-417ed9a02b18",
+  "id" : "1706813180842040000.64aa9c58-dede-4bcb-bdc6-791af9389e6f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:09.260-06:00"
+    "lastUpdated" : "2024-02-01T13:46:20.848-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310429667103000.9d5efff2-839f-457c-abdb-18627f3948d9",
+      "fullUrl" : "Provenance/1706813181220488000.211533e9-f802-4a2f-be40-e056e7d4e551",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310429667103000.9d5efff2-839f-457c-abdb-18627f3948d9",
+        "id" : "1706813181220488000.211533e9-f802-4a2f-be40-e056e7d4e551",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310429843613000.2a7c4848-2679-4603-b64d-61146928d861"
+            "reference" : "DiagnosticReport/1706813181443375000.56b565bc-bb59-4fb3-adc7-9c5af0d41107"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310429675117000.72691672-995d-4224-9ae9-3ae90beeacef",
+      "fullUrl" : "Provenance/1706813181228139000.0e4d9546-4b9f-47cf-9c44-1c928875daf1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310429675117000.72691672-995d-4224-9ae9-3ae90beeacef",
-        "recorded" : "2024-01-26T17:07:09Z",
+        "id" : "1706813181228139000.0e4d9546-4b9f-47cf-9c44-1c928875daf1",
+        "recorded" : "2024-02-01T13:46:21Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310429674639000.0884213f-6bf2-4316-9c6f-ccce52557611"
+              "reference" : "Organization/1706813181227657000.d84a351b-1633-4d89-9b72-b307ad38d0b4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310429674639000.0884213f-6bf2-4316-9c6f-ccce52557611",
+      "fullUrl" : "Organization/1706813181227657000.d84a351b-1633-4d89-9b72-b307ad38d0b4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310429674639000.0884213f-6bf2-4316-9c6f-ccce52557611",
+        "id" : "1706813181227657000.d84a351b-1633-4d89-9b72-b307ad38d0b4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310429694651000.62f2963e-08fb-4070-b2da-16a5431aad36",
+      "fullUrl" : "ServiceRequest/1706813181252694000.8d30a4fd-e791-442c-9f6a-a551c7fd5428",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310429694651000.62f2963e-08fb-4070-b2da-16a5431aad36",
+        "id" : "1706813181252694000.8d30a4fd-e791-442c-9f6a-a551c7fd5428",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310429685025000.d24cdd42-3660-452a-b8c2-fcab425061e2"
+                  "reference" : "Organization/1706813181238509000.fab8a895-77da-42f3-aca5-f873c659f71f"
                 }
               },
               {
@@ -302,10 +307,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310429685025000.d24cdd42-3660-452a-b8c2-fcab425061e2",
+      "fullUrl" : "Organization/1706813181238509000.fab8a895-77da-42f3-aca5-f873c659f71f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310429685025000.d24cdd42-3660-452a-b8c2-fcab425061e2",
+        "id" : "1706813181238509000.fab8a895-77da-42f3-aca5-f873c659f71f",
         "identifier" : [
           {
             "extension" : [
@@ -337,10 +342,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310429843613000.2a7c4848-2679-4603-b64d-61146928d861",
+      "fullUrl" : "DiagnosticReport/1706813181443375000.56b565bc-bb59-4fb3-adc7-9c5af0d41107",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310429843613000.2a7c4848-2679-4603-b64d-61146928d861",
+        "id" : "1706813181443375000.56b565bc-bb59-4fb3-adc7-9c5af0d41107",
         "identifier" : [
           {
             "extension" : [
@@ -373,7 +378,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310429694651000.62f2963e-08fb-4070-b2da-16a5431aad36"
+            "reference" : "ServiceRequest/1706813181252694000.8d30a4fd-e791-442c-9f6a-a551c7fd5428"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-organization-null-org-type.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-organization-null-org-type.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310438961957000.83d353b7-d3ba-4199-8ad9-fb4698acc5fd",
+  "id" : "1706813190401172000.4087766a-b0e1-4227-9a91-a3ad85076728",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:18.986-06:00"
+    "lastUpdated" : "2024-02-01T13:46:30.408-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310439526043000.01dff215-372e-4903-94fc-9cb85b6c5ffd",
+      "fullUrl" : "Provenance/1706813190783759000.c52e2814-c57f-47f2-ad68-0571abdd70f6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310439526043000.01dff215-372e-4903-94fc-9cb85b6c5ffd",
+        "id" : "1706813190783759000.c52e2814-c57f-47f2-ad68-0571abdd70f6",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310439752841000.4695d150-c71e-4835-bc36-e7af3edfe9f3"
+            "reference" : "DiagnosticReport/1706813190956782000.1949e2eb-d7dc-4e76-b0c3-c639b2c0b974"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310439537479000.3342d5e0-be47-4349-add6-45dd6aa7ee8d",
+      "fullUrl" : "Provenance/1706813190792375000.81364d29-47df-4931-8e63-23aeb80f2a5a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310439537479000.3342d5e0-be47-4349-add6-45dd6aa7ee8d",
-        "recorded" : "2024-01-26T17:07:19Z",
+        "id" : "1706813190792375000.81364d29-47df-4931-8e63-23aeb80f2a5a",
+        "recorded" : "2024-02-01T13:46:30Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310439537043000.9c8972e9-d9d4-4110-a769-19ceefcdbd0b"
+              "reference" : "Organization/1706813190791897000.c0d47fe0-aa7b-41cd-9b7a-214c2fa3ae56"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310439537043000.9c8972e9-d9d4-4110-a769-19ceefcdbd0b",
+      "fullUrl" : "Organization/1706813190791897000.c0d47fe0-aa7b-41cd-9b7a-214c2fa3ae56",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310439537043000.9c8972e9-d9d4-4110-a769-19ceefcdbd0b",
+        "id" : "1706813190791897000.c0d47fe0-aa7b-41cd-9b7a-214c2fa3ae56",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310439566526000.39f3eba1-c9fb-46fb-a8f6-a713109a9583",
+      "fullUrl" : "ServiceRequest/1706813190813561000.339a030c-ecee-470b-8215-df11b2200378",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310439566526000.39f3eba1-c9fb-46fb-a8f6-a713109a9583",
+        "id" : "1706813190813561000.339a030c-ecee-470b-8215-df11b2200378",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310439552742000.feeb0533-d53d-4158-815f-40cecd137085"
+                  "reference" : "Organization/1706813190802409000.bd411806-f4be-4b94-b019-9ce3a8377364"
                 }
               },
               {
@@ -259,7 +264,7 @@
               }
             },
             "assigner" : {
-              "reference" : "Organization/1706310439554274000.6b6540e5-e9c7-48bd-9dfb-47756b4461ac"
+              "reference" : "Organization/1706813190803396000.069d0ec4-0ead-4a42-b264-10e614695411"
             }
           }
         ],
@@ -292,10 +297,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310439552742000.feeb0533-d53d-4158-815f-40cecd137085",
+      "fullUrl" : "Organization/1706813190802409000.bd411806-f4be-4b94-b019-9ce3a8377364",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310439552742000.feeb0533-d53d-4158-815f-40cecd137085",
+        "id" : "1706813190802409000.bd411806-f4be-4b94-b019-9ce3a8377364",
         "identifier" : [
           {
             "extension" : [
@@ -327,10 +332,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310439554274000.6b6540e5-e9c7-48bd-9dfb-47756b4461ac",
+      "fullUrl" : "Organization/1706813190803396000.069d0ec4-0ead-4a42-b264-10e614695411",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310439554274000.6b6540e5-e9c7-48bd-9dfb-47756b4461ac",
+        "id" : "1706813190803396000.069d0ec4-0ead-4a42-b264-10e614695411",
         "identifier" : [
           {
             "extension" : [
@@ -361,10 +366,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310439752841000.4695d150-c71e-4835-bc36-e7af3edfe9f3",
+      "fullUrl" : "DiagnosticReport/1706813190956782000.1949e2eb-d7dc-4e76-b0c3-c639b2c0b974",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310439752841000.4695d150-c71e-4835-bc36-e7af3edfe9f3",
+        "id" : "1706813190956782000.1949e2eb-d7dc-4e76-b0c3-c639b2c0b974",
         "identifier" : [
           {
             "extension" : [
@@ -397,7 +402,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310439566526000.39f3eba1-c9fb-46fb-a8f6-a713109a9583"
+            "reference" : "ServiceRequest/1706813190813561000.339a030c-ecee-470b-8215-df11b2200378"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-organization.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-organization.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310448425710000.2570a258-8df7-42f6-9820-199f69e07167",
+  "id" : "1706813199931938000.c45d4347-9087-4d78-a850-782021b63495",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:28.439-06:00"
+    "lastUpdated" : "2024-02-01T13:46:39.937-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310448820542000.5e9caf46-7c8b-432d-946a-abb60bfbd64f",
+      "fullUrl" : "Provenance/1706813200301906000.c6060741-f2e1-47fb-a3cd-1829fcb464c0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310448820542000.5e9caf46-7c8b-432d-946a-abb60bfbd64f",
+        "id" : "1706813200301906000.c6060741-f2e1-47fb-a3cd-1829fcb464c0",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310448996578000.fda7c2a6-2482-4990-8bc6-059c62270443"
+            "reference" : "DiagnosticReport/1706813200487496000.e8c5e776-2b83-41be-a400-60153b81bf75"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310448829528000.6675f8eb-6d98-46b3-b9b8-2f230011f9c9",
+      "fullUrl" : "Provenance/1706813200309866000.89529c15-e25e-4007-bee5-d2955641b481",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310448829528000.6675f8eb-6d98-46b3-b9b8-2f230011f9c9",
-        "recorded" : "2024-01-26T17:07:28Z",
+        "id" : "1706813200309866000.89529c15-e25e-4007-bee5-d2955641b481",
+        "recorded" : "2024-02-01T13:46:40Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310448828505000.60209c21-b857-45e5-b025-b588e99bd7d6"
+              "reference" : "Organization/1706813200309408000.2979d48d-da41-4b11-b557-372e8a28cd39"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310448828505000.60209c21-b857-45e5-b025-b588e99bd7d6",
+      "fullUrl" : "Organization/1706813200309408000.2979d48d-da41-4b11-b557-372e8a28cd39",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310448828505000.60209c21-b857-45e5-b025-b588e99bd7d6",
+        "id" : "1706813200309408000.2979d48d-da41-4b11-b557-372e8a28cd39",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310448851131000.6ed28d25-c7a5-4df5-8ade-5ce1e865082e",
+      "fullUrl" : "ServiceRequest/1706813200332610000.bd3460df-77b9-4e1d-9b4d-75415178cbd1",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310448851131000.6ed28d25-c7a5-4df5-8ade-5ce1e865082e",
+        "id" : "1706813200332610000.bd3460df-77b9-4e1d-9b4d-75415178cbd1",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310448840153000.eb7d713f-e604-4004-b2f7-67120c0b0197"
+                  "reference" : "Organization/1706813200321826000.7945556b-dc14-4875-85b7-22ba2590d99b"
                 }
               },
               {
@@ -259,7 +264,7 @@
               }
             },
             "assigner" : {
-              "reference" : "Organization/1706310448840945000.48a43d91-6120-4477-b081-dc17714a692f"
+              "reference" : "Organization/1706813200322655000.ab79928a-a909-41a0-abf2-87c67fde56bf"
             }
           }
         ],
@@ -292,10 +297,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310448840153000.eb7d713f-e604-4004-b2f7-67120c0b0197",
+      "fullUrl" : "Organization/1706813200321826000.7945556b-dc14-4875-85b7-22ba2590d99b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310448840153000.eb7d713f-e604-4004-b2f7-67120c0b0197",
+        "id" : "1706813200321826000.7945556b-dc14-4875-85b7-22ba2590d99b",
         "identifier" : [
           {
             "extension" : [
@@ -327,10 +332,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310448840945000.48a43d91-6120-4477-b081-dc17714a692f",
+      "fullUrl" : "Organization/1706813200322655000.ab79928a-a909-41a0-abf2-87c67fde56bf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310448840945000.48a43d91-6120-4477-b081-dc17714a692f",
+        "id" : "1706813200322655000.ab79928a-a909-41a0-abf2-87c67fde56bf",
         "identifier" : [
           {
             "extension" : [
@@ -362,10 +367,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310448996578000.fda7c2a6-2482-4990-8bc6-059c62270443",
+      "fullUrl" : "DiagnosticReport/1706813200487496000.e8c5e776-2b83-41be-a400-60153b81bf75",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310448996578000.fda7c2a6-2482-4990-8bc6-059c62270443",
+        "id" : "1706813200487496000.e8c5e776-2b83-41be-a400-60153b81bf75",
         "identifier" : [
           {
             "extension" : [
@@ -398,7 +403,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310448851131000.6ed28d25-c7a5-4df5-8ade-5ce1e865082e"
+            "reference" : "ServiceRequest/1706813200332610000.bd3460df-77b9-4e1d-9b4d-75415178cbd1"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-iso-no-cx-4-1.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-iso-no-cx-4-1.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310457479318000.4f979c85-907b-4a4b-8886-4f18a487fe91",
+  "id" : "1706813209333259000.df43864a-56c7-4a32-8f80-058f83807924",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:37.497-06:00"
+    "lastUpdated" : "2024-02-01T13:46:49.340-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310457895134000.bb48240f-1f14-4a58-b8d9-7dc5c27a1d63",
+      "fullUrl" : "Provenance/1706813209707329000.d83155f5-b5eb-40a7-8e44-68a6666e860e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310457895134000.bb48240f-1f14-4a58-b8d9-7dc5c27a1d63",
+        "id" : "1706813209707329000.d83155f5-b5eb-40a7-8e44-68a6666e860e",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310458069121000.dc3c777d-2c6c-4e87-afb4-cae4d6ecfff5"
+            "reference" : "DiagnosticReport/1706813209882911000.76c6f8df-cc4d-4601-8c9b-8afa0a3b459f"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310457903206000.47f24797-7ec6-49ee-8fb1-b4f214b484f0",
+      "fullUrl" : "Provenance/1706813209715862000.bda2da50-36cf-4f1f-9503-93b729506fd0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310457903206000.47f24797-7ec6-49ee-8fb1-b4f214b484f0",
-        "recorded" : "2024-01-26T17:07:37Z",
+        "id" : "1706813209715862000.bda2da50-36cf-4f1f-9503-93b729506fd0",
+        "recorded" : "2024-02-01T13:46:49Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310457902755000.a9b0c3d6-664f-4584-8161-84f63ccf1a74"
+              "reference" : "Organization/1706813209714710000.c1b39cd6-eb54-4e9d-b972-7380edc882d4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310457902755000.a9b0c3d6-664f-4584-8161-84f63ccf1a74",
+      "fullUrl" : "Organization/1706813209714710000.c1b39cd6-eb54-4e9d-b972-7380edc882d4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310457902755000.a9b0c3d6-664f-4584-8161-84f63ccf1a74",
+        "id" : "1706813209714710000.c1b39cd6-eb54-4e9d-b972-7380edc882d4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310457923508000.ea405227-2eca-43f0-8140-3650c2ab6ba7",
+      "fullUrl" : "ServiceRequest/1706813209741019000.e48805fd-98fd-40f0-9319-0759978fadea",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310457923508000.ea405227-2eca-43f0-8140-3650c2ab6ba7",
+        "id" : "1706813209741019000.e48805fd-98fd-40f0-9319-0759978fadea",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310457913813000.095aeb7e-1609-41c8-bb2f-0db9ee3273cc"
+                  "reference" : "Organization/1706813209727322000.4f7acf22-2402-468f-822b-ce44a222955e"
                 }
               },
               {
@@ -302,10 +307,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310457913813000.095aeb7e-1609-41c8-bb2f-0db9ee3273cc",
+      "fullUrl" : "Organization/1706813209727322000.4f7acf22-2402-468f-822b-ce44a222955e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310457913813000.095aeb7e-1609-41c8-bb2f-0db9ee3273cc",
+        "id" : "1706813209727322000.4f7acf22-2402-468f-822b-ce44a222955e",
         "identifier" : [
           {
             "extension" : [
@@ -337,10 +342,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310458069121000.dc3c777d-2c6c-4e87-afb4-cae4d6ecfff5",
+      "fullUrl" : "DiagnosticReport/1706813209882911000.76c6f8df-cc4d-4601-8c9b-8afa0a3b459f",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310458069121000.dc3c777d-2c6c-4e87-afb4-cae4d6ecfff5",
+        "id" : "1706813209882911000.76c6f8df-cc4d-4601-8c9b-8afa0a3b459f",
         "identifier" : [
           {
             "extension" : [
@@ -373,7 +378,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310457923508000.ea405227-2eca-43f0-8140-3650c2ab6ba7"
+            "reference" : "ServiceRequest/1706813209741019000.e48805fd-98fd-40f0-9319-0759978fadea"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-iso-no-cx-4-2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-iso-no-cx-4-2.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310466302556000.18d50a15-ac6f-4972-8233-99f7329a2a5d",
+  "id" : "1706813218792570000.a03f7f43-ab92-4265-8cbc-4c282f696ec3",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:46.317-06:00"
+    "lastUpdated" : "2024-02-01T13:46:58.799-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310466706783000.e02bf1e7-6b28-40e0-90ab-8de0688b7bf3",
+      "fullUrl" : "Provenance/1706813219169591000.b78ec195-4430-426f-9a1d-63af07dc4558",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310466706783000.e02bf1e7-6b28-40e0-90ab-8de0688b7bf3",
+        "id" : "1706813219169591000.b78ec195-4430-426f-9a1d-63af07dc4558",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310466882731000.be83d820-b631-4568-95da-b3a6e25e04d4"
+            "reference" : "DiagnosticReport/1706813219339376000.501c2d79-7f8a-410b-85d0-53be3cf7e1ea"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310466715121000.e0c73433-c354-4718-a461-8055070c637f",
+      "fullUrl" : "Provenance/1706813219177829000.29351754-ebf9-462a-958c-dc09b58c93e9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310466715121000.e0c73433-c354-4718-a461-8055070c637f",
-        "recorded" : "2024-01-26T17:07:46Z",
+        "id" : "1706813219177829000.29351754-ebf9-462a-958c-dc09b58c93e9",
+        "recorded" : "2024-02-01T13:46:59Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310466714066000.bf028d2c-1116-4c7f-ad8a-70a6fe2cebca"
+              "reference" : "Organization/1706813219177378000.37115cd9-b730-4e95-82f9-d0d159ca1717"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310466714066000.bf028d2c-1116-4c7f-ad8a-70a6fe2cebca",
+      "fullUrl" : "Organization/1706813219177378000.37115cd9-b730-4e95-82f9-d0d159ca1717",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310466714066000.bf028d2c-1116-4c7f-ad8a-70a6fe2cebca",
+        "id" : "1706813219177378000.37115cd9-b730-4e95-82f9-d0d159ca1717",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310466736317000.ea9d71a6-aa7d-4f0e-8709-79b41215daef",
+      "fullUrl" : "ServiceRequest/1706813219196266000.515890a1-1e10-4e8a-8d16-06e5286e477a",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310466736317000.ea9d71a6-aa7d-4f0e-8709-79b41215daef",
+        "id" : "1706813219196266000.515890a1-1e10-4e8a-8d16-06e5286e477a",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310466725507000.c1753811-1cec-460a-9289-c29e4ccf5813"
+                  "reference" : "Organization/1706813219187195000.c5de9ec1-f767-451b-ba84-4a78be321baf"
                 }
               },
               {
@@ -302,10 +307,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310466725507000.c1753811-1cec-460a-9289-c29e4ccf5813",
+      "fullUrl" : "Organization/1706813219187195000.c5de9ec1-f767-451b-ba84-4a78be321baf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310466725507000.c1753811-1cec-460a-9289-c29e4ccf5813",
+        "id" : "1706813219187195000.c5de9ec1-f767-451b-ba84-4a78be321baf",
         "identifier" : [
           {
             "extension" : [
@@ -337,10 +342,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310466882731000.be83d820-b631-4568-95da-b3a6e25e04d4",
+      "fullUrl" : "DiagnosticReport/1706813219339376000.501c2d79-7f8a-410b-85d0-53be3cf7e1ea",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310466882731000.be83d820-b631-4568-95da-b3a6e25e04d4",
+        "id" : "1706813219339376000.501c2d79-7f8a-410b-85d0-53be3cf7e1ea",
         "identifier" : [
           {
             "extension" : [
@@ -373,7 +378,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310466736317000.ea9d71a6-aa7d-4f0e-8709-79b41215daef"
+            "reference" : "ServiceRequest/1706813219196266000.515890a1-1e10-4e8a-8d16-06e5286e477a"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-iso.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310475075504000.4075ac34-08fe-47c1-b20c-e35e2db75368",
+  "id" : "1706813228667027000.b2f88b91-e885-4548-9a5c-1a273ff1fb8f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:07:55.092-06:00"
+    "lastUpdated" : "2024-02-01T13:47:08.673-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310475487038000.2ebf477e-1583-47ab-ba35-12c70ab418fd",
+      "fullUrl" : "Provenance/1706813229141237000.7d109fb8-cba4-42c0-af08-c06c655456be",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310475487038000.2ebf477e-1583-47ab-ba35-12c70ab418fd",
+        "id" : "1706813229141237000.7d109fb8-cba4-42c0-af08-c06c655456be",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310475658286000.22d96dce-34e4-4e0f-962c-39d85a48dd8c"
+            "reference" : "DiagnosticReport/1706813229332584000.be8a967d-9657-401c-aebe-101696bbaf91"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310475496538000.1cef16da-42a1-4967-bd2c-29b52bbc82d2",
+      "fullUrl" : "Provenance/1706813229150454000.9d03aa30-70e5-49a0-bafc-55d2c1376a34",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310475496538000.1cef16da-42a1-4967-bd2c-29b52bbc82d2",
-        "recorded" : "2024-01-26T17:07:55Z",
+        "id" : "1706813229150454000.9d03aa30-70e5-49a0-bafc-55d2c1376a34",
+        "recorded" : "2024-02-01T13:47:09Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310475496063000.eaf7a781-70e2-4440-8191-019c1135ce82"
+              "reference" : "Organization/1706813229149836000.a82187e0-b674-452c-b266-172cf670f8da"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310475496063000.eaf7a781-70e2-4440-8191-019c1135ce82",
+      "fullUrl" : "Organization/1706813229149836000.a82187e0-b674-452c-b266-172cf670f8da",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310475496063000.eaf7a781-70e2-4440-8191-019c1135ce82",
+        "id" : "1706813229149836000.a82187e0-b674-452c-b266-172cf670f8da",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310475515776000.357099a5-f5f4-4e31-aa93-bcb43da65455",
+      "fullUrl" : "ServiceRequest/1706813229172237000.00d82ba7-889e-41a6-b376-38caf0b720a9",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310475515776000.357099a5-f5f4-4e31-aa93-bcb43da65455",
+        "id" : "1706813229172237000.00d82ba7-889e-41a6-b376-38caf0b720a9",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310475506829000.ce4df5f3-87fc-4694-8418-79e3a60d7d2b"
+                  "reference" : "Organization/1706813229161482000.45cb191d-097d-4c0e-a855-456be1483c23"
                 }
               },
               {
@@ -306,10 +311,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310475506829000.ce4df5f3-87fc-4694-8418-79e3a60d7d2b",
+      "fullUrl" : "Organization/1706813229161482000.45cb191d-097d-4c0e-a855-456be1483c23",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310475506829000.ce4df5f3-87fc-4694-8418-79e3a60d7d2b",
+        "id" : "1706813229161482000.45cb191d-097d-4c0e-a855-456be1483c23",
         "identifier" : [
           {
             "extension" : [
@@ -341,10 +346,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310475658286000.22d96dce-34e4-4e0f-962c-39d85a48dd8c",
+      "fullUrl" : "DiagnosticReport/1706813229332584000.be8a967d-9657-401c-aebe-101696bbaf91",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310475658286000.22d96dce-34e4-4e0f-962c-39d85a48dd8c",
+        "id" : "1706813229332584000.be8a967d-9657-401c-aebe-101696bbaf91",
         "identifier" : [
           {
             "extension" : [
@@ -377,7 +382,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310475515776000.357099a5-f5f4-4e31-aa93-bcb43da65455"
+            "reference" : "ServiceRequest/1706813229172237000.00d82ba7-889e-41a6-b376-38caf0b720a9"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-uuid-no-cx-4-1.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-uuid-no-cx-4-1.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310484655182000.cb3d4c85-e26c-40d8-95d6-9f14fac0d7b0",
+  "id" : "1706813238879773000.f6db3ffe-f5ad-4ad8-8fd2-578253e44f6e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:08:04.668-06:00"
+    "lastUpdated" : "2024-02-01T13:47:18.887-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310485132465000.11adf380-2107-490c-a772-4be847a2af9b",
+      "fullUrl" : "Provenance/1706813239303019000.77ad2ce3-7a7e-433b-86d4-037067da62e0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310485132465000.11adf380-2107-490c-a772-4be847a2af9b",
+        "id" : "1706813239303019000.77ad2ce3-7a7e-433b-86d4-037067da62e0",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310485355447000.a70c16ce-9a9a-4fb6-a5e5-db49adc84476"
+            "reference" : "DiagnosticReport/1706813239495031000.393c364b-61a9-442e-9b2c-6bba049a66fb"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310485141064000.5fc394a7-704b-4238-9b19-efa410b330dc",
+      "fullUrl" : "Provenance/1706813239311455000.1d40defc-6365-4ab4-ad3d-d85a878083a7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310485141064000.5fc394a7-704b-4238-9b19-efa410b330dc",
-        "recorded" : "2024-01-26T17:08:05Z",
+        "id" : "1706813239311455000.1d40defc-6365-4ab4-ad3d-d85a878083a7",
+        "recorded" : "2024-02-01T13:47:19Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310485140638000.40df6076-cc2b-4f8b-becb-676d032ae166"
+              "reference" : "Organization/1706813239310954000.9a3adfba-3bb4-4244-b7c0-16e5d65a1eb0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310485140638000.40df6076-cc2b-4f8b-becb-676d032ae166",
+      "fullUrl" : "Organization/1706813239310954000.9a3adfba-3bb4-4244-b7c0-16e5d65a1eb0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310485140638000.40df6076-cc2b-4f8b-becb-676d032ae166",
+        "id" : "1706813239310954000.9a3adfba-3bb4-4244-b7c0-16e5d65a1eb0",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310485165850000.35fe565c-2f23-41f5-b1b7-614dde7b9856",
+      "fullUrl" : "ServiceRequest/1706813239332403000.2279b5a9-7590-4bf7-9d77-5b0443228fe1",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310485165850000.35fe565c-2f23-41f5-b1b7-614dde7b9856",
+        "id" : "1706813239332403000.2279b5a9-7590-4bf7-9d77-5b0443228fe1",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310485152587000.c02c83aa-a284-4608-96d2-c0391f0a1478"
+                  "reference" : "Organization/1706813239322980000.fb00906f-dc65-44f6-a955-d411ccca1198"
                 }
               },
               {
@@ -302,10 +307,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310485152587000.c02c83aa-a284-4608-96d2-c0391f0a1478",
+      "fullUrl" : "Organization/1706813239322980000.fb00906f-dc65-44f6-a955-d411ccca1198",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310485152587000.c02c83aa-a284-4608-96d2-c0391f0a1478",
+        "id" : "1706813239322980000.fb00906f-dc65-44f6-a955-d411ccca1198",
         "identifier" : [
           {
             "extension" : [
@@ -337,10 +342,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310485355447000.a70c16ce-9a9a-4fb6-a5e5-db49adc84476",
+      "fullUrl" : "DiagnosticReport/1706813239495031000.393c364b-61a9-442e-9b2c-6bba049a66fb",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310485355447000.a70c16ce-9a9a-4fb6-a5e5-db49adc84476",
+        "id" : "1706813239495031000.393c364b-61a9-442e-9b2c-6bba049a66fb",
         "identifier" : [
           {
             "extension" : [
@@ -373,7 +378,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310485165850000.35fe565c-2f23-41f5-b1b7-614dde7b9856"
+            "reference" : "ServiceRequest/1706813239332403000.2279b5a9-7590-4bf7-9d77-5b0443228fe1"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-uuid-no-cx-4-2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-uuid-no-cx-4-2.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310493263886000.0bf87f98-8fed-498a-b927-0b46d136d67b",
+  "id" : "1706813248948298000.8c410255-f82b-4ac7-bf46-be9c77e60869",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:08:13.276-06:00"
+    "lastUpdated" : "2024-02-01T13:47:28.954-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310493644066000.a61df080-9297-4df7-b2d9-fc0c01cbf43f",
+      "fullUrl" : "Provenance/1706813249370448000.89086ef4-7304-44cb-9d39-60574f2b779d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310493644066000.a61df080-9297-4df7-b2d9-fc0c01cbf43f",
+        "id" : "1706813249370448000.89086ef4-7304-44cb-9d39-60574f2b779d",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310493803856000.d3fd07a8-b061-486d-89a6-ba59896f1436"
+            "reference" : "DiagnosticReport/1706813249570502000.f5bb9e8f-fb92-49ed-8d1e-cdf8fd0ec949"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310493651588000.a4331a01-131b-4351-a1b6-4f1dc3d1450e",
+      "fullUrl" : "Provenance/1706813249378811000.9f5529d9-66e8-466e-8605-5820e82aeac5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310493651588000.a4331a01-131b-4351-a1b6-4f1dc3d1450e",
-        "recorded" : "2024-01-26T17:08:13Z",
+        "id" : "1706813249378811000.9f5529d9-66e8-466e-8605-5820e82aeac5",
+        "recorded" : "2024-02-01T13:47:29Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310493651106000.4f6c74d7-8974-4d3a-bdfc-d7e0949a2533"
+              "reference" : "Organization/1706813249378336000.d6226347-f250-47b9-bf30-d2a2e9d284d2"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310493651106000.4f6c74d7-8974-4d3a-bdfc-d7e0949a2533",
+      "fullUrl" : "Organization/1706813249378336000.d6226347-f250-47b9-bf30-d2a2e9d284d2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310493651106000.4f6c74d7-8974-4d3a-bdfc-d7e0949a2533",
+        "id" : "1706813249378336000.d6226347-f250-47b9-bf30-d2a2e9d284d2",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310493670678000.7f4f3e5d-276b-48cf-986d-fed6f0483c23",
+      "fullUrl" : "ServiceRequest/1706813249400597000.6c3380c5-e37e-41b0-86c9-e4a62a476045",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310493670678000.7f4f3e5d-276b-48cf-986d-fed6f0483c23",
+        "id" : "1706813249400597000.6c3380c5-e37e-41b0-86c9-e4a62a476045",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310493661271000.182e2837-ec9e-4314-9d47-185b15d560c2"
+                  "reference" : "Organization/1706813249390210000.53edc0c6-373a-422b-beb3-bc1294f85738"
                 }
               },
               {
@@ -302,10 +307,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310493661271000.182e2837-ec9e-4314-9d47-185b15d560c2",
+      "fullUrl" : "Organization/1706813249390210000.53edc0c6-373a-422b-beb3-bc1294f85738",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310493661271000.182e2837-ec9e-4314-9d47-185b15d560c2",
+        "id" : "1706813249390210000.53edc0c6-373a-422b-beb3-bc1294f85738",
         "identifier" : [
           {
             "extension" : [
@@ -337,10 +342,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310493803856000.d3fd07a8-b061-486d-89a6-ba59896f1436",
+      "fullUrl" : "DiagnosticReport/1706813249570502000.f5bb9e8f-fb92-49ed-8d1e-cdf8fd0ec949",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310493803856000.d3fd07a8-b061-486d-89a6-ba59896f1436",
+        "id" : "1706813249570502000.f5bb9e8f-fb92-49ed-8d1e-cdf8fd0ec949",
         "identifier" : [
           {
             "extension" : [
@@ -373,7 +378,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310493670678000.7f4f3e5d-276b-48cf-986d-fed6f0483c23"
+            "reference" : "ServiceRequest/1706813249400597000.6c3380c5-e37e-41b0-86c9-e4a62a476045"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/cx/cx-identifier-system-uuid.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310502537385000.bf97cfe5-f5a7-43c3-8f85-25101149cb60",
+  "id" : "1706813259186882000.14ab350a-0ee0-4552-a534-6a3a3e49c96d",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:08:22.551-06:00"
+    "lastUpdated" : "2024-02-01T13:47:39.194-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310502910218000.50d96919-24be-4609-b90f-395fae1e9593",
+      "fullUrl" : "Provenance/1706813259564115000.5e3f4198-401d-4d0b-bf60-29be2090a17c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310502910218000.50d96919-24be-4609-b90f-395fae1e9593",
+        "id" : "1706813259564115000.5e3f4198-401d-4d0b-bf60-29be2090a17c",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310503073090000.67ccd4fa-a834-4595-b898-bc6143fd1309"
+            "reference" : "DiagnosticReport/1706813259765436000.631e6c2f-d3b7-4266-9950-5199868cc1ca"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310502917261000.7a5645b3-f862-4c93-b0f7-510c7241c295",
+      "fullUrl" : "Provenance/1706813259572889000.9c7f399b-88a9-40cb-8582-b09f340fde17",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310502917261000.7a5645b3-f862-4c93-b0f7-510c7241c295",
-        "recorded" : "2024-01-26T17:08:22Z",
+        "id" : "1706813259572889000.9c7f399b-88a9-40cb-8582-b09f340fde17",
+        "recorded" : "2024-02-01T13:47:39Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310502916697000.1d859698-2200-43e6-8141-0e8e7d649929"
+              "reference" : "Organization/1706813259572364000.8d3cf80c-f9bc-4287-b760-92c9d7429bb1"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310502916697000.1d859698-2200-43e6-8141-0e8e7d649929",
+      "fullUrl" : "Organization/1706813259572364000.8d3cf80c-f9bc-4287-b760-92c9d7429bb1",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310502916697000.1d859698-2200-43e6-8141-0e8e7d649929",
+        "id" : "1706813259572364000.8d3cf80c-f9bc-4287-b760-92c9d7429bb1",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310502934752000.fcbe41f0-9b74-4ab4-bbc2-559fc3bc6172",
+      "fullUrl" : "ServiceRequest/1706813259595547000.1bcf1a64-dee7-43aa-8e2a-723c1807ce7d",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310502934752000.fcbe41f0-9b74-4ab4-bbc2-559fc3bc6172",
+        "id" : "1706813259595547000.1bcf1a64-dee7-43aa-8e2a-723c1807ce7d",
         "identifier" : [
           {
             "extension" : [
@@ -167,7 +172,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706310502926933000.93d15c6b-8a36-4a3f-8d33-ac44d5faf857"
+                  "reference" : "Organization/1706813259584617000.e3373cce-5343-4b9f-9231-61912e2ee83c"
                 }
               },
               {
@@ -306,10 +311,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310502926933000.93d15c6b-8a36-4a3f-8d33-ac44d5faf857",
+      "fullUrl" : "Organization/1706813259584617000.e3373cce-5343-4b9f-9231-61912e2ee83c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310502926933000.93d15c6b-8a36-4a3f-8d33-ac44d5faf857",
+        "id" : "1706813259584617000.e3373cce-5343-4b9f-9231-61912e2ee83c",
         "identifier" : [
           {
             "extension" : [
@@ -341,10 +346,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310503073090000.67ccd4fa-a834-4595-b898-bc6143fd1309",
+      "fullUrl" : "DiagnosticReport/1706813259765436000.631e6c2f-d3b7-4266-9950-5199868cc1ca",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310503073090000.67ccd4fa-a834-4595-b898-bc6143fd1309",
+        "id" : "1706813259765436000.631e6c2f-d3b7-4266-9950-5199868cc1ca",
         "identifier" : [
           {
             "extension" : [
@@ -377,7 +382,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310502934752000.fcbe41f0-9b74-4ab4-bbc2-559fc3bc6172"
+            "reference" : "ServiceRequest/1706813259595547000.1bcf1a64-dee7-43aa-8e2a-723c1807ce7d"
           }
         ],
         "status" : "unknown",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dld/DLD-to-Location.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dld/DLD-to-Location.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310515698332000.65949074-0cda-44ec-83d2-ab25628bd713",
+  "id" : "1706813354149346000.dd8458d7-a0be-4615-9ea4-8116ba83cc26",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:08:35.710-06:00"
+    "lastUpdated" : "2024-02-01T13:49:14.156-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310515783984000.30ccb592-4ef0-4f51-aad3-f2d722881ebb"
+          "reference" : "Organization/1706813354198963000.791fad30-e61c-478c-a99d-8771d58980ed"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310515783984000.30ccb592-4ef0-4f51-aad3-f2d722881ebb",
+      "fullUrl" : "Organization/1706813354198963000.791fad30-e61c-478c-a99d-8771d58980ed",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310515783984000.30ccb592-4ef0-4f51-aad3-f2d722881ebb",
+        "id" : "1706813354198963000.791fad30-e61c-478c-a99d-8771d58980ed",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310516068258000.bd195587-10af-40cb-a6d5-7a90c6105219",
+      "fullUrl" : "Provenance/1706813354536134000.ed64dfba-c3e2-4c2b-8f2b-4fdad54cbe58",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310516068258000.bd195587-10af-40cb-a6d5-7a90c6105219",
+        "id" : "1706813354536134000.ed64dfba-c3e2-4c2b-8f2b-4fdad54cbe58",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310516074948000.0047484a-2515-428b-8ef9-420f115e4637",
+      "fullUrl" : "Provenance/1706813354543596000.84e3290d-f7f2-4b90-9c96-03064d6c3807",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310516074948000.0047484a-2515-428b-8ef9-420f115e4637",
-        "recorded" : "2024-01-26T17:08:36Z",
+        "id" : "1706813354543596000.84e3290d-f7f2-4b90-9c96-03064d6c3807",
+        "recorded" : "2024-02-01T13:49:14Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310516073914000.dcf80b99-ccb1-4a9d-8656-fc89bc09d274"
+              "reference" : "Organization/1706813354542969000.4d3ec21b-20bf-4354-a17c-c0d63a0a9396"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310516073914000.dcf80b99-ccb1-4a9d-8656-fc89bc09d274",
+      "fullUrl" : "Organization/1706813354542969000.4d3ec21b-20bf-4354-a17c-c0d63a0a9396",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310516073914000.dcf80b99-ccb1-4a9d-8656-fc89bc09d274",
+        "id" : "1706813354542969000.4d3ec21b-20bf-4354-a17c-c0d63a0a9396",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310516086449000.65e69b3d-c4df-4184-818c-4c609b923de8",
+      "fullUrl" : "Patient/1706813354559988000.7b334b86-9a55-4fbd-bd4e-0e4e15f5a8a7",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310516086449000.65e69b3d-c4df-4184-818c-4c609b923de8"
+        "id" : "1706813354559988000.7b334b86-9a55-4fbd-bd4e-0e4e15f5a8a7"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310516086993000.79f258d5-09d9-46db-85bd-f6797c8dfbfe",
+      "fullUrl" : "Provenance/1706813354560601000.84dbcad6-1b7f-4549-8d8d-cf1bbfc03ddd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310516086993000.79f258d5-09d9-46db-85bd-f6797c8dfbfe",
+        "id" : "1706813354560601000.84dbcad6-1b7f-4549-8d8d-cf1bbfc03ddd",
         "target" : [
           {
-            "reference" : "Patient/1706310516086449000.65e69b3d-c4df-4184-818c-4c609b923de8"
+            "reference" : "Patient/1706813354559988000.7b334b86-9a55-4fbd-bd4e-0e4e15f5a8a7"
           }
         ],
-        "recorded" : "2024-01-26T17:08:36Z",
+        "recorded" : "2024-02-01T13:49:14Z",
         "activity" : {
           "coding" : [
             {
@@ -167,30 +172,30 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706310516090454000.052d25a8-214f-4a3f-9ee7-59c2178f608f",
+      "fullUrl" : "Encounter/1706813354565377000.ad7b07de-319f-4115-875f-1c637fce3c37",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706310516090454000.052d25a8-214f-4a3f-9ee7-59c2178f608f",
+        "id" : "1706813354565377000.ad7b07de-319f-4115-875f-1c637fce3c37",
         "subject" : {
-          "reference" : "Patient/1706310516086449000.65e69b3d-c4df-4184-818c-4c609b923de8"
+          "reference" : "Patient/1706813354559988000.7b334b86-9a55-4fbd-bd4e-0e4e15f5a8a7"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706310516090732000.420d07c8-cc4f-43ec-ade3-1ed39f548fa5"
+            "reference" : "EpisodeOfCare/1706813354565635000.d84e1546-a493-41e8-bfb2-2e8289bb16f0"
           }
         ],
         "hospitalization" : {
           "destination" : {
-            "reference" : "Location/1706310516089363000.61ef6b87-7ef7-48ad-95fd-6785b9889642"
+            "reference" : "Location/1706813354563050000.8a5def6d-4a43-46f1-925b-680d6579aed0"
           }
         }
       }
     },
     {
-      "fullUrl" : "Location/1706310516089363000.61ef6b87-7ef7-48ad-95fd-6785b9889642",
+      "fullUrl" : "Location/1706813354563050000.8a5def6d-4a43-46f1-925b-680d6579aed0",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310516089363000.61ef6b87-7ef7-48ad-95fd-6785b9889642",
+        "id" : "1706813354563050000.8a5def6d-4a43-46f1-925b-680d6579aed0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
@@ -221,10 +226,10 @@
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706310516090732000.420d07c8-cc4f-43ec-ade3-1ed39f548fa5",
+      "fullUrl" : "EpisodeOfCare/1706813354565635000.d84e1546-a493-41e8-bfb2-2e8289bb16f0",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706310516090732000.420d07c8-cc4f-43ec-ade3-1ed39f548fa5",
+        "id" : "1706813354565635000.d84e1546-a493-41e8-bfb2-2e8289bb16f0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dr/dr-to-period.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dr/dr-to-period.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653488001780000.5cb9d6bc-0fe6-4089-82f9-4b5b814f3bbb",
+  "id" : "1706818806728334000.07670a1d-a2c6-434a-a1b6-4a1b024204e6",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:24:48.008-05:00"
+    "lastUpdated" : "2024-02-01T15:20:06.735-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706653488076137000.18b5a461-c04f-42a9-aec6-215bdf9ab6c6"
+          "reference" : "Organization/1706818806779231000.31ec5c1f-b69f-46ce-851b-b2f28be70710"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706653488076137000.18b5a461-c04f-42a9-aec6-215bdf9ab6c6",
+      "fullUrl" : "Organization/1706818806779231000.31ec5c1f-b69f-46ce-851b-b2f28be70710",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653488076137000.18b5a461-c04f-42a9-aec6-215bdf9ab6c6",
+        "id" : "1706818806779231000.31ec5c1f-b69f-46ce-851b-b2f28be70710",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653488389684000.aa2f80e0-b4df-49d9-9d89-e55a346d5bcf",
+      "fullUrl" : "Provenance/1706818807188013000.98dbe409-a703-4b92-a2a5-a322714e668e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653488389684000.aa2f80e0-b4df-49d9-9d89-e55a346d5bcf",
+        "id" : "1706818807188013000.98dbe409-a703-4b92-a2a5-a322714e668e",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653488396785000.5490fa96-1674-4b21-90f4-cd86bccfb90b",
+      "fullUrl" : "Provenance/1706818807197935000.bc0932d4-f7ca-478a-be68-c3946e066684",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653488396785000.5490fa96-1674-4b21-90f4-cd86bccfb90b",
-        "recorded" : "2024-01-30T17:24:48Z",
+        "id" : "1706818807197935000.bc0932d4-f7ca-478a-be68-c3946e066684",
+        "recorded" : "2024-02-01T15:20:07Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653488395832000.ba875f95-c453-48c7-82a9-66d35b278857"
+              "reference" : "Organization/1706818807197314000.8ff59c48-c602-48af-ac92-f16016ad6312"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653488395832000.ba875f95-c453-48c7-82a9-66d35b278857",
+      "fullUrl" : "Organization/1706818807197314000.8ff59c48-c602-48af-ac92-f16016ad6312",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653488395832000.ba875f95-c453-48c7-82a9-66d35b278857",
+        "id" : "1706818807197314000.8ff59c48-c602-48af-ac92-f16016ad6312",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653488419683000.77e166e8-ef04-4825-a81e-46070e4c2532",
+      "fullUrl" : "Patient/1706818807232269000.ff085a45-7f0e-4b73-9ef1-51b1f8445a07",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653488419683000.77e166e8-ef04-4825-a81e-46070e4c2532",
+        "id" : "1706818807232269000.ff085a45-7f0e-4b73-9ef1-51b1f8445a07",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706653488413826000.e5467424-4607-4ce0-9cc9-4433677333f2"
+              "reference" : "Organization/1706818807225135000.c71fe5dd-58ea-4df5-a7bc-1077a6471548"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653488413826000.e5467424-4607-4ce0-9cc9-4433677333f2",
+      "fullUrl" : "Organization/1706818807225135000.c71fe5dd-58ea-4df5-a7bc-1077a6471548",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653488413826000.e5467424-4607-4ce0-9cc9-4433677333f2",
+        "id" : "1706818807225135000.c71fe5dd-58ea-4df5-a7bc-1077a6471548",
         "contact" : [
           {
             "address" : {
@@ -276,16 +281,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653488421644000.bb2321ff-a0f9-408b-8173-7f4b69c1e7e9",
+      "fullUrl" : "Provenance/1706818807236401000.c357e4ef-4299-44a1-9729-bdfa3c3948b4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653488421644000.bb2321ff-a0f9-408b-8173-7f4b69c1e7e9",
+        "id" : "1706818807236401000.c357e4ef-4299-44a1-9729-bdfa3c3948b4",
         "target" : [
           {
-            "reference" : "Patient/1706653488419683000.77e166e8-ef04-4825-a81e-46070e4c2532"
+            "reference" : "Patient/1706818807232269000.ff085a45-7f0e-4b73-9ef1-51b1f8445a07"
           }
         ],
-        "recorded" : "2024-01-30T17:24:48Z",
+        "recorded" : "2024-02-01T15:20:07Z",
         "activity" : {
           "coding" : [
             {
@@ -297,10 +302,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706653488424297000.3e0caa2f-0fa7-4cbe-a9b7-65d2b9272ad3",
+      "fullUrl" : "RelatedPerson/1706818807240384000.235528c8-d1f3-4c9c-8b8b-5ed6e5d44dbc",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706653488424297000.3e0caa2f-0fa7-4cbe-a9b7-65d2b9272ad3",
+        "id" : "1706818807240384000.235528c8-d1f3-4c9c-8b8b-5ed6e5d44dbc",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -308,7 +313,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706653488419683000.77e166e8-ef04-4825-a81e-46070e4c2532"
+          "reference" : "Patient/1706818807232269000.ff085a45-7f0e-4b73-9ef1-51b1f8445a07"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-day-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-day-precision-to-dateTime.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653564953812000.db22b4bf-6b1e-42b8-a6c9-ae86db846396",
+  "id" : "1706813699626013000.6f464860-8763-4c5a-835b-066afd320d9f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:26:04.960-05:00"
+    "lastUpdated" : "2024-02-01T13:54:59.632-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653565344185000.1686427f-74b0-4edd-8824-dcb774207520",
+      "fullUrl" : "Provenance/1706813700003339000.f26861ec-3e1e-4b1f-8b9b-a6cfbfcd373b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653565344185000.1686427f-74b0-4edd-8824-dcb774207520",
+        "id" : "1706813700003339000.f26861ec-3e1e-4b1f-8b9b-a6cfbfcd373b",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653565352871000.a9e80d78-84b0-4650-9adf-d325f798341d",
+      "fullUrl" : "Provenance/1706813700011357000.2dfc9471-2af3-48f6-8b04-abc2d95d253e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653565352871000.a9e80d78-84b0-4650-9adf-d325f798341d",
-        "recorded" : "2024-01-30T17:26:05Z",
+        "id" : "1706813700011357000.2dfc9471-2af3-48f6-8b04-abc2d95d253e",
+        "recorded" : "2024-02-01T13:55:00Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653565352028000.1341356f-e672-4621-9fde-0ed9aa6c3a0a"
+              "reference" : "Organization/1706813700010697000.d432b35c-c6e3-4e85-823e-6ef6e9a63686"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653565352028000.1341356f-e672-4621-9fde-0ed9aa6c3a0a",
+      "fullUrl" : "Organization/1706813700010697000.d432b35c-c6e3-4e85-823e-6ef6e9a63686",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653565352028000.1341356f-e672-4621-9fde-0ed9aa6c3a0a",
+        "id" : "1706813700010697000.d432b35c-c6e3-4e85-823e-6ef6e9a63686",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653565376156000.6768b715-a949-49f1-bb27-cf73ff30ccae",
+      "fullUrl" : "Patient/1706813700029237000.205fd37f-8c8a-4584-86bb-b4e9a961392d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653565376156000.6768b715-a949-49f1-bb27-cf73ff30ccae",
+        "id" : "1706813700029237000.205fd37f-8c8a-4584-86bb-b4e9a961392d",
         "contact" : [
           {
             "name" : {},
@@ -152,16 +157,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653565377366000.8829308f-882b-49b6-82ee-f1e43bb2bde7",
+      "fullUrl" : "Provenance/1706813700030955000.b7eae1c5-5328-41af-befa-9229dc07ba29",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653565377366000.8829308f-882b-49b6-82ee-f1e43bb2bde7",
+        "id" : "1706813700030955000.b7eae1c5-5328-41af-befa-9229dc07ba29",
         "target" : [
           {
-            "reference" : "Patient/1706653565376156000.6768b715-a949-49f1-bb27-cf73ff30ccae"
+            "reference" : "Patient/1706813700029237000.205fd37f-8c8a-4584-86bb-b4e9a961392d"
           }
         ],
-        "recorded" : "2024-01-30T17:26:05Z",
+        "recorded" : "2024-02-01T13:55:00Z",
         "activity" : {
           "coding" : [
             {
@@ -173,10 +178,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706653565379241000.5de66385-7923-4da5-86d4-c284d97f6ca2",
+      "fullUrl" : "RelatedPerson/1706813700032768000.fcc29c0f-4b87-4384-96c0-2ba4cdd83418",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706653565379241000.5de66385-7923-4da5-86d4-c284d97f6ca2",
+        "id" : "1706813700032768000.fcc29c0f-4b87-4384-96c0-2ba4cdd83418",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -184,7 +189,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706653565376156000.6768b715-a949-49f1-bb27-cf73ff30ccae"
+          "reference" : "Patient/1706813700029237000.205fd37f-8c8a-4584-86bb-b4e9a961392d"
         },
         "period" : {
           "start" : "2021-01-02",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-month-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-month-precision-to-dateTime.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653574420083000.94ace416-fe39-4f88-ba07-95c9a1e9f8f7",
+  "id" : "1706813708605552000.ff7f35e2-f2a9-49b4-8ed9-ed966a76528f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:26:14.430-05:00"
+    "lastUpdated" : "2024-02-01T13:55:08.612-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653574861056000.b5573b6a-aa7f-4546-8c6f-21b8fd08205f",
+      "fullUrl" : "Provenance/1706813708980006000.d80e05f4-4afe-4880-ae9b-07b4dc0ce42c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653574861056000.b5573b6a-aa7f-4546-8c6f-21b8fd08205f",
+        "id" : "1706813708980006000.d80e05f4-4afe-4880-ae9b-07b4dc0ce42c",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653574876653000.5977c54f-1502-4dbc-97fa-29d0baf0f301",
+      "fullUrl" : "Provenance/1706813708990995000.774c56ac-fcfd-43a3-ac51-af3fa1fa8583",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653574876653000.5977c54f-1502-4dbc-97fa-29d0baf0f301",
-        "recorded" : "2024-01-30T17:26:14Z",
+        "id" : "1706813708990995000.774c56ac-fcfd-43a3-ac51-af3fa1fa8583",
+        "recorded" : "2024-02-01T13:55:08Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653574876100000.e65bf5f3-c2fe-47cb-9fbb-55d3be3bf1b3"
+              "reference" : "Organization/1706813708990501000.aa9931ff-7c43-42bb-8f39-12d90998f40b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653574876100000.e65bf5f3-c2fe-47cb-9fbb-55d3be3bf1b3",
+      "fullUrl" : "Organization/1706813708990501000.aa9931ff-7c43-42bb-8f39-12d90998f40b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653574876100000.e65bf5f3-c2fe-47cb-9fbb-55d3be3bf1b3",
+        "id" : "1706813708990501000.aa9931ff-7c43-42bb-8f39-12d90998f40b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653574900275000.eef41485-3da3-478a-8fd6-05bedb32766b",
+      "fullUrl" : "Patient/1706813709008025000.98a6cc7b-e86d-4aa6-9fb9-7165283ad99d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653574900275000.eef41485-3da3-478a-8fd6-05bedb32766b",
+        "id" : "1706813709008025000.98a6cc7b-e86d-4aa6-9fb9-7165283ad99d",
         "contact" : [
           {
             "name" : {},
@@ -152,16 +157,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653574901926000.c397e353-d3f5-4350-a2ef-83d15a2b37b9",
+      "fullUrl" : "Provenance/1706813709009143000.0c35a90c-758b-4409-95aa-d52a9a42e409",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653574901926000.c397e353-d3f5-4350-a2ef-83d15a2b37b9",
+        "id" : "1706813709009143000.0c35a90c-758b-4409-95aa-d52a9a42e409",
         "target" : [
           {
-            "reference" : "Patient/1706653574900275000.eef41485-3da3-478a-8fd6-05bedb32766b"
+            "reference" : "Patient/1706813709008025000.98a6cc7b-e86d-4aa6-9fb9-7165283ad99d"
           }
         ],
-        "recorded" : "2024-01-30T17:26:14Z",
+        "recorded" : "2024-02-01T13:55:09Z",
         "activity" : {
           "coding" : [
             {
@@ -173,10 +178,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706653574904399000.dbc3be37-c581-442f-84c1-cbcf5aaa7487",
+      "fullUrl" : "RelatedPerson/1706813709011046000.77666e38-f07c-4c85-8cd5-31e1a2053742",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706653574904399000.dbc3be37-c581-442f-84c1-cbcf5aaa7487",
+        "id" : "1706813709011046000.77666e38-f07c-4c85-8cd5-31e1a2053742",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -184,7 +189,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706653574900275000.eef41485-3da3-478a-8fd6-05bedb32766b"
+          "reference" : "Patient/1706813709008025000.98a6cc7b-e86d-4aa6-9fb9-7165283ad99d"
         },
         "period" : {
           "start" : "2021-01",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-year-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-year-precision-to-dateTime.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653583699224000.1387c944-c7e7-4b86-8d9d-db2f1a01bc16",
+  "id" : "1706813717590381000.b58cb75f-6490-41a3-84e2-be61dd55e448",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:26:23.706-05:00"
+    "lastUpdated" : "2024-02-01T13:55:17.597-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653584077122000.cc76489f-d312-46e5-a490-19a879bbc73c",
+      "fullUrl" : "Provenance/1706813717973471000.75b9b340-18f1-498c-a73c-85fb487870ce",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653584077122000.cc76489f-d312-46e5-a490-19a879bbc73c",
+        "id" : "1706813717973471000.75b9b340-18f1-498c-a73c-85fb487870ce",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653584084725000.3d2c68cc-56d1-43a7-b473-adf42f16432a",
+      "fullUrl" : "Provenance/1706813717981701000.de0b7541-c11b-4964-b86d-01742d72e2a4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653584084725000.3d2c68cc-56d1-43a7-b473-adf42f16432a",
-        "recorded" : "2024-01-30T17:26:24Z",
+        "id" : "1706813717981701000.de0b7541-c11b-4964-b86d-01742d72e2a4",
+        "recorded" : "2024-02-01T13:55:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653584084281000.880211b2-7092-48ae-bbc7-2f6f7e45808a"
+              "reference" : "Organization/1706813717980597000.5b4932b7-f34e-4e07-ac6d-645e602e6f0b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653584084281000.880211b2-7092-48ae-bbc7-2f6f7e45808a",
+      "fullUrl" : "Organization/1706813717980597000.5b4932b7-f34e-4e07-ac6d-645e602e6f0b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653584084281000.880211b2-7092-48ae-bbc7-2f6f7e45808a",
+        "id" : "1706813717980597000.5b4932b7-f34e-4e07-ac6d-645e602e6f0b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653584101890000.d5cae635-1e7f-4a36-9f44-47827bdcf83d",
+      "fullUrl" : "Patient/1706813717999811000.e3f993cf-6f8c-4630-a4c8-1d7b6be1cfdd",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653584101890000.d5cae635-1e7f-4a36-9f44-47827bdcf83d",
+        "id" : "1706813717999811000.e3f993cf-6f8c-4630-a4c8-1d7b6be1cfdd",
         "contact" : [
           {
             "name" : {},
@@ -152,16 +157,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653584102709000.7c0106ba-6cf6-40e3-8321-4c009fdc2e11",
+      "fullUrl" : "Provenance/1706813718000847000.c05a469c-751b-42fe-9159-e943b511ef4d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653584102709000.7c0106ba-6cf6-40e3-8321-4c009fdc2e11",
+        "id" : "1706813718000847000.c05a469c-751b-42fe-9159-e943b511ef4d",
         "target" : [
           {
-            "reference" : "Patient/1706653584101890000.d5cae635-1e7f-4a36-9f44-47827bdcf83d"
+            "reference" : "Patient/1706813717999811000.e3f993cf-6f8c-4630-a4c8-1d7b6be1cfdd"
           }
         ],
-        "recorded" : "2024-01-30T17:26:24Z",
+        "recorded" : "2024-02-01T13:55:18Z",
         "activity" : {
           "coding" : [
             {
@@ -173,10 +178,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706653584104110000.606c5c92-22f5-4979-bdcf-319bb0126277",
+      "fullUrl" : "RelatedPerson/1706813718002436000.2dde92a3-0014-43fc-b192-dfb323f214f1",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706653584104110000.606c5c92-22f5-4979-bdcf-319bb0126277",
+        "id" : "1706813718002436000.2dde92a3-0014-43fc-b192-dfb323f214f1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -184,7 +189,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706653584101890000.d5cae635-1e7f-4a36-9f44-47827bdcf83d"
+          "reference" : "Patient/1706813717999811000.e3f993cf-6f8c-4630-a4c8-1d7b6be1cfdd"
         },
         "period" : {
           "start" : "2021",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-zero-year-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dt/dt-zero-year-to-dateTime.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653592896757000.2394af79-cc52-430b-b4c4-f923874faf13",
+  "id" : "1706813727309315000.1854d37c-f9cc-45d3-93a6-52e354dc7351",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:26:32.904-05:00"
+    "lastUpdated" : "2024-02-01T13:55:27.319-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653593274598000.5f5533a6-8921-469f-9422-0a159d10239c",
+      "fullUrl" : "Provenance/1706813727690588000.6a28593b-d6e8-434b-9b98-e46e1d0f5c91",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653593274598000.5f5533a6-8921-469f-9422-0a159d10239c",
+        "id" : "1706813727690588000.6a28593b-d6e8-434b-9b98-e46e1d0f5c91",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653593283423000.627bb332-f525-4fec-ac5e-d5a6e8f52ea7",
+      "fullUrl" : "Provenance/1706813727697924000.0d32cea2-8ea9-4fc5-8477-9b0522326876",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653593283423000.627bb332-f525-4fec-ac5e-d5a6e8f52ea7",
-        "recorded" : "2024-01-30T17:26:33Z",
+        "id" : "1706813727697924000.0d32cea2-8ea9-4fc5-8477-9b0522326876",
+        "recorded" : "2024-02-01T13:55:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653593282662000.911927d9-5ec8-407d-a6c0-9e871fc1433d"
+              "reference" : "Organization/1706813727697442000.cfebd733-7b58-4624-8a3d-d9e74e2ad33a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653593282662000.911927d9-5ec8-407d-a6c0-9e871fc1433d",
+      "fullUrl" : "Organization/1706813727697442000.cfebd733-7b58-4624-8a3d-d9e74e2ad33a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653593282662000.911927d9-5ec8-407d-a6c0-9e871fc1433d",
+        "id" : "1706813727697442000.cfebd733-7b58-4624-8a3d-d9e74e2ad33a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653593305545000.25d51b08-53b0-4fc5-8c46-cda007f4e8c4",
+      "fullUrl" : "Patient/1706813727715138000.e44baa57-52ee-4eca-807f-4ca84f9ac539",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653593305545000.25d51b08-53b0-4fc5-8c46-cda007f4e8c4",
+        "id" : "1706813727715138000.e44baa57-52ee-4eca-807f-4ca84f9ac539",
         "contact" : [
           {
             "name" : {},
@@ -150,16 +155,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653593306491000.2847cc27-ad22-4f7b-bbb3-ab9d91235b0a",
+      "fullUrl" : "Provenance/1706813727716152000.44623270-5105-47cb-8757-172f7399da0e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653593306491000.2847cc27-ad22-4f7b-bbb3-ab9d91235b0a",
+        "id" : "1706813727716152000.44623270-5105-47cb-8757-172f7399da0e",
         "target" : [
           {
-            "reference" : "Patient/1706653593305545000.25d51b08-53b0-4fc5-8c46-cda007f4e8c4"
+            "reference" : "Patient/1706813727715138000.e44baa57-52ee-4eca-807f-4ca84f9ac539"
           }
         ],
-        "recorded" : "2024-01-30T17:26:33Z",
+        "recorded" : "2024-02-01T13:55:27Z",
         "activity" : {
           "coding" : [
             {
@@ -171,10 +176,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706653593308225000.e0a381ae-375c-4e6a-97f9-c873aa0a694a",
+      "fullUrl" : "RelatedPerson/1706813727718151000.213c3003-da87-4a56-b872-146e5d27ecee",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706653593308225000.e0a381ae-375c-4e6a-97f9-c873aa0a694a",
+        "id" : "1706813727718151000.213c3003-da87-4a56-b872-146e5d27ecee",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -182,7 +187,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706653593305545000.25d51b08-53b0-4fc5-8c46-cda007f4e8c4"
+          "reference" : "Patient/1706813727715138000.e44baa57-52ee-4eca-807f-4ca84f9ac539"
         },
         "period" : {
           "_start" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-csec-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-csec-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310567906244000.36bde712-4543-4c43-a730-1ad68783b323",
+  "id" : "1706813374010965000.6b055787-7aa3-4461-8703-4303c27a4e9e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:09:27.922-06:00"
+    "lastUpdated" : "2024-02-01T13:49:34.017-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310568327311000.0e6cd1af-103a-4cb1-ae07-5d8d6f3b9f70",
+      "fullUrl" : "Provenance/1706813374392397000.f92dd188-e188-4443-a2fe-1e83a19cd73b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310568327311000.0e6cd1af-103a-4cb1-ae07-5d8d6f3b9f70",
+        "id" : "1706813374392397000.f92dd188-e188-4443-a2fe-1e83a19cd73b",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310568334126000.55f4daf0-5a9b-4bc6-8ec6-1a13514806b8",
+      "fullUrl" : "Provenance/1706813374398727000.c8c29a81-0771-4457-9aad-b7e4ca8c4bce",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310568334126000.55f4daf0-5a9b-4bc6-8ec6-1a13514806b8",
-        "recorded" : "2024-01-26T17:09:28Z",
+        "id" : "1706813374398727000.c8c29a81-0771-4457-9aad-b7e4ca8c4bce",
+        "recorded" : "2024-02-01T13:49:34Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310568333605000.62e70f7a-ba5f-475b-80da-9c501ccf403b"
+              "reference" : "Organization/1706813374398295000.a972d8e3-e6b2-44da-90f5-3e2bc9668ce8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310568333605000.62e70f7a-ba5f-475b-80da-9c501ccf403b",
+      "fullUrl" : "Organization/1706813374398295000.a972d8e3-e6b2-44da-90f5-3e2bc9668ce8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310568333605000.62e70f7a-ba5f-475b-80da-9c501ccf403b",
+        "id" : "1706813374398295000.a972d8e3-e6b2-44da-90f5-3e2bc9668ce8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310568348819000.6a40bcbd-bbf9-4213-992c-772e7d435486",
+      "fullUrl" : "Patient/1706813374417868000.20a3b7f2-685c-4542-8165-0fe29beb5ce6",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310568348819000.6a40bcbd-bbf9-4213-992c-772e7d435486",
+        "id" : "1706813374417868000.20a3b7f2-685c-4542-8165-0fe29beb5ce6",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310568349495000.705783f6-1aa6-46fc-9d3c-cb9a5dfe7735",
+      "fullUrl" : "Provenance/1706813374418750000.f75b0f48-91e5-4f3e-b0fd-5e47d74e971d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310568349495000.705783f6-1aa6-46fc-9d3c-cb9a5dfe7735",
+        "id" : "1706813374418750000.f75b0f48-91e5-4f3e-b0fd-5e47d74e971d",
         "target" : [
           {
-            "reference" : "Patient/1706310568348819000.6a40bcbd-bbf9-4213-992c-772e7d435486"
+            "reference" : "Patient/1706813374417868000.20a3b7f2-685c-4542-8165-0fe29beb5ce6"
           }
         ],
-        "recorded" : "2024-01-26T17:09:28Z",
+        "recorded" : "2024-02-01T13:49:34Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-day-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-day-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310576989160000.96b4f5c6-e8d3-4cda-8370-0cc543509129",
+  "id" : "1706813383587401000.74c557e3-9944-4947-84a6-7e5de2eb1de0",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:09:37.003-06:00"
+    "lastUpdated" : "2024-02-01T13:49:43.594-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310577357158000.5ff6f167-a351-47cf-a60b-b679518d41f5",
+      "fullUrl" : "Provenance/1706813383940133000.08f5c73c-a658-41ee-8b07-48a99f114d0e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310577357158000.5ff6f167-a351-47cf-a60b-b679518d41f5",
+        "id" : "1706813383940133000.08f5c73c-a658-41ee-8b07-48a99f114d0e",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310577364985000.f383b1a6-d14c-4c68-9553-7d1b1cab2c2d",
+      "fullUrl" : "Provenance/1706813383951168000.b16b2213-3e0d-4208-b9cc-ae1b17bae4a4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310577364985000.f383b1a6-d14c-4c68-9553-7d1b1cab2c2d",
-        "recorded" : "2024-01-26T17:09:37Z",
+        "id" : "1706813383951168000.b16b2213-3e0d-4208-b9cc-ae1b17bae4a4",
+        "recorded" : "2024-02-01T13:49:43Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310577364421000.4b10e198-d6ca-4d9a-beb1-ae5be9e3a28a"
+              "reference" : "Organization/1706813383950510000.f2f3b57c-8a02-42f7-99dd-a7a093d7a868"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310577364421000.4b10e198-d6ca-4d9a-beb1-ae5be9e3a28a",
+      "fullUrl" : "Organization/1706813383950510000.f2f3b57c-8a02-42f7-99dd-a7a093d7a868",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310577364421000.4b10e198-d6ca-4d9a-beb1-ae5be9e3a28a",
+        "id" : "1706813383950510000.f2f3b57c-8a02-42f7-99dd-a7a093d7a868",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310577382006000.b8f180f2-8e0a-4d3f-9fd1-e7b1da9e5270",
+      "fullUrl" : "Patient/1706813383969903000.8f2c78bd-4ff8-41a3-86c9-84ec5b538b8c",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310577382006000.b8f180f2-8e0a-4d3f-9fd1-e7b1da9e5270",
+        "id" : "1706813383969903000.8f2c78bd-4ff8-41a3-86c9-84ec5b538b8c",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310577382820000.4477444a-2e38-4700-a591-23abb70c5709",
+      "fullUrl" : "Provenance/1706813383970625000.88f91792-3596-4110-bf72-bb4702848420",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310577382820000.4477444a-2e38-4700-a591-23abb70c5709",
+        "id" : "1706813383970625000.88f91792-3596-4110-bf72-bb4702848420",
         "target" : [
           {
-            "reference" : "Patient/1706310577382006000.b8f180f2-8e0a-4d3f-9fd1-e7b1da9e5270"
+            "reference" : "Patient/1706813383969903000.8f2c78bd-4ff8-41a3-86c9-84ec5b538b8c"
           }
         ],
-        "recorded" : "2024-01-26T17:09:37Z",
+        "recorded" : "2024-02-01T13:49:43Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-dsec-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-dsec-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310585033471000.bae11655-3cd6-4278-b4ed-6fc4f6b2a80b",
+  "id" : "1706813392754078000.216543e2-5ead-45ec-a60b-0e3227dadca6",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:09:45.049-06:00"
+    "lastUpdated" : "2024-02-01T13:49:52.761-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310585424745000.ed5c5b91-583c-4f00-8048-9131c7ebde4c",
+      "fullUrl" : "Provenance/1706813393130766000.3147070e-981c-4ea6-a8d3-eff0152fcaa5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310585424745000.ed5c5b91-583c-4f00-8048-9131c7ebde4c",
+        "id" : "1706813393130766000.3147070e-981c-4ea6-a8d3-eff0152fcaa5",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310585431458000.8b884bb5-cab4-4142-861e-b83d97ae72b4",
+      "fullUrl" : "Provenance/1706813393138530000.9c98c8cb-498e-4f19-b037-d03113121d91",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310585431458000.8b884bb5-cab4-4142-861e-b83d97ae72b4",
-        "recorded" : "2024-01-26T17:09:45Z",
+        "id" : "1706813393138530000.9c98c8cb-498e-4f19-b037-d03113121d91",
+        "recorded" : "2024-02-01T13:49:53Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310585431047000.6eaaa854-91cf-404e-a92e-fe769f345b91"
+              "reference" : "Organization/1706813393138081000.2e331c77-ba37-469c-b771-89cd773e089e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310585431047000.6eaaa854-91cf-404e-a92e-fe769f345b91",
+      "fullUrl" : "Organization/1706813393138081000.2e331c77-ba37-469c-b771-89cd773e089e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310585431047000.6eaaa854-91cf-404e-a92e-fe769f345b91",
+        "id" : "1706813393138081000.2e331c77-ba37-469c-b771-89cd773e089e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310585449854000.0dfce600-7ea8-4771-b066-cde5ed7d5427",
+      "fullUrl" : "Patient/1706813393155947000.4e99a457-103f-48c5-866a-2d907b0722d3",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310585449854000.0dfce600-7ea8-4771-b066-cde5ed7d5427",
+        "id" : "1706813393155947000.4e99a457-103f-48c5-866a-2d907b0722d3",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310585450657000.c5ca2010-7695-490b-a5b7-6d7bf5aaa8ff",
+      "fullUrl" : "Provenance/1706813393160953000.6c34c554-601b-4da1-82b0-c02be777becd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310585450657000.c5ca2010-7695-490b-a5b7-6d7bf5aaa8ff",
+        "id" : "1706813393160953000.6c34c554-601b-4da1-82b0-c02be777becd",
         "target" : [
           {
-            "reference" : "Patient/1706310585449854000.0dfce600-7ea8-4771-b066-cde5ed7d5427"
+            "reference" : "Patient/1706813393155947000.4e99a457-103f-48c5-866a-2d907b0722d3"
           }
         ],
-        "recorded" : "2024-01-26T17:09:45Z",
+        "recorded" : "2024-02-01T13:49:53Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-hour-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-hour-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310593801675000.de3f103b-6f97-48b0-b6e4-fb15dc3d6e5a",
+  "id" : "1706813402351527000.b7aa6503-f70f-47ab-a6e0-733bb06ea140",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:09:53.820-06:00"
+    "lastUpdated" : "2024-02-01T13:50:02.357-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310594187702000.d2439746-4eed-43f3-92d0-f49056e48051",
+      "fullUrl" : "Provenance/1706813402777136000.11541a56-8ed5-4e98-a8c7-22c47ea5728c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310594187702000.d2439746-4eed-43f3-92d0-f49056e48051",
+        "id" : "1706813402777136000.11541a56-8ed5-4e98-a8c7-22c47ea5728c",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310594195004000.85002beb-3071-4d67-ac14-58c0c9a12ed7",
+      "fullUrl" : "Provenance/1706813402787245000.3d1d6283-0bac-4ea7-a637-76d12b487add",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310594195004000.85002beb-3071-4d67-ac14-58c0c9a12ed7",
-        "recorded" : "2024-01-26T17:09:54Z",
+        "id" : "1706813402787245000.3d1d6283-0bac-4ea7-a637-76d12b487add",
+        "recorded" : "2024-02-01T13:50:02Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310594194466000.1aa7f5d2-ac55-48d3-baf1-66072bc2bfcb"
+              "reference" : "Organization/1706813402786651000.22fb799c-6251-4d16-9b20-8a13197d2025"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310594194466000.1aa7f5d2-ac55-48d3-baf1-66072bc2bfcb",
+      "fullUrl" : "Organization/1706813402786651000.22fb799c-6251-4d16-9b20-8a13197d2025",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310594194466000.1aa7f5d2-ac55-48d3-baf1-66072bc2bfcb",
+        "id" : "1706813402786651000.22fb799c-6251-4d16-9b20-8a13197d2025",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310594213141000.a49d0e21-a26c-4065-8ff7-b69648a57a76",
+      "fullUrl" : "Patient/1706813402812580000.b36e8762-3756-4a9b-b999-ca5fe71035da",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310594213141000.a49d0e21-a26c-4065-8ff7-b69648a57a76",
+        "id" : "1706813402812580000.b36e8762-3756-4a9b-b999-ca5fe71035da",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310594213907000.2653f772-8aa9-4c3d-ac4e-00871a7b2988",
+      "fullUrl" : "Provenance/1706813402813697000.02909f52-58a9-4fed-a3dd-21e392503603",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310594213907000.2653f772-8aa9-4c3d-ac4e-00871a7b2988",
+        "id" : "1706813402813697000.02909f52-58a9-4fed-a3dd-21e392503603",
         "target" : [
           {
-            "reference" : "Patient/1706310594213141000.a49d0e21-a26c-4065-8ff7-b69648a57a76"
+            "reference" : "Patient/1706813402812580000.b36e8762-3756-4a9b-b999-ca5fe71035da"
           }
         ],
-        "recorded" : "2024-01-26T17:09:54Z",
+        "recorded" : "2024-02-01T13:50:02Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-minute-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-minute-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310602755925000.bac80cbf-cd7d-4ad4-9d56-79caa68ae531",
+  "id" : "1706813412115108000.81e09c68-03c1-493d-a861-4433a65131b3",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:02.769-06:00"
+    "lastUpdated" : "2024-02-01T13:50:12.121-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310603132098000.994f7066-6471-4e10-bb94-cc438c59bd40",
+      "fullUrl" : "Provenance/1706813412494621000.5ba0b1be-398b-4fa2-9dae-d929ef8de9ed",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310603132098000.994f7066-6471-4e10-bb94-cc438c59bd40",
+        "id" : "1706813412494621000.5ba0b1be-398b-4fa2-9dae-d929ef8de9ed",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310603139210000.b036aebf-d973-4fd5-98d7-a1ef091a711d",
+      "fullUrl" : "Provenance/1706813412502456000.d7cb7469-dcd7-44b8-9f8c-7d291ad68162",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310603139210000.b036aebf-d973-4fd5-98d7-a1ef091a711d",
-        "recorded" : "2024-01-26T17:10:03Z",
+        "id" : "1706813412502456000.d7cb7469-dcd7-44b8-9f8c-7d291ad68162",
+        "recorded" : "2024-02-01T13:50:12Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310603138566000.edaed0eb-4e1a-4d2b-9563-69f437e26fd2"
+              "reference" : "Organization/1706813412501986000.82282123-4fdc-4d57-91b0-3953fd24907b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310603138566000.edaed0eb-4e1a-4d2b-9563-69f437e26fd2",
+      "fullUrl" : "Organization/1706813412501986000.82282123-4fdc-4d57-91b0-3953fd24907b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310603138566000.edaed0eb-4e1a-4d2b-9563-69f437e26fd2",
+        "id" : "1706813412501986000.82282123-4fdc-4d57-91b0-3953fd24907b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310603156160000.2a73745b-fe94-4a9b-91f6-18161bc1662a",
+      "fullUrl" : "Patient/1706813412520247000.aef691bc-264f-4d4f-9706-1c7b27c48919",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310603156160000.2a73745b-fe94-4a9b-91f6-18161bc1662a",
+        "id" : "1706813412520247000.aef691bc-264f-4d4f-9706-1c7b27c48919",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310603156927000.8bbd34b6-d3dc-4de3-898e-482c64621993",
+      "fullUrl" : "Provenance/1706813412521018000.50861e86-6f8c-49c4-aab0-929829155770",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310603156927000.8bbd34b6-d3dc-4de3-898e-482c64621993",
+        "id" : "1706813412521018000.50861e86-6f8c-49c4-aab0-929829155770",
         "target" : [
           {
-            "reference" : "Patient/1706310603156160000.2a73745b-fe94-4a9b-91f6-18161bc1662a"
+            "reference" : "Patient/1706813412520247000.aef691bc-264f-4d4f-9706-1c7b27c48919"
           }
         ],
-        "recorded" : "2024-01-26T17:10:03Z",
+        "recorded" : "2024-02-01T13:50:12Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-mmsec-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-mmsec-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310611295625000.0d3ced2a-7a08-4a73-8044-aeb93e14ae29",
+  "id" : "1706813421728464000.acfdb6cb-b2af-4ff9-be49-b5019b2833b9",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:11.308-06:00"
+    "lastUpdated" : "2024-02-01T13:50:21.734-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310611685960000.2cb92c92-9ab5-4cbd-9b7c-35a26eecafff",
+      "fullUrl" : "Provenance/1706813422100816000.8ee969bd-3a12-44b7-b54d-23cdfd55f5ac",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310611685960000.2cb92c92-9ab5-4cbd-9b7c-35a26eecafff",
+        "id" : "1706813422100816000.8ee969bd-3a12-44b7-b54d-23cdfd55f5ac",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310611693135000.07b88e30-c23e-4d2f-9c86-d983200db9ef",
+      "fullUrl" : "Provenance/1706813422108357000.4e8ec8ed-54e6-4d45-9668-94ab11c13b30",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310611693135000.07b88e30-c23e-4d2f-9c86-d983200db9ef",
-        "recorded" : "2024-01-26T17:10:11Z",
+        "id" : "1706813422108357000.4e8ec8ed-54e6-4d45-9668-94ab11c13b30",
+        "recorded" : "2024-02-01T13:50:22Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310611692744000.86abba98-13cf-41d7-b254-ff49d1cacfee"
+              "reference" : "Organization/1706813422107913000.5a5f434c-528d-403f-8bde-1069096829a6"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310611692744000.86abba98-13cf-41d7-b254-ff49d1cacfee",
+      "fullUrl" : "Organization/1706813422107913000.5a5f434c-528d-403f-8bde-1069096829a6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310611692744000.86abba98-13cf-41d7-b254-ff49d1cacfee",
+        "id" : "1706813422107913000.5a5f434c-528d-403f-8bde-1069096829a6",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310611709819000.2937ed0c-497f-42ff-893c-4a4ccd2ae532",
+      "fullUrl" : "Patient/1706813422126043000.0d431b35-d883-40d9-a26e-b84a3b4b2841",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310611709819000.2937ed0c-497f-42ff-893c-4a4ccd2ae532",
+        "id" : "1706813422126043000.0d431b35-d883-40d9-a26e-b84a3b4b2841",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310611710468000.87e3ce3d-db51-4bc5-bdcf-a2de64573872",
+      "fullUrl" : "Provenance/1706813422127015000.14b64c80-7868-4c01-baf7-5eec2c4c5042",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310611710468000.87e3ce3d-db51-4bc5-bdcf-a2de64573872",
+        "id" : "1706813422127015000.14b64c80-7868-4c01-baf7-5eec2c4c5042",
         "target" : [
           {
-            "reference" : "Patient/1706310611709819000.2937ed0c-497f-42ff-893c-4a4ccd2ae532"
+            "reference" : "Patient/1706813422126043000.0d431b35-d883-40d9-a26e-b84a3b4b2841"
           }
         ],
-        "recorded" : "2024-01-26T17:10:11Z",
+        "recorded" : "2024-02-01T13:50:22Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-month-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-month-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310619824702000.1f17e866-4f71-4cd1-a0e3-ec54019f58e6",
+  "id" : "1706813430927504000.f94a1524-3632-4cd3-bd95-9b93393fe87f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:19.838-06:00"
+    "lastUpdated" : "2024-02-01T13:50:30.934-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310620208352000.9d86d263-5868-461b-bfea-aa7384ddc9fe",
+      "fullUrl" : "Provenance/1706813431292698000.f0a3453d-7084-49a9-b28a-527b57d42435",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310620208352000.9d86d263-5868-461b-bfea-aa7384ddc9fe",
+        "id" : "1706813431292698000.f0a3453d-7084-49a9-b28a-527b57d42435",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310620216772000.901894cf-593f-4d50-872a-b4620a40d1f0",
+      "fullUrl" : "Provenance/1706813431300774000.8bcb6b37-146d-46dc-ae38-a095fe803d13",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310620216772000.901894cf-593f-4d50-872a-b4620a40d1f0",
-        "recorded" : "2024-01-26T17:10:20Z",
+        "id" : "1706813431300774000.8bcb6b37-146d-46dc-ae38-a095fe803d13",
+        "recorded" : "2024-02-01T13:50:31Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310620215886000.4f2257b9-1e40-4afb-b97d-58f7bb050579"
+              "reference" : "Organization/1706813431300268000.5de7f474-bc45-404b-b167-0d7467aa3e4c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310620215886000.4f2257b9-1e40-4afb-b97d-58f7bb050579",
+      "fullUrl" : "Organization/1706813431300268000.5de7f474-bc45-404b-b167-0d7467aa3e4c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310620215886000.4f2257b9-1e40-4afb-b97d-58f7bb050579",
+        "id" : "1706813431300268000.5de7f474-bc45-404b-b167-0d7467aa3e4c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310620235841000.4fbef50f-dde3-4d3c-9ea8-1f5b5acc8cfe",
+      "fullUrl" : "Patient/1706813431318749000.1e28fe87-02ac-4747-9c15-67b22bda63c2",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310620235841000.4fbef50f-dde3-4d3c-9ea8-1f5b5acc8cfe",
+        "id" : "1706813431318749000.1e28fe87-02ac-4747-9c15-67b22bda63c2",
         "birthDate" : "1970-10",
         "_birthDate" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310620236571000.4f100dc2-f6a0-43e1-8bc8-573bf50c43ae",
+      "fullUrl" : "Provenance/1706813431319501000.6291bade-77be-4bcd-812c-bb46aac4d0a7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310620236571000.4f100dc2-f6a0-43e1-8bc8-573bf50c43ae",
+        "id" : "1706813431319501000.6291bade-77be-4bcd-812c-bb46aac4d0a7",
         "target" : [
           {
-            "reference" : "Patient/1706310620235841000.4fbef50f-dde3-4d3c-9ea8-1f5b5acc8cfe"
+            "reference" : "Patient/1706813431318749000.1e28fe87-02ac-4747-9c15-67b22bda63c2"
           }
         ],
-        "recorded" : "2024-01-26T17:10:20Z",
+        "recorded" : "2024-02-01T13:50:31Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-msec-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-msec-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310628497656000.a1279b11-fd10-46fe-b669-cd6188fa3153",
+  "id" : "1706813440067499000.6ddd5a86-c305-4d70-a1f0-ca34910a8c43",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:28.512-06:00"
+    "lastUpdated" : "2024-02-01T13:50:40.074-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310628869859000.f6f90975-b03e-4fb5-bd17-c4ae96cd8330",
+      "fullUrl" : "Provenance/1706813440453384000.7de8d454-8fd0-4f34-972a-71c6f4ee0a36",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310628869859000.f6f90975-b03e-4fb5-bd17-c4ae96cd8330",
+        "id" : "1706813440453384000.7de8d454-8fd0-4f34-972a-71c6f4ee0a36",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310628877401000.6d733ee1-2dc7-41b7-905f-c6b16edaf491",
+      "fullUrl" : "Provenance/1706813440460962000.9e3a28a4-50ce-44de-a3a1-fe8ad99a78ac",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310628877401000.6d733ee1-2dc7-41b7-905f-c6b16edaf491",
-        "recorded" : "2024-01-26T17:10:28Z",
+        "id" : "1706813440460962000.9e3a28a4-50ce-44de-a3a1-fe8ad99a78ac",
+        "recorded" : "2024-02-01T13:50:40Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310628876920000.7715c38c-1072-41f0-9a1f-77d07f4d4d4b"
+              "reference" : "Organization/1706813440460493000.5927874d-b339-4780-81df-3fe524b1a6d0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310628876920000.7715c38c-1072-41f0-9a1f-77d07f4d4d4b",
+      "fullUrl" : "Organization/1706813440460493000.5927874d-b339-4780-81df-3fe524b1a6d0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310628876920000.7715c38c-1072-41f0-9a1f-77d07f4d4d4b",
+        "id" : "1706813440460493000.5927874d-b339-4780-81df-3fe524b1a6d0",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310628895379000.30bda310-beeb-4981-8c33-ad5c71d21002",
+      "fullUrl" : "Patient/1706813440482899000.df0e37e0-c029-42ae-818d-8832a173baf1",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310628895379000.30bda310-beeb-4981-8c33-ad5c71d21002",
+        "id" : "1706813440482899000.df0e37e0-c029-42ae-818d-8832a173baf1",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310628896108000.a3418a7b-c27b-4226-9c87-6b16ffbbf606",
+      "fullUrl" : "Provenance/1706813440483665000.164c30ec-f94a-4de3-bad7-13ce12db4b44",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310628896108000.a3418a7b-c27b-4226-9c87-6b16ffbbf606",
+        "id" : "1706813440483665000.164c30ec-f94a-4de3-bad7-13ce12db4b44",
         "target" : [
           {
-            "reference" : "Patient/1706310628895379000.30bda310-beeb-4981-8c33-ad5c71d21002"
+            "reference" : "Patient/1706813440482899000.df0e37e0-c029-42ae-818d-8832a173baf1"
           }
         ],
-        "recorded" : "2024-01-26T17:10:28Z",
+        "recorded" : "2024-02-01T13:50:40Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-second-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-second-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310636913595000.67dccfcd-f47a-4260-a3c1-44255f7c0a54",
+  "id" : "1706813449594748000.dc9faafe-788a-4965-996a-d5ba2791ca05",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:36.928-06:00"
+    "lastUpdated" : "2024-02-01T13:50:49.600-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310637298412000.3bef34a2-1e1a-43af-840a-a899b537ee80",
+      "fullUrl" : "Provenance/1706813449984492000.546167fc-9aad-4439-ad36-97fa56fd2dd1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310637298412000.3bef34a2-1e1a-43af-840a-a899b537ee80",
+        "id" : "1706813449984492000.546167fc-9aad-4439-ad36-97fa56fd2dd1",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310637305097000.2a8d9305-d69f-4182-9730-818f14ed1ea5",
+      "fullUrl" : "Provenance/1706813449992795000.c9392ebc-d6e6-4fff-b928-90d0cc9efb19",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310637305097000.2a8d9305-d69f-4182-9730-818f14ed1ea5",
-        "recorded" : "2024-01-26T17:10:37Z",
+        "id" : "1706813449992795000.c9392ebc-d6e6-4fff-b928-90d0cc9efb19",
+        "recorded" : "2024-02-01T13:50:49Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310637304506000.21949a6e-cfca-470c-8d7d-109fc7067f01"
+              "reference" : "Organization/1706813449992333000.13b83238-381e-45ff-a5dd-e5385f9aa45a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310637304506000.21949a6e-cfca-470c-8d7d-109fc7067f01",
+      "fullUrl" : "Organization/1706813449992333000.13b83238-381e-45ff-a5dd-e5385f9aa45a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310637304506000.21949a6e-cfca-470c-8d7d-109fc7067f01",
+        "id" : "1706813449992333000.13b83238-381e-45ff-a5dd-e5385f9aa45a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310637324594000.ed66a26d-bdd9-40a5-af66-4dbd14750b27",
+      "fullUrl" : "Patient/1706813450011279000.e53a9d9e-859b-4d41-b09c-0299540abd29",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310637324594000.ed66a26d-bdd9-40a5-af66-4dbd14750b27",
+        "id" : "1706813450011279000.e53a9d9e-859b-4d41-b09c-0299540abd29",
         "birthDate" : "1970-10-31",
         "_birthDate" : {
           "extension" : [
@@ -140,16 +145,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310637325489000.233f79da-37b3-45f4-9e17-a1c191ea083b",
+      "fullUrl" : "Provenance/1706813450012003000.7a436367-74c0-4ae5-918d-75c779315212",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310637325489000.233f79da-37b3-45f4-9e17-a1c191ea083b",
+        "id" : "1706813450012003000.7a436367-74c0-4ae5-918d-75c779315212",
         "target" : [
           {
-            "reference" : "Patient/1706310637324594000.ed66a26d-bdd9-40a5-af66-4dbd14750b27"
+            "reference" : "Patient/1706813450011279000.e53a9d9e-859b-4d41-b09c-0299540abd29"
           }
         ],
-        "recorded" : "2024-01-26T17:10:37Z",
+        "recorded" : "2024-02-01T13:50:50Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-year-precision-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-year-precision-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310645408738000.ab935c94-2f55-4e47-995d-2bcf3a2e7f19",
+  "id" : "1706813458927605000.77fb5b63-7418-489b-b09d-936c26abebdd",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:45.423-06:00"
+    "lastUpdated" : "2024-02-01T13:50:58.939-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310645786516000.58fafd37-da29-4c46-b8cc-f12ebf75cd15",
+      "fullUrl" : "Provenance/1706813459306751000.60fe96ce-4d94-4965-9e73-8e4d5a8e6205",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310645786516000.58fafd37-da29-4c46-b8cc-f12ebf75cd15",
+        "id" : "1706813459306751000.60fe96ce-4d94-4965-9e73-8e4d5a8e6205",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310645793587000.77725e12-5823-4f5a-a95a-a847f21ed308",
+      "fullUrl" : "Provenance/1706813459316345000.8d97283c-8ef8-43be-a008-7f2643a65f3a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310645793587000.77725e12-5823-4f5a-a95a-a847f21ed308",
-        "recorded" : "2024-01-26T17:10:45Z",
+        "id" : "1706813459316345000.8d97283c-8ef8-43be-a008-7f2643a65f3a",
+        "recorded" : "2024-02-01T13:50:59Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310645793197000.c05c599a-7adb-4da6-9e56-eda416f9f089"
+              "reference" : "Organization/1706813459315882000.1fd1e2ac-eb2c-46d4-a326-a39e4c8e6fb4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310645793197000.c05c599a-7adb-4da6-9e56-eda416f9f089",
+      "fullUrl" : "Organization/1706813459315882000.1fd1e2ac-eb2c-46d4-a326-a39e4c8e6fb4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310645793197000.c05c599a-7adb-4da6-9e56-eda416f9f089",
+        "id" : "1706813459315882000.1fd1e2ac-eb2c-46d4-a326-a39e4c8e6fb4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310645809352000.1fc88b65-6d4e-4d61-8bf5-18c311de112c",
+      "fullUrl" : "Patient/1706813459336152000.c9c96ea3-d1af-4652-8428-265e29572551",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310645809352000.1fc88b65-6d4e-4d61-8bf5-18c311de112c",
+        "id" : "1706813459336152000.c9c96ea3-d1af-4652-8428-265e29572551",
         "birthDate" : "1970",
         "_birthDate" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310645810024000.07ae3693-d9df-46d2-af2d-ce0ce269d223",
+      "fullUrl" : "Provenance/1706813459337048000.3017cd69-fe7f-4b6c-962b-ef8b73acaf35",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310645810024000.07ae3693-d9df-46d2-af2d-ce0ce269d223",
+        "id" : "1706813459337048000.3017cd69-fe7f-4b6c-962b-ef8b73acaf35",
         "target" : [
           {
-            "reference" : "Patient/1706310645809352000.1fc88b65-6d4e-4d61-8bf5-18c311de112c"
+            "reference" : "Patient/1706813459336152000.c9c96ea3-d1af-4652-8428-265e29572551"
           }
         ],
-        "recorded" : "2024-01-26T17:10:45Z",
+        "recorded" : "2024-02-01T13:50:59Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-zero-year-to-date.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/date/dtm-zero-year-to-date.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310653557446000.67cbdfca-95ab-4cdf-8bf5-6034d99b58c4",
+  "id" : "1706813467895854000.1c1e5b41-b0ec-4d90-8342-278ec694655e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:10:53.572-06:00"
+    "lastUpdated" : "2024-02-01T13:51:07.902-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310653929512000.1334d5ad-486b-43e5-bb84-4e68ce7a0fb3",
+      "fullUrl" : "Provenance/1706813468275096000.f7aa1a89-19f9-4074-a96a-312817b59c29",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310653929512000.1334d5ad-486b-43e5-bb84-4e68ce7a0fb3",
+        "id" : "1706813468275096000.f7aa1a89-19f9-4074-a96a-312817b59c29",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310653936793000.c00d16f6-06f3-4459-b54a-e5c424454745",
+      "fullUrl" : "Provenance/1706813468282580000.c83ca84b-dc0d-4223-8d95-cfe89cc7d2ec",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310653936793000.c00d16f6-06f3-4459-b54a-e5c424454745",
-        "recorded" : "2024-01-26T17:10:53Z",
+        "id" : "1706813468282580000.c83ca84b-dc0d-4223-8d95-cfe89cc7d2ec",
+        "recorded" : "2024-02-01T13:51:08Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310653935850000.6b4fa99b-ef6f-4248-a594-4226634f4d03"
+              "reference" : "Organization/1706813468282119000.885fe58e-6ee6-4463-bccc-0dfdb8999add"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310653935850000.6b4fa99b-ef6f-4248-a594-4226634f4d03",
+      "fullUrl" : "Organization/1706813468282119000.885fe58e-6ee6-4463-bccc-0dfdb8999add",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310653935850000.6b4fa99b-ef6f-4248-a594-4226634f4d03",
+        "id" : "1706813468282119000.885fe58e-6ee6-4463-bccc-0dfdb8999add",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310653952696000.bba9d76b-15a2-404b-8425-ce37efab6ba8",
+      "fullUrl" : "Patient/1706813468297816000.490cfee2-57e7-4919-b34f-f15a5fa55dac",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310653952696000.bba9d76b-15a2-404b-8425-ce37efab6ba8",
+        "id" : "1706813468297816000.490cfee2-57e7-4919-b34f-f15a5fa55dac",
         "_birthDate" : {
           "extension" : [
             {
@@ -135,16 +140,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310653953368000.0c4db2e3-8bb6-4f95-b5b1-48e71a00afcc",
+      "fullUrl" : "Provenance/1706813468298508000.5c369485-dffe-4dbd-9189-d5e2571d02aa",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310653953368000.0c4db2e3-8bb6-4f95-b5b1-48e71a00afcc",
+        "id" : "1706813468298508000.5c369485-dffe-4dbd-9189-d5e2571d02aa",
         "target" : [
           {
-            "reference" : "Patient/1706310653952696000.bba9d76b-15a2-404b-8425-ce37efab6ba8"
+            "reference" : "Patient/1706813468297816000.490cfee2-57e7-4919-b34f-f15a5fa55dac"
           }
         ],
-        "recorded" : "2024-01-26T17:10:53Z",
+        "recorded" : "2024-02-01T13:51:08Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-csec-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-csec-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310662262454000.f7758c52-2464-42dc-9124-e02914257d44",
+  "id" : "1706813476944815000.df6d0c32-5c32-4ab2-a709-af7714cb3d04",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:02.276-06:00"
+    "lastUpdated" : "2024-02-01T13:51:16.952-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310662625234000.426143f8-7701-44a2-845b-02dfe7ee8145",
+      "fullUrl" : "Provenance/1706813477325332000.4f622878-9166-48cf-8425-9980389e8f9c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310662625234000.426143f8-7701-44a2-845b-02dfe7ee8145",
+        "id" : "1706813477325332000.4f622878-9166-48cf-8425-9980389e8f9c",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310662633234000.3fab63f1-8190-4445-9323-baf8bcbccedc",
+      "fullUrl" : "Provenance/1706813477332980000.6dbcfae7-3fc9-4d42-9ae4-5f7039f23147",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310662633234000.3fab63f1-8190-4445-9323-baf8bcbccedc",
-        "recorded" : "2024-01-26T17:11:02Z",
+        "id" : "1706813477332980000.6dbcfae7-3fc9-4d42-9ae4-5f7039f23147",
+        "recorded" : "2024-02-01T13:51:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310662632691000.dc19d6f5-3752-4857-a5f5-5829fe2c7151"
+              "reference" : "Organization/1706813477332535000.da0dbb17-1032-4708-80a1-1a28eac20812"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310662632691000.dc19d6f5-3752-4857-a5f5-5829fe2c7151",
+      "fullUrl" : "Organization/1706813477332535000.da0dbb17-1032-4708-80a1-1a28eac20812",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310662632691000.dc19d6f5-3752-4857-a5f5-5829fe2c7151",
+        "id" : "1706813477332535000.da0dbb17-1032-4708-80a1-1a28eac20812",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310662646862000.42cdc7d8-f55d-491d-929e-109b288b4324",
+      "fullUrl" : "Patient/1706813477348422000.2fba5fbc-eb48-44fa-af30-5432ea9ac2a6",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310662646862000.42cdc7d8-f55d-491d-929e-109b288b4324",
+        "id" : "1706813477348422000.2fba5fbc-eb48-44fa-af30-5432ea9ac2a6",
         "deceasedDateTime" : "2023-11-02T11:04:05.67Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310662647574000.0be0166a-4092-4aa6-aa48-67b0b93241f4",
+      "fullUrl" : "Provenance/1706813477349208000.8d5f5103-df70-45d8-9fad-20c477e63a89",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310662647574000.0be0166a-4092-4aa6-aa48-67b0b93241f4",
+        "id" : "1706813477349208000.8d5f5103-df70-45d8-9fad-20c477e63a89",
         "target" : [
           {
-            "reference" : "Patient/1706310662646862000.42cdc7d8-f55d-491d-929e-109b288b4324"
+            "reference" : "Patient/1706813477348422000.2fba5fbc-eb48-44fa-af30-5432ea9ac2a6"
           }
         ],
-        "recorded" : "2024-01-26T17:11:02Z",
+        "recorded" : "2024-02-01T13:51:17Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-day-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-day-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310670760173000.f7ef51a1-b1f0-4926-a042-3d14e8904355",
+  "id" : "1706813486007243000.d604290e-32c5-4a1d-9d41-bdda576bbd00",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:10.774-06:00"
+    "lastUpdated" : "2024-02-01T13:51:26.014-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310671134797000.6b5191d0-6237-4e34-a876-d88ab934275d",
+      "fullUrl" : "Provenance/1706813486382591000.de7ce988-5c58-47a9-9740-64fab845c384",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310671134797000.6b5191d0-6237-4e34-a876-d88ab934275d",
+        "id" : "1706813486382591000.de7ce988-5c58-47a9-9740-64fab845c384",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310671143299000.ff81f1e3-7b81-405e-8e4f-3b4006a41357",
+      "fullUrl" : "Provenance/1706813486390347000.539587dd-1bd2-4b74-b2e6-520f1a58b929",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310671143299000.ff81f1e3-7b81-405e-8e4f-3b4006a41357",
-        "recorded" : "2024-01-26T17:11:11Z",
+        "id" : "1706813486390347000.539587dd-1bd2-4b74-b2e6-520f1a58b929",
+        "recorded" : "2024-02-01T13:51:26Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310671141957000.7559c5a3-b4f4-43f2-9f78-cfedf4d8afc4"
+              "reference" : "Organization/1706813486389871000.38bd3f29-4ebd-44ee-bbec-d9f2de8b054a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310671141957000.7559c5a3-b4f4-43f2-9f78-cfedf4d8afc4",
+      "fullUrl" : "Organization/1706813486389871000.38bd3f29-4ebd-44ee-bbec-d9f2de8b054a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310671141957000.7559c5a3-b4f4-43f2-9f78-cfedf4d8afc4",
+        "id" : "1706813486389871000.38bd3f29-4ebd-44ee-bbec-d9f2de8b054a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310671157229000.c8873cac-9e5f-4b20-badc-e12b5be89620",
+      "fullUrl" : "Patient/1706813486406031000.6fb090dd-09ae-43c2-868b-514d63fca944",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310671157229000.c8873cac-9e5f-4b20-badc-e12b5be89620",
+        "id" : "1706813486406031000.6fb090dd-09ae-43c2-868b-514d63fca944",
         "deceasedDateTime" : "2023-11-02",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310671158039000.5f4f3a4e-9e57-4d24-8206-376b68c96f37",
+      "fullUrl" : "Provenance/1706813486406809000.892b3823-8db2-4ee0-81fb-81af25bdd1ca",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310671158039000.5f4f3a4e-9e57-4d24-8206-376b68c96f37",
+        "id" : "1706813486406809000.892b3823-8db2-4ee0-81fb-81af25bdd1ca",
         "target" : [
           {
-            "reference" : "Patient/1706310671157229000.c8873cac-9e5f-4b20-badc-e12b5be89620"
+            "reference" : "Patient/1706813486406031000.6fb090dd-09ae-43c2-868b-514d63fca944"
           }
         ],
-        "recorded" : "2024-01-26T17:11:11Z",
+        "recorded" : "2024-02-01T13:51:26Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-dsec-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-dsec-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310679339565000.79e42b0e-df71-4ee7-85be-e11894444c82",
+  "id" : "1706813495390303000.64ff67a2-5d15-4f60-bdc6-2055ae6df503",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:19.354-06:00"
+    "lastUpdated" : "2024-02-01T13:51:35.397-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310679716693000.1a790d44-4623-487d-bc8c-967186ac126d",
+      "fullUrl" : "Provenance/1706813495750703000.0ad7f4dd-7d13-4468-8d28-73babfe8cf5c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310679716693000.1a790d44-4623-487d-bc8c-967186ac126d",
+        "id" : "1706813495750703000.0ad7f4dd-7d13-4468-8d28-73babfe8cf5c",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310679723093000.5e135d82-cfe1-4131-95dd-9d7a5cd95cdc",
+      "fullUrl" : "Provenance/1706813495757820000.5acc7e7b-e6c0-46ed-a8a5-94990bce80d5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310679723093000.5e135d82-cfe1-4131-95dd-9d7a5cd95cdc",
-        "recorded" : "2024-01-26T17:11:19Z",
+        "id" : "1706813495757820000.5acc7e7b-e6c0-46ed-a8a5-94990bce80d5",
+        "recorded" : "2024-02-01T13:51:35Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310679722681000.4e9ce6e3-8d6b-424d-9487-ae2a6f91377c"
+              "reference" : "Organization/1706813495757292000.fed9cd79-4280-4e6d-bf0f-cf580e1ad5e4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310679722681000.4e9ce6e3-8d6b-424d-9487-ae2a6f91377c",
+      "fullUrl" : "Organization/1706813495757292000.fed9cd79-4280-4e6d-bf0f-cf580e1ad5e4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310679722681000.4e9ce6e3-8d6b-424d-9487-ae2a6f91377c",
+        "id" : "1706813495757292000.fed9cd79-4280-4e6d-bf0f-cf580e1ad5e4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310679735555000.ab9d73e8-f735-4751-b0bb-3828c69986db",
+      "fullUrl" : "Patient/1706813495771953000.399f1d95-85ac-4cbb-8301-11fd64c984c8",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310679735555000.ab9d73e8-f735-4751-b0bb-3828c69986db",
+        "id" : "1706813495771953000.399f1d95-85ac-4cbb-8301-11fd64c984c8",
         "deceasedDateTime" : "2023-11-02T11:04:05.6Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310679736174000.2b7fac2a-c150-410b-9e72-4ec5e1705a18",
+      "fullUrl" : "Provenance/1706813495772567000.4b9c8ef9-133c-4f54-8b63-3ca841800aa8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310679736174000.2b7fac2a-c150-410b-9e72-4ec5e1705a18",
+        "id" : "1706813495772567000.4b9c8ef9-133c-4f54-8b63-3ca841800aa8",
         "target" : [
           {
-            "reference" : "Patient/1706310679735555000.ab9d73e8-f735-4751-b0bb-3828c69986db"
+            "reference" : "Patient/1706813495771953000.399f1d95-85ac-4cbb-8301-11fd64c984c8"
           }
         ],
-        "recorded" : "2024-01-26T17:11:19Z",
+        "recorded" : "2024-02-01T13:51:35Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-hour-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-hour-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310687583695000.d1946b62-8e77-475a-8aeb-c85bfdd35c58",
+  "id" : "1706813505020984000.7767a6f1-07b7-4809-a05c-783595e6e700",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:27.596-06:00"
+    "lastUpdated" : "2024-02-01T13:51:45.028-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310687960175000.6298a635-aa03-409b-a6ff-f8492d049cfa",
+      "fullUrl" : "Provenance/1706813505445737000.d446fcb6-a946-477d-8f39-7dfb9287a096",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310687960175000.6298a635-aa03-409b-a6ff-f8492d049cfa",
+        "id" : "1706813505445737000.d446fcb6-a946-477d-8f39-7dfb9287a096",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310687966913000.09388d9c-e466-49f5-80c3-2cc93d71edf0",
+      "fullUrl" : "Provenance/1706813505454007000.ef3225fd-10af-4f60-83fe-77bd1c0c809f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310687966913000.09388d9c-e466-49f5-80c3-2cc93d71edf0",
-        "recorded" : "2024-01-26T17:11:27Z",
+        "id" : "1706813505454007000.ef3225fd-10af-4f60-83fe-77bd1c0c809f",
+        "recorded" : "2024-02-01T13:51:45Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310687966505000.5696fa7a-da50-436e-80ea-f80f7b1eff7e"
+              "reference" : "Organization/1706813505453499000.049da5d8-0fe7-4892-b935-38cd1b29ccbf"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310687966505000.5696fa7a-da50-436e-80ea-f80f7b1eff7e",
+      "fullUrl" : "Organization/1706813505453499000.049da5d8-0fe7-4892-b935-38cd1b29ccbf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310687966505000.5696fa7a-da50-436e-80ea-f80f7b1eff7e",
+        "id" : "1706813505453499000.049da5d8-0fe7-4892-b935-38cd1b29ccbf",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310687982033000.c3cb01b9-992b-4531-8b38-488e52b3fa85",
+      "fullUrl" : "Patient/1706813505470166000.6c0a700a-810a-49fe-af98-1617b49b5fd5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310687982033000.c3cb01b9-992b-4531-8b38-488e52b3fa85",
+        "id" : "1706813505470166000.6c0a700a-810a-49fe-af98-1617b49b5fd5",
         "deceasedDateTime" : "2023-11-02T11:00:00Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310687982849000.8b4dcf23-3ff3-4c09-b6c6-4b8b6519caea",
+      "fullUrl" : "Provenance/1706813505471922000.6b138875-8136-4997-88b9-871503453cad",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310687982849000.8b4dcf23-3ff3-4c09-b6c6-4b8b6519caea",
+        "id" : "1706813505471922000.6b138875-8136-4997-88b9-871503453cad",
         "target" : [
           {
-            "reference" : "Patient/1706310687982033000.c3cb01b9-992b-4531-8b38-488e52b3fa85"
+            "reference" : "Patient/1706813505470166000.6c0a700a-810a-49fe-af98-1617b49b5fd5"
           }
         ],
-        "recorded" : "2024-01-26T17:11:27Z",
+        "recorded" : "2024-02-01T13:51:45Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-minute-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-minute-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310696730549000.7d474b49-4c9e-486e-bb06-79f4ba160e52",
+  "id" : "1706813514491478000.c71e8f61-5cda-42dc-be81-39c74b37fb78",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:36.745-06:00"
+    "lastUpdated" : "2024-02-01T13:51:54.497-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310697109375000.24b7b4a7-426a-4404-80d8-24bbc46ed7a7",
+      "fullUrl" : "Provenance/1706813514862866000.4b83f539-85ef-45ba-964e-608c53d5b707",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310697109375000.24b7b4a7-426a-4404-80d8-24bbc46ed7a7",
+        "id" : "1706813514862866000.4b83f539-85ef-45ba-964e-608c53d5b707",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310697116106000.6f4afcdd-370e-4496-9eb4-bf6b7fbf8a8c",
+      "fullUrl" : "Provenance/1706813514873246000.eee54e35-0666-4f43-8da9-38b626eed739",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310697116106000.6f4afcdd-370e-4496-9eb4-bf6b7fbf8a8c",
-        "recorded" : "2024-01-26T17:11:37Z",
+        "id" : "1706813514873246000.eee54e35-0666-4f43-8da9-38b626eed739",
+        "recorded" : "2024-02-01T13:51:54Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310697115665000.4721e62c-50ec-4042-b8e6-f7ce706084f3"
+              "reference" : "Organization/1706813514872676000.1a87fb68-d1cd-4d63-ac3d-8d77b4e55f79"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310697115665000.4721e62c-50ec-4042-b8e6-f7ce706084f3",
+      "fullUrl" : "Organization/1706813514872676000.1a87fb68-d1cd-4d63-ac3d-8d77b4e55f79",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310697115665000.4721e62c-50ec-4042-b8e6-f7ce706084f3",
+        "id" : "1706813514872676000.1a87fb68-d1cd-4d63-ac3d-8d77b4e55f79",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310697129597000.80e7f6f5-22d1-43ab-b47b-0cfdc5d93348",
+      "fullUrl" : "Patient/1706813514892552000.da2cb2e7-0913-4189-85a1-f3bfeaeb9358",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310697129597000.80e7f6f5-22d1-43ab-b47b-0cfdc5d93348",
+        "id" : "1706813514892552000.da2cb2e7-0913-4189-85a1-f3bfeaeb9358",
         "deceasedDateTime" : "2023-11-02T11:04:00Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310697130224000.882be76c-c26d-48cb-8b0c-f501470aad20",
+      "fullUrl" : "Provenance/1706813514893312000.761b1441-c7ba-4492-b11a-de12f3c961ae",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310697130224000.882be76c-c26d-48cb-8b0c-f501470aad20",
+        "id" : "1706813514893312000.761b1441-c7ba-4492-b11a-de12f3c961ae",
         "target" : [
           {
-            "reference" : "Patient/1706310697129597000.80e7f6f5-22d1-43ab-b47b-0cfdc5d93348"
+            "reference" : "Patient/1706813514892552000.da2cb2e7-0913-4189-85a1-f3bfeaeb9358"
           }
         ],
-        "recorded" : "2024-01-26T17:11:37Z",
+        "recorded" : "2024-02-01T13:51:54Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-mmsec-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-mmsec-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310705613951000.832ffab9-46ea-47a0-905c-bba19151dc04",
+  "id" : "1706813523732896000.3ddf45fc-17c5-4e85-b7b6-1edb572558eb",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:45.631-06:00"
+    "lastUpdated" : "2024-02-01T13:52:03.739-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310705989715000.eae6e59a-0b81-40f7-ba51-a9116bb45e86",
+      "fullUrl" : "Provenance/1706813524182527000.3e85ad6c-593a-400d-b97b-cb57cd17aa4f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310705989715000.eae6e59a-0b81-40f7-ba51-a9116bb45e86",
+        "id" : "1706813524182527000.3e85ad6c-593a-400d-b97b-cb57cd17aa4f",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310705996936000.87bfc787-cea8-4fb6-baa8-06d5f79beda4",
+      "fullUrl" : "Provenance/1706813524191703000.f56db02a-2b35-4c0c-bf1f-2837dcd949bb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310705996936000.87bfc787-cea8-4fb6-baa8-06d5f79beda4",
-        "recorded" : "2024-01-26T17:11:45Z",
+        "id" : "1706813524191703000.f56db02a-2b35-4c0c-bf1f-2837dcd949bb",
+        "recorded" : "2024-02-01T13:52:04Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310705996431000.c2e8a540-77e2-4198-85c4-2f93190c463f"
+              "reference" : "Organization/1706813524191035000.ff2f7bdd-5a07-4494-980f-ce43cff390ac"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310705996431000.c2e8a540-77e2-4198-85c4-2f93190c463f",
+      "fullUrl" : "Organization/1706813524191035000.ff2f7bdd-5a07-4494-980f-ce43cff390ac",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310705996431000.c2e8a540-77e2-4198-85c4-2f93190c463f",
+        "id" : "1706813524191035000.ff2f7bdd-5a07-4494-980f-ce43cff390ac",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310706009492000.feb52802-9acb-4db5-8e45-2c9f3a2670d3",
+      "fullUrl" : "Patient/1706813524208600000.41b2e17e-8b4c-4f56-9ff2-e5fa15be0745",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310706009492000.feb52802-9acb-4db5-8e45-2c9f3a2670d3",
+        "id" : "1706813524208600000.41b2e17e-8b4c-4f56-9ff2-e5fa15be0745",
         "deceasedDateTime" : "2023-11-02T11:04:05.6789Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310706010137000.1e760b1e-5229-4f7a-9d8b-47318d42ac89",
+      "fullUrl" : "Provenance/1706813524209376000.53f7a6bb-ee17-4027-a539-8a69aa0c6c63",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310706010137000.1e760b1e-5229-4f7a-9d8b-47318d42ac89",
+        "id" : "1706813524209376000.53f7a6bb-ee17-4027-a539-8a69aa0c6c63",
         "target" : [
           {
-            "reference" : "Patient/1706310706009492000.feb52802-9acb-4db5-8e45-2c9f3a2670d3"
+            "reference" : "Patient/1706813524208600000.41b2e17e-8b4c-4f56-9ff2-e5fa15be0745"
           }
         ],
-        "recorded" : "2024-01-26T17:11:46Z",
+        "recorded" : "2024-02-01T13:52:04Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-month-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-month-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310714407059000.342a010c-e68f-4449-ad82-9b3eafe01a9c",
+  "id" : "1706813533032805000.6f1f9b70-e9ac-4ae0-b514-75c5aca7baca",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:11:54.420-06:00"
+    "lastUpdated" : "2024-02-01T13:52:13.039-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310714781485000.a152da5c-d218-4fdb-a64e-0d6339745cd5",
+      "fullUrl" : "Provenance/1706813533419383000.27a7be1b-7510-4116-a2ac-d04c44354fed",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310714781485000.a152da5c-d218-4fdb-a64e-0d6339745cd5",
+        "id" : "1706813533419383000.27a7be1b-7510-4116-a2ac-d04c44354fed",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310714788855000.bccc8fa0-41ab-4f8f-9ae3-4860b18772c4",
+      "fullUrl" : "Provenance/1706813533427485000.d1b4113c-f452-4d46-b3cc-6649e268e77d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310714788855000.bccc8fa0-41ab-4f8f-9ae3-4860b18772c4",
-        "recorded" : "2024-01-26T17:11:54Z",
+        "id" : "1706813533427485000.d1b4113c-f452-4d46-b3cc-6649e268e77d",
+        "recorded" : "2024-02-01T13:52:13Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310714787659000.4a62dc3f-7b30-4003-a41f-8f987d34cfc3"
+              "reference" : "Organization/1706813533426819000.718ac84c-4591-43f0-991a-ed50bc3bcb1d"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310714787659000.4a62dc3f-7b30-4003-a41f-8f987d34cfc3",
+      "fullUrl" : "Organization/1706813533426819000.718ac84c-4591-43f0-991a-ed50bc3bcb1d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310714787659000.4a62dc3f-7b30-4003-a41f-8f987d34cfc3",
+        "id" : "1706813533426819000.718ac84c-4591-43f0-991a-ed50bc3bcb1d",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310714804301000.1684db9e-14fe-4b6f-8e6f-336e9236d136",
+      "fullUrl" : "Patient/1706813533443384000.f61b120c-4c54-4038-83ed-9f4e8a4f0a67",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310714804301000.1684db9e-14fe-4b6f-8e6f-336e9236d136",
+        "id" : "1706813533443384000.f61b120c-4c54-4038-83ed-9f4e8a4f0a67",
         "deceasedDateTime" : "2023-11",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310714805088000.15b526a8-527e-4e7d-a2de-99c53d9dee66",
+      "fullUrl" : "Provenance/1706813533444123000.262527ed-b006-40eb-b097-32ee8d05bc84",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310714805088000.15b526a8-527e-4e7d-a2de-99c53d9dee66",
+        "id" : "1706813533444123000.262527ed-b006-40eb-b097-32ee8d05bc84",
         "target" : [
           {
-            "reference" : "Patient/1706310714804301000.1684db9e-14fe-4b6f-8e6f-336e9236d136"
+            "reference" : "Patient/1706813533443384000.f61b120c-4c54-4038-83ed-9f4e8a4f0a67"
           }
         ],
-        "recorded" : "2024-01-26T17:11:54Z",
+        "recorded" : "2024-02-01T13:52:13Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-msec-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-msec-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310723132381000.c5c78d5f-c98e-4132-b8f8-755d629b8fd3",
+  "id" : "1706813542322596000.40698622-3391-43fd-957c-18bc74a17cf7",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:03.146-06:00"
+    "lastUpdated" : "2024-02-01T13:52:22.328-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310723500617000.76e181d3-a48e-413d-be10-39227a2964fe",
+      "fullUrl" : "Provenance/1706813542709540000.71663bbc-b8f8-4efe-9198-abdf296e838a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310723500617000.76e181d3-a48e-413d-be10-39227a2964fe",
+        "id" : "1706813542709540000.71663bbc-b8f8-4efe-9198-abdf296e838a",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310723507766000.4f2f975b-002a-44e5-a0df-0f36d1772012",
+      "fullUrl" : "Provenance/1706813542716807000.7a962533-769b-4d50-95fe-a8154884ce89",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310723507766000.4f2f975b-002a-44e5-a0df-0f36d1772012",
-        "recorded" : "2024-01-26T17:12:03Z",
+        "id" : "1706813542716807000.7a962533-769b-4d50-95fe-a8154884ce89",
+        "recorded" : "2024-02-01T13:52:22Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310723507353000.fb501332-434f-499f-891e-50ffc0a650b7"
+              "reference" : "Organization/1706813542716341000.6c7be2cc-5ae8-4e9c-a3c6-c01f6702ee8a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310723507353000.fb501332-434f-499f-891e-50ffc0a650b7",
+      "fullUrl" : "Organization/1706813542716341000.6c7be2cc-5ae8-4e9c-a3c6-c01f6702ee8a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310723507353000.fb501332-434f-499f-891e-50ffc0a650b7",
+        "id" : "1706813542716341000.6c7be2cc-5ae8-4e9c-a3c6-c01f6702ee8a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310723521933000.35f6e408-24c8-4862-9f41-dd730cf55142",
+      "fullUrl" : "Patient/1706813542732094000.ea2050bb-f912-4bb3-b247-6fba973b4501",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310723521933000.35f6e408-24c8-4862-9f41-dd730cf55142",
+        "id" : "1706813542732094000.ea2050bb-f912-4bb3-b247-6fba973b4501",
         "deceasedDateTime" : "2023-11-02T11:04:05.678Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310723522684000.10a9f008-c7b1-4307-b85e-29484f222a04",
+      "fullUrl" : "Provenance/1706813542732839000.efbfba3d-1da4-46de-9b72-dc00108804ae",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310723522684000.10a9f008-c7b1-4307-b85e-29484f222a04",
+        "id" : "1706813542732839000.efbfba3d-1da4-46de-9b72-dc00108804ae",
         "target" : [
           {
-            "reference" : "Patient/1706310723521933000.35f6e408-24c8-4862-9f41-dd730cf55142"
+            "reference" : "Patient/1706813542732094000.ea2050bb-f912-4bb3-b247-6fba973b4501"
           }
         ],
-        "recorded" : "2024-01-26T17:12:03Z",
+        "recorded" : "2024-02-01T13:52:22Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-second-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-second-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310731082308000.131dbfa7-b205-42d5-9c22-baab2500c3c9",
+  "id" : "1706813551794629000.7d44b12f-39b2-423e-81b5-203678f5f72f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:11.098-06:00"
+    "lastUpdated" : "2024-02-01T13:52:31.801-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310731450270000.4b7a45c2-a1b0-455e-97ee-53dd285805de",
+      "fullUrl" : "Provenance/1706813552176615000.549dda28-6a7c-4c47-9c28-e65de149263a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310731450270000.4b7a45c2-a1b0-455e-97ee-53dd285805de",
+        "id" : "1706813552176615000.549dda28-6a7c-4c47-9c28-e65de149263a",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310731457373000.2e3b3f32-65a3-486d-8d69-1653a0eea7fc",
+      "fullUrl" : "Provenance/1706813552184490000.c5058e3b-7845-4bea-9eb7-2295501b9719",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310731457373000.2e3b3f32-65a3-486d-8d69-1653a0eea7fc",
-        "recorded" : "2024-01-26T17:12:11Z",
+        "id" : "1706813552184490000.c5058e3b-7845-4bea-9eb7-2295501b9719",
+        "recorded" : "2024-02-01T13:52:32Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310731456424000.7c9bc69b-ceac-46b2-863f-67b546196142"
+              "reference" : "Organization/1706813552183986000.7926b3b6-26a0-49cc-907f-50efc17d3274"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310731456424000.7c9bc69b-ceac-46b2-863f-67b546196142",
+      "fullUrl" : "Organization/1706813552183986000.7926b3b6-26a0-49cc-907f-50efc17d3274",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310731456424000.7c9bc69b-ceac-46b2-863f-67b546196142",
+        "id" : "1706813552183986000.7926b3b6-26a0-49cc-907f-50efc17d3274",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310731470486000.e783b959-0e3e-40ea-ae09-88433aebe6f1",
+      "fullUrl" : "Patient/1706813552199269000.1f9f36ca-b3b4-4ddc-a51f-acdbd2d07f31",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310731470486000.e783b959-0e3e-40ea-ae09-88433aebe6f1",
+        "id" : "1706813552199269000.1f9f36ca-b3b4-4ddc-a51f-acdbd2d07f31",
         "deceasedDateTime" : "2023-11-02T11:04:05Z",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310731471148000.c02f925d-93f9-4661-8c43-700565ec9a1c",
+      "fullUrl" : "Provenance/1706813552199985000.efe02174-225e-4ccc-87d9-a86a023b7231",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310731471148000.c02f925d-93f9-4661-8c43-700565ec9a1c",
+        "id" : "1706813552199985000.efe02174-225e-4ccc-87d9-a86a023b7231",
         "target" : [
           {
-            "reference" : "Patient/1706310731470486000.e783b959-0e3e-40ea-ae09-88433aebe6f1"
+            "reference" : "Patient/1706813552199269000.1f9f36ca-b3b4-4ddc-a51f-acdbd2d07f31"
           }
         ],
-        "recorded" : "2024-01-26T17:12:11Z",
+        "recorded" : "2024-02-01T13:52:32Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-year-precision-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-year-precision-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310739738557000.2b1e005d-df25-4029-b1ae-d505225a4057",
+  "id" : "1706813560643992000.96a3b6f5-75fe-4baf-858b-3013980bc0ad",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:19.751-06:00"
+    "lastUpdated" : "2024-02-01T13:52:40.650-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310740117428000.17675958-0b68-42a4-b07e-16ce3112e3fb",
+      "fullUrl" : "Provenance/1706813561025228000.0b4741b8-d3a2-4579-8e48-653401c48d42",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310740117428000.17675958-0b68-42a4-b07e-16ce3112e3fb",
+        "id" : "1706813561025228000.0b4741b8-d3a2-4579-8e48-653401c48d42",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310740124190000.665eda71-c7f5-48ad-babd-30d7875b1d4d",
+      "fullUrl" : "Provenance/1706813561032950000.160145b4-5590-4459-9f1f-69faf0d964f1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310740124190000.665eda71-c7f5-48ad-babd-30d7875b1d4d",
-        "recorded" : "2024-01-26T17:12:20Z",
+        "id" : "1706813561032950000.160145b4-5590-4459-9f1f-69faf0d964f1",
+        "recorded" : "2024-02-01T13:52:41Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310740123583000.b4e95866-426e-4773-95ec-7fff777dfc0d"
+              "reference" : "Organization/1706813561032371000.094e88b4-4d27-4fd1-8784-33c434947ed4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310740123583000.b4e95866-426e-4773-95ec-7fff777dfc0d",
+      "fullUrl" : "Organization/1706813561032371000.094e88b4-4d27-4fd1-8784-33c434947ed4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310740123583000.b4e95866-426e-4773-95ec-7fff777dfc0d",
+        "id" : "1706813561032371000.094e88b4-4d27-4fd1-8784-33c434947ed4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310740136695000.ede5333e-0750-4d1f-9624-3b14ec2cacd0",
+      "fullUrl" : "Patient/1706813561047915000.480f7354-043c-4954-8801-13570eb7c872",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310740136695000.ede5333e-0750-4d1f-9624-3b14ec2cacd0",
+        "id" : "1706813561047915000.480f7354-043c-4954-8801-13570eb7c872",
         "deceasedDateTime" : "2023",
         "_deceasedDateTime" : {
           "extension" : [
@@ -136,16 +141,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310740137360000.235fac87-c2a6-43e3-8106-856b6ca5eaa0",
+      "fullUrl" : "Provenance/1706813561048629000.7a4fdcc6-992f-4cc1-a6ae-25db9c912299",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310740137360000.235fac87-c2a6-43e3-8106-856b6ca5eaa0",
+        "id" : "1706813561048629000.7a4fdcc6-992f-4cc1-a6ae-25db9c912299",
         "target" : [
           {
-            "reference" : "Patient/1706310740136695000.ede5333e-0750-4d1f-9624-3b14ec2cacd0"
+            "reference" : "Patient/1706813561047915000.480f7354-043c-4954-8801-13570eb7c872"
           }
         ],
-        "recorded" : "2024-01-26T17:12:20Z",
+        "recorded" : "2024-02-01T13:52:41Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-zero-year-to-dateTime.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/dateTime/dtm-zero-year-to-dateTime.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310748140020000.940898ef-c2d9-4053-a953-5829aa0c1a75",
+  "id" : "1706813569978879000.a199926c-9975-4177-9ba1-7028fa7b3e54",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:28.153-06:00"
+    "lastUpdated" : "2024-02-01T13:52:49.986-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310748513320000.60c29ab5-e18e-42ea-abef-fb2bf75b2dce",
+      "fullUrl" : "Provenance/1706813570386980000.7b0dd0f9-f142-4b12-aea0-5741754599a2",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310748513320000.60c29ab5-e18e-42ea-abef-fb2bf75b2dce",
+        "id" : "1706813570386980000.7b0dd0f9-f142-4b12-aea0-5741754599a2",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310748520529000.e75d3607-ea05-4185-b3b1-7c2ed1258d6a",
+      "fullUrl" : "Provenance/1706813570395055000.04cf447e-6449-4f66-853a-0788c9b6e29a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310748520529000.e75d3607-ea05-4185-b3b1-7c2ed1258d6a",
-        "recorded" : "2024-01-26T17:12:28Z",
+        "id" : "1706813570395055000.04cf447e-6449-4f66-853a-0788c9b6e29a",
+        "recorded" : "2024-02-01T13:52:50Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310748520115000.86aca0bb-9db5-4fd2-97f6-9a7a172b37f0"
+              "reference" : "Organization/1706813570394569000.5bb93bd7-3989-44dd-b09d-06cb402439c4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310748520115000.86aca0bb-9db5-4fd2-97f6-9a7a172b37f0",
+      "fullUrl" : "Organization/1706813570394569000.5bb93bd7-3989-44dd-b09d-06cb402439c4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310748520115000.86aca0bb-9db5-4fd2-97f6-9a7a172b37f0",
+        "id" : "1706813570394569000.5bb93bd7-3989-44dd-b09d-06cb402439c4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310748535482000.012646bc-7ab5-40fc-9a2d-ccbe3973ba17",
+      "fullUrl" : "Patient/1706813570412579000.08a82ef4-bb30-4e87-acb3-dbe57fe10633",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310748535482000.012646bc-7ab5-40fc-9a2d-ccbe3973ba17",
+        "id" : "1706813570412579000.08a82ef4-bb30-4e87-acb3-dbe57fe10633",
         "_deceasedDateTime" : {
           "extension" : [
             {
@@ -135,16 +140,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310748536192000.bd01bd6a-58c5-4673-9716-edc22ee5ed1e",
+      "fullUrl" : "Provenance/1706813570413567000.d7072b4b-0a22-4b71-96fd-1d4c6b0e287e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310748536192000.bd01bd6a-58c5-4673-9716-edc22ee5ed1e",
+        "id" : "1706813570413567000.d7072b4b-0a22-4b71-96fd-1d4c6b0e287e",
         "target" : [
           {
-            "reference" : "Patient/1706310748535482000.012646bc-7ab5-40fc-9a2d-ccbe3973ba17"
+            "reference" : "Patient/1706813570412579000.08a82ef4-bb30-4e87-acb3-dbe57fe10633"
           }
         ],
-        "recorded" : "2024-01-26T17:12:28Z",
+        "recorded" : "2024-02-01T13:52:50Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-csec-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-csec-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310759156393000.9d7c515d-ed30-48b0-a673-b049c1689309",
+  "id" : "1706813582051351000.f43d5a80-3e82-4cbd-90f8-18bae382a7eb",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:39.170-06:00"
+    "lastUpdated" : "2024-02-01T13:53:02.058-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310759540667000.bc61730d-edcd-41f0-b3fd-d05a9590a145",
+      "fullUrl" : "Provenance/1706813582467279000.1923c4b1-af49-436a-b5dc-358e8cd3bcac",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310759540667000.bc61730d-edcd-41f0-b3fd-d05a9590a145",
+        "id" : "1706813582467279000.1923c4b1-af49-436a-b5dc-358e8cd3bcac",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310759702446000.f8e43da3-e87c-44fc-8394-15f6ebb41aae"
+            "reference" : "DiagnosticReport/1706813582650442000.ae8d806c-c25a-4ee8-9dd1-2cb00c6f9376"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310759547308000.5e26fe96-3a96-4d31-8601-322644666e9d",
+      "fullUrl" : "Provenance/1706813582475844000.bd6e7909-b771-4a82-bbf3-5b9c9d6c2fe6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310759547308000.5e26fe96-3a96-4d31-8601-322644666e9d",
-        "recorded" : "2024-01-26T17:12:39Z",
+        "id" : "1706813582475844000.bd6e7909-b771-4a82-bbf3-5b9c9d6c2fe6",
+        "recorded" : "2024-02-01T13:53:02Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310759546920000.6175b608-f456-4afe-b5f6-5dcd95fd8cf4"
+              "reference" : "Organization/1706813582475380000.805c08f3-7c59-493f-ab82-8d5d7e683594"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310759546920000.6175b608-f456-4afe-b5f6-5dcd95fd8cf4",
+      "fullUrl" : "Organization/1706813582475380000.805c08f3-7c59-493f-ab82-8d5d7e683594",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310759546920000.6175b608-f456-4afe-b5f6-5dcd95fd8cf4",
+        "id" : "1706813582475380000.805c08f3-7c59-493f-ab82-8d5d7e683594",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310759560610000.037873dd-3d2c-4fe2-878b-1f7045669d34",
+      "fullUrl" : "Patient/1706813582490680000.cc8558d7-a58d-4300-b9f6-adf87852c751",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310759560610000.037873dd-3d2c-4fe2-878b-1f7045669d34"
+        "id" : "1706813582490680000.cc8558d7-a58d-4300-b9f6-adf87852c751"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310759561100000.963b1e87-8c9a-4566-84f1-7e117b80abf9",
+      "fullUrl" : "Provenance/1706813582491409000.c3d968e2-07e5-4fc6-b3f7-aa7f6ca1ec35",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310759561100000.963b1e87-8c9a-4566-84f1-7e117b80abf9",
+        "id" : "1706813582491409000.c3d968e2-07e5-4fc6-b3f7-aa7f6ca1ec35",
         "target" : [
           {
-            "reference" : "Patient/1706310759560610000.037873dd-3d2c-4fe2-878b-1f7045669d34"
+            "reference" : "Patient/1706813582490680000.cc8558d7-a58d-4300-b9f6-adf87852c751"
           }
         ],
-        "recorded" : "2024-01-26T17:12:39Z",
+        "recorded" : "2024-02-01T13:53:02Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310759566239000.1402959d-8c67-46dd-af5f-35be6c305050",
+      "fullUrl" : "ServiceRequest/1706813582497111000.eef64b97-ffa0-42c6-821b-855eecb4550a",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310759566239000.1402959d-8c67-46dd-af5f-35be6c305050",
+        "id" : "1706813582497111000.eef64b97-ffa0-42c6-821b-855eecb4550a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310759560610000.037873dd-3d2c-4fe2-878b-1f7045669d34"
+          "reference" : "Patient/1706813582490680000.cc8558d7-a58d-4300-b9f6-adf87852c751"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310759702446000.f8e43da3-e87c-44fc-8394-15f6ebb41aae",
+      "fullUrl" : "DiagnosticReport/1706813582650442000.ae8d806c-c25a-4ee8-9dd1-2cb00c6f9376",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310759702446000.f8e43da3-e87c-44fc-8394-15f6ebb41aae",
+        "id" : "1706813582650442000.ae8d806c-c25a-4ee8-9dd1-2cb00c6f9376",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310759566239000.1402959d-8c67-46dd-af5f-35be6c305050"
+            "reference" : "ServiceRequest/1706813582497111000.eef64b97-ffa0-42c6-821b-855eecb4550a"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310759560610000.037873dd-3d2c-4fe2-878b-1f7045669d34"
+          "reference" : "Patient/1706813582490680000.cc8558d7-a58d-4300-b9f6-adf87852c751"
         },
         "issued" : "2023-08-15T03:04:05.67Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-day-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-day-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310768380539000.5eeefd06-d295-4ebb-adac-fcf4035685c0",
+  "id" : "1706813591857798000.f91d489f-ca5b-41c8-8767-5348aabe822b",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:48.394-06:00"
+    "lastUpdated" : "2024-02-01T13:53:11.864-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310768744900000.728c8e86-380a-4f64-8642-039c6605a097",
+      "fullUrl" : "Provenance/1706813592319287000.ccb77578-8b73-452f-bd86-5a61f4369fd5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310768744900000.728c8e86-380a-4f64-8642-039c6605a097",
+        "id" : "1706813592319287000.ccb77578-8b73-452f-bd86-5a61f4369fd5",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310768911220000.6b9f3e81-d8bd-4837-86bb-48716368e254"
+            "reference" : "DiagnosticReport/1706813592537494000.05c9dea1-a3af-434a-ab06-61a076ed6f65"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310768752356000.b6e61caa-e885-45a3-87d5-3ce8da84d577",
+      "fullUrl" : "Provenance/1706813592327046000.5d351816-27bd-4a93-ac53-51128b1b4e77",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310768752356000.b6e61caa-e885-45a3-87d5-3ce8da84d577",
-        "recorded" : "2024-01-26T17:12:48Z",
+        "id" : "1706813592327046000.5d351816-27bd-4a93-ac53-51128b1b4e77",
+        "recorded" : "2024-02-01T13:53:12Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310768751869000.5cf921da-8a09-4b8e-b9fd-e820d625d327"
+              "reference" : "Organization/1706813592326316000.da40715a-e0e1-497c-965e-ccfe1e267123"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310768751869000.5cf921da-8a09-4b8e-b9fd-e820d625d327",
+      "fullUrl" : "Organization/1706813592326316000.da40715a-e0e1-497c-965e-ccfe1e267123",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310768751869000.5cf921da-8a09-4b8e-b9fd-e820d625d327",
+        "id" : "1706813592326316000.da40715a-e0e1-497c-965e-ccfe1e267123",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310768764301000.08c8e40c-8c74-4539-9a12-2c86d4dd279b",
+      "fullUrl" : "Patient/1706813592342066000.297edcb1-b097-40fa-a32d-4509135af15c",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310768764301000.08c8e40c-8c74-4539-9a12-2c86d4dd279b"
+        "id" : "1706813592342066000.297edcb1-b097-40fa-a32d-4509135af15c"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310768764839000.83476edd-da0b-4344-85c7-23dffb8c7ca2",
+      "fullUrl" : "Provenance/1706813592343396000.b44c905d-2dae-4299-8f50-896dfd2700c9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310768764839000.83476edd-da0b-4344-85c7-23dffb8c7ca2",
+        "id" : "1706813592343396000.b44c905d-2dae-4299-8f50-896dfd2700c9",
         "target" : [
           {
-            "reference" : "Patient/1706310768764301000.08c8e40c-8c74-4539-9a12-2c86d4dd279b"
+            "reference" : "Patient/1706813592342066000.297edcb1-b097-40fa-a32d-4509135af15c"
           }
         ],
-        "recorded" : "2024-01-26T17:12:48Z",
+        "recorded" : "2024-02-01T13:53:12Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310768769888000.a77b2b46-bb4c-4c7a-8297-99d1fce19c13",
+      "fullUrl" : "ServiceRequest/1706813592354332000.3e91b238-e97e-42a2-a5ba-a37c9d65de62",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310768769888000.a77b2b46-bb4c-4c7a-8297-99d1fce19c13",
+        "id" : "1706813592354332000.3e91b238-e97e-42a2-a5ba-a37c9d65de62",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310768764301000.08c8e40c-8c74-4539-9a12-2c86d4dd279b"
+          "reference" : "Patient/1706813592342066000.297edcb1-b097-40fa-a32d-4509135af15c"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310768911220000.6b9f3e81-d8bd-4837-86bb-48716368e254",
+      "fullUrl" : "DiagnosticReport/1706813592537494000.05c9dea1-a3af-434a-ab06-61a076ed6f65",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310768911220000.6b9f3e81-d8bd-4837-86bb-48716368e254",
+        "id" : "1706813592537494000.05c9dea1-a3af-434a-ab06-61a076ed6f65",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310768769888000.a77b2b46-bb4c-4c7a-8297-99d1fce19c13"
+            "reference" : "ServiceRequest/1706813592354332000.3e91b238-e97e-42a2-a5ba-a37c9d65de62"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310768764301000.08c8e40c-8c74-4539-9a12-2c86d4dd279b"
+          "reference" : "Patient/1706813592342066000.297edcb1-b097-40fa-a32d-4509135af15c"
         },
         "issued" : "2023-08-15",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-dsec-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-dsec-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310776999209000.f820aee8-8cb0-47ad-91b8-9d46f93672db",
+  "id" : "1706813601876416000.6880ab97-f266-434a-a5ec-e645a3afc032",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:12:57.012-06:00"
+    "lastUpdated" : "2024-02-01T13:53:21.882-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310777585159000.9c9fdc18-cc40-4ae6-ba67-56c1080236a1",
+      "fullUrl" : "Provenance/1706813602255323000.ab817a35-1d7c-4819-aa5b-0d9d6c8f661c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310777585159000.9c9fdc18-cc40-4ae6-ba67-56c1080236a1",
+        "id" : "1706813602255323000.ab817a35-1d7c-4819-aa5b-0d9d6c8f661c",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310777737700000.22b03889-6293-4db9-a457-25063761d273"
+            "reference" : "DiagnosticReport/1706813602431781000.1c821931-d9ae-482f-8770-f186732f3228"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310777591783000.b0cf6a2b-9819-444a-ae2b-9a3bda3bca0e",
+      "fullUrl" : "Provenance/1706813602265943000.b42adc5f-bce5-49d4-a2e2-a8b3ad859a0e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310777591783000.b0cf6a2b-9819-444a-ae2b-9a3bda3bca0e",
-        "recorded" : "2024-01-26T17:12:57Z",
+        "id" : "1706813602265943000.b42adc5f-bce5-49d4-a2e2-a8b3ad859a0e",
+        "recorded" : "2024-02-01T13:53:22Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310777591383000.daf51f35-86ee-4d4c-a858-5e2724f04d1a"
+              "reference" : "Organization/1706813602265309000.9d3c7720-79ac-4f9d-b2a7-3a2e7194ddfe"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310777591383000.daf51f35-86ee-4d4c-a858-5e2724f04d1a",
+      "fullUrl" : "Organization/1706813602265309000.9d3c7720-79ac-4f9d-b2a7-3a2e7194ddfe",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310777591383000.daf51f35-86ee-4d4c-a858-5e2724f04d1a",
+        "id" : "1706813602265309000.9d3c7720-79ac-4f9d-b2a7-3a2e7194ddfe",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310777604261000.d21c7f93-36f9-4d5d-b138-a4c4dc879c95",
+      "fullUrl" : "Patient/1706813602280376000.19f55444-bde1-46b5-b3ff-1fa9440a22d0",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310777604261000.d21c7f93-36f9-4d5d-b138-a4c4dc879c95"
+        "id" : "1706813602280376000.19f55444-bde1-46b5-b3ff-1fa9440a22d0"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310777604849000.f2e59e4e-8790-4d93-bbbc-62b94d3992a0",
+      "fullUrl" : "Provenance/1706813602281079000.5909ff36-b50c-4073-b73b-72979ef509e7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310777604849000.f2e59e4e-8790-4d93-bbbc-62b94d3992a0",
+        "id" : "1706813602281079000.5909ff36-b50c-4073-b73b-72979ef509e7",
         "target" : [
           {
-            "reference" : "Patient/1706310777604261000.d21c7f93-36f9-4d5d-b138-a4c4dc879c95"
+            "reference" : "Patient/1706813602280376000.19f55444-bde1-46b5-b3ff-1fa9440a22d0"
           }
         ],
-        "recorded" : "2024-01-26T17:12:57Z",
+        "recorded" : "2024-02-01T13:53:22Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310777609437000.942056cd-672a-4df6-b361-950d825e38de",
+      "fullUrl" : "ServiceRequest/1706813602289513000.99d6d42c-98d7-4782-b1d6-d3c7a50e79ad",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310777609437000.942056cd-672a-4df6-b361-950d825e38de",
+        "id" : "1706813602289513000.99d6d42c-98d7-4782-b1d6-d3c7a50e79ad",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310777604261000.d21c7f93-36f9-4d5d-b138-a4c4dc879c95"
+          "reference" : "Patient/1706813602280376000.19f55444-bde1-46b5-b3ff-1fa9440a22d0"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310777737700000.22b03889-6293-4db9-a457-25063761d273",
+      "fullUrl" : "DiagnosticReport/1706813602431781000.1c821931-d9ae-482f-8770-f186732f3228",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310777737700000.22b03889-6293-4db9-a457-25063761d273",
+        "id" : "1706813602431781000.1c821931-d9ae-482f-8770-f186732f3228",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310777609437000.942056cd-672a-4df6-b361-950d825e38de"
+            "reference" : "ServiceRequest/1706813602289513000.99d6d42c-98d7-4782-b1d6-d3c7a50e79ad"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310777604261000.d21c7f93-36f9-4d5d-b138-a4c4dc879c95"
+          "reference" : "Patient/1706813602280376000.19f55444-bde1-46b5-b3ff-1fa9440a22d0"
         },
         "issued" : "2023-08-15T03:04:05.6Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-hour-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-hour-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310786210813000.5751426d-96ad-4a11-80ed-0ae58c30c7c2",
+  "id" : "1706813611658237000.9993bed7-69ac-435c-9236-dd527e23ed23",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:13:06.224-06:00"
+    "lastUpdated" : "2024-02-01T13:53:31.664-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310786581912000.17b81590-7026-4edf-ad93-3a3afed6f214",
+      "fullUrl" : "Provenance/1706813612057245000.8499eb7e-f1e7-43c5-9f12-596febb289a0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310786581912000.17b81590-7026-4edf-ad93-3a3afed6f214",
+        "id" : "1706813612057245000.8499eb7e-f1e7-43c5-9f12-596febb289a0",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310786747058000.c274c0eb-3cbd-4444-8779-19f77d7fc1e2"
+            "reference" : "DiagnosticReport/1706813612250632000.72252e70-a6da-4eaa-b522-cb2c6a9dae66"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310786588757000.a43a891d-8df1-4710-b926-4781b54ec494",
+      "fullUrl" : "Provenance/1706813612065111000.7a0aad44-7c23-4cc0-af38-f20e77d68ed7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310786588757000.a43a891d-8df1-4710-b926-4781b54ec494",
-        "recorded" : "2024-01-26T17:13:06Z",
+        "id" : "1706813612065111000.7a0aad44-7c23-4cc0-af38-f20e77d68ed7",
+        "recorded" : "2024-02-01T13:53:32Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310786588249000.0f76e6a0-c732-4344-b64b-73a12b0202f0"
+              "reference" : "Organization/1706813612064370000.e2a4d3fc-189a-499f-8ee7-047260893fcc"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310786588249000.0f76e6a0-c732-4344-b64b-73a12b0202f0",
+      "fullUrl" : "Organization/1706813612064370000.e2a4d3fc-189a-499f-8ee7-047260893fcc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310786588249000.0f76e6a0-c732-4344-b64b-73a12b0202f0",
+        "id" : "1706813612064370000.e2a4d3fc-189a-499f-8ee7-047260893fcc",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310786601336000.5a5a441f-6a4b-48cd-a5ea-5b7c52ef10e1",
+      "fullUrl" : "Patient/1706813612081222000.71cd9022-32c8-4626-8b1d-5c198922b80b",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310786601336000.5a5a441f-6a4b-48cd-a5ea-5b7c52ef10e1"
+        "id" : "1706813612081222000.71cd9022-32c8-4626-8b1d-5c198922b80b"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310786601847000.fea10b5a-d48d-45c5-94d8-5070787a7065",
+      "fullUrl" : "Provenance/1706813612082014000.8301766a-dca2-4e53-b6ef-9bf03d56c8cf",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310786601847000.fea10b5a-d48d-45c5-94d8-5070787a7065",
+        "id" : "1706813612082014000.8301766a-dca2-4e53-b6ef-9bf03d56c8cf",
         "target" : [
           {
-            "reference" : "Patient/1706310786601336000.5a5a441f-6a4b-48cd-a5ea-5b7c52ef10e1"
+            "reference" : "Patient/1706813612081222000.71cd9022-32c8-4626-8b1d-5c198922b80b"
           }
         ],
-        "recorded" : "2024-01-26T17:13:06Z",
+        "recorded" : "2024-02-01T13:53:32Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310786606316000.3e346e2a-cb94-4084-a60a-6f9c942dcc03",
+      "fullUrl" : "ServiceRequest/1706813612087520000.a970291d-e6d0-43b6-8dae-4b162e2d1a23",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310786606316000.3e346e2a-cb94-4084-a60a-6f9c942dcc03",
+        "id" : "1706813612087520000.a970291d-e6d0-43b6-8dae-4b162e2d1a23",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310786601336000.5a5a441f-6a4b-48cd-a5ea-5b7c52ef10e1"
+          "reference" : "Patient/1706813612081222000.71cd9022-32c8-4626-8b1d-5c198922b80b"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310786747058000.c274c0eb-3cbd-4444-8779-19f77d7fc1e2",
+      "fullUrl" : "DiagnosticReport/1706813612250632000.72252e70-a6da-4eaa-b522-cb2c6a9dae66",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310786747058000.c274c0eb-3cbd-4444-8779-19f77d7fc1e2",
+        "id" : "1706813612250632000.72252e70-a6da-4eaa-b522-cb2c6a9dae66",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310786606316000.3e346e2a-cb94-4084-a60a-6f9c942dcc03"
+            "reference" : "ServiceRequest/1706813612087520000.a970291d-e6d0-43b6-8dae-4b162e2d1a23"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310786601336000.5a5a441f-6a4b-48cd-a5ea-5b7c52ef10e1"
+          "reference" : "Patient/1706813612081222000.71cd9022-32c8-4626-8b1d-5c198922b80b"
         },
         "issued" : "2023-08-15T03:00:00Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-minute-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-minute-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310795087266000.842d7380-32a0-492b-aee6-7df2306ee1b1",
+  "id" : "1706813621557046000.bd58e3f5-9cfa-4e21-ac34-cb86d921eb39",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:13:15.102-06:00"
+    "lastUpdated" : "2024-02-01T13:53:41.564-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310795469022000.6e506c2a-a7b8-4500-973e-769cff351163",
+      "fullUrl" : "Provenance/1706813622037381000.b52bbb5e-7b1d-4d5b-bb15-b6766e8891d8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310795469022000.6e506c2a-a7b8-4500-973e-769cff351163",
+        "id" : "1706813622037381000.b52bbb5e-7b1d-4d5b-bb15-b6766e8891d8",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310795641469000.db5215e9-c969-4865-9279-89453b409b04"
+            "reference" : "DiagnosticReport/1706813622244036000.bb8bb515-bc67-48b5-8f32-a1b4af7786f8"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310795476529000.6484a1b5-3387-4fb8-9754-4ccc2a2157a1",
+      "fullUrl" : "Provenance/1706813622046686000.d35d1919-4448-4db7-b9dd-b145f281c312",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310795476529000.6484a1b5-3387-4fb8-9754-4ccc2a2157a1",
-        "recorded" : "2024-01-26T17:13:15Z",
+        "id" : "1706813622046686000.d35d1919-4448-4db7-b9dd-b145f281c312",
+        "recorded" : "2024-02-01T13:53:42Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310795475996000.21bc451e-81a9-4d10-aec8-45061c5c66b5"
+              "reference" : "Organization/1706813622045947000.0a820faa-b415-4fc1-8722-9ec8461235e4"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310795475996000.21bc451e-81a9-4d10-aec8-45061c5c66b5",
+      "fullUrl" : "Organization/1706813622045947000.0a820faa-b415-4fc1-8722-9ec8461235e4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310795475996000.21bc451e-81a9-4d10-aec8-45061c5c66b5",
+        "id" : "1706813622045947000.0a820faa-b415-4fc1-8722-9ec8461235e4",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310795490183000.e1e5fbfe-f050-4015-bd6a-89dea808d91c",
+      "fullUrl" : "Patient/1706813622070947000.e19f2a9a-da41-4760-bb22-70856726efee",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310795490183000.e1e5fbfe-f050-4015-bd6a-89dea808d91c"
+        "id" : "1706813622070947000.e19f2a9a-da41-4760-bb22-70856726efee"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310795490828000.329d1d11-cebc-495f-a304-756af74f5317",
+      "fullUrl" : "Provenance/1706813622071700000.c7614009-f31f-46b8-93e2-39e960bb9eff",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310795490828000.329d1d11-cebc-495f-a304-756af74f5317",
+        "id" : "1706813622071700000.c7614009-f31f-46b8-93e2-39e960bb9eff",
         "target" : [
           {
-            "reference" : "Patient/1706310795490183000.e1e5fbfe-f050-4015-bd6a-89dea808d91c"
+            "reference" : "Patient/1706813622070947000.e19f2a9a-da41-4760-bb22-70856726efee"
           }
         ],
-        "recorded" : "2024-01-26T17:13:15Z",
+        "recorded" : "2024-02-01T13:53:42Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310795495408000.84282c2f-b280-4c7c-8f78-6bfe17aab596",
+      "fullUrl" : "ServiceRequest/1706813622077125000.ba40f7c0-ca21-4ad9-b2fc-e5dcd1bc7bc1",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310795495408000.84282c2f-b280-4c7c-8f78-6bfe17aab596",
+        "id" : "1706813622077125000.ba40f7c0-ca21-4ad9-b2fc-e5dcd1bc7bc1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310795490183000.e1e5fbfe-f050-4015-bd6a-89dea808d91c"
+          "reference" : "Patient/1706813622070947000.e19f2a9a-da41-4760-bb22-70856726efee"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310795641469000.db5215e9-c969-4865-9279-89453b409b04",
+      "fullUrl" : "DiagnosticReport/1706813622244036000.bb8bb515-bc67-48b5-8f32-a1b4af7786f8",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310795641469000.db5215e9-c969-4865-9279-89453b409b04",
+        "id" : "1706813622244036000.bb8bb515-bc67-48b5-8f32-a1b4af7786f8",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310795495408000.84282c2f-b280-4c7c-8f78-6bfe17aab596"
+            "reference" : "ServiceRequest/1706813622077125000.ba40f7c0-ca21-4ad9-b2fc-e5dcd1bc7bc1"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310795490183000.e1e5fbfe-f050-4015-bd6a-89dea808d91c"
+          "reference" : "Patient/1706813622070947000.e19f2a9a-da41-4760-bb22-70856726efee"
         },
         "issued" : "2023-08-15T03:04:00Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-mmsec-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-mmsec-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310803890023000.48b9cf47-654a-42b3-818b-39416496544d",
+  "id" : "1706813631363701000.fd0027a9-d696-4763-8a55-c9e3b6c5e3cd",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:13:23.906-06:00"
+    "lastUpdated" : "2024-02-01T13:53:51.371-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310804261172000.cbe207ae-466e-4d77-a9fb-b0f11989fc2e",
+      "fullUrl" : "Provenance/1706813631775981000.b0719fc0-dafc-45b4-801e-a43d5dd5b5b6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310804261172000.cbe207ae-466e-4d77-a9fb-b0f11989fc2e",
+        "id" : "1706813631775981000.b0719fc0-dafc-45b4-801e-a43d5dd5b5b6",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310804420700000.76600d53-2dc7-4050-98a9-f1bf900f32ef"
+            "reference" : "DiagnosticReport/1706813631967027000.31580123-c242-4e64-8b31-2f1982c298fc"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310804268286000.da6fd5bb-2423-4816-9e30-8cb1c79453dd",
+      "fullUrl" : "Provenance/1706813631784439000.532a3001-8da1-4a6c-b713-fad7e494a470",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310804268286000.da6fd5bb-2423-4816-9e30-8cb1c79453dd",
-        "recorded" : "2024-01-26T17:13:24Z",
+        "id" : "1706813631784439000.532a3001-8da1-4a6c-b713-fad7e494a470",
+        "recorded" : "2024-02-01T13:53:51Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310804267779000.3bcd954f-ed83-49c6-9215-395b5df7e750"
+              "reference" : "Organization/1706813631783771000.920ba7ce-7d39-4311-b794-fa68b7e4d6ac"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310804267779000.3bcd954f-ed83-49c6-9215-395b5df7e750",
+      "fullUrl" : "Organization/1706813631783771000.920ba7ce-7d39-4311-b794-fa68b7e4d6ac",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310804267779000.3bcd954f-ed83-49c6-9215-395b5df7e750",
+        "id" : "1706813631783771000.920ba7ce-7d39-4311-b794-fa68b7e4d6ac",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310804280178000.c60572fc-5cfd-4f78-8cd6-10013d8d570c",
+      "fullUrl" : "Patient/1706813631798395000.5942977b-c753-4fbf-8371-3c49e09d8a16",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310804280178000.c60572fc-5cfd-4f78-8cd6-10013d8d570c"
+        "id" : "1706813631798395000.5942977b-c753-4fbf-8371-3c49e09d8a16"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310804280704000.6a6519b3-83f9-4c39-b200-712797d56036",
+      "fullUrl" : "Provenance/1706813631799137000.c7a8969a-06cb-4679-b2b7-babdaa8ab38a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310804280704000.6a6519b3-83f9-4c39-b200-712797d56036",
+        "id" : "1706813631799137000.c7a8969a-06cb-4679-b2b7-babdaa8ab38a",
         "target" : [
           {
-            "reference" : "Patient/1706310804280178000.c60572fc-5cfd-4f78-8cd6-10013d8d570c"
+            "reference" : "Patient/1706813631798395000.5942977b-c753-4fbf-8371-3c49e09d8a16"
           }
         ],
-        "recorded" : "2024-01-26T17:13:24Z",
+        "recorded" : "2024-02-01T13:53:51Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310804284837000.797b26af-cac6-44ad-8241-8132fc588faf",
+      "fullUrl" : "ServiceRequest/1706813631804072000.9160a87f-c3ae-4f1c-9f55-fd4b8a21d699",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310804284837000.797b26af-cac6-44ad-8241-8132fc588faf",
+        "id" : "1706813631804072000.9160a87f-c3ae-4f1c-9f55-fd4b8a21d699",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310804280178000.c60572fc-5cfd-4f78-8cd6-10013d8d570c"
+          "reference" : "Patient/1706813631798395000.5942977b-c753-4fbf-8371-3c49e09d8a16"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310804420700000.76600d53-2dc7-4050-98a9-f1bf900f32ef",
+      "fullUrl" : "DiagnosticReport/1706813631967027000.31580123-c242-4e64-8b31-2f1982c298fc",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310804420700000.76600d53-2dc7-4050-98a9-f1bf900f32ef",
+        "id" : "1706813631967027000.31580123-c242-4e64-8b31-2f1982c298fc",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310804284837000.797b26af-cac6-44ad-8241-8132fc588faf"
+            "reference" : "ServiceRequest/1706813631804072000.9160a87f-c3ae-4f1c-9f55-fd4b8a21d699"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310804280178000.c60572fc-5cfd-4f78-8cd6-10013d8d570c"
+          "reference" : "Patient/1706813631798395000.5942977b-c753-4fbf-8371-3c49e09d8a16"
         },
         "issued" : "2023-08-15T03:04:05.6789Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-month-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-month-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310812466584000.c9930b24-d720-46a8-8d59-a66184d0b9fd",
+  "id" : "1706813641088253000.ca73adbf-9f4b-48bc-b2eb-5a1abc916cba",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:13:32.481-06:00"
+    "lastUpdated" : "2024-02-01T13:54:01.094-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310813080191000.ad146a1c-d938-43d6-9fb3-dd3fa0916769",
+      "fullUrl" : "Provenance/1706813641470918000.3a994198-8c1a-4200-933d-59772fcbc650",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310813080191000.ad146a1c-d938-43d6-9fb3-dd3fa0916769",
+        "id" : "1706813641470918000.3a994198-8c1a-4200-933d-59772fcbc650",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310813280181000.730401c8-7cbd-4f7e-99a9-c4423c85889d"
+            "reference" : "DiagnosticReport/1706813641658110000.3e9e25b6-1906-4876-b786-a99dc3330fe5"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310813087320000.d3a60384-c541-4a1f-b07d-fb8330bb3ac2",
+      "fullUrl" : "Provenance/1706813641478580000.69ef01b8-f12e-4585-b559-03954d6099e6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310813087320000.d3a60384-c541-4a1f-b07d-fb8330bb3ac2",
-        "recorded" : "2024-01-26T17:13:33Z",
+        "id" : "1706813641478580000.69ef01b8-f12e-4585-b559-03954d6099e6",
+        "recorded" : "2024-02-01T13:54:01Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310813086855000.fbb52dcd-5aa2-478a-a47d-d8a9b4a3ed78"
+              "reference" : "Organization/1706813641478120000.c05e0981-f02f-4a02-86b4-2f237c4eadc9"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310813086855000.fbb52dcd-5aa2-478a-a47d-d8a9b4a3ed78",
+      "fullUrl" : "Organization/1706813641478120000.c05e0981-f02f-4a02-86b4-2f237c4eadc9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310813086855000.fbb52dcd-5aa2-478a-a47d-d8a9b4a3ed78",
+        "id" : "1706813641478120000.c05e0981-f02f-4a02-86b4-2f237c4eadc9",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310813102965000.9b97e0de-4968-4c94-ae11-80094edc5397",
+      "fullUrl" : "Patient/1706813641492439000.a351c076-e9e4-4d8c-8287-38c448185182",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310813102965000.9b97e0de-4968-4c94-ae11-80094edc5397"
+        "id" : "1706813641492439000.a351c076-e9e4-4d8c-8287-38c448185182"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310813103554000.a7bac942-21b1-4ed9-9dcc-62da3e8dd80a",
+      "fullUrl" : "Provenance/1706813641493189000.269301c7-8fb8-40b5-ba31-5347d51ec7ac",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310813103554000.a7bac942-21b1-4ed9-9dcc-62da3e8dd80a",
+        "id" : "1706813641493189000.269301c7-8fb8-40b5-ba31-5347d51ec7ac",
         "target" : [
           {
-            "reference" : "Patient/1706310813102965000.9b97e0de-4968-4c94-ae11-80094edc5397"
+            "reference" : "Patient/1706813641492439000.a351c076-e9e4-4d8c-8287-38c448185182"
           }
         ],
-        "recorded" : "2024-01-26T17:13:33Z",
+        "recorded" : "2024-02-01T13:54:01Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310813108080000.4af4548d-6f17-4bda-80ba-ca8d06ed3a1b",
+      "fullUrl" : "ServiceRequest/1706813641498682000.99ee57ea-0f90-4f24-977c-ccdc8c09bde1",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310813108080000.4af4548d-6f17-4bda-80ba-ca8d06ed3a1b",
+        "id" : "1706813641498682000.99ee57ea-0f90-4f24-977c-ccdc8c09bde1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310813102965000.9b97e0de-4968-4c94-ae11-80094edc5397"
+          "reference" : "Patient/1706813641492439000.a351c076-e9e4-4d8c-8287-38c448185182"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310813280181000.730401c8-7cbd-4f7e-99a9-c4423c85889d",
+      "fullUrl" : "DiagnosticReport/1706813641658110000.3e9e25b6-1906-4876-b786-a99dc3330fe5",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310813280181000.730401c8-7cbd-4f7e-99a9-c4423c85889d",
+        "id" : "1706813641658110000.3e9e25b6-1906-4876-b786-a99dc3330fe5",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310813108080000.4af4548d-6f17-4bda-80ba-ca8d06ed3a1b"
+            "reference" : "ServiceRequest/1706813641498682000.99ee57ea-0f90-4f24-977c-ccdc8c09bde1"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310813102965000.9b97e0de-4968-4c94-ae11-80094edc5397"
+          "reference" : "Patient/1706813641492439000.a351c076-e9e4-4d8c-8287-38c448185182"
         },
         "issued" : "2023-08",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-msec-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-msec-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310822067205000.e0742662-cddf-4b69-9b73-9f754c7d461f",
+  "id" : "1706813650657787000.d2440bb2-4555-49ee-b0ad-72728628ec1e",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:13:42.081-06:00"
+    "lastUpdated" : "2024-02-01T13:54:10.663-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310822880394000.d81d2ece-90f7-451b-b3fd-673a8e86233a",
+      "fullUrl" : "Provenance/1706813651019845000.e46e8749-73a4-4edd-aa09-465ff8abb384",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310822880394000.d81d2ece-90f7-451b-b3fd-673a8e86233a",
+        "id" : "1706813651019845000.e46e8749-73a4-4edd-aa09-465ff8abb384",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310823044086000.ae165e90-c1d9-4034-9d66-0279d11d6faf"
+            "reference" : "DiagnosticReport/1706813651207396000.3c36b109-3b57-4560-8ed9-41ee008ba14b"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310822886730000.908e0ed0-5d5c-4f17-bdf2-22c06ec952fc",
+      "fullUrl" : "Provenance/1706813651028258000.2eaa9a33-ce24-4dfd-8013-5c144d61716c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310822886730000.908e0ed0-5d5c-4f17-bdf2-22c06ec952fc",
-        "recorded" : "2024-01-26T17:13:42Z",
+        "id" : "1706813651028258000.2eaa9a33-ce24-4dfd-8013-5c144d61716c",
+        "recorded" : "2024-02-01T13:54:11Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310822886336000.bfcd90b3-1054-4201-957f-30ff1eabd456"
+              "reference" : "Organization/1706813651027793000.74957832-9827-4a45-9df5-3cb3c388ebde"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310822886336000.bfcd90b3-1054-4201-957f-30ff1eabd456",
+      "fullUrl" : "Organization/1706813651027793000.74957832-9827-4a45-9df5-3cb3c388ebde",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310822886336000.bfcd90b3-1054-4201-957f-30ff1eabd456",
+        "id" : "1706813651027793000.74957832-9827-4a45-9df5-3cb3c388ebde",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310822900647000.ce5cedd9-3778-44c6-a918-7fdf92df4f76",
+      "fullUrl" : "Patient/1706813651042235000.8d51d9e6-c054-4c77-b088-28f206965da9",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310822900647000.ce5cedd9-3778-44c6-a918-7fdf92df4f76"
+        "id" : "1706813651042235000.8d51d9e6-c054-4c77-b088-28f206965da9"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310822901182000.a8740a68-6c8e-407b-a1e4-ce14027b425d",
+      "fullUrl" : "Provenance/1706813651042918000.28882d02-8be3-499e-9b3c-3079e40ae332",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310822901182000.a8740a68-6c8e-407b-a1e4-ce14027b425d",
+        "id" : "1706813651042918000.28882d02-8be3-499e-9b3c-3079e40ae332",
         "target" : [
           {
-            "reference" : "Patient/1706310822900647000.ce5cedd9-3778-44c6-a918-7fdf92df4f76"
+            "reference" : "Patient/1706813651042235000.8d51d9e6-c054-4c77-b088-28f206965da9"
           }
         ],
-        "recorded" : "2024-01-26T17:13:42Z",
+        "recorded" : "2024-02-01T13:54:11Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310822906037000.0f040428-6bf2-4b79-aaec-7925fb4b704c",
+      "fullUrl" : "ServiceRequest/1706813651048652000.457725bd-5799-474e-960a-1b17a90e38b7",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310822906037000.0f040428-6bf2-4b79-aaec-7925fb4b704c",
+        "id" : "1706813651048652000.457725bd-5799-474e-960a-1b17a90e38b7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310822900647000.ce5cedd9-3778-44c6-a918-7fdf92df4f76"
+          "reference" : "Patient/1706813651042235000.8d51d9e6-c054-4c77-b088-28f206965da9"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310823044086000.ae165e90-c1d9-4034-9d66-0279d11d6faf",
+      "fullUrl" : "DiagnosticReport/1706813651207396000.3c36b109-3b57-4560-8ed9-41ee008ba14b",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310823044086000.ae165e90-c1d9-4034-9d66-0279d11d6faf",
+        "id" : "1706813651207396000.3c36b109-3b57-4560-8ed9-41ee008ba14b",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310822906037000.0f040428-6bf2-4b79-aaec-7925fb4b704c"
+            "reference" : "ServiceRequest/1706813651048652000.457725bd-5799-474e-960a-1b17a90e38b7"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310822900647000.ce5cedd9-3778-44c6-a918-7fdf92df4f76"
+          "reference" : "Patient/1706813651042235000.8d51d9e6-c054-4c77-b088-28f206965da9"
         },
         "issued" : "2023-08-15T03:04:05.678Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-second-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-second-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310831368378000.de39fb7b-7025-4bdd-94c5-b659e9375b87",
+  "id" : "1706813660840224000.2dec57c5-7850-45e3-b7eb-b29e2159ab5c",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:13:51.381-06:00"
+    "lastUpdated" : "2024-02-01T13:54:20.847-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310831737825000.df8d1903-f628-4cc2-9b38-7836fe7a3c2c",
+      "fullUrl" : "Provenance/1706813661216310000.5d9f08b2-ea2a-44f3-8333-ba93e6bb9904",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310831737825000.df8d1903-f628-4cc2-9b38-7836fe7a3c2c",
+        "id" : "1706813661216310000.5d9f08b2-ea2a-44f3-8333-ba93e6bb9904",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310831904792000.e37cb1e4-d61b-4a77-a2c1-63ec66f07ab1"
+            "reference" : "DiagnosticReport/1706813661395133000.b7c5bbc9-8584-4023-b817-3386e6cc799d"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310831744808000.7b19ce16-d004-48c4-ade0-7b2af4933e56",
+      "fullUrl" : "Provenance/1706813661224794000.a0cda71c-0e03-4898-b466-9d2548f5c2df",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310831744808000.7b19ce16-d004-48c4-ade0-7b2af4933e56",
-        "recorded" : "2024-01-26T17:13:51Z",
+        "id" : "1706813661224794000.a0cda71c-0e03-4898-b466-9d2548f5c2df",
+        "recorded" : "2024-02-01T13:54:21Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310831744204000.892c335c-21f2-48d8-a936-708734fcae5d"
+              "reference" : "Organization/1706813661224326000.d42d2307-78e4-4613-996f-01454c94d61f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310831744204000.892c335c-21f2-48d8-a936-708734fcae5d",
+      "fullUrl" : "Organization/1706813661224326000.d42d2307-78e4-4613-996f-01454c94d61f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310831744204000.892c335c-21f2-48d8-a936-708734fcae5d",
+        "id" : "1706813661224326000.d42d2307-78e4-4613-996f-01454c94d61f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310831758708000.bbd2c7aa-1b22-4a29-b039-56ff5858bbb4",
+      "fullUrl" : "Patient/1706813661243461000.36b6adc0-285d-44ff-a89f-0d40275ac5b5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310831758708000.bbd2c7aa-1b22-4a29-b039-56ff5858bbb4"
+        "id" : "1706813661243461000.36b6adc0-285d-44ff-a89f-0d40275ac5b5"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310831759347000.a6245649-8fb6-4f2a-b21b-f13a4bbddf34",
+      "fullUrl" : "Provenance/1706813661244405000.58ba8f4b-5687-4e1d-8bc1-d4f84e0c5125",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310831759347000.a6245649-8fb6-4f2a-b21b-f13a4bbddf34",
+        "id" : "1706813661244405000.58ba8f4b-5687-4e1d-8bc1-d4f84e0c5125",
         "target" : [
           {
-            "reference" : "Patient/1706310831758708000.bbd2c7aa-1b22-4a29-b039-56ff5858bbb4"
+            "reference" : "Patient/1706813661243461000.36b6adc0-285d-44ff-a89f-0d40275ac5b5"
           }
         ],
-        "recorded" : "2024-01-26T17:13:51Z",
+        "recorded" : "2024-02-01T13:54:21Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310831764349000.a3e46eb7-289b-453d-9249-4c3c93054ed9",
+      "fullUrl" : "ServiceRequest/1706813661250157000.baa76876-91f0-4a91-8096-b85d725f498f",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310831764349000.a3e46eb7-289b-453d-9249-4c3c93054ed9",
+        "id" : "1706813661250157000.baa76876-91f0-4a91-8096-b85d725f498f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310831758708000.bbd2c7aa-1b22-4a29-b039-56ff5858bbb4"
+          "reference" : "Patient/1706813661243461000.36b6adc0-285d-44ff-a89f-0d40275ac5b5"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310831904792000.e37cb1e4-d61b-4a77-a2c1-63ec66f07ab1",
+      "fullUrl" : "DiagnosticReport/1706813661395133000.b7c5bbc9-8584-4023-b817-3386e6cc799d",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310831904792000.e37cb1e4-d61b-4a77-a2c1-63ec66f07ab1",
+        "id" : "1706813661395133000.b7c5bbc9-8584-4023-b817-3386e6cc799d",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310831764349000.a3e46eb7-289b-453d-9249-4c3c93054ed9"
+            "reference" : "ServiceRequest/1706813661250157000.baa76876-91f0-4a91-8096-b85d725f498f"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310831758708000.bbd2c7aa-1b22-4a29-b039-56ff5858bbb4"
+          "reference" : "Patient/1706813661243461000.36b6adc0-285d-44ff-a89f-0d40275ac5b5"
         },
         "issued" : "2023-08-15T03:04:05Z",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-year-precision-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-year-precision-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310840319403000.d27b4647-ee6e-41c7-8154-83e43ddaebbb",
+  "id" : "1706813670193372000.0a7e3999-0a3d-48bd-9b11-18c8f8b51d91",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:14:00.334-06:00"
+    "lastUpdated" : "2024-02-01T13:54:30.200-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310840695057000.41e4ed67-b9f8-42e8-90ed-f4a7582d14c7",
+      "fullUrl" : "Provenance/1706813670572855000.64eb8aff-3d7c-429b-9eaa-175d374fc161",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310840695057000.41e4ed67-b9f8-42e8-90ed-f4a7582d14c7",
+        "id" : "1706813670572855000.64eb8aff-3d7c-429b-9eaa-175d374fc161",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310840856301000.d36e879a-0717-4539-9263-c57ec0dbd94e"
+            "reference" : "DiagnosticReport/1706813670756963000.efbf67ce-c0f0-4cbc-b9c2-6b9f9455716e"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310840702546000.9e5d5ba0-911d-45ae-8b21-138dfcd15e51",
+      "fullUrl" : "Provenance/1706813670581805000.93c71074-31f6-426a-bcff-e403d8b08267",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310840702546000.9e5d5ba0-911d-45ae-8b21-138dfcd15e51",
-        "recorded" : "2024-01-26T17:14:00Z",
+        "id" : "1706813670581805000.93c71074-31f6-426a-bcff-e403d8b08267",
+        "recorded" : "2024-02-01T13:54:30Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310840702145000.f9607748-ad68-45fe-a6f6-22d5ebab47f7"
+              "reference" : "Organization/1706813670581334000.f59cf92e-724a-469d-a6b0-b0939b090144"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310840702145000.f9607748-ad68-45fe-a6f6-22d5ebab47f7",
+      "fullUrl" : "Organization/1706813670581334000.f59cf92e-724a-469d-a6b0-b0939b090144",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310840702145000.f9607748-ad68-45fe-a6f6-22d5ebab47f7",
+        "id" : "1706813670581334000.f59cf92e-724a-469d-a6b0-b0939b090144",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310840716667000.cea47ca4-7eec-419e-a77a-bed10df086f8",
+      "fullUrl" : "Patient/1706813670596430000.211e0db3-3c9e-4a0e-b02a-bb3fbbb639af",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310840716667000.cea47ca4-7eec-419e-a77a-bed10df086f8"
+        "id" : "1706813670596430000.211e0db3-3c9e-4a0e-b02a-bb3fbbb639af"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310840717239000.45c86866-cf38-4a8d-b8cc-5e78bcbbbd1c",
+      "fullUrl" : "Provenance/1706813670597369000.6cb9f558-ad0a-431e-b7e5-8c8734340b34",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310840717239000.45c86866-cf38-4a8d-b8cc-5e78bcbbbd1c",
+        "id" : "1706813670597369000.6cb9f558-ad0a-431e-b7e5-8c8734340b34",
         "target" : [
           {
-            "reference" : "Patient/1706310840716667000.cea47ca4-7eec-419e-a77a-bed10df086f8"
+            "reference" : "Patient/1706813670596430000.211e0db3-3c9e-4a0e-b02a-bb3fbbb639af"
           }
         ],
-        "recorded" : "2024-01-26T17:14:00Z",
+        "recorded" : "2024-02-01T13:54:30Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310840722181000.17dd21c7-fea5-4dd6-8d13-020ae781f1ca",
+      "fullUrl" : "ServiceRequest/1706813670605956000.6b6fc7a8-811c-42cb-8033-c76384636b82",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310840722181000.17dd21c7-fea5-4dd6-8d13-020ae781f1ca",
+        "id" : "1706813670605956000.6b6fc7a8-811c-42cb-8033-c76384636b82",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310840716667000.cea47ca4-7eec-419e-a77a-bed10df086f8"
+          "reference" : "Patient/1706813670596430000.211e0db3-3c9e-4a0e-b02a-bb3fbbb639af"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310840856301000.d36e879a-0717-4539-9263-c57ec0dbd94e",
+      "fullUrl" : "DiagnosticReport/1706813670756963000.efbf67ce-c0f0-4cbc-b9c2-6b9f9455716e",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310840856301000.d36e879a-0717-4539-9263-c57ec0dbd94e",
+        "id" : "1706813670756963000.efbf67ce-c0f0-4cbc-b9c2-6b9f9455716e",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310840722181000.17dd21c7-fea5-4dd6-8d13-020ae781f1ca"
+            "reference" : "ServiceRequest/1706813670605956000.6b6fc7a8-811c-42cb-8033-c76384636b82"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310840716667000.cea47ca4-7eec-419e-a77a-bed10df086f8"
+          "reference" : "Patient/1706813670596430000.211e0db3-3c9e-4a0e-b02a-bb3fbbb639af"
         },
         "issued" : "2023",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-zero-year-to-instant.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/dtm/instant/dtm-zero-year-to-instant.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310849048757000.0c27ef7b-e58e-4819-a2e4-b13864ba9c93",
+  "id" : "1706813679860026000.e2b79a1b-ec37-41e3-aafd-674b4e7ad87f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:14:09.062-06:00"
+    "lastUpdated" : "2024-02-01T13:54:39.866-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "20230816123358"
   },
   "type" : "message",
-  "timestamp" : "2023-08-16T12:33:58.000-05:00",
+  "timestamp" : "2023-08-16T13:33:58.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310849420842000.ece9525e-b999-449e-88ee-f5e08c7610e2",
+      "fullUrl" : "Provenance/1706813680220553000.092563d5-bc39-4bc2-9cd9-280b2edf07c7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310849420842000.ece9525e-b999-449e-88ee-f5e08c7610e2",
+        "id" : "1706813680220553000.092563d5-bc39-4bc2-9cd9-280b2edf07c7",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706310849604217000.c4299a66-1345-4f0b-bd81-6c661bd36bd2"
+            "reference" : "DiagnosticReport/1706813680401040000.314da1d2-c7d8-4312-87a2-ec15b79ea7cb"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310849428221000.f8f186b7-30f0-4984-8453-aa38001a1ccf",
+      "fullUrl" : "Provenance/1706813680228588000.8c070648-32cb-4dd1-90d8-15f17274d0ed",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310849428221000.f8f186b7-30f0-4984-8453-aa38001a1ccf",
-        "recorded" : "2024-01-26T17:14:09Z",
+        "id" : "1706813680228588000.8c070648-32cb-4dd1-90d8-15f17274d0ed",
+        "recorded" : "2024-02-01T13:54:40Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310849427610000.7acff5f0-8baa-4c75-89b5-f146fd85ffad"
+              "reference" : "Organization/1706813680228129000.3ed889bf-75fa-45ba-a30a-8c4147cc2053"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310849427610000.7acff5f0-8baa-4c75-89b5-f146fd85ffad",
+      "fullUrl" : "Organization/1706813680228129000.3ed889bf-75fa-45ba-a30a-8c4147cc2053",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310849427610000.7acff5f0-8baa-4c75-89b5-f146fd85ffad",
+        "id" : "1706813680228129000.3ed889bf-75fa-45ba-a30a-8c4147cc2053",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310849442082000.11e879fa-d06c-449a-b7db-5087c23767e4",
+      "fullUrl" : "Patient/1706813680242286000.183fd3ee-d500-460b-92ec-2b10a2cf2391",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310849442082000.11e879fa-d06c-449a-b7db-5087c23767e4"
+        "id" : "1706813680242286000.183fd3ee-d500-460b-92ec-2b10a2cf2391"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310849442672000.3001de16-4abc-41a3-ace1-b29e92f12fd4",
+      "fullUrl" : "Provenance/1706813680242883000.59a91c48-6489-4f8f-94ed-4838080306ad",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310849442672000.3001de16-4abc-41a3-ace1-b29e92f12fd4",
+        "id" : "1706813680242883000.59a91c48-6489-4f8f-94ed-4838080306ad",
         "target" : [
           {
-            "reference" : "Patient/1706310849442082000.11e879fa-d06c-449a-b7db-5087c23767e4"
+            "reference" : "Patient/1706813680242286000.183fd3ee-d500-460b-92ec-2b10a2cf2391"
           }
         ],
-        "recorded" : "2024-01-26T17:14:09Z",
+        "recorded" : "2024-02-01T13:54:40Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310849448860000.1f5360d2-5982-48d2-a11e-f49fe67e5be6",
+      "fullUrl" : "ServiceRequest/1706813680248235000.5958eb28-29c8-46f5-a28d-39b8787cf8e1",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310849448860000.1f5360d2-5982-48d2-a11e-f49fe67e5be6",
+        "id" : "1706813680248235000.5958eb28-29c8-46f5-a28d-39b8787cf8e1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -252,15 +257,15 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310849442082000.11e879fa-d06c-449a-b7db-5087c23767e4"
+          "reference" : "Patient/1706813680242286000.183fd3ee-d500-460b-92ec-2b10a2cf2391"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310849604217000.c4299a66-1345-4f0b-bd81-6c661bd36bd2",
+      "fullUrl" : "DiagnosticReport/1706813680401040000.314da1d2-c7d8-4312-87a2-ec15b79ea7cb",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310849604217000.c4299a66-1345-4f0b-bd81-6c661bd36bd2",
+        "id" : "1706813680401040000.314da1d2-c7d8-4312-87a2-ec15b79ea7cb",
         "identifier" : [
           {
             "extension" : [
@@ -295,7 +300,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310849448860000.1f5360d2-5982-48d2-a11e-f49fe67e5be6"
+            "reference" : "ServiceRequest/1706813680248235000.5958eb28-29c8-46f5-a28d-39b8787cf8e1"
           }
         ],
         "status" : "final",
@@ -319,7 +324,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310849442082000.11e879fa-d06c-449a-b7db-5087c23767e4"
+          "reference" : "Patient/1706813680242286000.183fd3ee-d500-460b-92ec-2b10a2cf2391"
         },
         "_issued" : {
           "extension" : [

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Device-UDI-Carrier.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Device-UDI-Carrier.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653637402255000.ee6837ed-f5eb-4eaa-a78e-58fcb306f784",
+  "id" : "1706814027308651000.aff64779-354e-41e6-927e-2b220b726cd0",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:27:17.408-05:00"
+    "lastUpdated" : "2024-02-01T14:00:27.314-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653637776189000.93ddc642-6e18-4f8f-b1fe-55a8e7c9e908",
+      "fullUrl" : "Provenance/1706814027682325000.44b3dc4e-a244-4338-892a-921157261cf9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653637776189000.93ddc642-6e18-4f8f-b1fe-55a8e7c9e908",
+        "id" : "1706814027682325000.44b3dc4e-a244-4338-892a-921157261cf9",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653637785937000.12566a02-7a35-4e96-8afa-ad063b981655",
+      "fullUrl" : "Provenance/1706814027690144000.b0297284-223e-4859-87e3-0b994183d7f8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653637785937000.12566a02-7a35-4e96-8afa-ad063b981655",
-        "recorded" : "2024-01-30T17:27:17Z",
+        "id" : "1706814027690144000.b0297284-223e-4859-87e3-0b994183d7f8",
+        "recorded" : "2024-02-01T14:00:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653637785392000.dc55090e-7ba2-4f63-985a-de9e0ccebff7"
+              "reference" : "Organization/1706814027689304000.998c65fa-8801-4a5a-a0aa-d16439529990"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653637785392000.dc55090e-7ba2-4f63-985a-de9e0ccebff7",
+      "fullUrl" : "Organization/1706814027689304000.998c65fa-8801-4a5a-a0aa-d16439529990",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653637785392000.dc55090e-7ba2-4f63-985a-de9e0ccebff7",
+        "id" : "1706814027689304000.998c65fa-8801-4a5a-a0aa-d16439529990",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,23 +125,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653637800219000.88a03b8e-4bdf-48e3-bc05-8b3c59a6c9fd",
+      "fullUrl" : "Patient/1706814027703985000.b1edfa91-26cb-47c9-a119-6f43b74636fe",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653637800219000.88a03b8e-4bdf-48e3-bc05-8b3c59a6c9fd"
+        "id" : "1706814027703985000.b1edfa91-26cb-47c9-a119-6f43b74636fe"
       }
     },
     {
-      "fullUrl" : "Provenance/1706653637800812000.df489a2d-d810-40df-932e-9b35d95176c6",
+      "fullUrl" : "Provenance/1706814027704726000.7436e655-0a5f-4df5-8356-c7a8ca36dbd5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653637800812000.df489a2d-d810-40df-932e-9b35d95176c6",
+        "id" : "1706814027704726000.7436e655-0a5f-4df5-8356-c7a8ca36dbd5",
         "target" : [
           {
-            "reference" : "Patient/1706653637800219000.88a03b8e-4bdf-48e3-bc05-8b3c59a6c9fd"
+            "reference" : "Patient/1706814027703985000.b1edfa91-26cb-47c9-a119-6f43b74636fe"
           }
         ],
-        "recorded" : "2024-01-30T17:27:17Z",
+        "recorded" : "2024-02-01T14:00:27Z",
         "activity" : {
           "coding" : [
             {
@@ -148,10 +153,10 @@
       }
     },
     {
-      "fullUrl" : "Device/1706653637801697000.a513146d-5db2-4e0a-a5a5-59e7751b4169",
+      "fullUrl" : "Device/1706814027705650000.071ca971-6596-4629-abee-2bf4b93dbe2e",
       "resource" : {
         "resourceType" : "Device",
-        "id" : "1706653637801697000.a513146d-5db2-4e0a-a5a5-59e7751b4169",
+        "id" : "1706814027705650000.071ca971-6596-4629-abee-2bf4b93dbe2e",
         "udiCarrier" : [
           {
             "extension" : [

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Identifier-Extension.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Identifier-Extension.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653646475719000.eec02622-e16d-4578-83e6-4561da96cab8",
+  "id" : "1706814036847184000.3d347a96-9a46-44dc-9913-1f600ff193d6",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:27:26.482-05:00"
+    "lastUpdated" : "2024-02-01T14:00:36.857-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653646857278000.5f4a0875-e1cb-454c-a598-25e3b5c5e07e",
+      "fullUrl" : "Provenance/1706814037244176000.8b58b4e6-316d-45fb-91cb-2e6df301c29a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653646857278000.5f4a0875-e1cb-454c-a598-25e3b5c5e07e",
+        "id" : "1706814037244176000.8b58b4e6-316d-45fb-91cb-2e6df301c29a",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
           },
           {
-            "reference" : "DiagnosticReport/1706653647042136000.5c1da1e6-5dd2-4295-a2cc-86b0ffef7afc"
+            "reference" : "DiagnosticReport/1706814037425864000.8d1ce637-4608-4dd4-96c5-e47af3c6a77c"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653646865249000.9b5c5bb3-76e4-415a-a42a-da1178df4fa4",
+      "fullUrl" : "Provenance/1706814037252698000.a8901e56-678a-40e8-a13a-c4a950c523b1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653646865249000.9b5c5bb3-76e4-415a-a42a-da1178df4fa4",
-        "recorded" : "2024-01-30T17:27:26Z",
+        "id" : "1706814037252698000.a8901e56-678a-40e8-a13a-c4a950c523b1",
+        "recorded" : "2024-02-01T14:00:37Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653646864526000.3d6a302d-9619-4633-b8f3-145099892487"
+              "reference" : "Organization/1706814037252253000.2cbcc86e-f6f7-4138-a3da-3e855b2a34f0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653646864526000.3d6a302d-9619-4633-b8f3-145099892487",
+      "fullUrl" : "Organization/1706814037252253000.2cbcc86e-f6f7-4138-a3da-3e855b2a34f0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653646864526000.3d6a302d-9619-4633-b8f3-145099892487",
+        "id" : "1706814037252253000.2cbcc86e-f6f7-4138-a3da-3e855b2a34f0",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706653646886887000.dbac6b1c-d8d8-48df-a79b-a6f345d20210",
+      "fullUrl" : "ServiceRequest/1706814037273458000.0dde7699-f09a-40ce-a3a9-0cf3d7e2a535",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706653646886887000.dbac6b1c-d8d8-48df-a79b-a6f345d20210",
+        "id" : "1706814037273458000.0dde7699-f09a-40ce-a3a9-0cf3d7e2a535",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -284,15 +289,15 @@
               }
             }
           ],
-          "reference" : "Practitioner/1706653646876094000.fa24b9f8-44be-4531-a48c-430044bde07a"
+          "reference" : "Practitioner/1706814037263139000.2efe48d8-5e7e-4a33-a90b-5b24147d79a8"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706653646876094000.fa24b9f8-44be-4531-a48c-430044bde07a",
+      "fullUrl" : "Practitioner/1706814037263139000.2efe48d8-5e7e-4a33-a90b-5b24147d79a8",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706653646876094000.fa24b9f8-44be-4531-a48c-430044bde07a",
+        "id" : "1706814037263139000.2efe48d8-5e7e-4a33-a90b-5b24147d79a8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -343,10 +348,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706653647042136000.5c1da1e6-5dd2-4295-a2cc-86b0ffef7afc",
+      "fullUrl" : "DiagnosticReport/1706814037425864000.8d1ce637-4608-4dd4-96c5-e47af3c6a77c",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706653647042136000.5c1da1e6-5dd2-4295-a2cc-86b0ffef7afc",
+        "id" : "1706814037425864000.8d1ce637-4608-4dd4-96c5-e47af3c6a77c",
         "identifier" : [
           {
             "extension" : [
@@ -415,7 +420,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706653646886887000.dbac6b1c-d8d8-48df-a79b-a6f345d20210"
+            "reference" : "ServiceRequest/1706814037273458000.0dde7699-f09a-40ce-a3a9-0cf3d7e2a535"
           }
         ],
         "status" : "final",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Identifier-default-assigner.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Identifier-default-assigner.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653656049402000.0d3d2376-ab2a-485e-9bba-c8181ac45264",
+  "id" : "1706814046206975000.3f5bcfca-401c-4940-9612-9eb43bb1dfba",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:27:36.056-05:00"
+    "lastUpdated" : "2024-02-01T14:00:46.213-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706653656124152000.f0540c66-416b-4bb0-98cb-018a07cd9be2"
+          "reference" : "Organization/1706814046258632000.84734535-614c-408d-988e-db24278d8334"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706653656124152000.f0540c66-416b-4bb0-98cb-018a07cd9be2",
+      "fullUrl" : "Organization/1706814046258632000.84734535-614c-408d-988e-db24278d8334",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653656124152000.f0540c66-416b-4bb0-98cb-018a07cd9be2",
+        "id" : "1706814046258632000.84734535-614c-408d-988e-db24278d8334",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653656445128000.c5458f81-2593-4342-a198-2b2a8bd2219b",
+      "fullUrl" : "Provenance/1706814046589141000.81cd4df6-42f6-47bb-a5de-e1d5a8089e0d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653656445128000.c5458f81-2593-4342-a198-2b2a8bd2219b",
+        "id" : "1706814046589141000.81cd4df6-42f6-47bb-a5de-e1d5a8089e0d",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653656453414000.61c57a7b-5880-4b2e-adcf-b5cb546eaea5",
+      "fullUrl" : "Provenance/1706814046597256000.63391d20-9dec-47ae-a981-053870758e11",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653656453414000.61c57a7b-5880-4b2e-adcf-b5cb546eaea5",
-        "recorded" : "2024-01-30T17:27:36Z",
+        "id" : "1706814046597256000.63391d20-9dec-47ae-a981-053870758e11",
+        "recorded" : "2024-02-01T14:00:46Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653656452967000.c5d76606-eb41-4249-8c92-090d47c149b8"
+              "reference" : "Organization/1706814046596434000.86890e77-f4a1-47ad-8bb9-4684cd0b09c5"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653656452967000.c5d76606-eb41-4249-8c92-090d47c149b8",
+      "fullUrl" : "Organization/1706814046596434000.86890e77-f4a1-47ad-8bb9-4684cd0b09c5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653656452967000.c5d76606-eb41-4249-8c92-090d47c149b8",
+        "id" : "1706814046596434000.86890e77-f4a1-47ad-8bb9-4684cd0b09c5",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653656472261000.92fb683a-b4e1-411e-a9aa-c1ff2a508d6a",
+      "fullUrl" : "Patient/1706814046611848000.f3d5c3fd-0818-49a5-b16c-236b630ee971",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653656472261000.92fb683a-b4e1-411e-a9aa-c1ff2a508d6a"
+        "id" : "1706814046611848000.f3d5c3fd-0818-49a5-b16c-236b630ee971"
       }
     },
     {
-      "fullUrl" : "Provenance/1706653656472984000.a4a3b53b-dd25-4411-97ff-07b5d4b6c704",
+      "fullUrl" : "Provenance/1706814046612794000.04a3c0b5-80b9-4fe8-96ff-9481fe51d84b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653656472984000.a4a3b53b-dd25-4411-97ff-07b5d4b6c704",
+        "id" : "1706814046612794000.04a3c0b5-80b9-4fe8-96ff-9481fe51d84b",
         "target" : [
           {
-            "reference" : "Patient/1706653656472261000.92fb683a-b4e1-411e-a9aa-c1ff2a508d6a"
+            "reference" : "Patient/1706814046611848000.f3d5c3fd-0818-49a5-b16c-236b630ee971"
           }
         ],
-        "recorded" : "2024-01-30T17:27:36Z",
+        "recorded" : "2024-02-01T14:00:46Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706653656478820000.4fe632d1-964b-4fed-97f8-bd64f563f60b",
+      "fullUrl" : "Encounter/1706814046618036000.d618040b-d1f5-4f8d-a0f5-119c06be73a0",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706653656478820000.4fe632d1-964b-4fed-97f8-bd64f563f60b",
+        "id" : "1706814046618036000.d618040b-d1f5-4f8d-a0f5-119c06be73a0",
         "subject" : {
-          "reference" : "Patient/1706653656472261000.92fb683a-b4e1-411e-a9aa-c1ff2a508d6a"
+          "reference" : "Patient/1706814046611848000.f3d5c3fd-0818-49a5-b16c-236b630ee971"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706653656479052000.16151cb4-8984-4b08-a3ac-4a587260c1f9"
+            "reference" : "EpisodeOfCare/1706814046618245000.effa4847-a580-4561-8df7-37aa9a05b3d0"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706653656478533000.c0646ba4-a4f4-4911-88eb-50dc64adba2f"
+              "reference" : "Location/1706814046617786000.cc8937e1-208e-4d5b-b24e-75ae4a8adb9e"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706653656477227000.6a17b5a2-f1cf-48af-b6a7-4a508fa57190",
+      "fullUrl" : "Organization/1706814046616626000.fbdf5f24-adf9-44ef-9666-0e6a9f223939",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653656477227000.6a17b5a2-f1cf-48af-b6a7-4a508fa57190",
+        "id" : "1706814046616626000.fbdf5f24-adf9-44ef-9666-0e6a9f223939",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706653656478533000.c0646ba4-a4f4-4911-88eb-50dc64adba2f",
+      "fullUrl" : "Location/1706814046617786000.cc8937e1-208e-4d5b-b24e-75ae4a8adb9e",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706653656478533000.c0646ba4-a4f4-4911-88eb-50dc64adba2f",
+        "id" : "1706814046617786000.cc8937e1-208e-4d5b-b24e-75ae4a8adb9e",
         "identifier" : [
           {
             "extension" : [
@@ -289,7 +294,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706653656477227000.6a17b5a2-f1cf-48af-b6a7-4a508fa57190"
+              "reference" : "Organization/1706814046616626000.fbdf5f24-adf9-44ef-9666-0e6a9f223939"
             }
           }
         ],
@@ -305,10 +310,10 @@
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706653656479052000.16151cb4-8984-4b08-a3ac-4a587260c1f9",
+      "fullUrl" : "EpisodeOfCare/1706814046618245000.effa4847-a580-4561-8df7-37aa9a05b3d0",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706653656479052000.16151cb4-8984-4b08-a3ac-4a587260c1f9",
+        "id" : "1706814046618245000.effa4847-a580-4561-8df7-37aa9a05b3d0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Identifier-organization-assigner.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/ei/EI-to-Identifier-organization-assigner.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653665556339000.62449d9e-4686-402f-83f3-b0851cd69449",
+  "id" : "1706814055866008000.def7bf50-a771-4233-98c3-f9c79304873c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:27:45.563-05:00"
+    "lastUpdated" : "2024-02-01T14:00:55.873-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706653665627991000.fa977425-3863-44ac-bb0f-705285e50b77"
+          "reference" : "Organization/1706814055917255000.4ca2f300-a396-482a-9639-5ae9535f474a"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706653665627991000.fa977425-3863-44ac-bb0f-705285e50b77",
+      "fullUrl" : "Organization/1706814055917255000.4ca2f300-a396-482a-9639-5ae9535f474a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653665627991000.fa977425-3863-44ac-bb0f-705285e50b77",
+        "id" : "1706814055917255000.4ca2f300-a396-482a-9639-5ae9535f474a",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653665958134000.3bccfba2-c331-428a-9152-990bd4d6a25f",
+      "fullUrl" : "Provenance/1706814056251052000.5b731e0e-221d-49f7-bdf7-1d1c210cd948",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653665958134000.3bccfba2-c331-428a-9152-990bd4d6a25f",
+        "id" : "1706814056251052000.5b731e0e-221d-49f7-bdf7-1d1c210cd948",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706653665965909000.1796a529-0739-44a1-a90d-01462280bc23",
+      "fullUrl" : "Provenance/1706814056258386000.c1a4572d-3ca8-4546-b6ca-07e805382b0f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653665965909000.1796a529-0739-44a1-a90d-01462280bc23",
-        "recorded" : "2024-01-30T17:27:45Z",
+        "id" : "1706814056258386000.c1a4572d-3ca8-4546-b6ca-07e805382b0f",
+        "recorded" : "2024-02-01T14:00:56Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706653665965489000.f5f57613-0bfa-45a4-ab06-e84c3fc8781c"
+              "reference" : "Organization/1706814056257951000.94afa6f1-7f4e-45e1-acd8-3bec1445b9f0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706653665965489000.f5f57613-0bfa-45a4-ab06-e84c3fc8781c",
+      "fullUrl" : "Organization/1706814056257951000.94afa6f1-7f4e-45e1-acd8-3bec1445b9f0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653665965489000.f5f57613-0bfa-45a4-ab06-e84c3fc8781c",
+        "id" : "1706814056257951000.94afa6f1-7f4e-45e1-acd8-3bec1445b9f0",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706653665983267000.8d68bebb-1b26-480d-b555-dc8b462b921c",
+      "fullUrl" : "Patient/1706814056271086000.b3eff95d-c662-481f-8ecd-6519cade9263",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706653665983267000.8d68bebb-1b26-480d-b555-dc8b462b921c"
+        "id" : "1706814056271086000.b3eff95d-c662-481f-8ecd-6519cade9263"
       }
     },
     {
-      "fullUrl" : "Provenance/1706653665983779000.15e02c1a-5e8a-4b14-aaaf-adf440a32403",
+      "fullUrl" : "Provenance/1706814056271717000.ab436260-023d-4850-9c17-805485d35e75",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706653665983779000.15e02c1a-5e8a-4b14-aaaf-adf440a32403",
+        "id" : "1706814056271717000.ab436260-023d-4850-9c17-805485d35e75",
         "target" : [
           {
-            "reference" : "Patient/1706653665983267000.8d68bebb-1b26-480d-b555-dc8b462b921c"
+            "reference" : "Patient/1706814056271086000.b3eff95d-c662-481f-8ecd-6519cade9263"
           }
         ],
-        "recorded" : "2024-01-30T17:27:45Z",
+        "recorded" : "2024-02-01T14:00:56Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706653665987934000.06882d42-f808-4d81-a8a0-6f4443a1437d",
+      "fullUrl" : "Encounter/1706814056276845000.5f9cc5b5-5944-431d-af04-165a0d33ffc5",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706653665987934000.06882d42-f808-4d81-a8a0-6f4443a1437d",
+        "id" : "1706814056276845000.5f9cc5b5-5944-431d-af04-165a0d33ffc5",
         "subject" : {
-          "reference" : "Patient/1706653665983267000.8d68bebb-1b26-480d-b555-dc8b462b921c"
+          "reference" : "Patient/1706814056271086000.b3eff95d-c662-481f-8ecd-6519cade9263"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706653665988122000.8352c7c4-b6bf-4304-a26d-ec8eb9d29247"
+            "reference" : "EpisodeOfCare/1706814056277075000.04960333-af1d-479f-af5b-3c6fc191959d"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706653665987674000.8338e5ac-a0f1-4df8-9689-dc82ef059d7c"
+              "reference" : "Location/1706814056276392000.4573c76d-8c89-4004-b738-f0659bc52b36"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706653665987210000.e70b8df0-2032-4a6e-8269-9ed5e51e0593",
+      "fullUrl" : "Organization/1706814056275666000.080bfa82-bada-411b-a3b9-0ea16082ab31",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706653665987210000.e70b8df0-2032-4a6e-8269-9ed5e51e0593",
+        "id" : "1706814056275666000.080bfa82-bada-411b-a3b9-0ea16082ab31",
         "identifier" : [
           {
             "extension" : [
@@ -236,10 +241,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706653665987674000.8338e5ac-a0f1-4df8-9689-dc82ef059d7c",
+      "fullUrl" : "Location/1706814056276392000.4573c76d-8c89-4004-b738-f0659bc52b36",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706653665987674000.8338e5ac-a0f1-4df8-9689-dc82ef059d7c",
+        "id" : "1706814056276392000.4573c76d-8c89-4004-b738-f0659bc52b36",
         "identifier" : [
           {
             "extension" : [
@@ -281,7 +286,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706653665987210000.e70b8df0-2032-4a6e-8269-9ed5e51e0593"
+              "reference" : "Organization/1706814056275666000.080bfa82-bada-411b-a3b9-0ea16082ab31"
             }
           }
         ],
@@ -297,10 +302,10 @@
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706653665988122000.8352c7c4-b6bf-4304-a26d-ec8eb9d29247",
+      "fullUrl" : "EpisodeOfCare/1706814056277075000.04960333-af1d-479f-af5b-3c6fc191959d",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706653665988122000.8352c7c4-b6bf-4304-a26d-ec8eb9d29247",
+        "id" : "1706814056277075000.04960333-af1d-479f-af5b-3c6fc191959d",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/eip/EIP-to-Identifier-Both.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/eip/EIP-to-Identifier-Both.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310897213289000.42449f1a-324d-4277-8767-5391d278fe29",
+  "id" : "1706813910323869000.e02624da-e56a-44c1-aacb-11f514503c6f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:14:57.226-06:00"
+    "lastUpdated" : "2024-02-01T13:58:30.329-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310897296638000.fd3025b9-ed2e-4af0-8eed-b1b49d9a07d8"
+          "reference" : "Organization/1706813910369331000.061fddb6-4086-4560-8f3b-3be4ab5da417"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310897296638000.fd3025b9-ed2e-4af0-8eed-b1b49d9a07d8",
+      "fullUrl" : "Organization/1706813910369331000.061fddb6-4086-4560-8f3b-3be4ab5da417",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310897296638000.fd3025b9-ed2e-4af0-8eed-b1b49d9a07d8",
+        "id" : "1706813910369331000.061fddb6-4086-4560-8f3b-3be4ab5da417",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310897588451000.ed8c5ec7-032c-459f-9a00-a4e512267157",
+      "fullUrl" : "Provenance/1706813910797906000.4e6e17e3-1a0b-45ce-b181-f14f05c87d70",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310897588451000.ed8c5ec7-032c-459f-9a00-a4e512267157",
+        "id" : "1706813910797906000.4e6e17e3-1a0b-45ce-b181-f14f05c87d70",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310897759397000.f8492df7-06d2-49f1-9f3d-047c3dbcb80e"
+            "reference" : "DiagnosticReport/1706813910979417000.046a5ada-d67d-4636-90cc-1b76330ad73e"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310897595522000.a74d81fa-0f3e-4945-82c8-bfc688250ba0",
+      "fullUrl" : "Provenance/1706813910805596000.9c2bf400-d40f-460b-9057-76c80162335b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310897595522000.a74d81fa-0f3e-4945-82c8-bfc688250ba0",
-        "recorded" : "2024-01-26T17:14:57Z",
+        "id" : "1706813910805596000.9c2bf400-d40f-460b-9057-76c80162335b",
+        "recorded" : "2024-02-01T13:58:30Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310897595124000.9b7da364-0525-4146-8770-c3496dfc7b95"
+              "reference" : "Organization/1706813910805018000.1eae82f4-b9f1-49d0-ab18-6c91a9530602"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310897595124000.9b7da364-0525-4146-8770-c3496dfc7b95",
+      "fullUrl" : "Organization/1706813910805018000.1eae82f4-b9f1-49d0-ab18-6c91a9530602",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310897595124000.9b7da364-0525-4146-8770-c3496dfc7b95",
+        "id" : "1706813910805018000.1eae82f4-b9f1-49d0-ab18-6c91a9530602",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310897609813000.77fa3acb-d0a1-4c7a-9205-b5aeec2b31b3",
+      "fullUrl" : "Patient/1706813910820100000.8aa518ea-74ce-4744-96da-11d8ca1abef6",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310897609813000.77fa3acb-d0a1-4c7a-9205-b5aeec2b31b3"
+        "id" : "1706813910820100000.8aa518ea-74ce-4744-96da-11d8ca1abef6"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310897610408000.ad44bf33-2654-4797-90fd-b66461acec65",
+      "fullUrl" : "Provenance/1706813910820956000.273e4e75-ebd2-43ad-a24a-b83b3131f970",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310897610408000.ad44bf33-2654-4797-90fd-b66461acec65",
+        "id" : "1706813910820956000.273e4e75-ebd2-43ad-a24a-b83b3131f970",
         "target" : [
           {
-            "reference" : "Patient/1706310897609813000.77fa3acb-d0a1-4c7a-9205-b5aeec2b31b3"
+            "reference" : "Patient/1706813910820100000.8aa518ea-74ce-4744-96da-11d8ca1abef6"
           }
         ],
-        "recorded" : "2024-01-26T17:14:57Z",
+        "recorded" : "2024-02-01T13:58:30Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310897614036000.66931ca1-db4e-4ce2-a759-fdb0e1939bef",
+      "fullUrl" : "Specimen/1706813910824445000.ef1cec46-7956-4e54-ae31-97164e7e3ece",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310897614036000.66931ca1-db4e-4ce2-a759-fdb0e1939bef",
+        "id" : "1706813910824445000.ef1cec46-7956-4e54-ae31-97164e7e3ece",
         "identifier" : [
           {
             "extension" : [
@@ -279,10 +284,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310897757255000.f720578f-3d60-44d1-b300-1d0ae6b96ca8",
+      "fullUrl" : "ServiceRequest/1706813910976478000.09193098-fbaa-403a-8647-e61d2fc7ca03",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310897757255000.f720578f-3d60-44d1-b300-1d0ae6b96ca8",
+        "id" : "1706813910976478000.09193098-fbaa-403a-8647-e61d2fc7ca03",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -298,18 +303,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310897609813000.77fa3acb-d0a1-4c7a-9205-b5aeec2b31b3"
+          "reference" : "Patient/1706813910820100000.8aa518ea-74ce-4744-96da-11d8ca1abef6"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310897759397000.f8492df7-06d2-49f1-9f3d-047c3dbcb80e",
+      "fullUrl" : "DiagnosticReport/1706813910979417000.046a5ada-d67d-4636-90cc-1b76330ad73e",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310897759397000.f8492df7-06d2-49f1-9f3d-047c3dbcb80e",
+        "id" : "1706813910979417000.046a5ada-d67d-4636-90cc-1b76330ad73e",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310897757255000.f720578f-3d60-44d1-b300-1d0ae6b96ca8"
+            "reference" : "ServiceRequest/1706813910976478000.09193098-fbaa-403a-8647-e61d2fc7ca03"
           }
         ],
         "status" : "final",
@@ -327,11 +332,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310897609813000.77fa3acb-d0a1-4c7a-9205-b5aeec2b31b3"
+          "reference" : "Patient/1706813910820100000.8aa518ea-74ce-4744-96da-11d8ca1abef6"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310897614036000.66931ca1-db4e-4ce2-a759-fdb0e1939bef"
+            "reference" : "Specimen/1706813910824445000.ef1cec46-7956-4e54-ae31-97164e7e3ece"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/eip/EIP-to-Identifier-FillerAssignedIdentifier.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/eip/EIP-to-Identifier-FillerAssignedIdentifier.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310906029622000.f8295764-82cc-400a-8685-32521765e5e1",
+  "id" : "1706813920199717000.96c362d8-f68e-4eec-bb65-8648fb355c1a",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:06.043-06:00"
+    "lastUpdated" : "2024-02-01T13:58:40.206-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310906117284000.d61275e9-51fb-4e91-965f-baaafd5c5e64"
+          "reference" : "Organization/1706813920248517000.765aceda-f0f4-47e9-b492-d6a93d385f0f"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310906117284000.d61275e9-51fb-4e91-965f-baaafd5c5e64",
+      "fullUrl" : "Organization/1706813920248517000.765aceda-f0f4-47e9-b492-d6a93d385f0f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310906117284000.d61275e9-51fb-4e91-965f-baaafd5c5e64",
+        "id" : "1706813920248517000.765aceda-f0f4-47e9-b492-d6a93d385f0f",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310906398081000.39415ae2-ed87-4fff-9362-28ce7964e6a6",
+      "fullUrl" : "Provenance/1706813920608779000.e39d4111-5b0c-462f-b8f7-6a55ec998741",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310906398081000.39415ae2-ed87-4fff-9362-28ce7964e6a6",
+        "id" : "1706813920608779000.e39d4111-5b0c-462f-b8f7-6a55ec998741",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310906562469000.5b74908f-d81d-43b3-9efb-94541c7e16e0"
+            "reference" : "DiagnosticReport/1706813920794767000.47cd0c37-360a-4c77-8f0e-0b2dd26ba4c0"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310906405340000.4d39587b-4f6a-421e-a6c7-5ca597bc6e13",
+      "fullUrl" : "Provenance/1706813920617097000.28bbe05a-fb83-4627-9dc8-5ef5055660cb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310906405340000.4d39587b-4f6a-421e-a6c7-5ca597bc6e13",
-        "recorded" : "2024-01-26T17:15:06Z",
+        "id" : "1706813920617097000.28bbe05a-fb83-4627-9dc8-5ef5055660cb",
+        "recorded" : "2024-02-01T13:58:40Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310906404787000.99f64d15-55dc-4701-8e9e-ac83c05656f6"
+              "reference" : "Organization/1706813920615790000.43bddbdb-a421-4d1b-85f0-6caca3153cc2"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310906404787000.99f64d15-55dc-4701-8e9e-ac83c05656f6",
+      "fullUrl" : "Organization/1706813920615790000.43bddbdb-a421-4d1b-85f0-6caca3153cc2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310906404787000.99f64d15-55dc-4701-8e9e-ac83c05656f6",
+        "id" : "1706813920615790000.43bddbdb-a421-4d1b-85f0-6caca3153cc2",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310906417706000.df87f9dc-0671-4a47-a90f-30125de88f3c",
+      "fullUrl" : "Patient/1706813920634055000.33aa84f8-872c-42c3-88fa-ca2ee1435ce8",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310906417706000.df87f9dc-0671-4a47-a90f-30125de88f3c"
+        "id" : "1706813920634055000.33aa84f8-872c-42c3-88fa-ca2ee1435ce8"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310906418264000.306a0dee-7ba2-4a1e-8475-18f73610279e",
+      "fullUrl" : "Provenance/1706813920634672000.05cff581-32ff-4396-b6b5-a21c86fac4f7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310906418264000.306a0dee-7ba2-4a1e-8475-18f73610279e",
+        "id" : "1706813920634672000.05cff581-32ff-4396-b6b5-a21c86fac4f7",
         "target" : [
           {
-            "reference" : "Patient/1706310906417706000.df87f9dc-0671-4a47-a90f-30125de88f3c"
+            "reference" : "Patient/1706813920634055000.33aa84f8-872c-42c3-88fa-ca2ee1435ce8"
           }
         ],
-        "recorded" : "2024-01-26T17:15:06Z",
+        "recorded" : "2024-02-01T13:58:40Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310906420241000.8ea8c4ee-033f-45f9-8de0-dc4a429ad9e8",
+      "fullUrl" : "Specimen/1706813920636881000.2604e1fa-ff1b-426e-b009-a2ab4c9cb963",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310906420241000.8ea8c4ee-033f-45f9-8de0-dc4a429ad9e8",
+        "id" : "1706813920636881000.2604e1fa-ff1b-426e-b009-a2ab4c9cb963",
         "identifier" : [
           {
             "extension" : [
@@ -208,10 +213,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310906560428000.06eddfbf-e259-4b41-bd36-9a76d4f631d5",
+      "fullUrl" : "ServiceRequest/1706813920785710000.55f6291f-52cb-40aa-af1f-fd4b351c7fdf",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310906560428000.06eddfbf-e259-4b41-bd36-9a76d4f631d5",
+        "id" : "1706813920785710000.55f6291f-52cb-40aa-af1f-fd4b351c7fdf",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -227,18 +232,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310906417706000.df87f9dc-0671-4a47-a90f-30125de88f3c"
+          "reference" : "Patient/1706813920634055000.33aa84f8-872c-42c3-88fa-ca2ee1435ce8"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310906562469000.5b74908f-d81d-43b3-9efb-94541c7e16e0",
+      "fullUrl" : "DiagnosticReport/1706813920794767000.47cd0c37-360a-4c77-8f0e-0b2dd26ba4c0",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310906562469000.5b74908f-d81d-43b3-9efb-94541c7e16e0",
+        "id" : "1706813920794767000.47cd0c37-360a-4c77-8f0e-0b2dd26ba4c0",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310906560428000.06eddfbf-e259-4b41-bd36-9a76d4f631d5"
+            "reference" : "ServiceRequest/1706813920785710000.55f6291f-52cb-40aa-af1f-fd4b351c7fdf"
           }
         ],
         "status" : "final",
@@ -256,11 +261,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310906417706000.df87f9dc-0671-4a47-a90f-30125de88f3c"
+          "reference" : "Patient/1706813920634055000.33aa84f8-872c-42c3-88fa-ca2ee1435ce8"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310906420241000.8ea8c4ee-033f-45f9-8de0-dc4a429ad9e8"
+            "reference" : "Specimen/1706813920636881000.2604e1fa-ff1b-426e-b009-a2ab4c9cb963"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/eip/EIP-to-Identifier-PlacerAssignedIdentifier.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/eip/EIP-to-Identifier-PlacerAssignedIdentifier.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310915045719000.38f4fc04-c1c1-427d-adb1-62cafa9bb5a3",
+  "id" : "1706813929893091000.e72f3236-5e22-4a0f-9461-06e761511724",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:15.060-06:00"
+    "lastUpdated" : "2024-02-01T13:58:49.902-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310915138142000.88b9d289-d8fa-43da-9e36-3a728faf18ca"
+          "reference" : "Organization/1706813929945089000.17860a1d-6c3a-404b-a91d-9d2501010425"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310915138142000.88b9d289-d8fa-43da-9e36-3a728faf18ca",
+      "fullUrl" : "Organization/1706813929945089000.17860a1d-6c3a-404b-a91d-9d2501010425",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310915138142000.88b9d289-d8fa-43da-9e36-3a728faf18ca",
+        "id" : "1706813929945089000.17860a1d-6c3a-404b-a91d-9d2501010425",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310915424363000.fb76ad41-2d98-45af-a497-34eb0727c38f",
+      "fullUrl" : "Provenance/1706813930279581000.2b243405-bea0-4745-97fd-0efe0e5871f5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310915424363000.fb76ad41-2d98-45af-a497-34eb0727c38f",
+        "id" : "1706813930279581000.2b243405-bea0-4745-97fd-0efe0e5871f5",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706310915609852000.b4a2031a-c126-468a-a24e-3b02f1477bed"
+            "reference" : "DiagnosticReport/1706813930468178000.4ddc5d9d-b941-45c3-a016-1b96e06243ab"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310915433530000.ee5e8486-1ed1-45cc-892e-60d94d5f7265",
+      "fullUrl" : "Provenance/1706813930287300000.416c26e4-fbbe-4333-836d-c023af1c4739",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310915433530000.ee5e8486-1ed1-45cc-892e-60d94d5f7265",
-        "recorded" : "2024-01-26T17:15:15Z",
+        "id" : "1706813930287300000.416c26e4-fbbe-4333-836d-c023af1c4739",
+        "recorded" : "2024-02-01T13:58:50Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310915431987000.085f144c-9d35-4b1b-acb9-5886db97e93b"
+              "reference" : "Organization/1706813930286763000.340dca64-4cf0-4d3f-90e0-04c76ce436fe"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310915431987000.085f144c-9d35-4b1b-acb9-5886db97e93b",
+      "fullUrl" : "Organization/1706813930286763000.340dca64-4cf0-4d3f-90e0-04c76ce436fe",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310915431987000.085f144c-9d35-4b1b-acb9-5886db97e93b",
+        "id" : "1706813930286763000.340dca64-4cf0-4d3f-90e0-04c76ce436fe",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706310915448717000.5183436f-827a-4e33-b616-3aeb27520651",
+      "fullUrl" : "Patient/1706813930302649000.bede30ea-0c9a-42c0-9835-93b1a320e888",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706310915448717000.5183436f-827a-4e33-b616-3aeb27520651"
+        "id" : "1706813930302649000.bede30ea-0c9a-42c0-9835-93b1a320e888"
       }
     },
     {
-      "fullUrl" : "Provenance/1706310915450099000.8ca29747-91f5-48e3-8c81-94287263a90c",
+      "fullUrl" : "Provenance/1706813930303263000.039328ac-8fe6-485b-8362-17798ca71482",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310915450099000.8ca29747-91f5-48e3-8c81-94287263a90c",
+        "id" : "1706813930303263000.039328ac-8fe6-485b-8362-17798ca71482",
         "target" : [
           {
-            "reference" : "Patient/1706310915448717000.5183436f-827a-4e33-b616-3aeb27520651"
+            "reference" : "Patient/1706813930302649000.bede30ea-0c9a-42c0-9835-93b1a320e888"
           }
         ],
-        "recorded" : "2024-01-26T17:15:15Z",
+        "recorded" : "2024-02-01T13:58:50Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706310915452246000.341675d4-3356-483f-aa3c-ad573dcdc10a",
+      "fullUrl" : "Specimen/1706813930305623000.25b6dafc-6531-49a1-9b71-77742f4f237a",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706310915452246000.341675d4-3356-483f-aa3c-ad573dcdc10a",
+        "id" : "1706813930305623000.25b6dafc-6531-49a1-9b71-77742f4f237a",
         "identifier" : [
           {
             "extension" : [
@@ -208,10 +213,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706310915607193000.a7ce71ce-6893-4825-9cda-61137d036c47",
+      "fullUrl" : "ServiceRequest/1706813930465426000.cb289e59-5764-4fdf-ae15-0f4534ad7609",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706310915607193000.a7ce71ce-6893-4825-9cda-61137d036c47",
+        "id" : "1706813930465426000.cb289e59-5764-4fdf-ae15-0f4534ad7609",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -227,18 +232,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310915448717000.5183436f-827a-4e33-b616-3aeb27520651"
+          "reference" : "Patient/1706813930302649000.bede30ea-0c9a-42c0-9835-93b1a320e888"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706310915609852000.b4a2031a-c126-468a-a24e-3b02f1477bed",
+      "fullUrl" : "DiagnosticReport/1706813930468178000.4ddc5d9d-b941-45c3-a016-1b96e06243ab",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706310915609852000.b4a2031a-c126-468a-a24e-3b02f1477bed",
+        "id" : "1706813930468178000.4ddc5d9d-b941-45c3-a016-1b96e06243ab",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706310915607193000.a7ce71ce-6893-4825-9cda-61137d036c47"
+            "reference" : "ServiceRequest/1706813930465426000.cb289e59-5764-4fdf-ae15-0f4534ad7609"
           }
         ],
         "status" : "final",
@@ -256,11 +261,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706310915448717000.5183436f-827a-4e33-b616-3aeb27520651"
+          "reference" : "Patient/1706813930302649000.bede30ea-0c9a-42c0-9835-93b1a320e888"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706310915452246000.341675d4-3356-483f-aa3c-ad573dcdc10a"
+            "reference" : "Specimen/1706813930305623000.25b6dafc-6531-49a1-9b71-77742f4f237a"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-dns.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-dns.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310923328960000.adbaa3e2-b5e1-49e3-85ed-bf66445cac53",
+  "id" : "1706814206652690000.8d3e1d1e-3a1a-425b-89bc-5e7bc7afe3b1",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:23.342-06:00"
+    "lastUpdated" : "2024-02-01T14:03:26.659-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706310923415404000.369737f5-d14a-4ec6-ac73-bd0dc3a7ad6d"
+          "reference" : "Organization/1706814206729316000.ce49ebb0-bb46-4562-93ac-3c88f345418a"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706310923414430000.2ca9cf30-fd69-4136-a3a7-0a52fab3ee46",
+      "fullUrl" : "Location/1706814206726798000.b4c0d14d-94de-4f7b-afc5-105599e82bf0",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310923414430000.2ca9cf30-fd69-4136-a3a7-0a52fab3ee46",
+        "id" : "1706814206726798000.b4c0d14d-94de-4f7b-afc5-105599e82bf0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
@@ -79,17 +84,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310923415404000.369737f5-d14a-4ec6-ac73-bd0dc3a7ad6d",
+      "fullUrl" : "Organization/1706814206729316000.ce49ebb0-bb46-4562-93ac-3c88f345418a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310923415404000.369737f5-d14a-4ec6-ac73-bd0dc3a7ad6d",
+        "id" : "1706814206729316000.ce49ebb0-bb46-4562-93ac-3c88f345418a",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310923414430000.2ca9cf30-fd69-4136-a3a7-0a52fab3ee46"
+                  "reference" : "Location/1706814206726798000.b4c0d14d-94de-4f7b-afc5-105599e82bf0"
                 }
               }
             ]
@@ -98,10 +103,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310923901986000.eea0e1ae-049a-4795-a9e3-c284f9c27d5e",
+      "fullUrl" : "Provenance/1706814207055972000.e24d5b69-9ddf-44ee-8888-8ff11a0c40ff",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310923901986000.eea0e1ae-049a-4795-a9e3-c284f9c27d5e",
+        "id" : "1706814207055972000.e24d5b69-9ddf-44ee-8888-8ff11a0c40ff",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -126,17 +131,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310923901213000.4fafaa4d-01e0-42bf-a506-2a5c3e6cbcfc"
+              "reference" : "Organization/1706814207055646000.6df3fb6e-62ab-4d98-a122-d90bd8063c05"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706310923900352000.d3190aa8-d3b2-4471-8604-f80d3fa4458a",
+      "fullUrl" : "Location/1706814207054884000.cc9472e5-b281-4226-aba5-4eb73b151cb8",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310923900352000.d3190aa8-d3b2-4471-8604-f80d3fa4458a",
+        "id" : "1706814207054884000.cc9472e5-b281-4226-aba5-4eb73b151cb8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
@@ -165,17 +170,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310923901213000.4fafaa4d-01e0-42bf-a506-2a5c3e6cbcfc",
+      "fullUrl" : "Organization/1706814207055646000.6df3fb6e-62ab-4d98-a122-d90bd8063c05",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310923901213000.4fafaa4d-01e0-42bf-a506-2a5c3e6cbcfc",
+        "id" : "1706814207055646000.6df3fb6e-62ab-4d98-a122-d90bd8063c05",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310923900352000.d3190aa8-d3b2-4471-8604-f80d3fa4458a"
+                  "reference" : "Location/1706814207054884000.cc9472e5-b281-4226-aba5-4eb73b151cb8"
                 }
               }
             ]
@@ -184,11 +189,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310923910247000.c7362c26-a248-49cf-ae1b-22aea93b5b95",
+      "fullUrl" : "Provenance/1706814207063324000.1f11f553-3649-496e-8247-a9367b1961af",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310923910247000.c7362c26-a248-49cf-ae1b-22aea93b5b95",
-        "recorded" : "2024-01-26T17:15:23Z",
+        "id" : "1706814207063324000.1f11f553-3649-496e-8247-a9367b1961af",
+        "recorded" : "2024-02-01T14:03:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -210,17 +215,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310923909900000.f09fc52e-be33-4f84-899b-e60707c0feec"
+              "reference" : "Organization/1706814207062952000.7ea111ef-7325-495f-b220-11edcd22a74e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310923909900000.f09fc52e-be33-4f84-899b-e60707c0feec",
+      "fullUrl" : "Organization/1706814207062952000.7ea111ef-7325-495f-b220-11edcd22a74e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310923909900000.f09fc52e-be33-4f84-899b-e60707c0feec",
+        "id" : "1706814207062952000.7ea111ef-7325-495f-b220-11edcd22a74e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-empty-hd3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-empty-hd3.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310931851775000.76c34525-1596-4e48-b45c-2e446ef2b279",
+  "id" : "1706814217934245000.6e63b7de-8c00-4425-92d6-8e310144078f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:31.867-06:00"
+    "lastUpdated" : "2024-02-01T14:03:37.941-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706310931940628000.cadd61b2-3a2c-413d-8198-41e71c14dce2"
+          "reference" : "Organization/1706814218002549000.b2d6e46e-d92d-4db6-9480-593b51114157"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706310931939687000.ca82dc76-98d8-4891-980d-082913858da9",
+      "fullUrl" : "Location/1706814218001341000.37d7db19-2629-4f93-8a86-0ece85b2e07d",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310931939687000.ca82dc76-98d8-4891-980d-082913858da9",
+        "id" : "1706814218001341000.37d7db19-2629-4f93-8a86-0ece85b2e07d",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
@@ -75,17 +80,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310931940628000.cadd61b2-3a2c-413d-8198-41e71c14dce2",
+      "fullUrl" : "Organization/1706814218002549000.b2d6e46e-d92d-4db6-9480-593b51114157",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310931940628000.cadd61b2-3a2c-413d-8198-41e71c14dce2",
+        "id" : "1706814218002549000.b2d6e46e-d92d-4db6-9480-593b51114157",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310931939687000.ca82dc76-98d8-4891-980d-082913858da9"
+                  "reference" : "Location/1706814218001341000.37d7db19-2629-4f93-8a86-0ece85b2e07d"
                 }
               }
             ]
@@ -94,10 +99,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310932236041000.3996db3a-1e38-4182-8381-777703da71f4",
+      "fullUrl" : "Provenance/1706814218348592000.ae5c298d-5fab-42b4-9560-ef551e8d9665",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310932236041000.3996db3a-1e38-4182-8381-777703da71f4",
+        "id" : "1706814218348592000.ae5c298d-5fab-42b4-9560-ef551e8d9665",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -122,17 +127,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310932235789000.d3fe642f-787e-4945-a198-9ae9d889b731"
+              "reference" : "Organization/1706814218348112000.9c34e681-9a4f-4e3b-835e-aa94df2a069c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706310932235190000.2f225d64-b8e9-467f-85f1-d72215bffa80",
+      "fullUrl" : "Location/1706814218347252000.ed403958-4196-49ac-8910-2b5718dfac2c",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310932235190000.2f225d64-b8e9-467f-85f1-d72215bffa80",
+        "id" : "1706814218347252000.ed403958-4196-49ac-8910-2b5718dfac2c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
@@ -157,17 +162,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310932235789000.d3fe642f-787e-4945-a198-9ae9d889b731",
+      "fullUrl" : "Organization/1706814218348112000.9c34e681-9a4f-4e3b-835e-aa94df2a069c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310932235789000.d3fe642f-787e-4945-a198-9ae9d889b731",
+        "id" : "1706814218348112000.9c34e681-9a4f-4e3b-835e-aa94df2a069c",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310932235190000.2f225d64-b8e9-467f-85f1-d72215bffa80"
+                  "reference" : "Location/1706814218347252000.ed403958-4196-49ac-8910-2b5718dfac2c"
                 }
               }
             ]
@@ -176,11 +181,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310932243686000.2bc15181-33e7-4d66-9c94-4f5250f44c93",
+      "fullUrl" : "Provenance/1706814218356966000.df367561-b827-4add-8529-7287a7aec62d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310932243686000.2bc15181-33e7-4d66-9c94-4f5250f44c93",
-        "recorded" : "2024-01-26T17:15:32Z",
+        "id" : "1706814218356966000.df367561-b827-4add-8529-7287a7aec62d",
+        "recorded" : "2024-02-01T14:03:38Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -202,17 +207,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310932242835000.6e9e3360-c94d-4d38-8265-ef78643a7d22"
+              "reference" : "Organization/1706814218356630000.6520be9b-12a9-4db7-88bc-703082a645d9"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310932242835000.6e9e3360-c94d-4d38-8265-ef78643a7d22",
+      "fullUrl" : "Organization/1706814218356630000.6520be9b-12a9-4db7-88bc-703082a645d9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310932242835000.6e9e3360-c94d-4d38-8265-ef78643a7d22",
+        "id" : "1706814218356630000.6520be9b-12a9-4db7-88bc-703082a645d9",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-iso.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310940985090000.2fd06c2e-ffc2-4244-af39-f0a3c6dbe6dc",
+  "id" : "1706814228152147000.e3e0bae5-1005-4ea0-830e-b117cb54a09d",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:40.999-06:00"
+    "lastUpdated" : "2024-02-01T14:03:48.160-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706310941084888000.87ec4277-b866-41b8-9a9a-aaecdd3a9d59"
+          "reference" : "Organization/1706814228230305000.f17d7c66-1454-49d7-97f4-54a05e832212"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706310941083718000.a00cb96e-2db2-4ecb-8442-2d1351cc8f6f",
+      "fullUrl" : "Location/1706814228227463000.bf66ad21-38c7-4fcf-b8d1-60d016d0a2d2",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310941083718000.a00cb96e-2db2-4ecb-8442-2d1351cc8f6f",
+        "id" : "1706814228227463000.bf66ad21-38c7-4fcf-b8d1-60d016d0a2d2",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -80,17 +85,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310941084888000.87ec4277-b866-41b8-9a9a-aaecdd3a9d59",
+      "fullUrl" : "Organization/1706814228230305000.f17d7c66-1454-49d7-97f4-54a05e832212",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310941084888000.87ec4277-b866-41b8-9a9a-aaecdd3a9d59",
+        "id" : "1706814228230305000.f17d7c66-1454-49d7-97f4-54a05e832212",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310941083718000.a00cb96e-2db2-4ecb-8442-2d1351cc8f6f"
+                  "reference" : "Location/1706814228227463000.bf66ad21-38c7-4fcf-b8d1-60d016d0a2d2"
                 }
               }
             ]
@@ -99,10 +104,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310941401861000.9a527f91-e43f-466f-9de3-831e445ef110",
+      "fullUrl" : "Provenance/1706814228565316000.52e2bcef-439f-4443-a323-8d3c89a92a7c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310941401861000.9a527f91-e43f-466f-9de3-831e445ef110",
+        "id" : "1706814228565316000.52e2bcef-439f-4443-a323-8d3c89a92a7c",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -127,17 +132,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310941401578000.29e8b95a-b506-41b7-9fef-c178defbac4e"
+              "reference" : "Organization/1706814228564943000.03a37744-fbb0-4734-8e05-66508fa7a3a5"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706310941401085000.a5c766a3-8cba-472c-9f74-7fb91d73861e",
+      "fullUrl" : "Location/1706814228563951000.fbc27db2-bd62-491a-9efa-7c4094cd485b",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310941401085000.a5c766a3-8cba-472c-9f74-7fb91d73861e",
+        "id" : "1706814228563951000.fbc27db2-bd62-491a-9efa-7c4094cd485b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -167,17 +172,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310941401578000.29e8b95a-b506-41b7-9fef-c178defbac4e",
+      "fullUrl" : "Organization/1706814228564943000.03a37744-fbb0-4734-8e05-66508fa7a3a5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310941401578000.29e8b95a-b506-41b7-9fef-c178defbac4e",
+        "id" : "1706814228564943000.03a37744-fbb0-4734-8e05-66508fa7a3a5",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310941401085000.a5c766a3-8cba-472c-9f74-7fb91d73861e"
+                  "reference" : "Location/1706814228563951000.fbc27db2-bd62-491a-9efa-7c4094cd485b"
                 }
               }
             ]
@@ -186,11 +191,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310941410777000.44daad79-6c6d-40ee-a3a1-5dc5eaf06c2e",
+      "fullUrl" : "Provenance/1706814228575061000.59249ba0-01e9-4c5e-ae81-5a9efa23a8f5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310941410777000.44daad79-6c6d-40ee-a3a1-5dc5eaf06c2e",
-        "recorded" : "2024-01-26T17:15:41Z",
+        "id" : "1706814228575061000.59249ba0-01e9-4c5e-ae81-5a9efa23a8f5",
+        "recorded" : "2024-02-01T14:03:48Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -212,17 +217,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310941410469000.a921409a-3647-4cd3-93cc-c2f660e8532c"
+              "reference" : "Organization/1706814228574677000.64540394-b11d-406e-941b-04f7f58995aa"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310941410469000.a921409a-3647-4cd3-93cc-c2f660e8532c",
+      "fullUrl" : "Organization/1706814228574677000.64540394-b11d-406e-941b-04f7f58995aa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310941410469000.a921409a-3647-4cd3-93cc-c2f660e8532c",
+        "id" : "1706814228574677000.64540394-b11d-406e-941b-04f7f58995aa",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Location-uuid.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310950069409000.d1864dba-9253-4299-8022-7044568290b0",
+  "id" : "1706814237898610000.f44f1449-0e75-4821-875f-34d021be05d1",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:50.082-06:00"
+    "lastUpdated" : "2024-02-01T14:03:57.905-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706310950156264000.290d8192-fe05-4b62-8967-1acc9d7fe3be"
+          "reference" : "Organization/1706814237968606000.06805215-408d-4952-905d-b751490f8cb0"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706310950155342000.8420902e-426b-4dcf-98ce-7b8ef99895ea",
+      "fullUrl" : "Location/1706814237965402000.2af9d23c-689a-457b-944e-556e471343aa",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310950155342000.8420902e-426b-4dcf-98ce-7b8ef99895ea",
+        "id" : "1706814237965402000.2af9d23c-689a-457b-944e-556e471343aa",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -80,17 +85,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310950156264000.290d8192-fe05-4b62-8967-1acc9d7fe3be",
+      "fullUrl" : "Organization/1706814237968606000.06805215-408d-4952-905d-b751490f8cb0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310950156264000.290d8192-fe05-4b62-8967-1acc9d7fe3be",
+        "id" : "1706814237968606000.06805215-408d-4952-905d-b751490f8cb0",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310950155342000.8420902e-426b-4dcf-98ce-7b8ef99895ea"
+                  "reference" : "Location/1706814237965402000.2af9d23c-689a-457b-944e-556e471343aa"
                 }
               }
             ]
@@ -99,10 +104,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310950452245000.c1bbc48a-9b93-4fb6-a993-bd03663e00f5",
+      "fullUrl" : "Provenance/1706814238297276000.6fe6468e-792a-45c8-8f94-c00971809c13",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310950452245000.c1bbc48a-9b93-4fb6-a993-bd03663e00f5",
+        "id" : "1706814238297276000.6fe6468e-792a-45c8-8f94-c00971809c13",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -127,17 +132,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310950451755000.9d29a9bf-77aa-40f4-8b3c-14f84b27b740"
+              "reference" : "Organization/1706814238296803000.3184705d-951b-4045-920b-9c41a2ce98bb"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706310950451208000.16e8499a-48e8-4697-9f4e-f7c36df433cb",
+      "fullUrl" : "Location/1706814238295696000.564a87d5-59b3-4533-a1f6-c6328941338c",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706310950451208000.16e8499a-48e8-4697-9f4e-f7c36df433cb",
+        "id" : "1706814238295696000.564a87d5-59b3-4533-a1f6-c6328941338c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -167,17 +172,17 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310950451755000.9d29a9bf-77aa-40f4-8b3c-14f84b27b740",
+      "fullUrl" : "Organization/1706814238296803000.3184705d-951b-4045-920b-9c41a2ce98bb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310950451755000.9d29a9bf-77aa-40f4-8b3c-14f84b27b740",
+        "id" : "1706814238296803000.3184705d-951b-4045-920b-9c41a2ce98bb",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706310950451208000.16e8499a-48e8-4697-9f4e-f7c36df433cb"
+                  "reference" : "Location/1706814238295696000.564a87d5-59b3-4533-a1f6-c6328941338c"
                 }
               }
             ]
@@ -186,11 +191,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310950459650000.eec917b3-3555-44bb-b486-576bf1aaa366",
+      "fullUrl" : "Provenance/1706814238305970000.c0743dda-4e0a-4e49-bbb3-12cf4d4d8f81",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310950459650000.eec917b3-3555-44bb-b486-576bf1aaa366",
-        "recorded" : "2024-01-26T17:15:50Z",
+        "id" : "1706814238305970000.c0743dda-4e0a-4e49-bbb3-12cf4d4d8f81",
+        "recorded" : "2024-02-01T14:03:58Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -212,17 +217,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310950459314000.af771820-475e-43ff-b208-fad9711d3398"
+              "reference" : "Organization/1706814238305564000.597d2ea8-2768-467a-b0ce-2cecd3820d07"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310950459314000.af771820-475e-43ff-b208-fad9711d3398",
+      "fullUrl" : "Organization/1706814238305564000.597d2ea8-2768-467a-b0ce-2cecd3820d07",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310950459314000.af771820-475e-43ff-b208-fad9711d3398",
+        "id" : "1706814238305564000.597d2ea8-2768-467a-b0ce-2cecd3820d07",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-clia.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-clia.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310958293032000.0c1e4710-5514-4bd6-88c6-91087bc08ca0",
+  "id" : "1706814247540514000.e79b46de-8869-4d04-bd0d-7fc9c24bb3e2",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:15:58.307-06:00"
+    "lastUpdated" : "2024-02-01T14:04:07.547-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -32,7 +37,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310958391258000.7d87254b-8f7d-4e29-9f40-337a55977055"
+          "reference" : "Organization/1706814247591490000.f129851e-dd7e-454b-86d7-3944b9bf3cb1"
         },
         "source" : {
           "_endpoint" : {
@@ -47,10 +52,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310958391258000.7d87254b-8f7d-4e29-9f40-337a55977055",
+      "fullUrl" : "Organization/1706814247591490000.f129851e-dd7e-454b-86d7-3944b9bf3cb1",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310958391258000.7d87254b-8f7d-4e29-9f40-337a55977055",
+        "id" : "1706814247591490000.f129851e-dd7e-454b-86d7-3944b9bf3cb1",
         "identifier" : [
           {
             "extension" : [
@@ -82,10 +87,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310958684833000.40bdbc37-95e6-48b7-b49b-1adadfe9e5a5",
+      "fullUrl" : "Provenance/1706814247953595000.5f5bbdbd-2cc6-409c-9ebe-9e5f808faf48",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310958684833000.40bdbc37-95e6-48b7-b49b-1adadfe9e5a5",
+        "id" : "1706814247953595000.5f5bbdbd-2cc6-409c-9ebe-9e5f808faf48",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -110,17 +115,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310958683955000.72396f1b-6b8e-4f17-bf65-2f79ae74ff56"
+              "reference" : "Organization/1706814247952466000.1b6139a6-dd6c-4c55-911b-6763a4818c06"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310958683955000.72396f1b-6b8e-4f17-bf65-2f79ae74ff56",
+      "fullUrl" : "Organization/1706814247952466000.1b6139a6-dd6c-4c55-911b-6763a4818c06",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310958683955000.72396f1b-6b8e-4f17-bf65-2f79ae74ff56",
+        "id" : "1706814247952466000.1b6139a6-dd6c-4c55-911b-6763a4818c06",
         "identifier" : [
           {
             "extension" : [
@@ -152,11 +157,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310958856015000.cc8062b9-42c4-43f2-81d5-71d14bebf303",
+      "fullUrl" : "Provenance/1706814247963269000.0e856a40-4112-4b09-92d4-9d7f5a6a05fe",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310958856015000.cc8062b9-42c4-43f2-81d5-71d14bebf303",
-        "recorded" : "2024-01-26T17:15:58Z",
+        "id" : "1706814247963269000.0e856a40-4112-4b09-92d4-9d7f5a6a05fe",
+        "recorded" : "2024-02-01T14:04:07Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -178,17 +183,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310958854824000.bd569b7d-109a-437f-aaad-c4de77d1b75d"
+              "reference" : "Organization/1706814247962768000.52332a90-f47b-442b-b0fc-48388eba38c0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310958854824000.bd569b7d-109a-437f-aaad-c4de77d1b75d",
+      "fullUrl" : "Organization/1706814247962768000.52332a90-f47b-442b-b0fc-48388eba38c0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310958854824000.bd569b7d-109a-437f-aaad-c4de77d1b75d",
+        "id" : "1706814247962768000.52332a90-f47b-442b-b0fc-48388eba38c0",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-empty-hd3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-empty-hd3.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310966956076000.f1906bfd-e58b-49ed-b5a1-1f714b7d4ba7",
+  "id" : "1706814257434574000.1275aa02-9660-484f-9505-851686135150",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:06.971-06:00"
+    "lastUpdated" : "2024-02-01T14:04:17.441-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -32,7 +37,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310967047015000.de38a1fe-156c-4eea-b5c5-cd149d90d402"
+          "reference" : "Organization/1706814257483553000.f5577e4d-c2be-47a4-a075-c05c167d2860"
         },
         "source" : {
           "_endpoint" : {
@@ -47,10 +52,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310967047015000.de38a1fe-156c-4eea-b5c5-cd149d90d402",
+      "fullUrl" : "Organization/1706814257483553000.f5577e4d-c2be-47a4-a075-c05c167d2860",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310967047015000.de38a1fe-156c-4eea-b5c5-cd149d90d402",
+        "id" : "1706814257483553000.f5577e4d-c2be-47a4-a075-c05c167d2860",
         "identifier" : [
           {
             "extension" : [
@@ -81,10 +86,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310967341389000.e472d428-5073-4fe0-85fe-2cc58e51b151",
+      "fullUrl" : "Provenance/1706814257844791000.d9a2f8e7-e3de-411f-ba17-3aa9f7137288",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310967341389000.e472d428-5073-4fe0-85fe-2cc58e51b151",
+        "id" : "1706814257844791000.d9a2f8e7-e3de-411f-ba17-3aa9f7137288",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310967340417000.50cb2006-0830-4d77-8f0b-bd5254c317db"
+              "reference" : "Organization/1706814257843913000.31fa974a-bf05-4a8d-9870-61c8a1c06d26"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310967340417000.50cb2006-0830-4d77-8f0b-bd5254c317db",
+      "fullUrl" : "Organization/1706814257843913000.31fa974a-bf05-4a8d-9870-61c8a1c06d26",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310967340417000.50cb2006-0830-4d77-8f0b-bd5254c317db",
+        "id" : "1706814257843913000.31fa974a-bf05-4a8d-9870-61c8a1c06d26",
         "identifier" : [
           {
             "extension" : [
@@ -150,11 +155,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310967348138000.61828dcc-8ba5-4bf4-9744-c4b875238110",
+      "fullUrl" : "Provenance/1706814257853654000.b4f8c3da-6259-4860-ad5b-f4592b30e459",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310967348138000.61828dcc-8ba5-4bf4-9744-c4b875238110",
-        "recorded" : "2024-01-26T17:16:07Z",
+        "id" : "1706814257853654000.b4f8c3da-6259-4860-ad5b-f4592b30e459",
+        "recorded" : "2024-02-01T14:04:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -176,17 +181,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310967347802000.fc9708ba-3cfc-41c9-9a58-43be5a52e8e7"
+              "reference" : "Organization/1706814257852774000.cf0a7fea-f131-4d84-afdc-22164f540da5"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310967347802000.fc9708ba-3cfc-41c9-9a58-43be5a52e8e7",
+      "fullUrl" : "Organization/1706814257852774000.cf0a7fea-f131-4d84-afdc-22164f540da5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310967347802000.fc9708ba-3cfc-41c9-9a58-43be5a52e8e7",
+        "id" : "1706814257852774000.cf0a7fea-f131-4d84-afdc-22164f540da5",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-iso.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310975456565000.bee5980f-6d9c-4c95-b0d8-dd815c59a438",
+  "id" : "1706814266970735000.25b73237-1389-4fb8-bdcd-95dd9969857f",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:15.469-06:00"
+    "lastUpdated" : "2024-02-01T14:04:26.977-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -32,7 +37,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310975547971000.e0b440a1-0e2e-4f4d-87c9-4010a41ddcdd"
+          "reference" : "Organization/1706814267020649000.6982b87f-8907-47af-b0ce-921ff4c151fa"
         },
         "source" : {
           "_endpoint" : {
@@ -47,10 +52,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310975547971000.e0b440a1-0e2e-4f4d-87c9-4010a41ddcdd",
+      "fullUrl" : "Organization/1706814267020649000.6982b87f-8907-47af-b0ce-921ff4c151fa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310975547971000.e0b440a1-0e2e-4f4d-87c9-4010a41ddcdd",
+        "id" : "1706814267020649000.6982b87f-8907-47af-b0ce-921ff4c151fa",
         "identifier" : [
           {
             "extension" : [
@@ -83,10 +88,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310975840267000.40ee1264-ce73-4726-98a1-190218f52dd1",
+      "fullUrl" : "Provenance/1706814267385381000.74a6eca8-5f0c-475b-92c4-39195cc42498",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310975840267000.40ee1264-ce73-4726-98a1-190218f52dd1",
+        "id" : "1706814267385381000.74a6eca8-5f0c-475b-92c4-39195cc42498",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -111,17 +116,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310975839213000.eeefde1d-6cb0-4895-b247-ace94ca2921b"
+              "reference" : "Organization/1706814267384322000.a1e11ce5-4fe0-4b84-9e6e-7e248b456c07"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310975839213000.eeefde1d-6cb0-4895-b247-ace94ca2921b",
+      "fullUrl" : "Organization/1706814267384322000.a1e11ce5-4fe0-4b84-9e6e-7e248b456c07",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310975839213000.eeefde1d-6cb0-4895-b247-ace94ca2921b",
+        "id" : "1706814267384322000.a1e11ce5-4fe0-4b84-9e6e-7e248b456c07",
         "identifier" : [
           {
             "extension" : [
@@ -154,11 +159,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310975848853000.ea3dcf36-af1b-48d8-a573-709e2a5f747f",
+      "fullUrl" : "Provenance/1706814267393070000.52c5b4f2-8425-4fc0-b459-4c188afae041",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310975848853000.ea3dcf36-af1b-48d8-a573-709e2a5f747f",
-        "recorded" : "2024-01-26T17:16:15Z",
+        "id" : "1706814267393070000.52c5b4f2-8425-4fc0-b459-4c188afae041",
+        "recorded" : "2024-02-01T14:04:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -180,17 +185,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310975848415000.cba0f13a-86e2-4928-9b16-a8d8a0f09b55"
+              "reference" : "Organization/1706814267392335000.e02c1183-db12-4367-aec5-417c077f4656"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310975848415000.cba0f13a-86e2-4928-9b16-a8d8a0f09b55",
+      "fullUrl" : "Organization/1706814267392335000.e02c1183-db12-4367-aec5-417c077f4656",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310975848415000.cba0f13a-86e2-4928-9b16-a8d8a0f09b55",
+        "id" : "1706814267392335000.e02c1183-db12-4367-aec5-417c077f4656",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-Organization-uuid.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310983867994000.ee676b45-4d13-4962-844c-463aa10a17c7",
+  "id" : "1706814277203993000.32ff2a44-f2c7-4ee1-be9e-2313725bce10",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:23.881-06:00"
+    "lastUpdated" : "2024-02-01T14:04:37.211-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -32,7 +37,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706310983949951000.cedb5b01-7c5d-48ac-a9c5-f1c04744cb26"
+          "reference" : "Organization/1706814277255914000.fa0c7852-299d-4680-844a-8d9f621a9ea0"
         },
         "source" : {
           "_endpoint" : {
@@ -47,10 +52,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706310983949951000.cedb5b01-7c5d-48ac-a9c5-f1c04744cb26",
+      "fullUrl" : "Organization/1706814277255914000.fa0c7852-299d-4680-844a-8d9f621a9ea0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310983949951000.cedb5b01-7c5d-48ac-a9c5-f1c04744cb26",
+        "id" : "1706814277255914000.fa0c7852-299d-4680-844a-8d9f621a9ea0",
         "identifier" : [
           {
             "extension" : [
@@ -83,10 +88,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310984245313000.22707797-0588-4476-882e-a2378f4de9b3",
+      "fullUrl" : "Provenance/1706814277621124000.c7a91d97-1c4c-4677-8fb8-38e6fb8c339e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310984245313000.22707797-0588-4476-882e-a2378f4de9b3",
+        "id" : "1706814277621124000.c7a91d97-1c4c-4677-8fb8-38e6fb8c339e",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -111,17 +116,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310984244462000.753d5cb0-51ce-4749-9d83-886193ce0843"
+              "reference" : "Organization/1706814277620205000.a7ae2cab-883d-4b55-a5e5-cd54efbfb967"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310984244462000.753d5cb0-51ce-4749-9d83-886193ce0843",
+      "fullUrl" : "Organization/1706814277620205000.a7ae2cab-883d-4b55-a5e5-cd54efbfb967",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310984244462000.753d5cb0-51ce-4749-9d83-886193ce0843",
+        "id" : "1706814277620205000.a7ae2cab-883d-4b55-a5e5-cd54efbfb967",
         "identifier" : [
           {
             "extension" : [
@@ -154,11 +159,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310984253434000.c1ab96a2-f90d-4372-b64b-4fc4e7b42492",
+      "fullUrl" : "Provenance/1706814277628300000.9123c8c1-36d7-4cc7-8cdf-4d4372698127",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310984253434000.c1ab96a2-f90d-4372-b64b-4fc4e7b42492",
-        "recorded" : "2024-01-26T17:16:24Z",
+        "id" : "1706814277628300000.9123c8c1-36d7-4cc7-8cdf-4d4372698127",
+        "recorded" : "2024-02-01T14:04:37Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -180,17 +185,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310984253085000.42389419-2612-47f7-bb2c-799fbe769d4d"
+              "reference" : "Organization/1706814277627763000.44dee72a-9dd6-4a6f-840b-076911d3e28f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310984253085000.42389419-2612-47f7-bb2c-799fbe769d4d",
+      "fullUrl" : "Organization/1706814277627763000.44dee72a-9dd6-4a6f-840b-076911d3e28f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310984253085000.42389419-2612-47f7-bb2c-799fbe769d4d",
+        "id" : "1706814277627763000.44dee72a-9dd6-4a6f-840b-076911d3e28f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-clia.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-clia.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706310992266902000.29b3ec93-9694-4500-84df-e1ee9eb98430",
+  "id" : "1706814288471255000.e58dd1d0-b9c7-4f6c-902c-ff43bcc18f53",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:32.282-06:00"
+    "lastUpdated" : "2024-02-01T14:04:48.477-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706310992354402000.0cc0a688-4e70-4dab-8ff5-05f9aaa40cf8"
+          "reference" : "Organization/1706814288541113000.c0c094f2-e583-42cf-af5b-ab0fb4fd682e"
         }
       }
     },
     {
-      "fullUrl" : "Organization/1706310992354402000.0cc0a688-4e70-4dab-8ff5-05f9aaa40cf8",
+      "fullUrl" : "Organization/1706814288541113000.c0c094f2-e583-42cf-af5b-ab0fb4fd682e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310992354402000.0cc0a688-4e70-4dab-8ff5-05f9aaa40cf8",
+        "id" : "1706814288541113000.c0c094f2-e583-42cf-af5b-ab0fb4fd682e",
         "identifier" : [
           {
             "extension" : [
@@ -77,10 +82,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310992642988000.bd4fc2b4-6bf0-427a-b1da-7efc7af69315",
+      "fullUrl" : "Provenance/1706814288877531000.0189b49b-8a3d-4040-ac3a-1826ceb051ab",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310992642988000.bd4fc2b4-6bf0-427a-b1da-7efc7af69315",
+        "id" : "1706814288877531000.0189b49b-8a3d-4040-ac3a-1826ceb051ab",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -105,17 +110,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310992642628000.c7d308e5-e517-489a-806c-be2daff4dc05"
+              "reference" : "Organization/1706814288877176000.32c3e287-d876-42b8-9517-ab203d9d9338"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310992642628000.c7d308e5-e517-489a-806c-be2daff4dc05",
+      "fullUrl" : "Organization/1706814288877176000.32c3e287-d876-42b8-9517-ab203d9d9338",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310992642628000.c7d308e5-e517-489a-806c-be2daff4dc05",
+        "id" : "1706814288877176000.32c3e287-d876-42b8-9517-ab203d9d9338",
         "identifier" : [
           {
             "extension" : [
@@ -142,11 +147,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706310992650439000.aa004f2d-6b62-4403-b094-b326e866c1ac",
+      "fullUrl" : "Provenance/1706814288885029000.a0bc4b76-52b4-4626-a172-59872b375803",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706310992650439000.aa004f2d-6b62-4403-b094-b326e866c1ac",
-        "recorded" : "2024-01-26T17:16:32Z",
+        "id" : "1706814288885029000.a0bc4b76-52b4-4626-a172-59872b375803",
+        "recorded" : "2024-02-01T14:04:48Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -168,17 +173,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706310992650036000.3f4c9c2e-1bab-4f1c-9f56-4676c819ab6b"
+              "reference" : "Organization/1706814288884607000.ecdd6442-39ec-4b4d-89a7-eb2aec45a717"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706310992650036000.3f4c9c2e-1bab-4f1c-9f56-4676c819ab6b",
+      "fullUrl" : "Organization/1706814288884607000.ecdd6442-39ec-4b4d-89a7-eb2aec45a717",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706310992650036000.3f4c9c2e-1bab-4f1c-9f56-4676c819ab6b",
+        "id" : "1706814288884607000.ecdd6442-39ec-4b4d-89a7-eb2aec45a717",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-empty-hd3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-empty-hd3.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311000566070000.fe6be399-16e9-45e6-bd00-f78be8c1482e",
+  "id" : "1706814298650364000.05734168-2c24-46ea-b129-5e5038973dc6",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:40.579-06:00"
+    "lastUpdated" : "2024-02-01T14:04:58.657-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706311000658358000.8857f248-af00-4f82-9db0-01c1774c37fa"
+          "reference" : "Organization/1706814298723248000.88bdd013-6246-4bb5-85a8-58d41a98ce47"
         }
       }
     },
     {
-      "fullUrl" : "Organization/1706311000658358000.8857f248-af00-4f82-9db0-01c1774c37fa",
+      "fullUrl" : "Organization/1706814298723248000.88bdd013-6246-4bb5-85a8-58d41a98ce47",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311000658358000.8857f248-af00-4f82-9db0-01c1774c37fa",
+        "id" : "1706814298723248000.88bdd013-6246-4bb5-85a8-58d41a98ce47",
         "identifier" : [
           {
             "extension" : [
@@ -76,10 +81,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311000945602000.8b136b73-40ca-4857-970f-9a48c4b90f56",
+      "fullUrl" : "Provenance/1706814299066441000.0f29c027-3104-412a-ada7-4ac31780d5e2",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311000945602000.8b136b73-40ca-4857-970f-9a48c4b90f56",
+        "id" : "1706814299066441000.0f29c027-3104-412a-ada7-4ac31780d5e2",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -104,17 +109,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311000945196000.01163725-359e-4aba-96a2-68af13e53374"
+              "reference" : "Organization/1706814299065930000.215521fe-1542-4331-ab5e-3bcbdb9de191"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311000945196000.01163725-359e-4aba-96a2-68af13e53374",
+      "fullUrl" : "Organization/1706814299065930000.215521fe-1542-4331-ab5e-3bcbdb9de191",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311000945196000.01163725-359e-4aba-96a2-68af13e53374",
+        "id" : "1706814299065930000.215521fe-1542-4331-ab5e-3bcbdb9de191",
         "identifier" : [
           {
             "extension" : [
@@ -140,11 +145,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311000953835000.17edd7c0-168d-4eb3-b3bc-e8b957d771ee",
+      "fullUrl" : "Provenance/1706814299075414000.22441235-33f0-4774-8cba-757b6be3102f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311000953835000.17edd7c0-168d-4eb3-b3bc-e8b957d771ee",
-        "recorded" : "2024-01-26T17:16:40Z",
+        "id" : "1706814299075414000.22441235-33f0-4774-8cba-757b6be3102f",
+        "recorded" : "2024-02-01T14:04:59Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -166,17 +171,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311000953437000.0ef4855d-9f30-4517-b36c-0dd9a7833b0c"
+              "reference" : "Organization/1706814299074690000.191403b5-30fe-45ff-8c47-0151eea5092f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311000953437000.0ef4855d-9f30-4517-b36c-0dd9a7833b0c",
+      "fullUrl" : "Organization/1706814299074690000.191403b5-30fe-45ff-8c47-0151eea5092f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311000953437000.0ef4855d-9f30-4517-b36c-0dd9a7833b0c",
+        "id" : "1706814299074690000.191403b5-30fe-45ff-8c47-0151eea5092f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-iso.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311008980783000.8331f11b-fe8d-430c-8e42-57510c7a2a2c",
+  "id" : "1706814308189652000.5ef82216-0b17-460c-8847-2e3520529ee4",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:48.993-06:00"
+    "lastUpdated" : "2024-02-01T14:05:08.196-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706311009064734000.67b87941-1c7f-4b6e-9d2f-b565395c93f3"
+          "reference" : "Organization/1706814308261824000.7d920d11-8c7f-4b36-917c-943303ee7bc9"
         }
       }
     },
     {
-      "fullUrl" : "Organization/1706311009064734000.67b87941-1c7f-4b6e-9d2f-b565395c93f3",
+      "fullUrl" : "Organization/1706814308261824000.7d920d11-8c7f-4b36-917c-943303ee7bc9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311009064734000.67b87941-1c7f-4b6e-9d2f-b565395c93f3",
+        "id" : "1706814308261824000.7d920d11-8c7f-4b36-917c-943303ee7bc9",
         "identifier" : [
           {
             "extension" : [
@@ -77,10 +82,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311009371338000.4e9c4ccd-76b4-4f85-b71d-da74b3ea53b7",
+      "fullUrl" : "Provenance/1706814308587390000.beab7c23-78bb-4a6c-9ef0-0224e6e416d8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311009371338000.4e9c4ccd-76b4-4f85-b71d-da74b3ea53b7",
+        "id" : "1706814308587390000.beab7c23-78bb-4a6c-9ef0-0224e6e416d8",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -105,17 +110,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311009370991000.dd40472a-903f-4942-81c3-7b5d5f0d3792"
+              "reference" : "Organization/1706814308586953000.ba0b6b1f-ec66-414a-a689-ded057520754"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311009370991000.dd40472a-903f-4942-81c3-7b5d5f0d3792",
+      "fullUrl" : "Organization/1706814308586953000.ba0b6b1f-ec66-414a-a689-ded057520754",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311009370991000.dd40472a-903f-4942-81c3-7b5d5f0d3792",
+        "id" : "1706814308586953000.ba0b6b1f-ec66-414a-a689-ded057520754",
         "identifier" : [
           {
             "extension" : [
@@ -142,11 +147,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311009378651000.900d3070-cdc9-424f-b982-0ebd1753b0e4",
+      "fullUrl" : "Provenance/1706814308596260000.72fd45bc-f1d6-430a-8c4c-92f4d8043571",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311009378651000.900d3070-cdc9-424f-b982-0ebd1753b0e4",
-        "recorded" : "2024-01-26T17:16:49Z",
+        "id" : "1706814308596260000.72fd45bc-f1d6-430a-8c4c-92f4d8043571",
+        "recorded" : "2024-02-01T14:05:08Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -168,17 +173,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311009378321000.3ec240ad-c1db-45b4-a00a-13c96c1d1685"
+              "reference" : "Organization/1706814308595776000.6bcf5538-5ed6-461f-b3a5-0c6d4eee3faf"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311009378321000.3ec240ad-c1db-45b4-a00a-13c96c1d1685",
+      "fullUrl" : "Organization/1706814308595776000.6bcf5538-5ed6-461f-b3a5-0c6d4eee3faf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311009378321000.3ec240ad-c1db-45b4-a00a-13c96c1d1685",
+        "id" : "1706814308595776000.6bcf5538-5ed6-461f-b3a5-0c6d4eee3faf",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/hd/HD-to-extensionAssigningAuthority-uuid.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311017988161000.f22768e8-a420-4f58-a22b-7765865e63e9",
+  "id" : "1706814317692900000.af3a6d35-6854-465b-b463-66ffedd59db0",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:16:58.001-06:00"
+    "lastUpdated" : "2024-02-01T14:05:17.699-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706311018071963000.de2fee48-d3a4-4883-af8b-39b313212d96"
+          "reference" : "Organization/1706814317761860000.57f17020-6af5-4ae5-a958-86dbd1a3aece"
         }
       }
     },
     {
-      "fullUrl" : "Organization/1706311018071963000.de2fee48-d3a4-4883-af8b-39b313212d96",
+      "fullUrl" : "Organization/1706814317761860000.57f17020-6af5-4ae5-a958-86dbd1a3aece",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311018071963000.de2fee48-d3a4-4883-af8b-39b313212d96",
+        "id" : "1706814317761860000.57f17020-6af5-4ae5-a958-86dbd1a3aece",
         "identifier" : [
           {
             "extension" : [
@@ -77,10 +82,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311018370582000.6882abb7-9957-46ff-a3b5-6005c769bc35",
+      "fullUrl" : "Provenance/1706814318122743000.93780638-75cc-4ab8-a6d4-6b954cc0d600",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311018370582000.6882abb7-9957-46ff-a3b5-6005c769bc35",
+        "id" : "1706814318122743000.93780638-75cc-4ab8-a6d4-6b954cc0d600",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -105,17 +110,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311018370230000.3bde7cb8-f78e-41ae-9847-82e76ea5f643"
+              "reference" : "Organization/1706814318122156000.7223bb1f-3179-46b0-894f-cd7efb027abc"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311018370230000.3bde7cb8-f78e-41ae-9847-82e76ea5f643",
+      "fullUrl" : "Organization/1706814318122156000.7223bb1f-3179-46b0-894f-cd7efb027abc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311018370230000.3bde7cb8-f78e-41ae-9847-82e76ea5f643",
+        "id" : "1706814318122156000.7223bb1f-3179-46b0-894f-cd7efb027abc",
         "identifier" : [
           {
             "extension" : [
@@ -142,11 +147,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311018377436000.a802efcc-4c61-4fb2-b5cc-d24fabc8a499",
+      "fullUrl" : "Provenance/1706814318132195000.151447ad-9dbe-4a09-8164-558fd15df26c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311018377436000.a802efcc-4c61-4fb2-b5cc-d24fabc8a499",
-        "recorded" : "2024-01-26T17:16:58Z",
+        "id" : "1706814318132195000.151447ad-9dbe-4a09-8164-558fd15df26c",
+        "recorded" : "2024-02-01T14:05:18Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -168,17 +173,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311018377086000.f81fefdb-cb97-457a-8263-486976a85375"
+              "reference" : "Organization/1706814318130728000.9dd062bf-cd0d-4c88-8558-8ec65d614ed8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311018377086000.f81fefdb-cb97-457a-8263-486976a85375",
+      "fullUrl" : "Organization/1706814318130728000.9dd062bf-cd0d-4c88-8558-8ec65d614ed8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311018377086000.f81fefdb-cb97-457a-8263-486976a85375",
+        "id" : "1706814318130728000.9dd062bf-cd0d-4c88-8558-8ec65d614ed8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/id/ID-to-Encounter-pv2-22-F.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/id/ID-to-Encounter-pv2-22-F.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311032361504000.a608aa20-eb71-4fc6-8266-eb66ee5f15f9",
+  "id" : "1706815059089946000.7e88ce11-5de0-4a96-974a-44e0665f7441",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:17:12.393-06:00"
+    "lastUpdated" : "2024-02-01T14:17:39.097-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311032485440000.5a86f50e-c64c-4bcf-97b0-7e01a1141f2c"
+          "reference" : "Organization/1706815059139160000.ae26d4f8-7339-414f-9bf4-79d5cd7c6eca"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311032485440000.5a86f50e-c64c-4bcf-97b0-7e01a1141f2c",
+      "fullUrl" : "Organization/1706815059139160000.ae26d4f8-7339-414f-9bf4-79d5cd7c6eca",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311032485440000.5a86f50e-c64c-4bcf-97b0-7e01a1141f2c",
+        "id" : "1706815059139160000.ae26d4f8-7339-414f-9bf4-79d5cd7c6eca",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311032781178000.4c92f7cf-2bc0-401e-855a-818f7a37b299",
+      "fullUrl" : "Provenance/1706815059510217000.2794b449-edbf-41d6-9a5a-c04ca34e3dc5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311032781178000.4c92f7cf-2bc0-401e-855a-818f7a37b299",
+        "id" : "1706815059510217000.2794b449-edbf-41d6-9a5a-c04ca34e3dc5",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311032787660000.4e080c5b-8397-4bfc-bfba-71e3a48df200",
+      "fullUrl" : "Provenance/1706815059517740000.e238ff12-0ed7-488f-b258-fe318ac14f42",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311032787660000.4e080c5b-8397-4bfc-bfba-71e3a48df200",
-        "recorded" : "2024-01-26T17:17:12Z",
+        "id" : "1706815059517740000.e238ff12-0ed7-488f-b258-fe318ac14f42",
+        "recorded" : "2024-02-01T14:17:39Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311032787255000.f7c51beb-fb95-42f0-b34e-342fe2a0a84f"
+              "reference" : "Organization/1706815059517273000.7c1adf36-6d96-4c21-8545-604572bc5b98"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311032787255000.f7c51beb-fb95-42f0-b34e-342fe2a0a84f",
+      "fullUrl" : "Organization/1706815059517273000.7c1adf36-6d96-4c21-8545-604572bc5b98",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311032787255000.f7c51beb-fb95-42f0-b34e-342fe2a0a84f",
+        "id" : "1706815059517273000.7c1adf36-6d96-4c21-8545-604572bc5b98",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311032801308000.f562d821-d208-475c-a71e-ad8e4b60b1e6",
+      "fullUrl" : "Patient/1706815059533979000.c378f7b2-e6db-4a2f-a57f-b9f4a7c806b5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311032801308000.f562d821-d208-475c-a71e-ad8e4b60b1e6"
+        "id" : "1706815059533979000.c378f7b2-e6db-4a2f-a57f-b9f4a7c806b5"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311032802019000.7ebb039a-6c04-451a-b81a-af907cc04210",
+      "fullUrl" : "Provenance/1706815059534642000.0ed96056-ba56-4bb5-8067-c67e21049af1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311032802019000.7ebb039a-6c04-451a-b81a-af907cc04210",
+        "id" : "1706815059534642000.0ed96056-ba56-4bb5-8067-c67e21049af1",
         "target" : [
           {
-            "reference" : "Patient/1706311032801308000.f562d821-d208-475c-a71e-ad8e4b60b1e6"
+            "reference" : "Patient/1706815059533979000.c378f7b2-e6db-4a2f-a57f-b9f4a7c806b5"
           }
         ],
-        "recorded" : "2024-01-26T17:17:12Z",
+        "recorded" : "2024-02-01T14:17:39Z",
         "activity" : {
           "coding" : [
             {
@@ -167,10 +172,10 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311032804501000.ba820928-9e67-4976-a778-d47b43ee8b38",
+      "fullUrl" : "Encounter/1706815059537010000.339630b4-81f6-4ae6-9147-fced3bf3af1e",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311032804501000.ba820928-9e67-4976-a778-d47b43ee8b38",
+        "id" : "1706815059537010000.339630b4-81f6-4ae6-9147-fced3bf3af1e",
         "meta" : {
           "security" : [
             {
@@ -179,20 +184,20 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311032801308000.f562d821-d208-475c-a71e-ad8e4b60b1e6"
+          "reference" : "Patient/1706815059533979000.c378f7b2-e6db-4a2f-a57f-b9f4a7c806b5"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311032804744000.d9c82a19-f6de-40b9-aeab-1c9eb804d4bf"
+            "reference" : "EpisodeOfCare/1706815059537578000.f043f0ef-4ff9-43a9-aa19-e6451e2d3e23"
           }
         ]
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311032804744000.d9c82a19-f6de-40b9-aeab-1c9eb804d4bf",
+      "fullUrl" : "EpisodeOfCare/1706815059537578000.f043f0ef-4ff9-43a9-aa19-e6451e2d3e23",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311032804744000.d9c82a19-f6de-40b9-aeab-1c9eb804d4bf",
+        "id" : "1706815059537578000.f043f0ef-4ff9-43a9-aa19-e6451e2d3e23",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/id/ID-to-Encounter.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/id/ID-to-Encounter.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311041169766000.e8ab4c44-a721-481c-bd80-f00321d0284d",
+  "id" : "1706815069322680000.a0c271ce-9438-443b-b5e0-2f32eec65b59",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:17:21.183-06:00"
+    "lastUpdated" : "2024-02-01T14:17:49.329-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311041259095000.a78be670-a827-49f5-b74d-06219b8cdc03"
+          "reference" : "Organization/1706815069374880000.e0998ff0-a845-4272-b2ae-00bdd2f0bfe8"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311041259095000.a78be670-a827-49f5-b74d-06219b8cdc03",
+      "fullUrl" : "Organization/1706815069374880000.e0998ff0-a845-4272-b2ae-00bdd2f0bfe8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311041259095000.a78be670-a827-49f5-b74d-06219b8cdc03",
+        "id" : "1706815069374880000.e0998ff0-a845-4272-b2ae-00bdd2f0bfe8",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311041557584000.f569b948-a196-4d76-9b65-5a1192265b5c",
+      "fullUrl" : "Provenance/1706815069745862000.7aff88ed-d606-4648-8691-7c6fefda30cb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311041557584000.f569b948-a196-4d76-9b65-5a1192265b5c",
+        "id" : "1706815069745862000.7aff88ed-d606-4648-8691-7c6fefda30cb",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311041566683000.b8b5739b-975b-4fb6-bd2b-b8c82c5ea6ef",
+      "fullUrl" : "Provenance/1706815069753236000.132ed46b-c330-4014-92a9-b6fb221d440b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311041566683000.b8b5739b-975b-4fb6-bd2b-b8c82c5ea6ef",
-        "recorded" : "2024-01-26T17:17:21Z",
+        "id" : "1706815069753236000.132ed46b-c330-4014-92a9-b6fb221d440b",
+        "recorded" : "2024-02-01T14:17:49Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311041566215000.0d3341b2-35e8-49a9-8809-b4eec87d48c2"
+              "reference" : "Organization/1706815069752767000.3d38ac78-6bfe-4e39-b80d-4715b6654d27"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311041566215000.0d3341b2-35e8-49a9-8809-b4eec87d48c2",
+      "fullUrl" : "Organization/1706815069752767000.3d38ac78-6bfe-4e39-b80d-4715b6654d27",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311041566215000.0d3341b2-35e8-49a9-8809-b4eec87d48c2",
+        "id" : "1706815069752767000.3d38ac78-6bfe-4e39-b80d-4715b6654d27",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311041585245000.7e5384b8-5d38-4579-89f1-61d72d714a9c",
+      "fullUrl" : "Patient/1706815069769704000.e5435650-23fb-453e-88db-b5b08fd39ea7",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311041585245000.7e5384b8-5d38-4579-89f1-61d72d714a9c"
+        "id" : "1706815069769704000.e5435650-23fb-453e-88db-b5b08fd39ea7"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311041586522000.c2d0284d-e833-4c3c-ba88-23407a970abc",
+      "fullUrl" : "Provenance/1706815069770901000.67c1857c-27f6-480b-97d1-ce65a452dd08",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311041586522000.c2d0284d-e833-4c3c-ba88-23407a970abc",
+        "id" : "1706815069770901000.67c1857c-27f6-480b-97d1-ce65a452dd08",
         "target" : [
           {
-            "reference" : "Patient/1706311041585245000.7e5384b8-5d38-4579-89f1-61d72d714a9c"
+            "reference" : "Patient/1706815069769704000.e5435650-23fb-453e-88db-b5b08fd39ea7"
           }
         ],
-        "recorded" : "2024-01-26T17:17:21Z",
+        "recorded" : "2024-02-01T14:17:49Z",
         "activity" : {
           "coding" : [
             {
@@ -167,10 +172,10 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311041590756000.deeb8458-0dd6-434f-81c6-7a013ef27b36",
+      "fullUrl" : "Encounter/1706815069775935000.d602b43b-9498-4a56-9a24-604cac24bc73",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311041590756000.deeb8458-0dd6-434f-81c6-7a013ef27b36",
+        "id" : "1706815069775935000.d602b43b-9498-4a56-9a24-604cac24bc73",
         "meta" : {
           "security" : [
             {
@@ -179,20 +184,20 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311041585245000.7e5384b8-5d38-4579-89f1-61d72d714a9c"
+          "reference" : "Patient/1706815069769704000.e5435650-23fb-453e-88db-b5b08fd39ea7"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311041591012000.d84708ae-3149-4f20-8b63-4bd24b49b7b8"
+            "reference" : "EpisodeOfCare/1706815069776236000.aa13e85e-3a9e-4c6b-a697-fcd8de13268a"
           }
         ]
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311041591012000.d84708ae-3149-4f20-8b63-4bd24b49b7b8",
+      "fullUrl" : "EpisodeOfCare/1706815069776236000.aa13e85e-3a9e-4c6b-a697-fcd8de13268a",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311041591012000.d84708ae-3149-4f20-8b63-4bd24b49b7b8",
+        "id" : "1706815069776236000.aa13e85e-3a9e-4c6b-a697-fcd8de13268a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msg/MSG-to-Coding-missing-msg2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msg/MSG-to-Coding-missing-msg2.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311049531112000.ebf4494c-f716-4f1d-8b87-81766b5d67b6",
+  "id" : "1706815088832036000.63e481a5-3f7c-468e-a6a7-036cd50e3f2b",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:17:29.545-06:00"
+    "lastUpdated" : "2024-02-01T14:18:08.839-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,10 +47,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311049902507000.442fe0e1-431d-4e5b-b0b5-12230289dc1b",
+      "fullUrl" : "Provenance/1706815089282108000.d40ae836-fef2-4322-91d4-5ff2a802f25b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311049902507000.442fe0e1-431d-4e5b-b0b5-12230289dc1b",
+        "id" : "1706815089282108000.d40ae836-fef2-4322-91d4-5ff2a802f25b",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -62,11 +67,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311049909648000.6b89246b-f6f7-4afc-8757-6aebdc452413",
+      "fullUrl" : "Provenance/1706815089292006000.e427f8d2-232c-4695-813a-f2ee179b288f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311049909648000.6b89246b-f6f7-4afc-8757-6aebdc452413",
-        "recorded" : "2024-01-26T17:17:29Z",
+        "id" : "1706815089292006000.e427f8d2-232c-4695-813a-f2ee179b288f",
+        "recorded" : "2024-02-01T14:18:09Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -88,17 +93,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311049909235000.62095208-1c78-42d7-9576-c92fe4d85dd9"
+              "reference" : "Organization/1706815089291493000.ef65af6f-afce-4df7-b5d9-765e3558fa5e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311049909235000.62095208-1c78-42d7-9576-c92fe4d85dd9",
+      "fullUrl" : "Organization/1706815089291493000.ef65af6f-afce-4df7-b5d9-765e3558fa5e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311049909235000.62095208-1c78-42d7-9576-c92fe4d85dd9",
+        "id" : "1706815089291493000.ef65af6f-afce-4df7-b5d9-765e3558fa5e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msg/MSG-to-Coding.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msg/MSG-to-Coding.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311061581851000.49d744c9-00df-4e9e-97d3-7c1e28698fea",
+  "id" : "1706815104816281000.4bc5bf50-de62-42a2-9905-180d9c5d2d95",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:17:41.595-06:00"
+    "lastUpdated" : "2024-02-01T14:18:24.824-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311061961910000.5befd977-7d8d-47d6-b7b2-9ea2fa751181",
+      "fullUrl" : "Provenance/1706815105257901000.5b621c32-7eca-4ba0-8e2d-b5bb92d66c1a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311061961910000.5befd977-7d8d-47d6-b7b2-9ea2fa751181",
+        "id" : "1706815105257901000.5b621c32-7eca-4ba0-8e2d-b5bb92d66c1a",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311061968305000.8ea2304c-763d-4e5d-9920-f275ce17fcfc",
+      "fullUrl" : "Provenance/1706815105267791000.bd2ac29f-1049-45b9-9388-851b6c41f864",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311061968305000.8ea2304c-763d-4e5d-9920-f275ce17fcfc",
-        "recorded" : "2024-01-26T17:17:41Z",
+        "id" : "1706815105267791000.bd2ac29f-1049-45b9-9388-851b6c41f864",
+        "recorded" : "2024-02-01T14:18:25Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311061967763000.b3404df9-d92f-4e93-990c-24d11dc9a852"
+              "reference" : "Organization/1706815105267210000.cb2d6c43-7c18-43bd-9e58-f3adb52733db"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311061967763000.b3404df9-d92f-4e93-990c-24d11dc9a852",
+      "fullUrl" : "Organization/1706815105267210000.cb2d6c43-7c18-43bd-9e58-f3adb52733db",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311061967763000.b3404df9-d92f-4e93-990c-24d11dc9a852",
+        "id" : "1706815105267210000.cb2d6c43-7c18-43bd-9e58-f3adb52733db",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued-SFT-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued-SFT-valued.fhir
@@ -10,744 +10,1015 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "meta" : {
-        "security" : [ {
-          "code" : "security"
-        } ],
-        "tag" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "T"
-        } ]
-      },
-      "language" : "EN",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UTF-8"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.13",
-          "valueString" : "10"
-        }, {
-          "url" : "MSH.14",
-          "valueString" : "abc"
-        }, {
-          "url" : "MSH.15",
-          "valueString" : "ACCEPT"
-        }, {
-          "url" : "MSH.16",
-          "valueString" : "ACKNOLWEDGE"
-        }, {
-          "url" : "MSH.19",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "EN"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              } ],
-              "code" : "EN-US"
-            } ]
-          }
-        }, {
-          "url" : "MSH.20",
-          "valueString" : "UTF-16"
-        }, {
-          "url" : "MSH.21",
-          "valueIdentifier" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
-                "valueString" : "2.16.840.1.113883.9.82"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              } ]
-            } ],
-            "value" : "LAB_PRU_COMPONENT"
-          }
-        }, {
-          "url" : "MSH.21",
-          "valueIdentifier" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
-                "valueString" : "2.16.840.1.113883.9.22"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              } ]
-            } ],
-            "value" : "LAB_TO_COMPONENT"
-          }
-        }, {
-          "url" : "MSH.24",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Alt Sending App"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "Alt Sending App Universal"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "UUID"
-          } ]
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.5"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Receiving Application",
-        "endpoint" : "urn:oid:2.1.5",
-        "receiver" : {
-          "reference" : "Organization/1706714362132946000.851f6907-2985-4864-8835-0aad59c14144"
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-network-address"
-        } ],
-        "name" : "Receiving Network",
-        "endpoint" : "urn:oid:2.1.1",
-        "receiver" : {
-          "reference" : "Organization/1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7"
-        }
-      }, {
-        "receiver" : {
-          "reference" : "Organization/1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2"
-        }
-      } ],
-      "sender" : {
-        "reference" : "Organization/1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending Application"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.3.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
-          "valueString" : "Binary ID unknown"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
-          "valueString" : "description"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
-          "valueString" : "20220411"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
-          "valueReference" : {
-            "reference" : "Organization/1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e"
-          }
-        } ],
-        "software" : "STARLIMS",
-        "version" : "ELIMS V11",
-        "endpoint" : "urn:oid:2.1.3.1"
-      },
-      "responsible" : {
-        "reference" : "Organization/1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5"
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "3.1.2"
-      } ],
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "meta" : {
+          "security" : [
+            {
+              "code" : "security"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Sending Org"
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362132946000.851f6907-2985-4864-8835-0aad59c14144",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362132946000.851f6907-2985-4864-8835-0aad59c14144",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Receiving Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "7.1.1"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Receiving Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "7.1.1"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+          ],
+          "tag" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
+              "code" : "T"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-responsible-organization"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821"
+          ]
+        },
+        "language" : "EN",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.13",
+                "valueString" : "10"
+              },
+              {
+                "url" : "MSH.14",
+                "valueString" : "abc"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "ACCEPT"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "ACKNOLWEDGE"
+              },
+              {
+                "url" : "MSH.19",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "EN"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        }
+                      ],
+                      "code" : "EN-US"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "MSH.20",
+                "valueString" : "UTF-16"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.82"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_PRU_COMPONENT"
+                }
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_TO_COMPONENT"
+                }
+              },
+              {
+                "url" : "MSH.24",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Alt Sending App"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "Alt Sending App Universal"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueString" : "UUID"
+                  }
+                ]
+              }
+            ]
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Receiving Org"
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.10",
-          "valueString" : "CDC CLIA"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "CDC"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.16.840.1.114222.4"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
-          } ]
-        },
-        "value" : "CDC CLIA"
-      } ],
-      "name" : "CDC"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714362482666000.759eb551-300c-42bf-8e66-044604fd6f08",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714362482666000.759eb551-300c-42bf-8e66-044604fd6f08",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "author"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.5"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Receiving Application",
+            "endpoint" : "urn:oid:2.1.5",
+            "receiver" : {
+              "reference" : "Organization/1706714362132946000.851f6907-2985-4864-8835-0aad59c14144"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-network-address"
+              }
+            ],
+            "name" : "Receiving Network",
+            "endpoint" : "urn:oid:2.1.1",
+            "receiver" : {
+              "reference" : "Organization/1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7"
+            }
+          },
+          {
+            "receiver" : {
+              "reference" : "Organization/1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2"
+            }
+          }
+        ],
+        "sender" : {
+          "reference" : "Organization/1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca"
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending Application"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "2.1.3.1"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
+              "valueString" : "Binary ID unknown"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
+              "valueString" : "description"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
+              "valueString" : "20220411"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
+              "valueReference" : {
+                "reference" : "Organization/1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e"
+              }
+            }
+          ],
+          "software" : "STARLIMS",
+          "version" : "ELIMS V11",
+          "endpoint" : "urn:oid:2.1.3.1"
+        },
+        "responsible" : {
+          "reference" : "Organization/1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5"
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Facility"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "3.1.2"
+          }
+        ],
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5",
+        "extension" : [
+          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
             "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637"
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Sending Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714362491399000.acc0289a-ae08-475d-885f-44eb64c8b0a5",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714362491399000.acc0289a-ae08-475d-885f-44eb64c8b0a5",
-      "recorded" : "2024-01-31T10:19:22Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324"
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Sending Org"
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362132946000.851f6907-2985-4864-8835-0aad59c14144",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362132946000.851f6907-2985-4864-8835-0aad59c14144",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Receiving Facility"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "7.1.1"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Receiving Facility"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "7.1.1"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-responsible-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Receiving Org"
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.10",
+                "valueString" : "CDC CLIA"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "CDC"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.16.840.1.114222.4"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "XX"
+                }
+              ]
+            },
+            "value" : "CDC CLIA"
+          }
+        ],
+        "name" : "CDC"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714362482666000.759eb551-300c-42bf-8e66-044604fd6f08",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714362482666000.759eb551-300c-42bf-8e66-044604fd6f08",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "author"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Sending Org"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714362491399000.acc0289a-ae08-475d-885f-44eb64c8b0a5",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714362491399000.acc0289a-ae08-475d-885f-44eb64c8b0a5",
+        "recorded" : "2024-01-31T10:19:22Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued-SFT-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued-SFT-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653890850805000.fd4b6b1e-6330-4e97-9552-aa7e14207f33",
+  "id" : "1706714362055790000.f93f3a3c-d847-453a-b757-2cbc00319116",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:31:30.856-05:00"
+    "lastUpdated" : "2024-01-31T10:19:22.062-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -29,76 +29,91 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-13-sequence-number",
-        "valueString" : "10"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-14-continuation-pointer",
-        "valueString" : "abc"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-        "valueString" : "ACCEPT"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-        "valueString" : "ACKNOLWEDGE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "EN"
-          }, {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "alt-coding"
-            } ],
-            "code" : "EN-US"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-20-alternate-character-set-handling-scheme",
-        "valueString" : "UTF-16"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-24-hd-extension",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Alt Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Alt Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "UUID"
-        } ]
-      }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
         "valueString" : "UTF-8"
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
         "valueString" : "UNICODE"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-        "valueIdentifier" : {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "MSH.13",
+          "valueString" : "10"
+        }, {
+          "url" : "MSH.14",
+          "valueString" : "abc"
+        }, {
+          "url" : "MSH.15",
+          "valueString" : "ACCEPT"
+        }, {
+          "url" : "MSH.16",
+          "valueString" : "ACKNOLWEDGE"
+        }, {
+          "url" : "MSH.19",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "EN"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              } ],
+              "code" : "EN-US"
+            } ]
+          }
+        }, {
+          "url" : "MSH.20",
+          "valueString" : "UTF-16"
+        }, {
+          "url" : "MSH.21",
+          "valueIdentifier" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                "valueString" : "2.16.840.1.113883.9.82"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              } ]
+            } ],
+            "value" : "LAB_PRU_COMPONENT"
+          }
+        }, {
+          "url" : "MSH.21",
+          "valueIdentifier" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                "valueString" : "2.16.840.1.113883.9.22"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              } ]
+            } ],
+            "value" : "LAB_TO_COMPONENT"
+          }
+        }, {
+          "url" : "MSH.24",
           "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Alt Sending App"
+          }, {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueOid" : "urn:oid:2.16.840.1.113883.9.82"
-          } ],
-          "value" : "LAB_PRU_COMPONENT"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-        "valueIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
-          } ],
-          "value" : "LAB_TO_COMPONENT"
-        }
+            "valueString" : "Alt Sending App Universal"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "UUID"
+          } ]
+        } ]
       } ],
       "eventCoding" : {
         "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -119,7 +134,7 @@
         "name" : "Receiving Application",
         "endpoint" : "urn:oid:2.1.5",
         "receiver" : {
-          "reference" : "Organization/1706653890918097000.c4361283-49c1-4aff-992c-c61a505aded3"
+          "reference" : "Organization/1706714362132946000.851f6907-2985-4864-8835-0aad59c14144"
         }
       }, {
         "extension" : [ {
@@ -135,15 +150,15 @@
         "name" : "Receiving Network",
         "endpoint" : "urn:oid:2.1.1",
         "receiver" : {
-          "reference" : "Organization/1706653890920443000.2dca4ef5-983d-4d42-9c94-5212d871e0b4"
+          "reference" : "Organization/1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7"
         }
       }, {
         "receiver" : {
-          "reference" : "Organization/1706653890925673000.b4cec706-4b5b-48c2-b619-0ca7da1698a5"
+          "reference" : "Organization/1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2"
         }
       } ],
       "sender" : {
-        "reference" : "Organization/1706653890932398000.201df476-e1a9-457b-8404-a3643e103ee7"
+        "reference" : "Organization/1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca"
       },
       "source" : {
         "extension" : [ {
@@ -170,7 +185,7 @@
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
           "valueReference" : {
-            "reference" : "Organization/1706653890927973000.016c270c-6563-4d9b-87d9-d93fbafd183a"
+            "reference" : "Organization/1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e"
           }
         } ],
         "software" : "STARLIMS",
@@ -178,24 +193,20 @@
         "endpoint" : "urn:oid:2.1.3.1"
       },
       "responsible" : {
-        "reference" : "Organization/1706653890936616000.4493ad43-c426-4c42-8dab-13ce7ab053b7"
+        "reference" : "Organization/1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5"
       }
     }
   }, {
-    "fullUrl" : "Organization/1706653890918097000.c4361283-49c1-4aff-992c-c61a505aded3",
+    "fullUrl" : "Organization/1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653890918097000.c4361283-49c1-4aff-992c-c61a505aded3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
+      "id" : "1706714362105163000.52c63514-bff6-476b-9db7-f3da0c7cf7ca",
       "identifier" : [ {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
           "valueBoolean" : true
         } ],
-        "value" : "Receiving Facility"
+        "value" : "Facility"
       }, {
         "extension" : [ {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
@@ -204,48 +215,21 @@
         "type" : {
           "coding" : [ {
             "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
+            "code" : "UUID"
           } ]
         },
         "system" : "urn:ietf:rfc:3986",
-        "value" : "7.1.1"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706653890920443000.2dca4ef5-983d-4d42-9c94-5212d871e0b4",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706653890920443000.2dca4ef5-983d-4d42-9c94-5212d871e0b4",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
+        "value" : "3.1.2"
       } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Receiving Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "7.1.1"
+      "address" : [ {
+        "country" : "USA"
       } ]
     }
   }, {
-    "fullUrl" : "Location/1706653890923106000.4d68dca7-e6b3-4f72-8d60-7f852c26d4dd",
+    "fullUrl" : "Location/1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1706653890923106000.4d68dca7-e6b3-4f72-8d60-7f852c26d4dd",
+      "id" : "1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
         "valueCode" : "ISO"
@@ -266,10 +250,188 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1706653890925673000.b4cec706-4b5b-48c2-b619-0ca7da1698a5",
+    "fullUrl" : "Organization/1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653890925673000.b4cec706-4b5b-48c2-b619-0ca7da1698a5",
+      "id" : "1706714362131720000.0ab0ae6d-9573-4cda-b2df-6b4ac101b8a5",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714362127933000.704a0761-6174-4380-ba9f-9bd2e584b4c5"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Sending Org"
+    }
+  }, {
+    "fullUrl" : "Organization/1706714362132946000.851f6907-2985-4864-8835-0aad59c14144",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714362132946000.851f6907-2985-4864-8835-0aad59c14144",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Receiving Facility"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "7.1.1"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714362134276000.5f065951-5947-41f4-9b64-7d13001b64f7",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Receiving Facility"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "7.1.1"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714362137545000.35572ec9-1f7a-46c9-ae47-13601e74a2a2",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
         "valueCoding" : {
@@ -345,7 +507,7 @@
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
           "valueReference" : {
-            "reference" : "Location/1706653890923106000.4d68dca7-e6b3-4f72-8d60-7f852c26d4dd"
+            "reference" : "Location/1706714362136076000.9ef7c48c-ef19-48e7-98fd-b1bc20e95821"
           }
         } ],
         "type" : {
@@ -363,10 +525,10 @@
       "name" : "Receiving Org"
     }
   }, {
-    "fullUrl" : "Organization/1706653890927973000.016c270c-6563-4d9b-87d9-d93fbafd183a",
+    "fullUrl" : "Organization/1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653890927973000.016c270c-6563-4d9b-87d9-d93fbafd183a",
+      "id" : "1706714362140190000.5d468be4-2e7d-44b3-b01a-52c0b764e16e",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
         "extension" : [ {
@@ -403,157 +565,10 @@
       "name" : "CDC"
     }
   }, {
-    "fullUrl" : "Organization/1706653890932398000.201df476-e1a9-457b-8404-a3643e103ee7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706653890932398000.201df476-e1a9-457b-8404-a3643e103ee7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "3.1.2"
-      } ],
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706653890935531000.1b174b14-888c-4181-9675-8a0eabb13579",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706653890935531000.1b174b14-888c-4181-9675-8a0eabb13579",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706653890936616000.4493ad43-c426-4c42-8dab-13ce7ab053b7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706653890936616000.4493ad43-c426-4c42-8dab-13ce7ab053b7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706653890935531000.1b174b14-888c-4181-9675-8a0eabb13579"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Sending Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706653891243925000.d776627a-75af-4d9b-9bba-2febcf1de0f3",
+    "fullUrl" : "Provenance/1706714362482666000.759eb551-300c-42bf-8e66-044604fd6f08",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653891243925000.d776627a-75af-4d9b-9bba-2febcf1de0f3",
+      "id" : "1706714362482666000.759eb551-300c-42bf-8e66-044604fd6f08",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -571,15 +586,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706653891243730000.ce48ce2f-6c8f-43d0-bc67-6636a873714b"
+          "reference" : "Organization/1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Location/1706653891242503000.249f5c24-3682-41bc-8a31-63cee5d95b2e",
+    "fullUrl" : "Location/1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1706653891242503000.249f5c24-3682-41bc-8a31-63cee5d95b2e",
+      "id" : "1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
         "valueCode" : "ISO"
@@ -600,10 +615,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1706653891243730000.ce48ce2f-6c8f-43d0-bc67-6636a873714b",
+    "fullUrl" : "Organization/1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653891243730000.ce48ce2f-6c8f-43d0-bc67-6636a873714b",
+      "id" : "1706714362482454000.549d90f2-3a3e-449d-8de3-6d148bea9f37",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
         "valueCoding" : {
@@ -676,7 +691,7 @@
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
           "valueReference" : {
-            "reference" : "Location/1706653891242503000.249f5c24-3682-41bc-8a31-63cee5d95b2e"
+            "reference" : "Location/1706714362481384000.88244c93-f29c-44ef-97fe-5bc923198637"
           }
         } ],
         "type" : {
@@ -694,11 +709,11 @@
       "name" : "Sending Org"
     }
   }, {
-    "fullUrl" : "Provenance/1706653891252999000.5f014114-e72a-413a-84fb-d99a150c4f68",
+    "fullUrl" : "Provenance/1706714362491399000.acc0289a-ae08-475d-885f-44eb64c8b0a5",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653891252999000.5f014114-e72a-413a-84fb-d99a150c4f68",
-      "recorded" : "2024-01-30T17:31:31Z",
+      "id" : "1706714362491399000.acc0289a-ae08-475d-885f-44eb64c8b0a5",
+      "recorded" : "2024-01-31T10:19:22Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -713,15 +728,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706653891252681000.f2ff147c-2487-4622-8169-1344b1b7df63"
+          "reference" : "Organization/1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706653891252681000.f2ff147c-2487-4622-8169-1344b1b7df63",
+    "fullUrl" : "Organization/1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653891252681000.f2ff147c-2487-4622-8169-1344b1b7df63",
+      "id" : "1706714362491192000.36718c03-e00a-4b8c-b877-a50988b9f324",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued.fhir
@@ -10,688 +10,938 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "meta" : {
-        "security" : [ {
-          "code" : "security"
-        } ],
-        "tag" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "T"
-        } ]
-      },
-      "language" : "EN",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UTF-8"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.13",
-          "valueString" : "10"
-        }, {
-          "url" : "MSH.14",
-          "valueString" : "abc"
-        }, {
-          "url" : "MSH.15",
-          "valueString" : "ACCEPT"
-        }, {
-          "url" : "MSH.16",
-          "valueString" : "ACKNOLWEDGE"
-        }, {
-          "url" : "MSH.19",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "EN"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              } ],
-              "code" : "EN-US"
-            } ]
-          }
-        }, {
-          "url" : "MSH.20",
-          "valueString" : "UTF-16"
-        }, {
-          "url" : "MSH.21",
-          "valueIdentifier" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
-                "valueString" : "2.16.840.1.113883.9.82"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              } ]
-            } ],
-            "value" : "LAB_PRU_COMPONENT"
-          }
-        }, {
-          "url" : "MSH.21",
-          "valueIdentifier" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
-                "valueString" : "2.16.840.1.113883.9.22"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              } ]
-            } ],
-            "value" : "LAB_TO_COMPONENT"
-          }
-        }, {
-          "url" : "MSH.24",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Alt Sending App"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "Alt Sending App Universal"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "UUID"
-          } ]
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.5"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Receiving Application",
-        "endpoint" : "urn:oid:2.1.5",
-        "receiver" : {
-          "reference" : "Organization/1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45"
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-network-address"
-        } ],
-        "name" : "Receiving Network",
-        "endpoint" : "urn:oid:2.1.1",
-        "receiver" : {
-          "reference" : "Organization/1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab"
-        }
-      }, {
-        "receiver" : {
-          "reference" : "Organization/1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17"
-        }
-      } ],
-      "sender" : {
-        "reference" : "Organization/1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending Application"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.3.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:oid:2.1.3.1"
-      },
-      "responsible" : {
-        "reference" : "Organization/1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387"
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "3.1.2"
-      } ],
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "meta" : {
+          "security" : [
+            {
+              "code" : "security"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Sending Org"
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Receiving Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "7.1.1"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Receiving Facility"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "7.1.1"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+          ],
+          "tag" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
+              "code" : "T"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-responsible-organization"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
+          ]
         },
-        "value" : "123"
-      } ],
-      "name" : "Receiving Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714371874162000.bff7958b-81f9-49eb-ba07-de2490db74de",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714371874162000.bff7958b-81f9-49eb-ba07-de2490db74de",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        "language" : "EN",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.13",
+                "valueString" : "10"
+              },
+              {
+                "url" : "MSH.14",
+                "valueString" : "abc"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "ACCEPT"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "ACKNOLWEDGE"
+              },
+              {
+                "url" : "MSH.19",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "EN"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        }
+                      ],
+                      "code" : "EN-US"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "MSH.20",
+                "valueString" : "UTF-16"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.82"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_PRU_COMPONENT"
+                }
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.22"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "LAB_TO_COMPONENT"
+                }
+              },
+              {
+                "url" : "MSH.24",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Alt Sending App"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "Alt Sending App Universal"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueString" : "UUID"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "author"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.5"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Receiving Application",
+            "endpoint" : "urn:oid:2.1.5",
+            "receiver" : {
+              "reference" : "Organization/1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-network-address"
+              }
+            ],
+            "name" : "Receiving Network",
+            "endpoint" : "urn:oid:2.1.1",
+            "receiver" : {
+              "reference" : "Organization/1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab"
+            }
+          },
+          {
+            "receiver" : {
+              "reference" : "Organization/1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17"
+            }
+          }
+        ],
+        "sender" : {
+          "reference" : "Organization/1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302"
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending Application"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "2.1.3.1"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:oid:2.1.3.1"
+        },
+        "responsible" : {
+          "reference" : "Organization/1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387"
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Facility"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "3.1.2"
+          }
+        ],
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4",
+        "extension" : [
+          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
             "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9"
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Sending Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714371883395000.aa81246c-8600-4b61-b59d-1e0af3fab1d3",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714371883395000.aa81246c-8600-4b61-b59d-1e0af3fab1d3",
-      "recorded" : "2024-01-31T10:19:31Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516"
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Sending Org"
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Receiving Facility"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "7.1.1"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Receiving Facility"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "7.1.1"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-responsible-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Receiving Org"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714371874162000.bff7958b-81f9-49eb-ba07-de2490db74de",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714371874162000.bff7958b-81f9-49eb-ba07-de2490db74de",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "author"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Sending Org"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714371883395000.aa81246c-8600-4b61-b59d-1e0af3fab1d3",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714371883395000.aa81246c-8600-4b61-b59d-1e0af3fab1d3",
+        "recorded" : "2024-01-31T10:19:31Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-everything-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653900028186000.0e66f6a7-fa3a-44b1-80ab-23e850bed2a7",
+  "id" : "1706714371473398000.2a517335-c475-4b17-8649-56774b1107cf",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:31:40.033-05:00"
+    "lastUpdated" : "2024-01-31T10:19:31.480-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,915 +10,688 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "meta" : {
-          "security" : [
-            {
-              "code" : "security"
-            }
-          ],
-          "tag" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-              "code" : "T"
-            }
-          ]
-        },
-        "language" : "EN",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-13-sequence-number",
-            "valueString" : "10"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-14-continuation-pointer",
-            "valueString" : "abc"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-            "valueString" : "ACCEPT"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-            "valueString" : "ACKNOLWEDGE"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "EN"
-                },
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "alt-coding"
-                    }
-                  ],
-                  "code" : "EN-US"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-20-alternate-character-set-handling-scheme",
-            "valueString" : "UTF-16"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-24-hd-extension",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Alt Sending App"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "Alt Sending App Universal"
-              },
-              {
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "meta" : {
+        "security" : [ {
+          "code" : "security"
+        } ],
+        "tag" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
+          "code" : "T"
+        } ]
+      },
+      "language" : "EN",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+        "valueString" : "UTF-8"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+        "valueString" : "UNICODE"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "MSH.13",
+          "valueString" : "10"
+        }, {
+          "url" : "MSH.14",
+          "valueString" : "abc"
+        }, {
+          "url" : "MSH.15",
+          "valueString" : "ACCEPT"
+        }, {
+          "url" : "MSH.16",
+          "valueString" : "ACKNOLWEDGE"
+        }, {
+          "url" : "MSH.19",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "EN"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              } ],
+              "code" : "EN-US"
+            } ]
+          }
+        }, {
+          "url" : "MSH.20",
+          "valueString" : "UTF-16"
+        }, {
+          "url" : "MSH.21",
+          "valueIdentifier" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                "valueString" : "2.16.840.1.113883.9.82"
+              }, {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-            "valueString" : "UTF-8"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-            "valueString" : "UNICODE"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.82"
-                }
-              ],
-              "value" : "LAB_PRU_COMPONENT"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
-                }
-              ],
-              "value" : "LAB_TO_COMPONENT"
-            }
+                "valueCode" : "ISO"
+              } ]
+            } ],
+            "value" : "LAB_PRU_COMPONENT"
           }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "2.1.5"
-              },
-              {
+        }, {
+          "url" : "MSH.21",
+          "valueIdentifier" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                "valueString" : "2.16.840.1.113883.9.22"
+              }, {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-application"
-              }
-            ],
-            "name" : "Receiving Application",
-            "endpoint" : "urn:oid:2.1.5",
-            "receiver" : {
-              "reference" : "Organization/1706653900097034000.0162e772-318a-4a47-8fe3-dfc4d389fd42"
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "2.1.1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-network-address"
-              }
-            ],
-            "name" : "Receiving Network",
-            "endpoint" : "urn:oid:2.1.1",
-            "receiver" : {
-              "reference" : "Organization/1706653900099486000.ef3d448e-6882-48de-a540-45ca807d0ba1"
-            }
-          },
-          {
-            "receiver" : {
-              "reference" : "Organization/1706653900103849000.9ebd9707-5731-4081-ba34-0008a1847f13"
-            }
+                "valueCode" : "ISO"
+              } ]
+            } ],
+            "value" : "LAB_TO_COMPONENT"
           }
-        ],
-        "sender" : {
-          "reference" : "Organization/1706653900110106000.b20de1d0-b35a-47f9-bb97-1c56e9e8ce5f"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending Application"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "2.1.3.1"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:oid:2.1.3.1"
-        },
-        "responsible" : {
-          "reference" : "Organization/1706653900113910000.d5d26a14-57d6-4b28-8665-5a98bf7f6936"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900097034000.0162e772-318a-4a47-8fe3-dfc4d389fd42",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900097034000.0162e772-318a-4a47-8fe3-dfc4d389fd42",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-facility"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Receiving Facility"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "7.1.1"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900099486000.ef3d448e-6882-48de-a540-45ca807d0ba1",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900099486000.ef3d448e-6882-48de-a540-45ca807d0ba1",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-facility"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Receiving Facility"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "7.1.1"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706653900102000000.4f585880-f158-4df3-aac4-161dd7872b4a",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706653900102000000.4f585880-f158-4df3-aac4-161dd7872b4a",
-        "extension" : [
-          {
+        }, {
+          "url" : "MSH.24",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Alt Sending App"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "Alt Sending App Universal"
+          }, {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+            "valueString" : "UUID"
+          } ]
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "2.1.5"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-application"
+        } ],
+        "name" : "Receiving Application",
+        "endpoint" : "urn:oid:2.1.5",
+        "receiver" : {
+          "reference" : "Organization/1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900103849000.9ebd9707-5731-4081-ba34-0008a1847f13",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900103849000.9ebd9707-5731-4081-ba34-0008a1847f13",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-responsible-organization"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706653900102000000.4f585880-f158-4df3-aac4-161dd7872b4a"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Receiving Org"
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900110106000.b20de1d0-b35a-47f9-bb97-1c56e9e8ce5f",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900110106000.b20de1d0-b35a-47f9-bb97-1c56e9e8ce5f",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Facility"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "3.1.2"
-          }
-        ],
-        "address" : [
-          {
-            "country" : "USA"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706653900112622000.1ff210e0-bdf0-45e3-b5f8-848ae7b228e0",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706653900112622000.1ff210e0-bdf0-45e3-b5f8-848ae7b228e0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "2.1.1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-network-address"
+        } ],
+        "name" : "Receiving Network",
+        "endpoint" : "urn:oid:2.1.1",
+        "receiver" : {
+          "reference" : "Organization/1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900113910000.d5d26a14-57d6-4b28-8665-5a98bf7f6936",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900113910000.d5d26a14-57d6-4b28-8665-5a98bf7f6936",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706653900112622000.1ff210e0-bdf0-45e3-b5f8-848ae7b228e0"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Sending Org"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653900438374000.1288d553-fd1a-468a-83d1-9737414c3b2f",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653900438374000.1288d553-fd1a-468a-83d1-9737414c3b2f",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "author"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653900438181000.0c433090-7bc1-47a3-bf39-e3dc4b5f5c91"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706653900437130000.fdac178c-70b8-4ea1-a2d5-eaf82a18e675",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706653900437130000.fdac178c-70b8-4ea1-a2d5-eaf82a18e675",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+      }, {
+        "receiver" : {
+          "reference" : "Organization/1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900438181000.0c433090-7bc1-47a3-bf39-e3dc4b5f5c91",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900438181000.0c433090-7bc1-47a3-bf39-e3dc4b5f5c91",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706653900437130000.fdac178c-70b8-4ea1-a2d5-eaf82a18e675"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Sending Org"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653900452610000.66441e7b-67ef-46d4-8ff6-0c16251fedd5",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653900452610000.66441e7b-67ef-46d4-8ff6-0c16251fedd5",
-        "recorded" : "2024-01-30T17:31:40Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653900452352000.48585719-6257-4dd7-8663-bf13e7f80159"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653900452352000.48585719-6257-4dd7-8663-bf13e7f80159",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653900452352000.48585719-6257-4dd7-8663-bf13e7f80159",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+      } ],
+      "sender" : {
+        "reference" : "Organization/1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending Application"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "2.1.3.1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:oid:2.1.3.1"
+      },
+      "responsible" : {
+        "reference" : "Organization/1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371522067000.4f3d1c97-29e9-4331-b958-08562ff58302",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Facility"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "3.1.2"
+      } ],
+      "address" : [ {
+        "country" : "USA"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371547483000.ebffe512-744b-4ed8-8387-ccdedc348387",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714371543548000.4168c028-1c26-49e5-ab12-3282ab885bc4"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Sending Org"
+    }
+  }, {
+    "fullUrl" : "Organization/1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371548417000.de2db59c-6d90-4fdf-9d60-e25e2e993a45",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Receiving Facility"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "7.1.1"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371549839000.2cce4e8a-5726-4d82-af4e-6d7904bb42ab",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Receiving Facility"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "7.1.1"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371553798000.ed9892e6-84c4-40d0-b4cf-376d61303b17",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-responsible-organization"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714371552222000.950ec94d-b1a6-4ea8-b354-a1dac9011cae"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Receiving Org"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714371874162000.bff7958b-81f9-49eb-ba07-de2490db74de",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714371874162000.bff7958b-81f9-49eb-ba07-de2490db74de",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "author"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371873909000.0edbbc56-c708-4829-b7a5-aaa8bb414562",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714371872699000.c6d2fb43-c41f-4e3a-9422-42656ccb21b9"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Sending Org"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714371883395000.aa81246c-8600-4b61-b59d-1e0af3fab1d3",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714371883395000.aa81246c-8600-4b61-b59d-1e0af3fab1d3",
+      "recorded" : "2024-01-31T10:19:31Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714371882888000.61ecba5b-7c63-45ad-9372-a893b2f4e516",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-handles-multiple-msh18.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-handles-multiple-msh18.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653909236545000.f1e7288f-b7f6-403d-9661-ff736233873b",
+  "id" : "1706714380670154000.8408fd4b-d1fb-4d4e-b73c-64c23a642870",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:31:49.243-05:00"
+    "lastUpdated" : "2024-01-31T10:19:40.676-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -19,14 +19,17 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
         "valueString" : "UTF-8"
       }, {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
         "valueString" : "UNICODE"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
       } ],
       "eventCoding" : {
         "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -43,10 +46,10 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706653909622272000.bc312a22-5681-4f5b-9d84-1559d878be8b",
+    "fullUrl" : "Provenance/1706714381046832000.50a1bf8e-d446-4c27-aaf6-2bc2fa1f7221",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653909622272000.bc312a22-5681-4f5b-9d84-1559d878be8b",
+      "id" : "1706714381046832000.50a1bf8e-d446-4c27-aaf6-2bc2fa1f7221",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -58,11 +61,11 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706653909629735000.f8cddeb3-5cf9-472c-9329-1f8c2f1b2575",
+    "fullUrl" : "Provenance/1706714381055263000.20449ff6-ceea-4ff1-8379-e42ba61f89b2",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653909629735000.f8cddeb3-5cf9-472c-9329-1f8c2f1b2575",
-      "recorded" : "2024-01-30T17:31:49Z",
+      "id" : "1706714381055263000.20449ff6-ceea-4ff1-8379-e42ba61f89b2",
+      "recorded" : "2024-01-31T10:19:41Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -77,15 +80,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706653909629208000.ee7b830a-8264-4940-a5c9-26049cf8bcbb"
+          "reference" : "Organization/1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706653909629208000.ee7b830a-8264-4940-a5c9-26049cf8bcbb",
+    "fullUrl" : "Organization/1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653909629208000.ee7b830a-8264-4940-a5c9-26049cf8bcbb",
+      "id" : "1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-handles-multiple-msh18.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-handles-multiple-msh18.fhir
@@ -10,96 +10,127 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UTF-8"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714381046832000.50a1bf8e-d446-4c27-aaf6-2bc2fa1f7221",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714381046832000.50a1bf8e-d446-4c27-aaf6-2bc2fa1f7221",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714381046832000.50a1bf8e-d446-4c27-aaf6-2bc2fa1f7221",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714381046832000.50a1bf8e-d446-4c27-aaf6-2bc2fa1f7221",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714381055263000.20449ff6-ceea-4ff1-8379-e42ba61f89b2",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714381055263000.20449ff6-ceea-4ff1-8379-e42ba61f89b2",
+        "recorded" : "2024-01-31T10:19:41Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714381055263000.20449ff6-ceea-4ff1-8379-e42ba61f89b2",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714381055263000.20449ff6-ceea-4ff1-8379-e42ba61f89b2",
-      "recorded" : "2024-01-31T10:19:41Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714381054786000.a4a449df-cede-4aaa-98c0-13c589545745",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh17-valued-msh4-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh17-valued-msh4-not-valued.fhir
@@ -10,102 +10,134 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714390608609000.20f09daf-e6ca-4ec4-8d52-f3e0fdc51203",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714390608609000.20f09daf-e6ca-4ec4-8d52-f3e0fdc51203",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "sender" : {
+          "reference" : "Organization/1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714390608609000.20f09daf-e6ca-4ec4-8d52-f3e0fdc51203",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714390608609000.20f09daf-e6ca-4ec4-8d52-f3e0fdc51203",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714390617344000.0a402170-5c2b-4f46-9ce1-bda9c3eba168",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714390617344000.0a402170-5c2b-4f46-9ce1-bda9c3eba168",
+        "recorded" : "2024-01-31T10:19:50Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714390617344000.0a402170-5c2b-4f46-9ce1-bda9c3eba168",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714390617344000.0a402170-5c2b-4f46-9ce1-bda9c3eba168",
-      "recorded" : "2024-01-31T10:19:50Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh17-valued-msh4-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh17-valued-msh4-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653918442196000.090056df-e931-43df-b1f6-f2fc7dc51b13",
+  "id" : "1706714390195035000.cd533a82-4f07-43ce-ac4c-37a556d022bc",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:31:58.447-05:00"
+    "lastUpdated" : "2024-01-31T10:19:50.201-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,129 +10,102 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "sender" : {
-          "reference" : "Organization/1706653918510465000.87e77124-bea9-4285-a8cd-0ffc15bc99e8"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "sender" : {
+        "reference" : "Organization/1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653918510465000.87e77124-bea9-4285-a8cd-0ffc15bc99e8",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653918510465000.87e77124-bea9-4285-a8cd-0ffc15bc99e8",
-        "address" : [
-          {
-            "country" : "USA"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653918831964000.d8c393f8-c5d4-4840-9f17-30d665fda769",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653918831964000.d8c393f8-c5d4-4840-9f17-30d665fda769",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653918838384000.c891601d-ec95-4974-a34d-78dc2a6391e6",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653918838384000.c891601d-ec95-4974-a34d-78dc2a6391e6",
-        "recorded" : "2024-01-30T17:31:58Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653918837962000.6b69bd48-913b-458f-9144-c12279aaf75a"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653918837962000.6b69bd48-913b-458f-9144-c12279aaf75a",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653918837962000.6b69bd48-913b-458f-9144-c12279aaf75a",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714390248560000.914e3a0a-d634-4fee-a6e4-5ca16e6e8c06",
+      "address" : [ {
+        "country" : "USA"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714390608609000.20f09daf-e6ca-4ec4-8d52-f3e0fdc51203",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714390608609000.20f09daf-e6ca-4ec4-8d52-f3e0fdc51203",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714390617344000.0a402170-5c2b-4f46-9ce1-bda9c3eba168",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714390617344000.0a402170-5c2b-4f46-9ce1-bda9c3eba168",
+      "recorded" : "2024-01-31T10:19:50Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714390616854000.d4c7741e-b586-4730-99eb-2edf10f93ef9",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh23-msh25-valued-msh5-msh6-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh23-msh25-valued-msh5-msh6-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653927651235000.33496b7a-0857-46da-b358-16b5c5c11a73",
+  "id" : "1706714399379609000.d4b1aadd-e63b-4676-ae95-a21b957cb1ba",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:32:07.658-05:00"
+    "lastUpdated" : "2024-01-31T10:19:59.386-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,195 +10,148 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "2.1.1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-network-address"
-              }
-            ],
-            "name" : "Receiving Network",
-            "endpoint" : "urn:oid:2.1.1",
-            "receiver" : {
-              "reference" : "Organization/1706653927726033000.648957b5-73f2-4a91-8f95-98c5f6914cd3"
-            }
-          }
-        ],
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "2.1.1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-network-address"
+        } ],
+        "name" : "Receiving Network",
+        "endpoint" : "urn:oid:2.1.1",
+        "receiver" : {
+          "reference" : "Organization/1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653927726033000.648957b5-73f2-4a91-8f95-98c5f6914cd3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653927726033000.648957b5-73f2-4a91-8f95-98c5f6914cd3",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          }
-                        ],
-                        "code" : "2.16.840.1.114222.4.1.237821"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "code" : "2.16.840.1.114222.4.1.237821"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-responsible-organization"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "ISO"
-          }
-        ],
-        "name" : "CDC Prime"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653928051990000.9a90271b-0201-46f9-91a9-1f70acbe013c",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653928051990000.9a90271b-0201-46f9-91a9-1f70acbe013c",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+      } ],
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653928059134000.9aa92c32-1017-4d1d-8474-e208c00f8764",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653928059134000.9aa92c32-1017-4d1d-8474-e208c00f8764",
-        "recorded" : "2024-01-30T17:32:08Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653928058752000.7953ef14-7d0c-4758-8ce7-e1d652a671e4"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653928058752000.7953ef14-7d0c-4758-8ce7-e1d652a671e4",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653928058752000.7953ef14-7d0c-4758-8ce7-e1d652a671e4",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                } ],
+                "code" : "2.16.840.1.114222.4.1.237821"
+              } ]
+            }
+          } ],
+          "code" : "2.16.840.1.114222.4.1.237821"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-responsible-organization"
+      } ],
+      "identifier" : [ {
+        "value" : "ISO"
+      } ],
+      "name" : "CDC Prime"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714399762380000.71bcb5e4-5792-4f2e-b21c-e8d7d70b75ef",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714399762380000.71bcb5e4-5792-4f2e-b21c-e8d7d70b75ef",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714399770321000.02045ac7-885b-4278-9fbc-479ca2a461d1",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714399770321000.02045ac7-885b-4278-9fbc-479ca2a461d1",
+      "recorded" : "2024-01-31T10:19:59Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh23-msh25-valued-msh5-msh6-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh23-msh25-valued-msh5-msh6-not-valued.fhir
@@ -10,148 +10,200 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-network-address"
-        } ],
-        "name" : "Receiving Network",
-        "endpoint" : "urn:oid:2.1.1",
-        "receiver" : {
-          "reference" : "Organization/1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995"
-        }
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                } ],
-                "code" : "2.16.840.1.114222.4.1.237821"
-              } ]
-            }
-          } ],
-          "code" : "2.16.840.1.114222.4.1.237821"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-responsible-organization"
-      } ],
-      "identifier" : [ {
-        "value" : "ISO"
-      } ],
-      "name" : "CDC Prime"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714399762380000.71bcb5e4-5792-4f2e-b21c-e8d7d70b75ef",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714399762380000.71bcb5e4-5792-4f2e-b21c-e8d7d70b75ef",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-network-address"
+              }
+            ],
+            "name" : "Receiving Network",
+            "endpoint" : "urn:oid:2.1.1",
+            "receiver" : {
+              "reference" : "Organization/1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995"
+            }
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714399454293000.750cab3b-92c3-448f-befb-34ce25405995",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          }
+                        ],
+                        "code" : "2.16.840.1.114222.4.1.237821"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "code" : "2.16.840.1.114222.4.1.237821"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-responsible-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "ISO"
+          }
+        ],
+        "name" : "CDC Prime"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714399762380000.71bcb5e4-5792-4f2e-b21c-e8d7d70b75ef",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714399762380000.71bcb5e4-5792-4f2e-b21c-e8d7d70b75ef",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714399770321000.02045ac7-885b-4278-9fbc-479ca2a461d1",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714399770321000.02045ac7-885b-4278-9fbc-479ca2a461d1",
+        "recorded" : "2024-01-31T10:19:59Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714399770321000.02045ac7-885b-4278-9fbc-479ca2a461d1",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714399770321000.02045ac7-885b-4278-9fbc-479ca2a461d1",
-      "recorded" : "2024-01-31T10:19:59Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714399769881000.8101f658-afcc-4c32-93b0-556190ba0f91",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh24-valued-msh3-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh24-valued-msh3-not-valued.fhir
@@ -10,110 +10,147 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.24",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Alt Sending App"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "Alt Sending App Universal"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "UUID"
-          } ]
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:oid:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714409754670000.93fe452d-c0d7-4656-8d40-f21b6e4e3f92",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714409754670000.93fe452d-c0d7-4656-8d40-f21b6e4e3f92",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.24",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Alt Sending App"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "Alt Sending App Universal"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueString" : "UUID"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:oid:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714409754670000.93fe452d-c0d7-4656-8d40-f21b6e4e3f92",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714409754670000.93fe452d-c0d7-4656-8d40-f21b6e4e3f92",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714409762921000.f9bc5b16-41aa-4306-b84f-742294878823",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714409762921000.f9bc5b16-41aa-4306-b84f-742294878823",
+        "recorded" : "2024-01-31T10:20:09Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714409762921000.f9bc5b16-41aa-4306-b84f-742294878823",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714409762921000.f9bc5b16-41aa-4306-b84f-742294878823",
-      "recorded" : "2024-01-31T10:20:09Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh24-valued-msh3-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh24-valued-msh3-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653936824012000.16af7df4-9419-4d45-afaa-49b42f6a0d85",
+  "id" : "1706714409387954000.7b4a25fe-45fa-4e54-b794-3b7d1f6c1164",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:32:16.830-05:00"
+    "lastUpdated" : "2024-01-31T10:20:09.394-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,142 +10,110 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-24-hd-extension",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Alt Sending App"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "Alt Sending App Universal"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "UUID"
-              }
-            ]
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:oid:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653937200415000.43977aca-3c61-49fa-848c-2fcbf60f2c9e",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653937200415000.43977aca-3c61-49fa-848c-2fcbf60f2c9e",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653937212692000.df83dbc3-b496-4480-826a-739b9ea8e472",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653937212692000.df83dbc3-b496-4480-826a-739b9ea8e472",
-        "recorded" : "2024-01-30T17:32:17Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653937212263000.683a35fe-6662-4331-82cd-86baea051552"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653937212263000.683a35fe-6662-4331-82cd-86baea051552",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653937212263000.683a35fe-6662-4331-82cd-86baea051552",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "MSH.24",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Alt Sending App"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "Alt Sending App Universal"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "UUID"
+          } ]
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:oid:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714409754670000.93fe452d-c0d7-4656-8d40-f21b6e4e3f92",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714409754670000.93fe452d-c0d7-4656-8d40-f21b6e4e3f92",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714409762921000.f9bc5b16-41aa-4306-b84f-742294878823",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714409762921000.f9bc5b16-41aa-4306-b84f-742294878823",
+      "recorded" : "2024-01-31T10:20:09Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714409762475000.7c7cbc96-4459-47fb-bd33-76253ab5e3cb",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-different-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-different-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653945835488000.4e8df686-8c72-49d4-ba74-9950c10ef48b",
+  "id" : "1706714418759663000.7a7164af-cade-4b3b-95bc-c0c288933096",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:32:25.841-05:00"
+    "lastUpdated" : "2024-01-31T10:20:18.765-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -19,8 +19,11 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
       } ],
       "eventCoding" : {
         "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -64,10 +67,10 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706653946219853000.b831d1cd-e1ba-4d1c-9ad2-66615b582347",
+    "fullUrl" : "Provenance/1706714419141966000.6bb83ab2-5a95-4fe0-bdbb-0595b9be370d",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653946219853000.b831d1cd-e1ba-4d1c-9ad2-66615b582347",
+      "id" : "1706714419141966000.6bb83ab2-5a95-4fe0-bdbb-0595b9be370d",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -79,11 +82,11 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706653946228121000.c24a65c8-4066-4099-bc7c-a8a38686f141",
+    "fullUrl" : "Provenance/1706714419151069000.1f3895c0-189d-4700-b29d-7a0980a65e20",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653946228121000.c24a65c8-4066-4099-bc7c-a8a38686f141",
-      "recorded" : "2024-01-30T17:32:26Z",
+      "id" : "1706714419151069000.1f3895c0-189d-4700-b29d-7a0980a65e20",
+      "recorded" : "2024-01-31T10:20:19Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -98,15 +101,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706653946227335000.4d022fe3-eea0-48e6-9d4e-65b0f1516c33"
+          "reference" : "Organization/1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706653946227335000.4d022fe3-eea0-48e6-9d4e-65b0f1516c33",
+    "fullUrl" : "Organization/1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653946227335000.4d022fe3-eea0-48e6-9d4e-65b0f1516c33",
+      "id" : "1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-different-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-different-value.fhir
@@ -10,117 +10,157 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "3.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Receiving App",
-        "endpoint" : "urn:oid:3.1"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-network-address"
-        } ],
-        "name" : "Receiving Network",
-        "endpoint" : "urn:oid:2.1.1"
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714419141966000.6bb83ab2-5a95-4fe0-bdbb-0595b9be370d",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714419141966000.6bb83ab2-5a95-4fe0-bdbb-0595b9be370d",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "3.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Receiving App",
+            "endpoint" : "urn:oid:3.1"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-network-address"
+              }
+            ],
+            "name" : "Receiving Network",
+            "endpoint" : "urn:oid:2.1.1"
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714419141966000.6bb83ab2-5a95-4fe0-bdbb-0595b9be370d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714419141966000.6bb83ab2-5a95-4fe0-bdbb-0595b9be370d",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714419151069000.1f3895c0-189d-4700-b29d-7a0980a65e20",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714419151069000.1f3895c0-189d-4700-b29d-7a0980a65e20",
+        "recorded" : "2024-01-31T10:20:19Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714419151069000.1f3895c0-189d-4700-b29d-7a0980a65e20",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714419151069000.1f3895c0-189d-4700-b29d-7a0980a65e20",
-      "recorded" : "2024-01-31T10:20:19Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714419150627000.6d308bc9-3bdf-4745-82b7-e982fd9f5c54",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-same-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-same-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653954844781000.4e55f81f-3b0e-438d-bbe8-c81804aec7f1",
+  "id" : "1706714428246596000.08c831ca-b97e-4e57-aadb-17cfb1469f3f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:32:34.851-05:00"
+    "lastUpdated" : "2024-01-31T10:20:28.252-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -19,19 +19,22 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-25-hd-extension",
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
         "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
         }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
+          "url" : "MSH.25",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Sending App"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "Sending App Universal"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
         } ]
       } ],
       "eventCoding" : {
@@ -63,10 +66,10 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706653955222563000.28b99d34-a1e1-4fef-abe5-fecf7de5da1c",
+    "fullUrl" : "Provenance/1706714428628062000.79eed521-c1f2-49f3-980b-76ff819ea67d",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653955222563000.28b99d34-a1e1-4fef-abe5-fecf7de5da1c",
+      "id" : "1706714428628062000.79eed521-c1f2-49f3-980b-76ff819ea67d",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -78,11 +81,11 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706653955230389000.9571833a-720a-4b9f-8aa0-fbb2baf484ab",
+    "fullUrl" : "Provenance/1706714428637030000.f7db3a4b-849a-4038-8dd1-4038ba203c88",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706653955230389000.9571833a-720a-4b9f-8aa0-fbb2baf484ab",
-      "recorded" : "2024-01-30T17:32:35Z",
+      "id" : "1706714428637030000.f7db3a4b-849a-4038-8dd1-4038ba203c88",
+      "recorded" : "2024-01-31T10:20:28Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -97,15 +100,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706653955229969000.3fab0c45-2da4-49f8-88d8-f64c0a5ee224"
+          "reference" : "Organization/1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706653955229969000.3fab0c45-2da4-49f8-88d8-f64c0a5ee224",
+    "fullUrl" : "Organization/1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706653955229969000.3fab0c45-2da4-49f8-88d8-f64c0a5ee224",
+      "id" : "1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-same-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh5-msh25-same-value.fhir
@@ -10,116 +10,156 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.25",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Sending App"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "Sending App Universal"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App",
-        "endpoint" : "urn:oid:Sending App Universal"
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714428628062000.79eed521-c1f2-49f3-980b-76ff819ea67d",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714428628062000.79eed521-c1f2-49f3-980b-76ff819ea67d",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.25",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Sending App"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "Sending App Universal"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueString" : "ISO"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App",
+            "endpoint" : "urn:oid:Sending App Universal"
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714428628062000.79eed521-c1f2-49f3-980b-76ff819ea67d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714428628062000.79eed521-c1f2-49f3-980b-76ff819ea67d",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714428637030000.f7db3a4b-849a-4038-8dd1-4038ba203c88",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714428637030000.f7db3a4b-849a-4038-8dd1-4038ba203c88",
+        "recorded" : "2024-01-31T10:20:28Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714428637030000.f7db3a4b-849a-4038-8dd1-4038ba203c88",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714428637030000.f7db3a4b-849a-4038-8dd1-4038ba203c88",
-      "recorded" : "2024-01-31T10:20:28Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714428636511000.e582028a-7b8a-46c5-acdd-71468cde34ab",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh23-valued-msh5-msh25-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh23-valued-msh5-msh25-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653963982104000.b4deada2-9279-4bda-ad07-2f9f7542923f",
+  "id" : "1706714437401151000.7f1a331a-f3e8-4b87-bd5a-8d38fecba458",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:32:43.988-05:00"
+    "lastUpdated" : "2024-01-31T10:20:37.408-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,333 +10,250 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "receiver" : {
-              "reference" : "Organization/1706653964051976000.58d26619-6ce5-47b8-98b2-07f11d8b2211"
-            }
-          },
-          {
-            "receiver" : {
-              "reference" : "Organization/1706653964061081000.080ecf97-bde5-4d18-84e1-7b6f5646d462"
-            }
-          }
-        ],
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "receiver" : {
+          "reference" : "Organization/1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653964051976000.58d26619-6ce5-47b8-98b2-07f11d8b2211",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653964051976000.58d26619-6ce5-47b8-98b2-07f11d8b2211",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-facility"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "CDC Prime"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706653964057380000.d1f3127e-288a-47ef-b28a-9b093cc32fc0",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706653964057380000.d1f3127e-288a-47ef-b28a-9b093cc32fc0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+      }, {
+        "receiver" : {
+          "reference" : "Organization/1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653964061081000.080ecf97-bde5-4d18-84e1-7b6f5646d462",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653964061081000.080ecf97-bde5-4d18-84e1-7b6f5646d462",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-responsible-organization"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706653964057380000.d1f3127e-288a-47ef-b28a-9b093cc32fc0"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Org"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653964373740000.5755df3c-4842-4127-90b1-fae37f09b664",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653964373740000.5755df3c-4842-4127-90b1-fae37f09b664",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+      } ],
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653964381166000.e03ef3a7-bd4b-4db2-9693-4ee6c32f4737",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653964381166000.e03ef3a7-bd4b-4db2-9693-4ee6c32f4737",
-        "recorded" : "2024-01-30T17:32:44Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653964380822000.8a242d12-dc39-4683-8263-ff25e7b4b698"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653964380822000.8a242d12-dc39-4683-8263-ff25e7b4b698",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653964380822000.8a242d12-dc39-4683-8263-ff25e7b4b698",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "CDC Prime"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-responsible-organization"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714437778963000.6b6e9a67-59b7-4944-8731-c6528302fb2c",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714437778963000.6b6e9a67-59b7-4944-8731-c6528302fb2c",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714437785637000.0d23903e-aa03-4770-baa5-32a821915439",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714437785637000.0d23903e-aa03-4770-baa5-32a821915439",
+      "recorded" : "2024-01-31T10:20:37Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh23-valued-msh5-msh25-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh23-valued-msh5-msh25-not-valued.fhir
@@ -10,250 +10,338 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "receiver" : {
-          "reference" : "Organization/1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4"
-        }
-      }, {
-        "receiver" : {
-          "reference" : "Organization/1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210"
-        }
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Prime"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+        "destination" : [
+          {
+            "receiver" : {
+              "reference" : "Organization/1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
+          },
+          {
+            "receiver" : {
+              "reference" : "Organization/1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210"
+            }
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-responsible-organization"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714437465277000.14313dcb-cf9e-43e1-9915-9b43612251b4",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Prime"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d",
+        "extension" : [
+          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
             "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d"
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714437472992000.23e36003-4857-4f94-b98c-510ae6751210",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-responsible-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714437470582000.61cb69bd-00b9-424b-9d20-0ac55ff0f62d"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714437778963000.6b6e9a67-59b7-4944-8731-c6528302fb2c",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714437778963000.6b6e9a67-59b7-4944-8731-c6528302fb2c",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714437785637000.0d23903e-aa03-4770-baa5-32a821915439",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714437785637000.0d23903e-aa03-4770-baa5-32a821915439",
+        "recorded" : "2024-01-31T10:20:37Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "value" : "123"
-      } ],
-      "name" : "Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714437778963000.6b6e9a67-59b7-4944-8731-c6528302fb2c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714437778963000.6b6e9a67-59b7-4944-8731-c6528302fb2c",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714437785637000.0d23903e-aa03-4770-baa5-32a821915439",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714437785637000.0d23903e-aa03-4770-baa5-32a821915439",
-      "recorded" : "2024-01-31T10:20:37Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714437785308000.11e131d2-9a19-4476-bdc5-3a6f9fd0662a",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh25-valued-msh5-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh25-valued-msh5-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653973109988000.2905039e-335f-49ca-b2ba-120f32d41a0a",
+  "id" : "1706714446664172000.88fbaa2a-6074-4ab5-8743-9c2df462a637",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:32:53.117-05:00"
+    "lastUpdated" : "2024-01-31T10:20:46.671-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,179 +10,137 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "2.1.1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-network-address"
-              }
-            ],
-            "name" : "Receiving Network",
-            "endpoint" : "urn:oid:2.1.1",
-            "receiver" : {
-              "reference" : "Organization/1706653973178497000.6fa7448f-860c-4f19-9de8-cb617992027e"
-            }
-          }
-        ],
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "2.1.1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-network-address"
+        } ],
+        "name" : "Receiving Network",
+        "endpoint" : "urn:oid:2.1.1",
+        "receiver" : {
+          "reference" : "Organization/1706714446732996000.277da919-d539-4773-a112-b0c33c110008"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653973178497000.6fa7448f-860c-4f19-9de8-cb617992027e",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653973178497000.6fa7448f-860c-4f19-9de8-cb617992027e",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-facility"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "CDC Prime"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653973497329000.bc86ce4a-603f-4101-a8ad-f742e0bb957a",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653973497329000.bc86ce4a-603f-4101-a8ad-f742e0bb957a",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+      } ],
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653973504646000.24ada9b4-7d8d-46f8-9b05-01e80388bbbc",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653973504646000.24ada9b4-7d8d-46f8-9b05-01e80388bbbc",
-        "recorded" : "2024-01-30T17:32:53Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653973504217000.ad0664a1-ad2f-41c7-bc22-65e35aeec0f6"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653973504217000.ad0664a1-ad2f-41c7-bc22-65e35aeec0f6",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653973504217000.ad0664a1-ad2f-41c7-bc22-65e35aeec0f6",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714446732996000.277da919-d539-4773-a112-b0c33c110008",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714446732996000.277da919-d539-4773-a112-b0c33c110008",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "CDC Prime"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714447059903000.78bd1bdd-4a85-4d9a-b79c-6ba50331b888",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714447059903000.78bd1bdd-4a85-4d9a-b79c-6ba50331b888",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714447066945000.5ed68f60-b38c-44aa-ae58-0e947e596b50",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714447066945000.5ed68f60-b38c-44aa-ae58-0e947e596b50",
+      "recorded" : "2024-01-31T10:20:47Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh25-valued-msh5-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-msh6-msh25-valued-msh5-not-valued.fhir
@@ -10,137 +10,184 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.1.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-network-address"
-        } ],
-        "name" : "Receiving Network",
-        "endpoint" : "urn:oid:2.1.1",
-        "receiver" : {
-          "reference" : "Organization/1706714446732996000.277da919-d539-4773-a112-b0c33c110008"
-        }
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714446732996000.277da919-d539-4773-a112-b0c33c110008",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714446732996000.277da919-d539-4773-a112-b0c33c110008",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Prime"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714447059903000.78bd1bdd-4a85-4d9a-b79c-6ba50331b888",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714447059903000.78bd1bdd-4a85-4d9a-b79c-6ba50331b888",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.1.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-network-address"
+              }
+            ],
+            "name" : "Receiving Network",
+            "endpoint" : "urn:oid:2.1.1",
+            "receiver" : {
+              "reference" : "Organization/1706714446732996000.277da919-d539-4773-a112-b0c33c110008"
+            }
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714446732996000.277da919-d539-4773-a112-b0c33c110008",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714446732996000.277da919-d539-4773-a112-b0c33c110008",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Prime"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714447059903000.78bd1bdd-4a85-4d9a-b79c-6ba50331b888",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714447059903000.78bd1bdd-4a85-4d9a-b79c-6ba50331b888",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714447066945000.5ed68f60-b38c-44aa-ae58-0e947e596b50",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714447066945000.5ed68f60-b38c-44aa-ae58-0e947e596b50",
+        "recorded" : "2024-01-31T10:20:47Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714447066945000.5ed68f60-b38c-44aa-ae58-0e947e596b50",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714447066945000.5ed68f60-b38c-44aa-ae58-0e947e596b50",
-      "recorded" : "2024-01-31T10:20:47Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714447066520000.3ee7be27-cd11-4a49-a09e-1b9b12d182d7",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-MSH191.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-MSH191.fhir
@@ -10,108 +10,145 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "language" : "EN",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.19",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "EN"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              } ],
-              "code" : "EN-US"
-            } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "language" : "EN",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.19",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "EN"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        }
+                      ],
+                      "code" : "EN-US"
+                    }
+                  ]
+                }
+              }
+            ]
           }
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714456520139000.c42a1590-e997-483f-868d-7f7c4bab1253",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714456520139000.c42a1590-e997-483f-868d-7f7c4bab1253",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714456520139000.c42a1590-e997-483f-868d-7f7c4bab1253",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714456520139000.c42a1590-e997-483f-868d-7f7c4bab1253",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714456528987000.f101c5b1-f73d-41e6-af49-2ca6b4a2755d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714456528987000.f101c5b1-f73d-41e6-af49-2ca6b4a2755d",
+        "recorded" : "2024-01-31T10:20:56Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714456528987000.f101c5b1-f73d-41e6-af49-2ca6b4a2755d",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714456528987000.f101c5b1-f73d-41e6-af49-2ca6b4a2755d",
-      "recorded" : "2024-01-31T10:20:56Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-MSH191.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-MSH191.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653982135199000.6bc12389-c694-401d-9cd8-dca53851907c",
+  "id" : "1706714456137602000.bcfd1203-7439-4c68-8dfa-f82658ca5bb9",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:33:02.141-05:00"
+    "lastUpdated" : "2024-01-31T10:20:56.144-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,140 +10,108 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "language" : "EN",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "EN"
-                },
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "alt-coding"
-                    }
-                  ],
-                  "code" : "EN-US"
-                }
-              ]
-            }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "language" : "EN",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "MSH.19",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "EN"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              } ],
+              "code" : "EN-US"
+            } ]
           }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653982509582000.c69ac7ca-1610-413d-bffd-322ac2834ab4",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653982509582000.c69ac7ca-1610-413d-bffd-322ac2834ab4",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653982521204000.3db14417-3a02-4dfb-915b-6a9d8e0b9f21",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653982521204000.3db14417-3a02-4dfb-915b-6a9d8e0b9f21",
-        "recorded" : "2024-01-30T17:33:02Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653982520712000.b40fbaf3-8782-4c22-be3c-cb35e74fed06"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653982520712000.b40fbaf3-8782-4c22-be3c-cb35e74fed06",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653982520712000.b40fbaf3-8782-4c22-be3c-cb35e74fed06",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714456520139000.c42a1590-e997-483f-868d-7f7c4bab1253",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714456520139000.c42a1590-e997-483f-868d-7f7c4bab1253",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714456528987000.f101c5b1-f73d-41e6-af49-2ca6b4a2755d",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714456528987000.f101c5b1-f73d-41e6-af49-2ca6b4a2755d",
+      "recorded" : "2024-01-31T10:20:56Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714456528518000.b05250c7-6756-4906-8b50-bf4962db1527",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-msh3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-msh3.fhir
@@ -10,110 +10,147 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.24",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Alt Sending App"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "Alt Sending App Universal"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "UUID"
-          } ]
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:oid:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714465852674000.06d181d9-6734-421e-88cd-afc4a6a0c311",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714465852674000.06d181d9-6734-421e-88cd-afc4a6a0c311",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.24",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Alt Sending App"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "Alt Sending App Universal"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueString" : "UUID"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:oid:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714465852674000.06d181d9-6734-421e-88cd-afc4a6a0c311",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714465852674000.06d181d9-6734-421e-88cd-afc4a6a0c311",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714465861288000.2077450a-175d-4338-bced-bfbb873e1d03",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714465861288000.2077450a-175d-4338-bced-bfbb873e1d03",
+        "recorded" : "2024-01-31T10:21:05Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714465861288000.2077450a-175d-4338-bced-bfbb873e1d03",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714465861288000.2077450a-175d-4338-bced-bfbb873e1d03",
-      "recorded" : "2024-01-31T10:21:05Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-msh3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-prefers-msh3.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706653991081087000.8c4ae9fa-acc6-4449-95c9-7e58e3519fcf",
+  "id" : "1706714465463449000.a885ce8e-7b01-42e0-a7ed-1e16e1cb4222",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:33:11.088-05:00"
+    "lastUpdated" : "2024-01-31T10:21:05.474-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,142 +10,110 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-24-hd-extension",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Alt Sending App"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "Alt Sending App Universal"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "UUID"
-              }
-            ]
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:oid:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653991476443000.66bc2890-02b2-4e41-82ab-9fc7dca751c0",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653991476443000.66bc2890-02b2-4e41-82ab-9fc7dca751c0",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706653991484643000.d13c5199-830c-487f-9938-3900b530ecbf",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706653991484643000.d13c5199-830c-487f-9938-3900b530ecbf",
-        "recorded" : "2024-01-30T17:33:11Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706653991484115000.04ab7fb9-e6d6-4149-a21b-9e7b57bd6fc4"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706653991484115000.04ab7fb9-e6d6-4149-a21b-9e7b57bd6fc4",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706653991484115000.04ab7fb9-e6d6-4149-a21b-9e7b57bd6fc4",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "MSH.24",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Alt Sending App"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "Alt Sending App Universal"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "UUID"
+          } ]
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:oid:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714465852674000.06d181d9-6734-421e-88cd-afc4a6a0c311",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714465852674000.06d181d9-6734-421e-88cd-afc4a6a0c311",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714465861288000.2077450a-175d-4338-bced-bfbb873e1d03",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714465861288000.2077450a-175d-4338-bced-bfbb873e1d03",
+      "recorded" : "2024-01-31T10:21:05Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714465860800000.aa6aca31-fc90-46fb-8d99-398761af5802",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-msh8-msh11-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-msh8-msh11-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654000120368000.0c8eb0ed-d04e-4568-9731-67238d46d3b8",
+  "id" : "1706714474559173000.3e9092a4-8d04-4833-9404-e3207f296e54",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:33:20.127-05:00"
+    "lastUpdated" : "2024-01-31T10:21:14.567-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,121 +10,95 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "meta" : {
-          "security" : [
-            {
-              "code" : "security"
-            }
-          ]
-        },
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "meta" : {
+        "security" : [ {
+          "code" : "security"
+        } ]
+      },
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654000488178000.75d8b8e7-7b87-4f9c-9c2f-05d37808bab7",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654000488178000.75d8b8e7-7b87-4f9c-9c2f-05d37808bab7",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654000495070000.5d8d0492-d068-4e61-97d5-dae0bbc661b5",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654000495070000.5d8d0492-d068-4e61-97d5-dae0bbc661b5",
-        "recorded" : "2024-01-30T17:33:20Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654000494507000.6ad521d5-57c4-404d-aac8-109f14553b52"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654000494507000.6ad521d5-57c4-404d-aac8-109f14553b52",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654000494507000.6ad521d5-57c4-404d-aac8-109f14553b52",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714474936886000.428f42b7-65bf-45d4-ac76-6cca8522bf20",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714474936886000.428f42b7-65bf-45d4-ac76-6cca8522bf20",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714474944894000.3dae9d21-451f-4862-8837-bf38e8d314c4",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714474944894000.3dae9d21-451f-4862-8837-bf38e8d314c4",
+      "recorded" : "2024-01-31T10:21:14Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-msh8-msh11-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-msh8-msh11-not-valued.fhir
@@ -10,95 +10,126 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "meta" : {
-        "security" : [ {
-          "code" : "security"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714474936886000.428f42b7-65bf-45d4-ac76-6cca8522bf20",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714474936886000.428f42b7-65bf-45d4-ac76-6cca8522bf20",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "meta" : {
+          "security" : [
+            {
+              "code" : "security"
+            }
+          ]
+        },
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714474936886000.428f42b7-65bf-45d4-ac76-6cca8522bf20",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714474936886000.428f42b7-65bf-45d4-ac76-6cca8522bf20",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714474944894000.3dae9d21-451f-4862-8837-bf38e8d314c4",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714474944894000.3dae9d21-451f-4862-8837-bf38e8d314c4",
+        "recorded" : "2024-01-31T10:21:14Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714474944894000.3dae9d21-451f-4862-8837-bf38e8d314c4",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714474944894000.3dae9d21-451f-4862-8837-bf38e8d314c4",
-      "recorded" : "2024-01-31T10:21:14Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714474944367000.6da95e3c-7cc4-4c6b-805b-2432a593b100",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-sft-without-msh3-msh24.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-sft-without-msh3-msh24.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654009176421000.2a19fdab-ac66-41bf-81f9-6ac7138e0ae6",
+  "id" : "1706714483727523000.499e01d6-9b8f-4044-ae3a-62179929f387",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:33:29.183-05:00"
+    "lastUpdated" : "2024-01-31T10:21:23.734-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,193 +10,147 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
+          "valueString" : "Binary ID unknown"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
+          "valueString" : "description"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
+          "valueString" : "20220411"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
+          "valueReference" : {
+            "reference" : "Organization/1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f"
           }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
-              "valueString" : "Binary ID unknown"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
-              "valueString" : "description"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
-              "valueString" : "20220411"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
-              "valueReference" : {
-                "reference" : "Organization/1706654009245230000.34ba2e21-aa13-4667-a659-72aafe1dac0c"
-              }
-            }
-          ],
-          "software" : "STARLIMS",
-          "version" : "ELIMS V11",
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+        } ],
+        "software" : "STARLIMS",
+        "version" : "ELIMS V11",
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654009245230000.34ba2e21-aa13-4667-a659-72aafe1dac0c",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654009245230000.34ba2e21-aa13-4667-a659-72aafe1dac0c",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.10",
-                "valueString" : "CDC CLIA"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "CDC"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.16.840.1.114222.4"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "XX"
-                }
-              ]
-            },
-            "value" : "CDC CLIA"
-          }
-        ],
-        "name" : "CDC"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654009552625000.aca79f5d-b21f-4a1b-8148-8c20fc381642",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654009552625000.aca79f5d-b21f-4a1b-8148-8c20fc381642",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654009560426000.154c18da-bf45-4f70-9040-5af21f32108f",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654009560426000.154c18da-bf45-4f70-9040-5af21f32108f",
-        "recorded" : "2024-01-30T17:33:29Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654009560042000.695aec20-0cdd-44eb-bf83-abab0a2aff30"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654009560042000.695aec20-0cdd-44eb-bf83-abab0a2aff30",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654009560042000.695aec20-0cdd-44eb-bf83-abab0a2aff30",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.10",
+          "valueString" : "CDC CLIA"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "CDC"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.16.840.1.114222.4"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "XX"
+          } ]
+        },
+        "value" : "CDC CLIA"
+      } ],
+      "name" : "CDC"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714484120221000.3893fab0-dae7-4bb6-861a-c4cf1da9b514",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714484120221000.3893fab0-dae7-4bb6-861a-c4cf1da9b514",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714484127671000.9d837fc1-c765-401f-bd62-1bb16b65f900",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714484127671000.9d837fc1-c765-401f-bd62-1bb16b65f900",
+      "recorded" : "2024-01-31T10:21:24Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-sft-without-msh3-msh24.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-stores-sft-without-msh3-msh24.fhir
@@ -10,147 +10,198 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
-          "valueString" : "Binary ID unknown"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
-          "valueString" : "description"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
-          "valueString" : "20220411"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
-          "valueReference" : {
-            "reference" : "Organization/1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f"
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
-        } ],
-        "software" : "STARLIMS",
-        "version" : "ELIMS V11",
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.10",
-          "valueString" : "CDC CLIA"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "CDC"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.16.840.1.114222.4"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
-          } ]
-        },
-        "value" : "CDC CLIA"
-      } ],
-      "name" : "CDC"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714484120221000.3893fab0-dae7-4bb6-861a-c4cf1da9b514",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714484120221000.3893fab0-dae7-4bb6-861a-c4cf1da9b514",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
+              "valueString" : "Binary ID unknown"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
+              "valueString" : "description"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
+              "valueString" : "20220411"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
+              "valueReference" : {
+                "reference" : "Organization/1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f"
+              }
+            }
+          ],
+          "software" : "STARLIMS",
+          "version" : "ELIMS V11",
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714483803119000.8a7e2908-5463-469d-a17c-1e419444191f",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.10",
+                "valueString" : "CDC CLIA"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "CDC"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.16.840.1.114222.4"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "XX"
+                }
+              ]
+            },
+            "value" : "CDC CLIA"
+          }
+        ],
+        "name" : "CDC"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714484120221000.3893fab0-dae7-4bb6-861a-c4cf1da9b514",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714484120221000.3893fab0-dae7-4bb6-861a-c4cf1da9b514",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714484127671000.9d837fc1-c765-401f-bd62-1bb16b65f900",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714484127671000.9d837fc1-c765-401f-bd62-1bb16b65f900",
+        "recorded" : "2024-01-31T10:21:24Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714484127671000.9d837fc1-c765-401f-bd62-1bb16b65f900",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714484127671000.9d837fc1-c765-401f-bd62-1bb16b65f900",
-      "recorded" : "2024-01-31T10:21:24Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714484127205000.c64f8e91-3282-4596-a3e2-b9ac9a99e9b6",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-uses-MSH194.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-uses-MSH194.fhir
@@ -10,102 +10,136 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "language" : "EN-US",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "MSH.19",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              } ],
-              "code" : "EN-US"
-            } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "language" : "EN-US",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.19",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        }
+                      ],
+                      "code" : "EN-US"
+                    }
+                  ]
+                }
+              }
+            ]
           }
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714493395886000.a30a74b8-56f8-4c6f-8d45-69e22de392f9",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714493395886000.a30a74b8-56f8-4c6f-8d45-69e22de392f9",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714493395886000.a30a74b8-56f8-4c6f-8d45-69e22de392f9",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714493395886000.a30a74b8-56f8-4c6f-8d45-69e22de392f9",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714493403800000.266170ed-e07c-49cb-b8e3-849303785610",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714493403800000.266170ed-e07c-49cb-b8e3-849303785610",
+        "recorded" : "2024-01-31T10:21:33Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714493403800000.266170ed-e07c-49cb-b8e3-849303785610",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714493403800000.266170ed-e07c-49cb-b8e3-849303785610",
-      "recorded" : "2024-01-31T10:21:33Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-uses-MSH194.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/MSH-to-MessageHeader-uses-MSH194.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654018041653000.fa550e75-d87d-44f6-a579-8250428353a6",
+  "id" : "1706714493011477000.a440fa2a-8f85-4af4-aae9-96f310846b07",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:33:38.048-05:00"
+    "lastUpdated" : "2024-01-31T10:21:33.018-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,131 +10,102 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "language" : "EN-US",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-19-principal-language-of-message",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "alt-coding"
-                    }
-                  ],
-                  "code" : "EN-US"
-                }
-              ]
-            }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "language" : "EN-US",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "MSH.19",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              } ],
+              "code" : "EN-US"
+            } ]
           }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654018407433000.006e6690-3d31-4597-b462-6a9ab65b3d01",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654018407433000.006e6690-3d31-4597-b462-6a9ab65b3d01",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654018415946000.64debf11-69fe-4595-a4ea-7114b63a50f7",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654018415946000.64debf11-69fe-4595-a4ea-7114b63a50f7",
-        "recorded" : "2024-01-30T17:33:38Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654018414812000.abe8be40-969f-4207-aed5-7e0ce7818ad5"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654018414812000.abe8be40-969f-4207-aed5-7e0ce7818ad5",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654018414812000.abe8be40-969f-4207-aed5-7e0ce7818ad5",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714493395886000.a30a74b8-56f8-4c6f-8d45-69e22de392f9",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714493395886000.a30a74b8-56f8-4c6f-8d45-69e22de392f9",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714493403800000.266170ed-e07c-49cb-b8e3-849303785610",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714493403800000.266170ed-e07c-49cb-b8e3-849303785610",
+      "recorded" : "2024-01-31T10:21:33Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714493403303000.deb9194b-9911-4505-952e-172eeafd924c",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-dns.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-dns.fhir
@@ -10,103 +10,138 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "DNS"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App"
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714513468766000.1ad365fc-a10b-4b2c-abd4-1c738993a7d3",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714513468766000.1ad365fc-a10b-4b2c-abd4-1c738993a7d3",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "DNS"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App"
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714513468766000.1ad365fc-a10b-4b2c-abd4-1c738993a7d3",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714513468766000.1ad365fc-a10b-4b2c-abd4-1c738993a7d3",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714513476063000.5293d639-201c-4c09-9426-e1933b7b85a6",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714513476063000.5293d639-201c-4c09-9426-e1933b7b85a6",
+        "recorded" : "2024-01-31T10:21:53Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714513476063000.5293d639-201c-4c09-9426-e1933b7b85a6",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714513476063000.5293d639-201c-4c09-9426-e1933b7b85a6",
-      "recorded" : "2024-01-31T10:21:53Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-dns.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-dns.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654038345533000.be1f87d2-7326-499c-8588-b6539295e68a",
+  "id" : "1706714513058728000.1592333a-4d36-4117-8e38-136a69738aec",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:33:58.352-05:00"
+    "lastUpdated" : "2024-01-31T10:21:53.066-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,133 +10,103 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "Sending App Universal"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "DNS"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-application"
-              }
-            ],
-            "name" : "Sending App"
-          }
-        ],
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "DNS"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-application"
+        } ],
+        "name" : "Sending App"
+      } ],
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654038710871000.c7f0c6c8-c7c8-4788-92a2-e9e84f7f88e4",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654038710871000.c7f0c6c8-c7c8-4788-92a2-e9e84f7f88e4",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654038718052000.d26d0fa2-058e-4f11-82d6-91ab2078efac",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654038718052000.d26d0fa2-058e-4f11-82d6-91ab2078efac",
-        "recorded" : "2024-01-30T17:33:58Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654038717542000.96689ea3-95de-48cf-bd72-604ff6944e4f"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654038717542000.96689ea3-95de-48cf-bd72-604ff6944e4f",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654038717542000.96689ea3-95de-48cf-bd72-604ff6944e4f",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714513468766000.1ad365fc-a10b-4b2c-abd4-1c738993a7d3",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714513468766000.1ad365fc-a10b-4b2c-abd4-1c738993a7d3",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714513476063000.5293d639-201c-4c09-9426-e1933b7b85a6",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714513476063000.5293d639-201c-4c09-9426-e1933b7b85a6",
+      "recorded" : "2024-01-31T10:21:53Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714513475586000.6b791a90-1a44-4db5-965b-201c4c579754",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-iso.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654047344449000.13a631c7-a052-4337-9679-f92945aa11cf",
+  "id" : "1706714522930437000.7789063b-237e-4a5e-a0b5-1016e3bd7498",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:34:07.350-05:00"
+    "lastUpdated" : "2024-01-31T10:22:02.937-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -19,8 +19,11 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
       } ],
       "eventCoding" : {
         "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -51,10 +54,10 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706654047717974000.271cd3a4-e7f3-45ab-a6de-2fcb6def07ff",
+    "fullUrl" : "Provenance/1706714523313004000.0f82859f-ef8d-4cf2-87e1-f31b3f4ce354",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706654047717974000.271cd3a4-e7f3-45ab-a6de-2fcb6def07ff",
+      "id" : "1706714523313004000.0f82859f-ef8d-4cf2-87e1-f31b3f4ce354",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -66,11 +69,11 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706654047724461000.58384366-151d-434e-a280-1a9ec5e373a3",
+    "fullUrl" : "Provenance/1706714523321630000.aa82bbb5-adc8-4cde-96b3-ff861a526d73",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706654047724461000.58384366-151d-434e-a280-1a9ec5e373a3",
-      "recorded" : "2024-01-30T17:34:07Z",
+      "id" : "1706714523321630000.aa82bbb5-adc8-4cde-96b3-ff861a526d73",
+      "recorded" : "2024-01-31T10:22:03Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -85,15 +88,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706654047724006000.9c85a23e-bfb4-4731-a415-49f5fa5243e5"
+          "reference" : "Organization/1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706654047724006000.9c85a23e-bfb4-4731-a415-49f5fa5243e5",
+    "fullUrl" : "Organization/1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706654047724006000.9c85a23e-bfb4-4731-a415-49f5fa5243e5",
+      "id" : "1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-iso.fhir
@@ -10,104 +10,139 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App",
-        "endpoint" : "urn:oid:Sending App Universal"
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714523313004000.0f82859f-ef8d-4cf2-87e1-f31b3f4ce354",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714523313004000.0f82859f-ef8d-4cf2-87e1-f31b3f4ce354",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App",
+            "endpoint" : "urn:oid:Sending App Universal"
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714523313004000.0f82859f-ef8d-4cf2-87e1-f31b3f4ce354",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714523313004000.0f82859f-ef8d-4cf2-87e1-f31b3f4ce354",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714523321630000.aa82bbb5-adc8-4cde-96b3-ff861a526d73",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714523321630000.aa82bbb5-adc8-4cde-96b3-ff861a526d73",
+        "recorded" : "2024-01-31T10:22:03Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714523321630000.aa82bbb5-adc8-4cde-96b3-ff861a526d73",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714523321630000.aa82bbb5-adc8-4cde-96b3-ff861a526d73",
-      "recorded" : "2024-01-31T10:22:03Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714523320966000.1dfb5dce-0752-4251-943b-23ce8012909e",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-missing-hd3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-missing-hd3.fhir
@@ -10,106 +10,142 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App",
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714532485549000.db1ac2c6-3917-4b41-8cbc-5d60e5f88741",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714532485549000.db1ac2c6-3917-4b41-8cbc-5d60e5f88741",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App",
+            "_endpoint" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                  "valueCode" : "unknown"
+                }
+              ]
+            }
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714532485549000.db1ac2c6-3917-4b41-8cbc-5d60e5f88741",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714532485549000.db1ac2c6-3917-4b41-8cbc-5d60e5f88741",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714532493475000.539b9ca7-6c0d-4409-a65a-5bcc78a7bdd6",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714532493475000.539b9ca7-6c0d-4409-a65a-5bcc78a7bdd6",
+        "recorded" : "2024-01-31T10:22:12Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714532493475000.539b9ca7-6c0d-4409-a65a-5bcc78a7bdd6",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714532493475000.539b9ca7-6c0d-4409-a65a-5bcc78a7bdd6",
-      "recorded" : "2024-01-31T10:22:12Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-missing-hd3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-missing-hd3.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654056341753000.fcdd3864-485c-44a3-a75e-791ac9f126d2",
+  "id" : "1706714532106780000.6aa1477b-4e61-45d4-9b79-334f8e55044d",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:34:16.349-05:00"
+    "lastUpdated" : "2024-01-31T10:22:12.112-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -19,8 +19,11 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
       } ],
       "eventCoding" : {
         "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -53,10 +56,10 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706654056735528000.606c056e-b951-44a1-bef4-9d1962cc8d2d",
+    "fullUrl" : "Provenance/1706714532485549000.db1ac2c6-3917-4b41-8cbc-5d60e5f88741",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706654056735528000.606c056e-b951-44a1-bef4-9d1962cc8d2d",
+      "id" : "1706714532485549000.db1ac2c6-3917-4b41-8cbc-5d60e5f88741",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -68,11 +71,11 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706654056742906000.7bc16901-cc3e-4de9-a604-de9908ee06ad",
+    "fullUrl" : "Provenance/1706714532493475000.539b9ca7-6c0d-4409-a65a-5bcc78a7bdd6",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706654056742906000.7bc16901-cc3e-4de9-a604-de9908ee06ad",
-      "recorded" : "2024-01-30T17:34:16Z",
+      "id" : "1706714532493475000.539b9ca7-6c0d-4409-a65a-5bcc78a7bdd6",
+      "recorded" : "2024-01-31T10:22:12Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -87,15 +90,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706654056742206000.2319910a-479f-4f4f-8360-1f06a153dbf1"
+          "reference" : "Organization/1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706654056742206000.2319910a-479f-4f4f-8360-1f06a153dbf1",
+    "fullUrl" : "Organization/1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706654056742206000.2319910a-479f-4f4f-8360-1f06a153dbf1",
+      "id" : "1706714532492849000.4948fcef-d4a9-48e3-920e-77d591507292",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-msh6-not-valued-msh23-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-msh6-not-valued-msh23-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654065533630000.d1c6e491-2a67-4af7-82aa-8f063706462c",
+  "id" : "1706714541408440000.2c528e9b-fc35-4262-971b-86e431a62e7c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:34:25.540-05:00"
+    "lastUpdated" : "2024-01-31T10:22:21.415-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -19,8 +19,11 @@
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
         "valueString" : "^~\\&#"
       }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
       } ],
       "eventCoding" : {
         "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -41,7 +44,7 @@
         "name" : "Sending App",
         "endpoint" : "urn:oid:Sending App Universal",
         "receiver" : {
-          "reference" : "Organization/1706654065602370000.6f984ff4-6c1a-437f-9db9-2e719a3edf33"
+          "reference" : "Organization/1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b"
         }
       } ],
       "source" : {
@@ -54,10 +57,10 @@
       }
     }
   }, {
-    "fullUrl" : "Location/1706654065599412000.37fc3346-1078-4b3c-bfb4-e85be8808d8d",
+    "fullUrl" : "Location/1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683",
     "resource" : {
       "resourceType" : "Location",
-      "id" : "1706654065599412000.37fc3346-1078-4b3c-bfb4-e85be8808d8d",
+      "id" : "1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
         "valueCode" : "ISO"
@@ -78,10 +81,10 @@
       }
     }
   }, {
-    "fullUrl" : "Organization/1706654065602370000.6f984ff4-6c1a-437f-9db9-2e719a3edf33",
+    "fullUrl" : "Organization/1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706654065602370000.6f984ff4-6c1a-437f-9db9-2e719a3edf33",
+      "id" : "1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b",
       "extension" : [ {
         "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
         "valueCoding" : {
@@ -157,7 +160,7 @@
         }, {
           "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
           "valueReference" : {
-            "reference" : "Location/1706654065599412000.37fc3346-1078-4b3c-bfb4-e85be8808d8d"
+            "reference" : "Location/1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683"
           }
         } ],
         "type" : {
@@ -175,10 +178,10 @@
       "name" : "Org"
     }
   }, {
-    "fullUrl" : "Provenance/1706654065896968000.75550390-8864-44af-b72f-7cf812c312a7",
+    "fullUrl" : "Provenance/1706714541839348000.3372d1ab-5256-4641-9ba9-ecf91268b36c",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706654065896968000.75550390-8864-44af-b72f-7cf812c312a7",
+      "id" : "1706714541839348000.3372d1ab-5256-4641-9ba9-ecf91268b36c",
       "target" : [ {
         "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
       } ],
@@ -190,11 +193,11 @@
       }
     }
   }, {
-    "fullUrl" : "Provenance/1706654065903416000.88b9085d-8caa-4880-8afc-76d2c9c6c578",
+    "fullUrl" : "Provenance/1706714541848031000.2d4cd73b-b6c9-4f26-b8b9-3e826a12da9e",
     "resource" : {
       "resourceType" : "Provenance",
-      "id" : "1706654065903416000.88b9085d-8caa-4880-8afc-76d2c9c6c578",
-      "recorded" : "2024-01-30T17:34:25Z",
+      "id" : "1706714541848031000.2d4cd73b-b6c9-4f26-b8b9-3e826a12da9e",
+      "recorded" : "2024-01-31T10:22:21Z",
       "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
       "activity" : {
         "coding" : [ {
@@ -209,15 +212,15 @@
           } ]
         },
         "who" : {
-          "reference" : "Organization/1706654065902993000.200afe02-042d-4c88-96c1-fff2fd071aec"
+          "reference" : "Organization/1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad"
         }
       } ]
     }
   }, {
-    "fullUrl" : "Organization/1706654065902993000.200afe02-042d-4c88-96c1-fff2fd071aec",
+    "fullUrl" : "Organization/1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad",
     "resource" : {
       "resourceType" : "Organization",
-      "id" : "1706654065902993000.200afe02-042d-4c88-96c1-fff2fd071aec",
+      "id" : "1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad",
       "identifier" : [ {
         "value" : "CDC PRIME - Atlanta"
       }, {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-msh6-not-valued-msh23-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-msh6-not-valued-msh23-valued.fhir
@@ -10,228 +10,307 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App",
-        "endpoint" : "urn:oid:Sending App Universal",
-        "receiver" : {
-          "reference" : "Organization/1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b"
-        }
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App",
+            "endpoint" : "urn:oid:Sending App Universal",
+            "receiver" : {
+              "reference" : "Organization/1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-responsible-organization"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683",
+        "extension" : [
+          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
             "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683"
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714541484476000.af0ee623-569f-49aa-9009-bf465a52188b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-responsible-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714541481896000.a95d82c0-d96a-416d-b794-9c0467f37683"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714541839348000.3372d1ab-5256-4641-9ba9-ecf91268b36c",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714541839348000.3372d1ab-5256-4641-9ba9-ecf91268b36c",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714541848031000.2d4cd73b-b6c9-4f26-b8b9-3e826a12da9e",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714541848031000.2d4cd73b-b6c9-4f26-b8b9-3e826a12da9e",
+        "recorded" : "2024-01-31T10:22:21Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "value" : "123"
-      } ],
-      "name" : "Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714541839348000.3372d1ab-5256-4641-9ba9-ecf91268b36c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714541839348000.3372d1ab-5256-4641-9ba9-ecf91268b36c",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714541848031000.2d4cd73b-b6c9-4f26-b8b9-3e826a12da9e",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714541848031000.2d4cd73b-b6c9-4f26-b8b9-3e826a12da9e",
-      "recorded" : "2024-01-31T10:22:21Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714541847564000.89a7e51a-5451-49af-8c96-88bfee4c8fad",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-prefers-msh6.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-prefers-msh6.fhir
@@ -10,262 +10,354 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App",
-        "endpoint" : "urn:oid:Sending App Universal",
-        "receiver" : {
-          "reference" : "Organization/1706714550657323000.c0775d60-6398-468f-8745-301551973a85"
-        }
-      }, {
-        "receiver" : {
-          "reference" : "Organization/1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b"
-        }
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714550657323000.c0775d60-6398-468f-8745-301551973a85",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714550657323000.c0775d60-6398-468f-8745-301551973a85",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Prime"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App",
+            "endpoint" : "urn:oid:Sending App Universal",
+            "receiver" : {
+              "reference" : "Organization/1706714550657323000.c0775d60-6398-468f-8745-301551973a85"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
+          },
+          {
+            "receiver" : {
+              "reference" : "Organization/1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b"
+            }
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-responsible-organization"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714550657323000.c0775d60-6398-468f-8745-301551973a85",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714550657323000.c0775d60-6398-468f-8745-301551973a85",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Prime"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7",
+        "extension" : [
+          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
             "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7"
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-responsible-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714550997060000.0b662800-e0bb-4645-98ee-2a5ed42cc755",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714550997060000.0b662800-e0bb-4645-98ee-2a5ed42cc755",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714551003972000.2b722282-f9d1-4403-a8a0-1772fd495649",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714551003972000.2b722282-f9d1-4403-a8a0-1772fd495649",
+        "recorded" : "2024-01-31T10:22:31Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "value" : "123"
-      } ],
-      "name" : "Org"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714550997060000.0b662800-e0bb-4645-98ee-2a5ed42cc755",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714550997060000.0b662800-e0bb-4645-98ee-2a5ed42cc755",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714551003972000.2b722282-f9d1-4403-a8a0-1772fd495649",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714551003972000.2b722282-f9d1-4403-a8a0-1772fd495649",
-      "recorded" : "2024-01-31T10:22:31Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-prefers-msh6.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-prefers-msh6.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654075098908000.15403cbd-e877-4610-ab43-7f05094202b8",
+  "id" : "1706714550586684000.8fe084ce-6184-4e97-8e3c-b9387f4a086c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:34:35.107-05:00"
+    "lastUpdated" : "2024-01-31T10:22:30.594-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,349 +10,262 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "Sending App Universal"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-application"
-              }
-            ],
-            "name" : "Sending App",
-            "endpoint" : "urn:oid:Sending App Universal",
-            "receiver" : {
-              "reference" : "Organization/1706654075193379000.253fd2b4-6166-45ac-8c12-4eb88f0a5206"
-            }
-          },
-          {
-            "receiver" : {
-              "reference" : "Organization/1706654075203060000.43470b53-9f58-4933-8c57-b455535d8c37"
-            }
-          }
-        ],
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-application"
+        } ],
+        "name" : "Sending App",
+        "endpoint" : "urn:oid:Sending App Universal",
+        "receiver" : {
+          "reference" : "Organization/1706714550657323000.c0775d60-6398-468f-8745-301551973a85"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654075193379000.253fd2b4-6166-45ac-8c12-4eb88f0a5206",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654075193379000.253fd2b4-6166-45ac-8c12-4eb88f0a5206",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-facility"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "CDC Prime"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654075198155000.e407a8f6-3116-436a-9931-e5d791074c63",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654075198155000.e407a8f6-3116-436a-9931-e5d791074c63",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+      }, {
+        "receiver" : {
+          "reference" : "Organization/1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b"
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654075203060000.43470b53-9f58-4933-8c57-b455535d8c37",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654075203060000.43470b53-9f58-4933-8c57-b455535d8c37",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "receiving-responsible-organization"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654075198155000.e407a8f6-3116-436a-9931-e5d791074c63"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Org"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654075536643000.98fe79e9-2304-4fba-b09c-937d7a006b3a",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654075536643000.98fe79e9-2304-4fba-b09c-937d7a006b3a",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+      } ],
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654075544310000.50507929-e48b-4934-b874-68f0ea2cdafc",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654075544310000.50507929-e48b-4934-b874-68f0ea2cdafc",
-        "recorded" : "2024-01-30T17:34:35Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654075543852000.8cf3b583-724e-467a-a6a0-ec8ba99a0df0"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654075543852000.8cf3b583-724e-467a-a6a0-ec8ba99a0df0",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654075543852000.8cf3b583-724e-467a-a6a0-ec8ba99a0df0",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714550657323000.c0775d60-6398-468f-8745-301551973a85",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714550657323000.c0775d60-6398-468f-8745-301551973a85",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-facility"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "CDC Prime"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "ISO"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714550665112000.678d5dff-aac8-458d-a894-fdd4df6cf19b",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "receiving-responsible-organization"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714550660820000.65243d30-85b4-483f-a6c3-934b3ab19cc7"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714550997060000.0b662800-e0bb-4645-98ee-2a5ed42cc755",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714550997060000.0b662800-e0bb-4645-98ee-2a5ed42cc755",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714551003972000.2b722282-f9d1-4403-a8a0-1772fd495649",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714551003972000.2b722282-f9d1-4403-a8a0-1772fd495649",
+      "recorded" : "2024-01-31T10:22:31Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714551003610000.436b0eb5-2596-4eb1-b055-7b376fd5d2b7",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-uuid.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654084166072000.3a7a388f-efc0-4575-bd41-66bf7aabc326",
+  "id" : "1706714559852052000.bfb7815e-c599-4fde-85b0-a223e7fc34ea",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:34:44.172-05:00"
+    "lastUpdated" : "2024-01-31T10:22:39.858-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,134 +10,104 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "destination" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "Sending App Universal"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "UUID"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "receiving-application"
-              }
-            ],
-            "name" : "Sending App",
-            "endpoint" : "urn:uuid:Sending App Universal"
-          }
-        ],
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "destination" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "UUID"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "receiving-application"
+        } ],
+        "name" : "Sending App",
+        "endpoint" : "urn:uuid:Sending App Universal"
+      } ],
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654084533868000.5620b625-c9ec-4613-beed-e8b87041db77",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654084533868000.5620b625-c9ec-4613-beed-e8b87041db77",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654084541443000.69fc61e4-a4b4-4352-9a24-1cb8652c2ea6",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654084541443000.69fc61e4-a4b4-4352-9a24-1cb8652c2ea6",
-        "recorded" : "2024-01-30T17:34:44Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654084540979000.c1da516d-2f02-4a8e-ab9e-c109e068a556"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654084540979000.c1da516d-2f02-4a8e-ab9e-c109e068a556",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654084540979000.c1da516d-2f02-4a8e-ab9e-c109e068a556",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714560266466000.787ee3a1-e326-40c2-9be2-911c043baab5",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714560266466000.787ee3a1-e326-40c2-9be2-911c043baab5",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714560275513000.e9da99a5-38df-4e04-988a-417bd4b3b304",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714560275513000.e9da99a5-38df-4e04-988a-417bd4b3b304",
+      "recorded" : "2024-01-31T10:22:40Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Destination-uuid.fhir
@@ -10,104 +10,139 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "UUID"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "Sending App",
-        "endpoint" : "urn:uuid:Sending App Universal"
-      } ],
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714560266466000.787ee3a1-e326-40c2-9be2-911c043baab5",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714560266466000.787ee3a1-e326-40c2-9be2-911c043baab5",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "Sending App Universal"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "UUID"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "Sending App",
+            "endpoint" : "urn:uuid:Sending App Universal"
+          }
+        ],
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714560266466000.787ee3a1-e326-40c2-9be2-911c043baab5",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714560266466000.787ee3a1-e326-40c2-9be2-911c043baab5",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714560275513000.e9da99a5-38df-4e04-988a-417bd4b3b304",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714560275513000.e9da99a5-38df-4e04-988a-417bd4b3b304",
+        "recorded" : "2024-01-31T10:22:40Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714560275513000.e9da99a5-38df-4e04-988a-417bd4b3b304",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714560275513000.e9da99a5-38df-4e04-988a-417bd4b3b304",
-      "recorded" : "2024-01-31T10:22:40Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714560274324000.39371f17-bc09-4f41-bb3e-2b457deb532c",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-clia.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-clia.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654093051155000.fd84c05f-cb52-4f9b-832f-adaedd2fc5de",
+  "id" : "1706714569226396000.f64d1225-748d-417a-94fa-913eedd384b0",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:34:53.057-05:00"
+    "lastUpdated" : "2024-01-31T10:22:49.231-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,133 +10,104 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "CLIA"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "name" : "Sending App-CLIA:Sending App Universal",
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "CLIA"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "name" : "Sending App-CLIA:Sending App Universal",
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654093421780000.8d7158ed-3186-4b8c-aea6-cd23ea9c965d",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654093421780000.8d7158ed-3186-4b8c-aea6-cd23ea9c965d",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654093429137000.66bc5bcb-5bec-469f-8684-b26c9a7ee7f6",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654093429137000.66bc5bcb-5bec-469f-8684-b26c9a7ee7f6",
-        "recorded" : "2024-01-30T17:34:53Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654093428680000.5eed57a2-d40b-4fa3-a2b9-697eaacda5fa"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654093428680000.5eed57a2-d40b-4fa3-a2b9-697eaacda5fa",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654093428680000.5eed57a2-d40b-4fa3-a2b9-697eaacda5fa",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714569632358000.303eaa62-e5ce-48ab-9146-9143fe4d21bc",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714569632358000.303eaa62-e5ce-48ab-9146-9143fe4d21bc",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714569641409000.aaa232b6-cc0f-4d27-98b0-82c2a9ec1540",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714569641409000.aaa232b6-cc0f-4d27-98b0-82c2a9ec1540",
+      "recorded" : "2024-01-31T10:22:49Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-clia.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-clia.fhir
@@ -10,104 +10,138 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "CLIA"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "name" : "Sending App-CLIA:Sending App Universal",
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714569632358000.303eaa62-e5ce-48ab-9146-9143fe4d21bc",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714569632358000.303eaa62-e5ce-48ab-9146-9143fe4d21bc",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "CLIA"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "name" : "Sending App-CLIA:Sending App Universal",
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714569632358000.303eaa62-e5ce-48ab-9146-9143fe4d21bc",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714569632358000.303eaa62-e5ce-48ab-9146-9143fe4d21bc",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714569641409000.aaa232b6-cc0f-4d27-98b0-82c2a9ec1540",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714569641409000.aaa232b6-cc0f-4d27-98b0-82c2a9ec1540",
+        "recorded" : "2024-01-31T10:22:49Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714569641409000.aaa232b6-cc0f-4d27-98b0-82c2a9ec1540",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714569641409000.aaa232b6-cc0f-4d27-98b0-82c2a9ec1540",
-      "recorded" : "2024-01-31T10:22:49Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714569640758000.4c1f391a-4b87-4caa-8760-fc2adff41508",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-dns.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-dns.fhir
@@ -10,98 +10,130 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "DNS"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:dns:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714579185532000.3cc6568a-4a78-4ed3-8437-098273a50794",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714579185532000.3cc6568a-4a78-4ed3-8437-098273a50794",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "DNS"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:dns:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714579185532000.3cc6568a-4a78-4ed3-8437-098273a50794",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714579185532000.3cc6568a-4a78-4ed3-8437-098273a50794",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714579194813000.896bd940-ad45-4956-8805-a7ed87644e45",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714579194813000.896bd940-ad45-4956-8805-a7ed87644e45",
+        "recorded" : "2024-01-31T10:22:59Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714579194813000.896bd940-ad45-4956-8805-a7ed87644e45",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714579194813000.896bd940-ad45-4956-8805-a7ed87644e45",
-      "recorded" : "2024-01-31T10:22:59Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-dns.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-dns.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654101914074000.d9507ecb-9cdc-4352-a0bd-815ac1d922bc",
+  "id" : "1706714578787346000.33b5c793-3a05-4174-8f48-f930c4a35185",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:35:01.920-05:00"
+    "lastUpdated" : "2024-01-31T10:22:58.794-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,125 +10,98 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "DNS"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:dns:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654102309688000.9486a783-5ba1-4b25-99fd-8a1015f5cde8",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654102309688000.9486a783-5ba1-4b25-99fd-8a1015f5cde8",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654102318416000.9b82d346-d39c-4f33-bc27-7005b662de35",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654102318416000.9b82d346-d39c-4f33-bc27-7005b662de35",
-        "recorded" : "2024-01-30T17:35:02Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654102317985000.e22ac9fc-19ab-4265-98f0-7ddcb5ef7d41"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654102317985000.e22ac9fc-19ab-4265-98f0-7ddcb5ef7d41",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654102317985000.e22ac9fc-19ab-4265-98f0-7ddcb5ef7d41",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "DNS"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:dns:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714579185532000.3cc6568a-4a78-4ed3-8437-098273a50794",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714579185532000.3cc6568a-4a78-4ed3-8437-098273a50794",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714579194813000.896bd940-ad45-4956-8805-a7ed87644e45",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714579194813000.896bd940-ad45-4956-8805-a7ed87644e45",
+      "recorded" : "2024-01-31T10:22:59Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714579194197000.1523bad6-20b6-4a0b-9583-a5505382eada",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-iso.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654111694246000.fb229417-36be-4c2d-a210-4c91976a0851",
+  "id" : "1706714588218117000.8762a530-9d6d-4c29-a875-a83d3435b91b",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:35:11.700-05:00"
+    "lastUpdated" : "2024-01-31T10:23:08.225-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,125 +10,98 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:oid:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654112080587000.01c4ed80-9618-4a30-8fc6-c770bc75d14f",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654112080587000.01c4ed80-9618-4a30-8fc6-c770bc75d14f",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654112088627000.e3abdafc-3b70-4d66-9888-39f5cd4765d8",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654112088627000.e3abdafc-3b70-4d66-9888-39f5cd4765d8",
-        "recorded" : "2024-01-30T17:35:12Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654112088134000.fa1c9bdf-829d-4351-9838-902a9fad49b6"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654112088134000.fa1c9bdf-829d-4351-9838-902a9fad49b6",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654112088134000.fa1c9bdf-829d-4351-9838-902a9fad49b6",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:oid:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714588640442000.7b3efb72-2e5d-43a4-b299-ae7343e7e65a",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714588640442000.7b3efb72-2e5d-43a4-b299-ae7343e7e65a",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714588649381000.26998e80-cdd7-4c3a-a17d-50658d3a05ef",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714588649381000.26998e80-cdd7-4c3a-a17d-50658d3a05ef",
+      "recorded" : "2024-01-31T10:23:08Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-iso.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-iso.fhir
@@ -10,98 +10,130 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:oid:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714588640442000.7b3efb72-2e5d-43a4-b299-ae7343e7e65a",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714588640442000.7b3efb72-2e5d-43a4-b299-ae7343e7e65a",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:oid:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714588640442000.7b3efb72-2e5d-43a4-b299-ae7343e7e65a",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714588640442000.7b3efb72-2e5d-43a4-b299-ae7343e7e65a",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714588649381000.26998e80-cdd7-4c3a-a17d-50658d3a05ef",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714588649381000.26998e80-cdd7-4c3a-a17d-50658d3a05ef",
+        "recorded" : "2024-01-31T10:23:08Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714588649381000.26998e80-cdd7-4c3a-a17d-50658d3a05ef",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714588649381000.26998e80-cdd7-4c3a-a17d-50658d3a05ef",
-      "recorded" : "2024-01-31T10:23:08Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714588648896000.e6953bb1-969a-41b2-95c2-d187f1f93fa5",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-missing-hd2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-missing-hd2.fhir
@@ -10,95 +10,126 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "name" : "Sending App"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714597940950000.69c83d9c-cd2e-496f-9579-f7475e11075c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714597940950000.69c83d9c-cd2e-496f-9579-f7475e11075c",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "name" : "Sending App"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714597940950000.69c83d9c-cd2e-496f-9579-f7475e11075c",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714597940950000.69c83d9c-cd2e-496f-9579-f7475e11075c",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714597949629000.0992efc1-2b93-489b-b378-222e9059bd4e",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714597949629000.0992efc1-2b93-489b-b378-222e9059bd4e",
+        "recorded" : "2024-01-31T10:23:17Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714597949629000.0992efc1-2b93-489b-b378-222e9059bd4e",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714597949629000.0992efc1-2b93-489b-b378-222e9059bd4e",
-      "recorded" : "2024-01-31T10:23:17Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-missing-hd2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-missing-hd2.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654120960943000.0a85d6c4-db3b-4119-b4a7-02181dd4bd06",
+  "id" : "1706714597543819000.04134d2d-c8a4-42bf-aeca-2f38b07589a2",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:35:20.968-05:00"
+    "lastUpdated" : "2024-01-31T10:23:17.551-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,121 +10,95 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "name" : "Sending App"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654121365209000.58f61a13-7283-44b7-a4e6-c2a4225df336",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654121365209000.58f61a13-7283-44b7-a4e6-c2a4225df336",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654121373344000.5a57735d-716c-4b1a-9e50-69b4d252fe76",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654121373344000.5a57735d-716c-4b1a-9e50-69b4d252fe76",
-        "recorded" : "2024-01-30T17:35:21Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654121372831000.40e2c2bc-08d7-4ec5-967d-5e864f61ea3d"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654121372831000.40e2c2bc-08d7-4ec5-967d-5e864f61ea3d",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654121372831000.40e2c2bc-08d7-4ec5-967d-5e864f61ea3d",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "name" : "Sending App"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714597940950000.69c83d9c-cd2e-496f-9579-f7475e11075c",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714597940950000.69c83d9c-cd2e-496f-9579-f7475e11075c",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714597949629000.0992efc1-2b93-489b-b378-222e9059bd4e",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714597949629000.0992efc1-2b93-489b-b378-222e9059bd4e",
+      "recorded" : "2024-01-31T10:23:17Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714597949132000.f5c3435c-c036-4a62-a982-d60ee098457b",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uri.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uri.fhir
@@ -10,98 +10,130 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "URI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:uri:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714607375664000.c6b349ff-102f-495f-942b-131b9198fb14",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714607375664000.c6b349ff-102f-495f-942b-131b9198fb14",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "URI"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:uri:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714607375664000.c6b349ff-102f-495f-942b-131b9198fb14",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714607375664000.c6b349ff-102f-495f-942b-131b9198fb14",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714607384136000.ce85e725-503b-416b-9753-cf95c1a9f141",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714607384136000.ce85e725-503b-416b-9753-cf95c1a9f141",
+        "recorded" : "2024-01-31T10:23:27Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714607384136000.ce85e725-503b-416b-9753-cf95c1a9f141",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714607384136000.ce85e725-503b-416b-9753-cf95c1a9f141",
-      "recorded" : "2024-01-31T10:23:27Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uri.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uri.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654130677527000.1c283df0-87db-4bb6-99c5-24fc89311718",
+  "id" : "1706714606974635000.7416ecad-fd94-4996-be8e-984629fed03e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:35:30.684-05:00"
+    "lastUpdated" : "2024-01-31T10:23:26.982-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,125 +10,98 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "URI"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:uri:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654131119479000.25eaacee-18d6-45e0-876d-7cfd138bbc1c",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654131119479000.25eaacee-18d6-45e0-876d-7cfd138bbc1c",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654131128267000.f995e3a0-652d-496e-b809-7a15eddd5cc5",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654131128267000.f995e3a0-652d-496e-b809-7a15eddd5cc5",
-        "recorded" : "2024-01-30T17:35:31Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654131127790000.068702d0-c955-4f40-a2dc-4d78a64e0bd6"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654131127790000.068702d0-c955-4f40-a2dc-4d78a64e0bd6",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654131127790000.068702d0-c955-4f40-a2dc-4d78a64e0bd6",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "URI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:uri:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714607375664000.c6b349ff-102f-495f-942b-131b9198fb14",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714607375664000.c6b349ff-102f-495f-942b-131b9198fb14",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714607384136000.ce85e725-503b-416b-9753-cf95c1a9f141",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714607384136000.ce85e725-503b-416b-9753-cf95c1a9f141",
+      "recorded" : "2024-01-31T10:23:27Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714607383654000.feb1e801-f849-4e9f-bfba-fc31f3d000e3",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uuid.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654140230665000.c307c1b5-5910-4a29-806a-50d746bb7057",
+  "id" : "1706714616309173000.3d4621df-bbcf-4f42-a029-acada320172e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:35:40.237-05:00"
+    "lastUpdated" : "2024-01-31T10:23:36.314-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,125 +10,98 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "UUID"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            }
-          ],
-          "endpoint" : "urn:uuid:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654140626328000.1bdc7357-a15c-44ca-be9d-391814fbe761",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654140626328000.1bdc7357-a15c-44ca-be9d-391814fbe761",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654140633723000.81b4979d-ce64-4ad5-9ffa-48174db5814d",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654140633723000.81b4979d-ce64-4ad5-9ffa-48174db5814d",
-        "recorded" : "2024-01-30T17:35:40Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654140633247000.4e235714-1126-442b-805d-6a3eb089ec9d"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654140633247000.4e235714-1126-442b-805d-6a3eb089ec9d",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654140633247000.4e235714-1126-442b-805d-6a3eb089ec9d",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "UUID"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        } ],
+        "endpoint" : "urn:uuid:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714616687921000.17b19bea-83ed-4889-a875-0c8a85188fc4",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714616687921000.17b19bea-83ed-4889-a875-0c8a85188fc4",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714616696569000.570f949a-1bb2-4026-a242-25df910f8577",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714616696569000.570f949a-1bb2-4026-a242-25df910f8577",
+      "recorded" : "2024-01-31T10:23:36Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uuid.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-uuid.fhir
@@ -10,98 +10,130 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "UUID"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:uuid:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714616687921000.17b19bea-83ed-4889-a875-0c8a85188fc4",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714616687921000.17b19bea-83ed-4889-a875-0c8a85188fc4",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "UUID"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:uuid:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714616687921000.17b19bea-83ed-4889-a875-0c8a85188fc4",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714616687921000.17b19bea-83ed-4889-a875-0c8a85188fc4",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714616696569000.570f949a-1bb2-4026-a242-25df910f8577",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714616696569000.570f949a-1bb2-4026-a242-25df910f8577",
+        "recorded" : "2024-01-31T10:23:36Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714616696569000.570f949a-1bb2-4026-a242-25df910f8577",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714616696569000.570f949a-1bb2-4026-a242-25df910f8577",
-      "recorded" : "2024-01-31T10:23:36Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714616696074000.b85bc991-767f-4f7b-8e3e-d57909d2780a",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-with-SFT.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-with-SFT.fhir
@@ -10,154 +10,207 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Sending App"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "Sending App Universal"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
-          "valueString" : "Binary ID unknown"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
-          "valueString" : "description"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
-          "valueString" : "20220411"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
-          "valueReference" : {
-            "reference" : "Organization/1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509"
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
-        } ],
-        "software" : "STARLIMS",
-        "version" : "ELIMS V11",
-        "endpoint" : "urn:oid:Sending App Universal"
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.10",
-          "valueString" : "CDC CLIA"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "CDC"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.16.840.1.114222.4"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "XX"
-          } ]
-        },
-        "value" : "CDC CLIA"
-      } ],
-      "name" : "CDC"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714625859470000.ef707eb9-4582-4a60-b02e-c9f36b13efbb",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714625859470000.ef707eb9-4582-4a60-b02e-c9f36b13efbb",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "Sending App"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "Sending App Universal"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
+              "valueString" : "Binary ID unknown"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
+              "valueString" : "description"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
+              "valueString" : "20220411"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
+              "valueReference" : {
+                "reference" : "Organization/1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509"
+              }
+            }
+          ],
+          "software" : "STARLIMS",
+          "version" : "ELIMS V11",
+          "endpoint" : "urn:oid:Sending App Universal"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.10",
+                "valueString" : "CDC CLIA"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "CDC"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.16.840.1.114222.4"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "XX"
+                }
+              ]
+            },
+            "value" : "CDC CLIA"
+          }
+        ],
+        "name" : "CDC"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714625859470000.ef707eb9-4582-4a60-b02e-c9f36b13efbb",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714625859470000.ef707eb9-4582-4a60-b02e-c9f36b13efbb",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714625867504000.ca5b1400-be18-4c7e-b335-73726e32a07b",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714625867504000.ca5b1400-be18-4c7e-b335-73726e32a07b",
+        "recorded" : "2024-01-31T10:23:45Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714625867504000.ca5b1400-be18-4c7e-b335-73726e32a07b",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714625867504000.ca5b1400-be18-4c7e-b335-73726e32a07b",
-      "recorded" : "2024-01-31T10:23:45Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-with-SFT.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/msh/hd/HD-to-Source-with-SFT.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654149509162000.b224b277-ec18-44a4-b504-1212e20bd6a2",
+  "id" : "1706714625460035000.3d841082-c1af-40fa-898f-28d389d2392f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:35:49.516-05:00"
+    "lastUpdated" : "2024-01-31T10:23:45.465-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,202 +10,154 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Sending App"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "Sending App Universal"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "sending-application"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
+          "valueString" : "Binary ID unknown"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
+          "valueString" : "description"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
+          "valueString" : "20220411"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
+          "valueReference" : {
+            "reference" : "Organization/1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509"
           }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-              "valueString" : "Sending App"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "Sending App Universal"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "sending-application"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-binary-id",
-              "valueString" : "Binary ID unknown"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-software-description",
-              "valueString" : "description"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-install-date",
-              "valueString" : "20220411"
-            },
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
-              "valueReference" : {
-                "reference" : "Organization/1706654149583534000.e8655be7-c1cc-4470-87f7-01ea41b9217a"
-              }
-            }
-          ],
-          "software" : "STARLIMS",
-          "version" : "ELIMS V11",
-          "endpoint" : "urn:oid:Sending App Universal"
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654149583534000.e8655be7-c1cc-4470-87f7-01ea41b9217a",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654149583534000.e8655be7-c1cc-4470-87f7-01ea41b9217a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.10",
-                "valueString" : "CDC CLIA"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "CDC"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.16.840.1.114222.4"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "XX"
-                }
-              ]
-            },
-            "value" : "CDC CLIA"
-          }
-        ],
-        "name" : "CDC"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654149930606000.3d520c77-3674-4e72-b9a4-bd3a3fda3765",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654149930606000.3d520c77-3674-4e72-b9a4-bd3a3fda3765",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654149938557000.235bb853-7956-48c3-aeab-1ad36d686699",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654149938557000.235bb853-7956-48c3-aeab-1ad36d686699",
-        "recorded" : "2024-01-30T17:35:49Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654149938158000.08987b42-a41e-4606-b01d-df4a1a19aad8"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654149938158000.08987b42-a41e-4606-b01d-df4a1a19aad8",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654149938158000.08987b42-a41e-4606-b01d-df4a1a19aad8",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
+        } ],
+        "software" : "STARLIMS",
+        "version" : "ELIMS V11",
+        "endpoint" : "urn:oid:Sending App Universal"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714625531913000.a14540d4-20d4-43ce-9d00-2d477c176509",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.10",
+          "valueString" : "CDC CLIA"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "CDC"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.16.840.1.114222.4"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "XX"
+          } ]
+        },
+        "value" : "CDC CLIA"
+      } ],
+      "name" : "CDC"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714625859470000.ef707eb9-4582-4a60-b02e-c9f36b13efbb",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714625859470000.ef707eb9-4582-4a60-b02e-c9f36b13efbb",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714625867504000.ca5b1400-be18-4c7e-b335-73726e32a07b",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714625867504000.ca5b1400-be18-4c7e-b335-73726e32a07b",
+      "recorded" : "2024-01-31T10:23:45Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714625867112000.aba5fb8e-620c-4888-9568-67bd12c78f7c",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/ndl/NDL-to-PractitionerRole.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/ndl/NDL-to-PractitionerRole.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654200983672000.8b161fd5-5a82-4e0a-b3a3-fe70e8e57468",
+  "id" : "1706815174417340000.88aa25ae-9e1f-4a8d-bbd3-47b965eaa1ec",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:36:40.991-05:00"
+    "lastUpdated" : "2024-02-01T14:19:34.425-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,381 +10,523 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706654201060432000.006ee962-a901-4e4c-9c46-81cfab6192b9"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706654201060432000.006ee962-a901-4e4c-9c46-81cfab6192b9",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654201060432000.006ee962-a901-4e4c-9c46-81cfab6192b9",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654201387472000.96d57f19-5439-456a-9054-9a51816179c4",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654201387472000.96d57f19-5439-456a-9054-9a51816179c4",
-      "target" : [ {
-        "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
-      }, {
-        "reference" : "DiagnosticReport/1706654201595717000.1554b07c-3b17-45b2-859a-d469a6e2e64f"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654201395800000.24900ff4-0552-43de-b283-25571f7a70f5",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654201395800000.24900ff4-0552-43de-b283-25571f7a70f5",
-      "recorded" : "2024-01-30T17:36:41Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706654201395217000.c6c3b5f2-af92-428b-be54-3940a2941452"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654201395217000.c6c3b5f2-af92-428b-be54-3940a2941452",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654201395217000.c6c3b5f2-af92-428b-be54-3940a2941452",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706654201412453000.41910a02-437d-4cf4-8633-30f9c5125a08",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706654201412453000.41910a02-437d-4cf4-8633-30f9c5125a08",
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706654201595717000.1554b07c-3b17-45b2-859a-d469a6e2e64f",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706654201595717000.1554b07c-3b17-45b2-859a-d469a6e2e64f",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706654201412453000.41910a02-437d-4cf4-8633-30f9c5125a08"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      },
-      "performer" : [ {
-        "reference" : "PractitionerRole/1706654201594086000.0387d1fe-3475-4c50-9d6d-f8b3351b0430"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706654201572561000.11297223-2143-4c59-be90-94c111c75df8",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706654201572561000.11297223-2143-4c59-be90-94c111c75df8",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
-        "extension" : [ {
-          "url" : "CNN.3",
-          "valueString" : "JAMISON"
-        }, {
-          "url" : "CNN.4",
-          "valueString" : "S"
-        }, {
-          "url" : "CNN.5",
-          "valueString" : "ESQ"
-        }, {
-          "url" : "CNN.7",
-          "valueString" : "MD"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        } ],
-        "value" : "123"
-      } ],
-      "name" : [ {
-        "family" : "DOE",
-        "given" : [ "JAMISON", "S" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "ESQ", "MD" ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706654201574001000.7171e94a-0a29-48ee-9c3c-49118cacf26c",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706654201574001000.7171e94a-0a29-48ee-9c3c-49118cacf26c",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital A"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "status" : "active",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1706654201586578000.ae2bceb7-548d-4338-a900-37da89cf2ea7",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706654201586578000.ae2bceb7-548d-4338-a900-37da89cf2ea7",
-      "identifier" : [ {
-        "value" : "Building 123"
-      } ],
-      "status" : "active",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "bu"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1706654201587454000.6ec7ba8c-5ce7-4b98-9c29-bb27b07a6975",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706654201587454000.6ec7ba8c-5ce7-4b98-9c29-bb27b07a6975",
-      "identifier" : [ {
-        "value" : "Point of Care"
-      } ],
-      "status" : "active",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "_code" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/location-physical-type-poc",
-              "valueString" : "poc"
-            } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1706654201588192000.cbc99cca-548a-4eed-bdde-d4f7fbb2af7e",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706654201588192000.cbc99cca-548a-4eed-bdde-d4f7fbb2af7e",
-      "identifier" : [ {
-        "value" : "Floor A"
-      } ],
-      "status" : "active",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "lvl"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1706654201588880000.c839eca6-07db-4e40-8e03-96598b7471ae",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706654201588880000.c839eca6-07db-4e40-8e03-96598b7471ae",
-      "identifier" : [ {
-        "value" : "Room 101"
-      } ],
-      "status" : "active",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "ro"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1706654201589595000.4c730828-179b-4632-a1a7-be8afa04f0c0",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706654201589595000.4c730828-179b-4632-a1a7-be8afa04f0c0",
-      "identifier" : [ {
-        "value" : "Bed A"
-      } ],
-      "status" : "active",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "bd"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "PractitionerRole/1706654201594086000.0387d1fe-3475-4c50-9d6d-f8b3351b0430",
-    "resource" : {
-      "resourceType" : "PractitionerRole",
-      "id" : "1706654201594086000.0387d1fe-3475-4c50-9d6d-f8b3351b0430",
-      "extension" : [ {
-        "url" : "http://hl7.org/fhir/StructureDefinition/event-performerFunction",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "TRANS"
-          } ]
-        }
-      } ],
-      "period" : {
-        "start" : "2023-04-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230401102531-0400"
-          } ]
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
         },
-        "end" : "2023-05-01T10:25:31-04:00",
-        "_end" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230501102531-0400"
-          } ]
+        "sender" : {
+          "reference" : "Organization/1706815174469380000.9e2f3449-0ab6-46a3-beef-3eba30db8c47"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      },
-      "practitioner" : {
-        "reference" : "Practitioner/1706654201572561000.11297223-2143-4c59-be90-94c111c75df8"
-      },
-      "location" : [ {
-        "reference" : "Location/1706654201574001000.7171e94a-0a29-48ee-9c3c-49118cacf26c"
-      }, {
-        "reference" : "Location/1706654201586578000.ae2bceb7-548d-4338-a900-37da89cf2ea7"
-      }, {
-        "reference" : "Location/1706654201587454000.6ec7ba8c-5ce7-4b98-9c29-bb27b07a6975"
-      }, {
-        "reference" : "Location/1706654201588192000.cbc99cca-548a-4eed-bdde-d4f7fbb2af7e"
-      }, {
-        "reference" : "Location/1706654201588880000.c839eca6-07db-4e40-8e03-96598b7471ae"
-      }, {
-        "reference" : "Location/1706654201589595000.4c730828-179b-4632-a1a7-be8afa04f0c0"
-      } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815174469380000.9e2f3449-0ab6-46a3-beef-3eba30db8c47",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815174469380000.9e2f3449-0ab6-46a3-beef-3eba30db8c47",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815174850299000.c08b71ea-eb00-42c4-8e98-4971563eed94",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815174850299000.c08b71ea-eb00-42c4-8e98-4971563eed94",
+        "target" : [
+          {
+            "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815175052619000.61aea956-a21c-4f62-b0b6-677521eee836"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815174858529000.193d2ec0-2541-4c6b-ae4a-7f2db2f21e34",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815174858529000.193d2ec0-2541-4c6b-ae4a-7f2db2f21e34",
+        "recorded" : "2024-02-01T14:19:34Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815174857838000.567f9fd9-6089-42bb-a7b1-55ac05b0159c"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815174857838000.567f9fd9-6089-42bb-a7b1-55ac05b0159c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815174857838000.567f9fd9-6089-42bb-a7b1-55ac05b0159c",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815174874989000.9b84830e-e68d-4d55-954b-69c01780a864",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815174874989000.9b84830e-e68d-4d55-954b-69c01780a864",
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815175052619000.61aea956-a21c-4f62-b0b6-677521eee836",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815175052619000.61aea956-a21c-4f62-b0b6-677521eee836",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815174874989000.9b84830e-e68d-4d55-954b-69c01780a864"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        },
+        "performer" : [
+          {
+            "reference" : "PractitionerRole/1706815175051042000.5f42fb46-b1f3-4935-8377-4b182f2a4857"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706815175037573000.c0035d3c-b440-46d2-b973-7a0d77df2ce3",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706815175037573000.c0035d3c-b440-46d2-b973-7a0d77df2ce3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
+            "extension" : [
+              {
+                "url" : "CNN.3",
+                "valueString" : "JAMISON"
+              },
+              {
+                "url" : "CNN.4",
+                "valueString" : "S"
+              },
+              {
+                "url" : "CNN.5",
+                "valueString" : "ESQ"
+              },
+              {
+                "url" : "CNN.7",
+                "valueString" : "MD"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              }
+            ],
+            "value" : "123"
+          }
+        ],
+        "name" : [
+          {
+            "family" : "DOE",
+            "given" : [
+              "JAMISON",
+              "S"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "ESQ",
+              "MD"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815175038757000.fc6bf218-9e3b-44cf-bc6d-d6dd19bef221",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815175038757000.fc6bf218-9e3b-44cf-bc6d-d6dd19bef221",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital A"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "status" : "active",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815175049121000.b7a85b48-b98e-43b1-8f54-8612d03dcf16",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815175049121000.b7a85b48-b98e-43b1-8f54-8612d03dcf16",
+        "identifier" : [
+          {
+            "value" : "Building 123"
+          }
+        ],
+        "status" : "active",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "bu"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815175049732000.5f9ceb11-47ff-4294-bf88-5764db37b10b",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815175049732000.5f9ceb11-47ff-4294-bf88-5764db37b10b",
+        "identifier" : [
+          {
+            "value" : "Point of Care"
+          }
+        ],
+        "status" : "active",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "_code" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/location-physical-type-poc",
+                    "valueString" : "poc"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815175050146000.80df34e8-454f-4b63-a5fc-8c104d3306d9",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815175050146000.80df34e8-454f-4b63-a5fc-8c104d3306d9",
+        "identifier" : [
+          {
+            "value" : "Floor A"
+          }
+        ],
+        "status" : "active",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "lvl"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815175050530000.3d20e935-7e62-4e16-845d-a741a805d91a",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815175050530000.3d20e935-7e62-4e16-845d-a741a805d91a",
+        "identifier" : [
+          {
+            "value" : "Room 101"
+          }
+        ],
+        "status" : "active",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "ro"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815175050896000.02dd275c-4f55-493c-9ab1-54f8df164944",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815175050896000.02dd275c-4f55-493c-9ab1-54f8df164944",
+        "identifier" : [
+          {
+            "value" : "Bed A"
+          }
+        ],
+        "status" : "active",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "bd"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "PractitionerRole/1706815175051042000.5f42fb46-b1f3-4935-8377-4b182f2a4857",
+      "resource" : {
+        "resourceType" : "PractitionerRole",
+        "id" : "1706815175051042000.5f42fb46-b1f3-4935-8377-4b182f2a4857",
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/event-performerFunction",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code" : "TRANS"
+                }
+              ]
+            }
+          }
+        ],
+        "period" : {
+          "start" : "2023-04-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20230401102531-0400"
+              }
+            ]
+          },
+          "end" : "2023-05-01T10:25:31-04:00",
+          "_end" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        },
+        "practitioner" : {
+          "reference" : "Practitioner/1706815175037573000.c0035d3c-b440-46d2-b973-7a0d77df2ce3"
+        },
+        "location" : [
+          {
+            "reference" : "Location/1706815175038757000.fc6bf218-9e3b-44cf-bc6d-d6dd19bef221"
+          },
+          {
+            "reference" : "Location/1706815175049121000.b7a85b48-b98e-43b1-8f54-8612d03dcf16"
+          },
+          {
+            "reference" : "Location/1706815175049732000.5f9ceb11-47ff-4294-bf88-5764db37b10b"
+          },
+          {
+            "reference" : "Location/1706815175050146000.80df34e8-454f-4b63-a5fc-8c104d3306d9"
+          },
+          {
+            "reference" : "Location/1706815175050530000.3d20e935-7e62-4e16-845d-a741a805d91a"
+          },
+          {
+            "reference" : "Location/1706815175050896000.02dd275c-4f55-493c-9ab1-54f8df164944"
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-mostly-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-mostly-empty.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654254407225000.c13770c2-3821-45fd-b822-e268cd29bb8a",
+  "id" : "1706714027089398000.97816cb4-63e6-4ca6-847f-ab3be214d7fd",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:37:34.414-05:00"
+    "lastUpdated" : "2024-01-31T10:13:47.095-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,212 +10,160 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654254817354000.a41af763-4292-46bf-a9c4-f992e3626252",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654254817354000.a41af763-4292-46bf-a9c4-f992e3626252",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654254829641000.2df09465-c278-4377-a3e0-de78b652f5c4",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654254829641000.2df09465-c278-4377-a3e0-de78b652f5c4",
-        "recorded" : "2024-01-30T17:37:34Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654254828427000.df2457be-0ee7-48ba-824a-ea5b93dda425"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654254828427000.df2457be-0ee7-48ba-824a-ea5b93dda425",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654254828427000.df2457be-0ee7-48ba-824a-ea5b93dda425",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654254849082000.0610f400-691d-4c46-ad7f-6ea71462e2e0",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654254849082000.0610f400-691d-4c46-ad7f-6ea71462e2e0",
-        "contact" : [
-          {
-            "name" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                  "extension" : [
-                    {
-                      "url" : "XPN.2",
-                      "valueString" : "Bee"
-                    },
-                    {
-                      "url" : "XPN.7",
-                      "valueString" : "L"
-                    }
-                  ]
-                }
-              ],
-              "use" : "official",
-              "family" : "Bob",
-              "given" : [
-                "Bee"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654254850303000.f25319eb-4939-4b00-8fca-ccd349bedc88",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654254850303000.f25319eb-4939-4b00-8fca-ccd349bedc88",
-        "target" : [
-          {
-            "reference" : "Patient/1706654254849082000.0610f400-691d-4c46-ad7f-6ea71462e2e0"
-          }
-        ],
-        "recorded" : "2024-01-30T17:37:34Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "RelatedPerson/1706654254852645000.4dd585ce-1346-4e44-bf20-31a27279abd1",
-      "resource" : {
-        "resourceType" : "RelatedPerson",
-        "id" : "1706654254852645000.4dd585ce-1346-4e44-bf20-31a27279abd1",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "NK1"
-          }
-        ],
-        "patient" : {
-          "reference" : "Patient/1706654254849082000.0610f400-691d-4c46-ad7f-6ea71462e2e0"
-        },
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.2",
-                    "valueString" : "Bee"
-                  },
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "Bob",
-            "given" : [
-              "Bee"
-            ]
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714027441708000.ef7f8d0b-f328-422c-b9e0-f48387c6834b",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714027441708000.ef7f8d0b-f328-422c-b9e0-f48387c6834b",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714027448960000.759536c1-2f1a-4989-b184-659cf8835152",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714027448960000.759536c1-2f1a-4989-b184-659cf8835152",
+      "recorded" : "2024-01-31T10:13:47Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a",
+      "contact" : [ {
+        "name" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+            "extension" : [ {
+              "url" : "XPN.2",
+              "valueString" : "Bee"
+            }, {
+              "url" : "XPN.7",
+              "valueString" : "L"
+            } ]
+          } ],
+          "use" : "official",
+          "family" : "Bob",
+          "given" : [ "Bee" ]
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714027467663000.85be0eab-e277-4f61-985e-bf6efe611885",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714027467663000.85be0eab-e277-4f61-985e-bf6efe611885",
+      "target" : [ {
+        "reference" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a"
+      } ],
+      "recorded" : "2024-01-31T10:13:47Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "RelatedPerson/1706714027469512000.3aca05aa-5d6f-4a29-a91f-8c5726cf19b2",
+    "resource" : {
+      "resourceType" : "RelatedPerson",
+      "id" : "1706714027469512000.3aca05aa-5d6f-4a29-a91f-8c5726cf19b2",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "NK1"
+      } ],
+      "patient" : {
+        "reference" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a"
+      },
+      "name" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.2",
+            "valueString" : "Bee"
+          }, {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "Bob",
+        "given" : [ "Bee" ]
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-mostly-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-mostly-empty.fhir
@@ -10,160 +10,217 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714027441708000.ef7f8d0b-f328-422c-b9e0-f48387c6834b",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714027441708000.ef7f8d0b-f328-422c-b9e0-f48387c6834b",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714027441708000.ef7f8d0b-f328-422c-b9e0-f48387c6834b",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714027441708000.ef7f8d0b-f328-422c-b9e0-f48387c6834b",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714027448960000.759536c1-2f1a-4989-b184-659cf8835152",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714027448960000.759536c1-2f1a-4989-b184-659cf8835152",
+        "recorded" : "2024-01-31T10:13:47Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a",
+        "contact" : [
+          {
+            "name" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                  "extension" : [
+                    {
+                      "url" : "XPN.2",
+                      "valueString" : "Bee"
+                    },
+                    {
+                      "url" : "XPN.7",
+                      "valueString" : "L"
+                    }
+                  ]
+                }
+              ],
+              "use" : "official",
+              "family" : "Bob",
+              "given" : [
+                "Bee"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714027467663000.85be0eab-e277-4f61-985e-bf6efe611885",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714027467663000.85be0eab-e277-4f61-985e-bf6efe611885",
+        "target" : [
+          {
+            "reference" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a"
+          }
+        ],
+        "recorded" : "2024-01-31T10:13:47Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706714027469512000.3aca05aa-5d6f-4a29-a91f-8c5726cf19b2",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706714027469512000.3aca05aa-5d6f-4a29-a91f-8c5726cf19b2",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a"
+        },
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "Bee"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Bob",
+            "given" : [
+              "Bee"
+            ]
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706714027448960000.759536c1-2f1a-4989-b184-659cf8835152",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714027448960000.759536c1-2f1a-4989-b184-659cf8835152",
-      "recorded" : "2024-01-31T10:13:47Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714027448435000.3c3e9aee-fff2-461e-b83e-c783cede849d",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a",
-      "contact" : [ {
-        "name" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-            "extension" : [ {
-              "url" : "XPN.2",
-              "valueString" : "Bee"
-            }, {
-              "url" : "XPN.7",
-              "valueString" : "L"
-            } ]
-          } ],
-          "use" : "official",
-          "family" : "Bob",
-          "given" : [ "Bee" ]
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714027467663000.85be0eab-e277-4f61-985e-bf6efe611885",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714027467663000.85be0eab-e277-4f61-985e-bf6efe611885",
-      "target" : [ {
-        "reference" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a"
-      } ],
-      "recorded" : "2024-01-31T10:13:47Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "RelatedPerson/1706714027469512000.3aca05aa-5d6f-4a29-a91f-8c5726cf19b2",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706714027469512000.3aca05aa-5d6f-4a29-a91f-8c5726cf19b2",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706714027466497000.fcb28ca5-ad59-49a4-9992-dffd8d52442a"
-      },
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "Bee"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Bob",
-        "given" : [ "Bee" ]
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-with-repeats.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-with-repeats.fhir
@@ -10,1452 +10,2020 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714037040613000.46a327ec-68c3-47cb-a5c5-97be9fa3213c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714037040613000.46a327ec-68c3-47cb-a5c5-97be9fa3213c",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714037047773000.7e77b8a7-c18f-439a-a084-b84af2c1d0f2",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714037047773000.7e77b8a7-c18f-439a-a084-b84af2c1d0f2",
-      "recorded" : "2024-01-31T10:13:57Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069",
-      "contact" : [ {
-        "extension" : [ {
-          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "HL70063"
-              } ],
-              "code" : "OTH",
-              "display" : "Other"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "L"
-              } ],
-              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-              "code" : "OT",
-              "display" : "OTHER RELATIONSHIP"
-            } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714037040613000.46a327ec-68c3-47cb-a5c5-97be9fa3213c",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714037040613000.46a327ec-68c3-47cb-a5c5-97be9fa3213c",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
           }
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "HL70063"
-              } ],
-              "code" : "OTH",
-              "display" : "Other"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "L"
-              } ],
-              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-              "code" : "OT",
-              "display" : "OTHER RELATIONSHIP"
-            } ]
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714037047773000.7e77b8a7-c18f-439a-a084-b84af2c1d0f2",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714037047773000.7e77b8a7-c18f-439a-a084-b84af2c1d0f2",
+        "recorded" : "2024-01-31T10:13:57Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30"
+            }
           }
-        } ],
-        "relationship" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-              "valueString" : "HL70063"
-            } ],
-            "code" : "ASC",
-            "display" : "Associate"
-          } ]
-        } ],
-        "name" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-            "extension" : [ {
-              "url" : "XPN.2",
-              "valueString" : "GENARO"
-            }, {
-              "url" : "XPN.7",
-              "valueString" : "L"
-            } ]
-          } ],
-          "use" : "official",
-          "family" : "SURYAN",
-          "given" : [ "GENARO" ]
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069",
+        "contact" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "HL70063"
+                        }
+                      ],
+                      "code" : "OTH",
+                      "display" : "Other"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "L"
+                        }
+                      ],
+                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                      "code" : "OT",
+                      "display" : "OTHER RELATIONSHIP"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "HL70063"
+                        }
+                      ],
+                      "code" : "OTH",
+                      "display" : "Other"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "L"
+                        }
+                      ],
+                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                      "code" : "OT",
+                      "display" : "OTHER RELATIONSHIP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "relationship" : [
+              {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      },
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                        "valueString" : "HL70063"
+                      }
+                    ],
+                    "code" : "ASC",
+                    "display" : "Associate"
+                  }
+                ]
+              }
+            ],
+            "name" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                  "extension" : [
+                    {
+                      "url" : "XPN.2",
+                      "valueString" : "GENARO"
+                    },
+                    {
+                      "url" : "XPN.7",
+                      "valueString" : "L"
+                    }
+                  ]
+                }
+              ],
+              "use" : "official",
+              "family" : "SURYAN",
+              "given" : [
+                "GENARO"
+              ]
+            },
+            "telecom" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "PRN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013954"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3954"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3954",
+                "use" : "home"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013999"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "PRN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013999"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3999"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3999",
+                "use" : "home"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "PRN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013954"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3954"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3954",
+                "use" : "home"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "555"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "4672293"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 555 467 2293"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 555 467 2293",
+                "use" : "work"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "555"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "4672222"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "4672222"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 555 467 2222"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 555 467 2222",
+                "use" : "work"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "555"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "4672293"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 555 467 2293"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 555 467 2293",
+                "use" : "work"
+              }
+            ],
+            "address" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                      "extension" : [
+                        {
+                          "url" : "SAD.1",
+                          "valueString" : "4861 20TH AVE"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.7",
+                      "valueCode" : "H"
+                    }
+                  ]
+                }
+              ],
+              "use" : "home",
+              "line" : [
+                "4861 20TH AVE"
+              ],
+              "city" : "THUNDER MOUNTAIN",
+              "state" : "NV",
+              "postalCode" : "99999",
+              "country" : "USA"
+            },
+            "gender" : "male",
+            "organization" : {
+              "reference" : "Organization/1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c"
+            },
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20220501102531-0400"
+                  }
+                ]
+              },
+              "end" : "2023-05-01T10:25:31-04:00",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20230501102531-0400"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          }
+        ],
+        "name" : "Org",
+        "contact" : [
+          {
+            "name" : {},
+            "telecom" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013954"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3954"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3954",
+                "use" : "work"
+              }
+            ],
+            "address" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                      "extension" : [
+                        {
+                          "url" : "SAD.1",
+                          "valueString" : "4861 20TH AVE"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.7",
+                      "valueCode" : "H"
+                    }
+                  ]
+                }
+              ],
+              "use" : "home",
+              "line" : [
+                "4861 20TH AVE"
+              ],
+              "city" : "AURORA",
+              "state" : "IG",
+              "postalCode" : "99999",
+              "country" : "USA"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714037081663000.26c545fd-4506-40fc-97fb-0cc3c1774ff4",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714037081663000.26c545fd-4506-40fc-97fb-0cc3c1774ff4",
+        "target" : [
+          {
+            "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
+          }
+        ],
+        "recorded" : "2024-01-31T10:13:57Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706714037092310000.93e2ef37-eeb6-4a01-93fa-2040af72a3eb",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706714037092310000.93e2ef37-eeb6-4a01-93fa-2040af72a3eb",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+            "extension" : [
+              {
+                "url" : "NK1.16",
+                "valueString" : "20100622"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-employee-number"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              }
+            ],
+            "value" : "IDNumber"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-identifier"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme2"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit2"
+              }
+            ],
+            "value" : "IDNumber2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-identifier"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme3"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit3"
+              }
+            ],
+            "value" : "IDNumber3"
+          },
+          {
+            "system" : "http://hl7.org/fhir/sid/us-ssn",
+            "value" : "111-11-1111"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
         },
-        "telecom" : [ {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013954"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "PRN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013954"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3954"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3954",
-          "use" : "home"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013999"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "PRN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013999"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3999"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3999",
-          "use" : "home"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013954"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "PRN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013954"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3954"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3954",
-          "use" : "home"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "555"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "4672293"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "4672293"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 555 467 2293"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 555 467 2293",
-          "use" : "work"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "555"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "4672222"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "4672222"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 555 467 2222"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 555 467 2222",
-          "use" : "work"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "555"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "4672293"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "4672293"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 555 467 2293"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 555 467 2293",
-          "use" : "work"
-        } ],
-        "address" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-              "extension" : [ {
-                "url" : "SAD.1",
-                "valueString" : "4861 20TH AVE"
-              } ]
-            }, {
-              "url" : "XAD.7",
-              "valueCode" : "H"
-            } ]
-          } ],
-          "use" : "home",
-          "line" : [ "4861 20TH AVE" ],
-          "city" : "THUNDER MOUNTAIN",
-          "state" : "NV",
-          "postalCode" : "99999",
-          "country" : "USA"
-        },
+        "relationship" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "relationship"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "OTH",
+                "display" : "Other"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "alt-coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "L"
+                  }
+                ],
+                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                "code" : "OT",
+                "display" : "OTHER RELATIONSHIP"
+              }
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-role"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "ASC",
+                "display" : "Associate"
+              }
+            ]
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "GENARO"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "SURYAN",
+            "given" : [
+              "GENARO"
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "GENARO"
+                  }
+                ]
+              }
+            ],
+            "family" : "SURY",
+            "given" : [
+              "GENARO"
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Plato"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Bob"
+          }
+        ],
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013999"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013999"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3999"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3999",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "555"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "4672293"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 555 467 2293"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "business-phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 555 467 2293",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "555"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "4672222"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "4672222"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 555 467 2222"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "business-phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 555 467 2222",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telephone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013333"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013333"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3333"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telephone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3333",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "123"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013454"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013454"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 123 301 3454"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "next-of-kin-telecomm-info"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 123 301 3454",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "456"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013454"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013454"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 456 301 3454"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telecomm-info"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 456 301 3454",
+            "use" : "home"
+          }
+        ],
         "gender" : "male",
-        "organization" : {
-          "reference" : "Organization/1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c"
+        "_gender" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      },
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                        "valueString" : "HL70001"
+                      }
+                    ],
+                    "code" : "M",
+                    "display" : "Male"
+                  }
+                ]
+              }
+            }
+          ]
         },
+        "birthDate" : "2010-06-22",
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "state" : "NV",
+            "postalCode" : "99999",
+            "country" : "USA"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "600 5TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "600 5TH AVE"
+            ],
+            "city" : "THUNDER VALLEY",
+            "state" : "NV",
+            "postalCode" : "12345",
+            "country" : "USA"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "AURORA",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4 10TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4 10TH AVE"
+            ],
+            "city" : "RIDGE",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA"
+          }
+        ],
         "period" : {
           "start" : "2022-05-01T10:25:31-04:00",
           "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20220501102531-0400"
-            } ]
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
           },
           "end" : "2023-05-01T10:25:31-04:00",
           "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20230501102531-0400"
-            } ]
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+        },
+        "communication" : [
+          {
+            "language" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "en",
+                  "display" : "English"
+                }
+              ]
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      } ],
-      "name" : "Org",
-      "contact" : [ {
-        "name" : { },
-        "telecom" : [ {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013954"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013954"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3954"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3954",
-          "use" : "work"
-        } ],
-        "address" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-              "extension" : [ {
-                "url" : "SAD.1",
-                "valueString" : "4861 20TH AVE"
-              } ]
-            }, {
-              "url" : "XAD.7",
-              "valueCode" : "H"
-            } ]
-          } ],
-          "use" : "home",
-          "line" : [ "4861 20TH AVE" ],
-          "city" : "AURORA",
-          "state" : "IG",
-          "postalCode" : "99999",
-          "country" : "USA"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714037081663000.26c545fd-4506-40fc-97fb-0cc3c1774ff4",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714037081663000.26c545fd-4506-40fc-97fb-0cc3c1774ff4",
-      "target" : [ {
-        "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
-      } ],
-      "recorded" : "2024-01-31T10:13:57Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+          }
+        ]
       }
-    }
-  }, {
-    "fullUrl" : "RelatedPerson/1706714037092310000.93e2ef37-eeb6-4a01-93fa-2040af72a3eb",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706714037092310000.93e2ef37-eeb6-4a01-93fa-2040af72a3eb",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
-        "extension" : [ {
-          "url" : "NK1.16",
-          "valueString" : "20100622"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-employee-number"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        } ],
-        "value" : "IDNumber"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-identifier"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme2"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit2"
-        } ],
-        "value" : "IDNumber2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-identifier"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme3"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit3"
-        } ],
-        "value" : "IDNumber3"
-      }, {
-        "system" : "http://hl7.org/fhir/sid/us-ssn",
-        "value" : "111-11-1111"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
-      },
-      "relationship" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "relationship"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "OTH",
-          "display" : "Other"
-        }, {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "alt-coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "L"
-          } ],
-          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-          "code" : "OT",
-          "display" : "OTHER RELATIONSHIP"
-        } ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-role"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "ASC",
-          "display" : "Associate"
-        } ]
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "GENARO"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "SURYAN",
-        "given" : [ "GENARO" ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "GENARO"
-          } ]
-        } ],
-        "family" : "SURY",
-        "given" : [ "GENARO" ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Plato"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Bob"
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013999"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013999"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3999"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3999",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "555"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "4672293"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "4672293"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 555 467 2293"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "business-phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 555 467 2293",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "555"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "4672222"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "4672222"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 555 467 2222"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "business-phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 555 467 2222",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telephone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013333"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013333"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3333"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telephone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3333",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "123"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013454"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013454"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 123 301 3454"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "next-of-kin-telecomm-info"
-        } ],
-        "system" : "phone",
-        "value" : "+1 123 301 3454",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "456"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013454"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013454"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 456 301 3454"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telecomm-info"
-        } ],
-        "system" : "phone",
-        "value" : "+1 456 301 3454",
-        "use" : "home"
-      } ],
-      "gender" : "male",
-      "_gender" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "HL70001"
-              } ],
-              "code" : "M",
-              "display" : "Male"
-            } ]
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706714037099155000.c7822891-defc-436a-b809-19f141da670d",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706714037099155000.c7822891-defc-436a-b809-19f141da670d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+            "extension" : [
+              {
+                "url" : "NK1.13",
+                "valueReference" : {
+                  "reference" : "Organization/1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa"
+                }
+              },
+              {
+                "url" : "NK1.13",
+                "valueReference" : {
+                  "reference" : "Organization/1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38"
+                }
+              },
+              {
+                "url" : "NK1.16",
+                "valueString" : "20100622"
+              }
+            ]
           }
-        } ]
-      },
-      "birthDate" : "2010-06-22",
-      "address" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "THUNDER MOUNTAIN",
-        "state" : "NV",
-        "postalCode" : "99999",
-        "country" : "USA"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "600 5TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "600 5TH AVE" ],
-        "city" : "THUNDER VALLEY",
-        "state" : "NV",
-        "postalCode" : "12345",
-        "country" : "USA"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "AURORA",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4 10TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4 10TH AVE" ],
-        "city" : "RIDGE",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA"
-      } ],
-      "period" : {
-        "start" : "2022-05-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20220501102531-0400"
-          } ]
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-employee-number"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              }
+            ],
+            "value" : "IDNumber"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-identifier"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme2"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit2"
+              }
+            ],
+            "value" : "IDNumber2"
+          },
+          {
+            "system" : "http://hl7.org/fhir/sid/us-ssn",
+            "value" : "111-11-1111"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
         },
-        "end" : "2023-05-01T10:25:31-04:00",
-        "_end" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230501102531-0400"
-          } ]
-        }
-      },
-      "communication" : [ {
-        "language" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "en",
-            "display" : "English"
-          } ]
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "RelatedPerson/1706714037099155000.c7822891-defc-436a-b809-19f141da670d",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706714037099155000.c7822891-defc-436a-b809-19f141da670d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
-        "extension" : [ {
-          "url" : "NK1.13",
-          "valueReference" : {
-            "reference" : "Organization/1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa"
+        "relationship" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "relationship"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "OTH",
+                "display" : "Other"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "alt-coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "L"
+                  }
+                ],
+                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                "code" : "OT",
+                "display" : "OTHER RELATIONSHIP"
+              }
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-role"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "ASC",
+                "display" : "Associate"
+              }
+            ]
           }
-        }, {
-          "url" : "NK1.13",
-          "valueReference" : {
-            "reference" : "Organization/1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38"
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Plato"
           }
-        }, {
-          "url" : "NK1.16",
-          "valueString" : "20100622"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-employee-number"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        } ],
-        "value" : "IDNumber"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-identifier"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme2"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit2"
-        } ],
-        "value" : "IDNumber2"
-      }, {
-        "system" : "http://hl7.org/fhir/sid/us-ssn",
-        "value" : "111-11-1111"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
-      },
-      "relationship" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "relationship"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "OTH",
-          "display" : "Other"
-        }, {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "alt-coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "L"
-          } ],
-          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-          "code" : "OT",
-          "display" : "OTHER RELATIONSHIP"
-        } ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-role"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "ASC",
-          "display" : "Associate"
-        } ]
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Plato"
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "555"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "4672293"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "4672293"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 555 467 2293"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "business-phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 555 467 2293",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telephone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "work"
-      } ],
-      "birthDate" : "2010-06-22",
-      "address" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "THUNDER MOUNTAIN",
-        "state" : "NV",
-        "postalCode" : "99999",
-        "country" : "USA"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "AURORA",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA"
-      } ],
-      "period" : {
-        "start" : "2022-05-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20220501102531-0400"
-          } ]
-        },
-        "end" : "2023-05-01T10:25:31-04:00",
-        "_end" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230501102531-0400"
-          } ]
+        ],
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "555"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "4672293"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 555 467 2293"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "business-phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 555 467 2293",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telephone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "work"
+          }
+        ],
+        "birthDate" : "2010-06-22",
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "state" : "NV",
+            "postalCode" : "99999",
+            "country" : "USA"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "AURORA",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA"
+          }
+        ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          "end" : "2023-05-01T10:25:31-04:00",
+          "_end" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
         }
       }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
+    },
+    {
+      "fullUrl" : "Organization/1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      } ],
-      "name" : "Org"
-    }
-  }, {
-    "fullUrl" : "Organization/1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
+          }
+        ],
+        "name" : "Org"
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "6789-0",
-                "display" : "TestText2"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "9876-5",
-                "display" : "TestAltText2"
-              } ],
-              "text" : "OriginalText2"
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "6789-0",
+                        "display" : "TestText2"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "9876-5",
+                        "display" : "TestAltText2"
+                      }
+                    ],
+                    "text" : "OriginalText2"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "6789-0",
+              "display" : "TestText2"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "6789-0",
-          "display" : "TestText2"
-        }
-      } ],
-      "name" : "Org2"
+          }
+        ],
+        "name" : "Org2"
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-with-repeats.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson-with-repeats.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654264167027000.8ce728bd-4538-47d2-a63d-042c518c6140",
+  "id" : "1706714036701162000.09d58d65-3739-4dd7-9106-0d0569e494b1",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:37:44.175-05:00"
+    "lastUpdated" : "2024-01-31T10:13:56.706-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,2005 +10,1452 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654264592881000.0fc0a40a-cf49-4624-acd4-366db64bb01d",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654264592881000.0fc0a40a-cf49-4624-acd4-366db64bb01d",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654264602895000.b99ace6c-4fc8-463c-8230-e856c4cf2d73",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654264602895000.b99ace6c-4fc8-463c-8230-e856c4cf2d73",
-        "recorded" : "2024-01-30T17:37:44Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654264602262000.edd091e2-f73c-456f-9ca6-90dbf216ef05"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654264602262000.edd091e2-f73c-456f-9ca6-90dbf216ef05",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654264602262000.edd091e2-f73c-456f-9ca6-90dbf216ef05",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654264645045000.33603d4d-f66f-4403-970a-5dabdbd9bff8",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654264645045000.33603d4d-f66f-4403-970a-5dabdbd9bff8",
-        "contact" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "HL70063"
-                        }
-                      ],
-                      "code" : "OTH",
-                      "display" : "Other"
-                    },
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "alt-coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "L"
-                        }
-                      ],
-                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                      "code" : "OT",
-                      "display" : "OTHER RELATIONSHIP"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "HL70063"
-                        }
-                      ],
-                      "code" : "OTH",
-                      "display" : "Other"
-                    },
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "alt-coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "L"
-                        }
-                      ],
-                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                      "code" : "OT",
-                      "display" : "OTHER RELATIONSHIP"
-                    }
-                  ]
-                }
-              }
-            ],
-            "relationship" : [
-              {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      },
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                        "valueString" : "HL70063"
-                      }
-                    ],
-                    "code" : "ASC",
-                    "display" : "Associate"
-                  }
-                ]
-              }
-            ],
-            "name" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                  "extension" : [
-                    {
-                      "url" : "XPN.2",
-                      "valueString" : "GENARO"
-                    },
-                    {
-                      "url" : "XPN.7",
-                      "valueString" : "L"
-                    }
-                  ]
-                }
-              ],
-              "use" : "official",
-              "family" : "SURYAN",
-              "given" : [
-                "GENARO"
-              ]
-            },
-            "telecom" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "PRN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013954"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3954"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3954",
-                "use" : "home"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013999"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "PRN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013999"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3999"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3999",
-                "use" : "home"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "PRN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013954"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3954"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3954",
-                "use" : "home"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "555"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "4672293"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 555 467 2293"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 555 467 2293",
-                "use" : "work"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "555"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "4672222"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "4672222"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 555 467 2222"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 555 467 2222",
-                "use" : "work"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "555"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "4672293"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 555 467 2293"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 555 467 2293",
-                "use" : "work"
-              }
-            ],
-            "address" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                      "extension" : [
-                        {
-                          "url" : "SAD.1",
-                          "valueString" : "4861 20TH AVE"
-                        }
-                      ]
-                    },
-                    {
-                      "url" : "XAD.7",
-                      "valueCode" : "H"
-                    }
-                  ]
-                }
-              ],
-              "use" : "home",
-              "line" : [
-                "4861 20TH AVE"
-              ],
-              "city" : "THUNDER MOUNTAIN",
-              "state" : "NV",
-              "postalCode" : "99999",
-              "country" : "USA"
-            },
-            "gender" : "male",
-            "organization" : {
-              "reference" : "Organization/1706654264634377000.8a2d77e3-1449-42af-97a0-510b33ea4a82"
-            },
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20220501102531-0400"
-                  }
-                ]
-              },
-              "end" : "2023-05-01T10:25:31-04:00",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20230501102531-0400"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654264634377000.8a2d77e3-1449-42af-97a0-510b33ea4a82",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654264634377000.8a2d77e3-1449-42af-97a0-510b33ea4a82",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          }
-        ],
-        "name" : "Org",
-        "contact" : [
-          {
-            "name" : {},
-            "telecom" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013954"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3954"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3954",
-                "use" : "work"
-              }
-            ],
-            "address" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                      "extension" : [
-                        {
-                          "url" : "SAD.1",
-                          "valueString" : "4861 20TH AVE"
-                        }
-                      ]
-                    },
-                    {
-                      "url" : "XAD.7",
-                      "valueCode" : "H"
-                    }
-                  ]
-                }
-              ],
-              "use" : "home",
-              "line" : [
-                "4861 20TH AVE"
-              ],
-              "city" : "AURORA",
-              "state" : "IG",
-              "postalCode" : "99999",
-              "country" : "USA"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654264651213000.23af3727-cfd6-4d90-8173-2a722755d007",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654264651213000.23af3727-cfd6-4d90-8173-2a722755d007",
-        "target" : [
-          {
-            "reference" : "Patient/1706654264645045000.33603d4d-f66f-4403-970a-5dabdbd9bff8"
-          }
-        ],
-        "recorded" : "2024-01-30T17:37:44Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "RelatedPerson/1706654264663570000.f54e3fcc-648d-4271-b829-ff187d4544b3",
-      "resource" : {
-        "resourceType" : "RelatedPerson",
-        "id" : "1706654264663570000.f54e3fcc-648d-4271-b829-ff187d4544b3",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "NK1"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-16-birth-date",
-            "valueString" : "20100622"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-employee-number"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              }
-            ],
-            "value" : "IDNumber"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-identifier"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme2"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit2"
-              }
-            ],
-            "value" : "IDNumber2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-identifier"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme3"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit3"
-              }
-            ],
-            "value" : "IDNumber3"
-          },
-          {
-            "system" : "http://hl7.org/fhir/sid/us-ssn",
-            "value" : "111-11-1111"
-          }
-        ],
-        "patient" : {
-          "reference" : "Patient/1706654264645045000.33603d4d-f66f-4403-970a-5dabdbd9bff8"
-        },
-        "relationship" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "relationship"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "OTH",
-                "display" : "Other"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "alt-coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "L"
-                  }
-                ],
-                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                "code" : "OT",
-                "display" : "OTHER RELATIONSHIP"
-              }
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-role"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "ASC",
-                "display" : "Associate"
-              }
-            ]
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.2",
-                    "valueString" : "GENARO"
-                  },
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "SURYAN",
-            "given" : [
-              "GENARO"
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.2",
-                    "valueString" : "GENARO"
-                  }
-                ]
-              }
-            ],
-            "family" : "SURY",
-            "given" : [
-              "GENARO"
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "Plato"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "Bob"
-          }
-        ],
-        "telecom" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013999"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013999"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3999"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3999",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "555"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "4672293"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 555 467 2293"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "business-phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 555 467 2293",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "555"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "4672222"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "4672222"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 555 467 2222"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "business-phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 555 467 2222",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telephone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013333"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013333"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3333"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telephone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3333",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "123"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013454"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013454"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 123 301 3454"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "next-of-kin-telecomm-info"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 123 301 3454",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "456"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013454"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013454"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 456 301 3454"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telecomm-info"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 456 301 3454",
-            "use" : "home"
-          }
-        ],
-        "gender" : "male",
-        "_gender" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      },
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                        "valueString" : "HL70001"
-                      }
-                    ],
-                    "code" : "M",
-                    "display" : "Male"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        "birthDate" : "2010-06-22",
-        "address" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "THUNDER MOUNTAIN",
-            "state" : "NV",
-            "postalCode" : "99999",
-            "country" : "USA"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "600 5TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "600 5TH AVE"
-            ],
-            "city" : "THUNDER VALLEY",
-            "state" : "NV",
-            "postalCode" : "12345",
-            "country" : "USA"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "AURORA",
-            "state" : "IG",
-            "postalCode" : "99999",
-            "country" : "USA"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4 10TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4 10TH AVE"
-            ],
-            "city" : "RIDGE",
-            "state" : "IG",
-            "postalCode" : "99999",
-            "country" : "USA"
-          }
-        ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          "end" : "2023-05-01T10:25:31-04:00",
-          "_end" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20230501102531-0400"
-              }
-            ]
-          }
-        },
-        "communication" : [
-          {
-            "language" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "en",
-                  "display" : "English"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "RelatedPerson/1706654264669883000.e8c4ac6d-6eb5-4e7b-8b63-2bc5f416ad7a",
-      "resource" : {
-        "resourceType" : "RelatedPerson",
-        "id" : "1706654264669883000.e8c4ac6d-6eb5-4e7b-8b63-2bc5f416ad7a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "NK1"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-13-organization-name",
-            "valueReference" : {
-              "reference" : "Organization/1706654264666691000.e352129d-542b-4990-8f6f-5a887d2b6259"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-13-organization-name",
-            "valueReference" : {
-              "reference" : "Organization/1706654264667351000.eafcd2ec-c47a-47d9-bb0e-ecfcfc8beccc"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-16-birth-date",
-            "valueString" : "20100622"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-employee-number"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              }
-            ],
-            "value" : "IDNumber"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-identifier"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme2"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit2"
-              }
-            ],
-            "value" : "IDNumber2"
-          },
-          {
-            "system" : "http://hl7.org/fhir/sid/us-ssn",
-            "value" : "111-11-1111"
-          }
-        ],
-        "patient" : {
-          "reference" : "Patient/1706654264645045000.33603d4d-f66f-4403-970a-5dabdbd9bff8"
-        },
-        "relationship" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "relationship"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "OTH",
-                "display" : "Other"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "alt-coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "L"
-                  }
-                ],
-                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                "code" : "OT",
-                "display" : "OTHER RELATIONSHIP"
-              }
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-role"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "ASC",
-                "display" : "Associate"
-              }
-            ]
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "Plato"
-          }
-        ],
-        "telecom" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "555"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "4672293"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 555 467 2293"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "business-phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 555 467 2293",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telephone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "work"
-          }
-        ],
-        "birthDate" : "2010-06-22",
-        "address" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "THUNDER MOUNTAIN",
-            "state" : "NV",
-            "postalCode" : "99999",
-            "country" : "USA"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "AURORA",
-            "state" : "IG",
-            "postalCode" : "99999",
-            "country" : "USA"
-          }
-        ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          "end" : "2023-05-01T10:25:31-04:00",
-          "_end" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20230501102531-0400"
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654264666691000.e352129d-542b-4990-8f6f-5a887d2b6259",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654264666691000.e352129d-542b-4990-8f6f-5a887d2b6259",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          }
-        ],
-        "name" : "Org"
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654264667351000.eafcd2ec-c47a-47d9-bb0e-ecfcfc8beccc",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654264667351000.eafcd2ec-c47a-47d9-bb0e-ecfcfc8beccc",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "6789-0",
-                        "display" : "TestText2"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "9876-5",
-                        "display" : "TestAltText2"
-                      }
-                    ],
-                    "text" : "OriginalText2"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "6789-0",
-              "display" : "TestText2"
-            }
-          }
-        ],
-        "name" : "Org2"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714037040613000.46a327ec-68c3-47cb-a5c5-97be9fa3213c",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714037040613000.46a327ec-68c3-47cb-a5c5-97be9fa3213c",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714037047773000.7e77b8a7-c18f-439a-a084-b84af2c1d0f2",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714037047773000.7e77b8a7-c18f-439a-a084-b84af2c1d0f2",
+      "recorded" : "2024-01-31T10:13:57Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714037047305000.083a6e5d-91f9-409a-8411-64f388ad7b30",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069",
+      "contact" : [ {
+        "extension" : [ {
+          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "HL70063"
+              } ],
+              "code" : "OTH",
+              "display" : "Other"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "L"
+              } ],
+              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+              "code" : "OT",
+              "display" : "OTHER RELATIONSHIP"
+            } ]
+          }
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "HL70063"
+              } ],
+              "code" : "OTH",
+              "display" : "Other"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "L"
+              } ],
+              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+              "code" : "OT",
+              "display" : "OTHER RELATIONSHIP"
+            } ]
+          }
+        } ],
+        "relationship" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+              "valueString" : "HL70063"
+            } ],
+            "code" : "ASC",
+            "display" : "Associate"
+          } ]
+        } ],
+        "name" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+            "extension" : [ {
+              "url" : "XPN.2",
+              "valueString" : "GENARO"
+            }, {
+              "url" : "XPN.7",
+              "valueString" : "L"
+            } ]
+          } ],
+          "use" : "official",
+          "family" : "SURYAN",
+          "given" : [ "GENARO" ]
+        },
+        "telecom" : [ {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013954"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "PRN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013954"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3954"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3954",
+          "use" : "home"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013999"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "PRN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013999"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3999"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3999",
+          "use" : "home"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013954"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "PRN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013954"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3954"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3954",
+          "use" : "home"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "555"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "4672293"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "4672293"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 555 467 2293"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 555 467 2293",
+          "use" : "work"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "555"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "4672222"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "4672222"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 555 467 2222"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 555 467 2222",
+          "use" : "work"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "555"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "4672293"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "4672293"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 555 467 2293"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 555 467 2293",
+          "use" : "work"
+        } ],
+        "address" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+              "extension" : [ {
+                "url" : "SAD.1",
+                "valueString" : "4861 20TH AVE"
+              } ]
+            }, {
+              "url" : "XAD.7",
+              "valueCode" : "H"
+            } ]
+          } ],
+          "use" : "home",
+          "line" : [ "4861 20TH AVE" ],
+          "city" : "THUNDER MOUNTAIN",
+          "state" : "NV",
+          "postalCode" : "99999",
+          "country" : "USA"
+        },
+        "gender" : "male",
+        "organization" : {
+          "reference" : "Organization/1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c"
+        },
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20220501102531-0400"
+            } ]
+          },
+          "end" : "2023-05-01T10:25:31-04:00",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20230501102531-0400"
+            } ]
+          }
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714037070825000.ad15fff3-1f3c-41a6-9e9c-ac8db128a82c",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      } ],
+      "name" : "Org",
+      "contact" : [ {
+        "name" : { },
+        "telecom" : [ {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013954"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013954"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3954"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3954",
+          "use" : "work"
+        } ],
+        "address" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+              "extension" : [ {
+                "url" : "SAD.1",
+                "valueString" : "4861 20TH AVE"
+              } ]
+            }, {
+              "url" : "XAD.7",
+              "valueCode" : "H"
+            } ]
+          } ],
+          "use" : "home",
+          "line" : [ "4861 20TH AVE" ],
+          "city" : "AURORA",
+          "state" : "IG",
+          "postalCode" : "99999",
+          "country" : "USA"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714037081663000.26c545fd-4506-40fc-97fb-0cc3c1774ff4",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714037081663000.26c545fd-4506-40fc-97fb-0cc3c1774ff4",
+      "target" : [ {
+        "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
+      } ],
+      "recorded" : "2024-01-31T10:13:57Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "RelatedPerson/1706714037092310000.93e2ef37-eeb6-4a01-93fa-2040af72a3eb",
+    "resource" : {
+      "resourceType" : "RelatedPerson",
+      "id" : "1706714037092310000.93e2ef37-eeb6-4a01-93fa-2040af72a3eb",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "NK1"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+        "extension" : [ {
+          "url" : "NK1.16",
+          "valueString" : "20100622"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-employee-number"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        } ],
+        "value" : "IDNumber"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-identifier"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme2"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit2"
+        } ],
+        "value" : "IDNumber2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-identifier"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme3"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit3"
+        } ],
+        "value" : "IDNumber3"
+      }, {
+        "system" : "http://hl7.org/fhir/sid/us-ssn",
+        "value" : "111-11-1111"
+      } ],
+      "patient" : {
+        "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
+      },
+      "relationship" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "relationship"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "OTH",
+          "display" : "Other"
+        }, {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "alt-coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "L"
+          } ],
+          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+          "code" : "OT",
+          "display" : "OTHER RELATIONSHIP"
+        } ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-role"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "ASC",
+          "display" : "Associate"
+        } ]
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.2",
+            "valueString" : "GENARO"
+          }, {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "SURYAN",
+        "given" : [ "GENARO" ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.2",
+            "valueString" : "GENARO"
+          } ]
+        } ],
+        "family" : "SURY",
+        "given" : [ "GENARO" ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "Plato"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "Bob"
+      } ],
+      "telecom" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013999"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013999"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3999"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3999",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "555"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "4672293"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "4672293"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 555 467 2293"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "business-phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 555 467 2293",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "555"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "4672222"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "4672222"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 555 467 2222"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "business-phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 555 467 2222",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telephone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013333"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013333"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3333"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telephone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3333",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "123"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013454"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013454"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 123 301 3454"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "next-of-kin-telecomm-info"
+        } ],
+        "system" : "phone",
+        "value" : "+1 123 301 3454",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "456"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013454"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013454"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 456 301 3454"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telecomm-info"
+        } ],
+        "system" : "phone",
+        "value" : "+1 456 301 3454",
+        "use" : "home"
+      } ],
+      "gender" : "male",
+      "_gender" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "HL70001"
+              } ],
+              "code" : "M",
+              "display" : "Male"
+            } ]
+          }
+        } ]
+      },
+      "birthDate" : "2010-06-22",
+      "address" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "THUNDER MOUNTAIN",
+        "state" : "NV",
+        "postalCode" : "99999",
+        "country" : "USA"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "600 5TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "600 5TH AVE" ],
+        "city" : "THUNDER VALLEY",
+        "state" : "NV",
+        "postalCode" : "12345",
+        "country" : "USA"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "AURORA",
+        "state" : "IG",
+        "postalCode" : "99999",
+        "country" : "USA"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4 10TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4 10TH AVE" ],
+        "city" : "RIDGE",
+        "state" : "IG",
+        "postalCode" : "99999",
+        "country" : "USA"
+      } ],
+      "period" : {
+        "start" : "2022-05-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20220501102531-0400"
+          } ]
+        },
+        "end" : "2023-05-01T10:25:31-04:00",
+        "_end" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230501102531-0400"
+          } ]
+        }
+      },
+      "communication" : [ {
+        "language" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "en",
+            "display" : "English"
+          } ]
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "RelatedPerson/1706714037099155000.c7822891-defc-436a-b809-19f141da670d",
+    "resource" : {
+      "resourceType" : "RelatedPerson",
+      "id" : "1706714037099155000.c7822891-defc-436a-b809-19f141da670d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "NK1"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+        "extension" : [ {
+          "url" : "NK1.13",
+          "valueReference" : {
+            "reference" : "Organization/1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa"
+          }
+        }, {
+          "url" : "NK1.13",
+          "valueReference" : {
+            "reference" : "Organization/1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38"
+          }
+        }, {
+          "url" : "NK1.16",
+          "valueString" : "20100622"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-employee-number"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        } ],
+        "value" : "IDNumber"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-identifier"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme2"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit2"
+        } ],
+        "value" : "IDNumber2"
+      }, {
+        "system" : "http://hl7.org/fhir/sid/us-ssn",
+        "value" : "111-11-1111"
+      } ],
+      "patient" : {
+        "reference" : "Patient/1706714037076712000.46f928fb-00f4-40c3-ba2c-aeb9ba2ce069"
+      },
+      "relationship" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "relationship"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "OTH",
+          "display" : "Other"
+        }, {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "alt-coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "L"
+          } ],
+          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+          "code" : "OT",
+          "display" : "OTHER RELATIONSHIP"
+        } ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-role"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "ASC",
+          "display" : "Associate"
+        } ]
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "Plato"
+      } ],
+      "telecom" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "555"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "4672293"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "4672293"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 555 467 2293"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "business-phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 555 467 2293",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telephone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "work"
+      } ],
+      "birthDate" : "2010-06-22",
+      "address" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "THUNDER MOUNTAIN",
+        "state" : "NV",
+        "postalCode" : "99999",
+        "country" : "USA"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "AURORA",
+        "state" : "IG",
+        "postalCode" : "99999",
+        "country" : "USA"
+      } ],
+      "period" : {
+        "start" : "2022-05-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20220501102531-0400"
+          } ]
+        },
+        "end" : "2023-05-01T10:25:31-04:00",
+        "_end" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230501102531-0400"
+          } ]
+        }
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714037095127000.01307145-4ccf-431f-a022-7367f2d3e7aa",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      } ],
+      "name" : "Org"
+    }
+  }, {
+    "fullUrl" : "Organization/1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714037095789000.178367bc-3e03-441e-8546-be43956f4a38",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "6789-0",
+                "display" : "TestText2"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "9876-5",
+                "display" : "TestAltText2"
+              } ],
+              "text" : "OriginalText2"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "6789-0",
+          "display" : "TestText2"
+        }
+      } ],
+      "name" : "Org2"
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654278686923000.2de937ab-1dea-4a3d-a90a-44739cbdbafa",
+  "id" : "1706714051908518000.551b6fe4-1f06-4238-b97b-8c9467bb6343",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:37:58.693-05:00"
+    "lastUpdated" : "2024-01-31T10:14:11.914-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,1595 +10,1158 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654279093698000.6b526f12-8f81-4177-a1e5-bcf1a2e26e46",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654279093698000.6b526f12-8f81-4177-a1e5-bcf1a2e26e46",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654279102725000.4600e92c-d145-4b8e-b75d-cd259acbeaa2",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654279102725000.4600e92c-d145-4b8e-b75d-cd259acbeaa2",
-        "recorded" : "2024-01-30T17:37:59Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654279102135000.7569b2e2-615d-4408-9215-39fba2ddb760"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654279102135000.7569b2e2-615d-4408-9215-39fba2ddb760",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654279102135000.7569b2e2-615d-4408-9215-39fba2ddb760",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654279131920000.d6dd85ba-ca01-435f-97fb-b46253b87630",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654279131920000.d6dd85ba-ca01-435f-97fb-b46253b87630",
-        "contact" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "HL70063"
-                        }
-                      ],
-                      "code" : "OTH",
-                      "display" : "Other"
-                    },
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "alt-coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "L"
-                        }
-                      ],
-                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                      "code" : "OT",
-                      "display" : "OTHER RELATIONSHIP"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "HL70063"
-                        }
-                      ],
-                      "code" : "OTH",
-                      "display" : "Other"
-                    },
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "alt-coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "L"
-                        }
-                      ],
-                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                      "code" : "OT",
-                      "display" : "OTHER RELATIONSHIP"
-                    }
-                  ]
-                }
-              }
-            ],
-            "relationship" : [
-              {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      },
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                        "valueString" : "HL70063"
-                      }
-                    ],
-                    "code" : "ASC",
-                    "display" : "Associate"
-                  }
-                ]
-              }
-            ],
-            "name" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                  "extension" : [
-                    {
-                      "url" : "XPN.2",
-                      "valueString" : "GENARO"
-                    },
-                    {
-                      "url" : "XPN.7",
-                      "valueString" : "L"
-                    }
-                  ]
-                }
-              ],
-              "use" : "official",
-              "family" : "SURYAN",
-              "given" : [
-                "GENARO"
-              ]
-            },
-            "telecom" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "PRN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013954"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3954"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3954",
-                "use" : "home"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "PRN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013954"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3954"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3954",
-                "use" : "home"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "555"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "4672293"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 555 467 2293"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 555 467 2293",
-                "use" : "work"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "555"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "4672293"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 555 467 2293"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 555 467 2293",
-                "use" : "work"
-              }
-            ],
-            "address" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                      "extension" : [
-                        {
-                          "url" : "SAD.1",
-                          "valueString" : "4861 20TH AVE"
-                        }
-                      ]
-                    },
-                    {
-                      "url" : "XAD.7",
-                      "valueCode" : "H"
-                    }
-                  ]
-                }
-              ],
-              "use" : "home",
-              "line" : [
-                "4861 20TH AVE"
-              ],
-              "city" : "THUNDER MOUNTAIN",
-              "state" : "NV",
-              "postalCode" : "99999",
-              "country" : "USA"
-            },
-            "gender" : "male",
-            "organization" : {
-              "reference" : "Organization/1706654279127896000.f21fea64-7f8c-4a6c-aa41-1019754525f4"
-            },
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20220501102531-0400"
-                  }
-                ]
-              },
-              "end" : "2023-05-01T10:25:31-04:00",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20230501102531-0400"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654279127896000.f21fea64-7f8c-4a6c-aa41-1019754525f4",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654279127896000.f21fea64-7f8c-4a6c-aa41-1019754525f4",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          }
-        ],
-        "name" : "Org2",
-        "contact" : [
-          {
-            "name" : {},
-            "telecom" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                    "valueString" : "1"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                    "valueString" : "720"
-                  },
-                  {
-                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                    "extension" : [
-                      {
-                        "url" : "XTN.2",
-                        "valueString" : "WPN"
-                      },
-                      {
-                        "url" : "XTN.3",
-                        "valueString" : "PH"
-                      },
-                      {
-                        "url" : "XTN.7",
-                        "valueString" : "3013954"
-                      },
-                      {
-                        "url" : "XTN.12",
-                        "valueString" : "+1 720 301 3954"
-                      }
-                    ]
-                  }
-                ],
-                "system" : "phone",
-                "value" : "+1 720 301 3954",
-                "use" : "work"
-              }
-            ],
-            "address" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                      "extension" : [
-                        {
-                          "url" : "SAD.1",
-                          "valueString" : "4861 20TH AVE"
-                        }
-                      ]
-                    },
-                    {
-                      "url" : "XAD.7",
-                      "valueCode" : "H"
-                    }
-                  ]
-                }
-              ],
-              "use" : "home",
-              "line" : [
-                "4861 20TH AVE"
-              ],
-              "city" : "AURORA",
-              "state" : "IG",
-              "postalCode" : "99999",
-              "country" : "USA"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654279136422000.f7c26022-1824-452c-88e0-afcd8d3ad0b5",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654279136422000.f7c26022-1824-452c-88e0-afcd8d3ad0b5",
-        "target" : [
-          {
-            "reference" : "Patient/1706654279131920000.d6dd85ba-ca01-435f-97fb-b46253b87630"
-          }
-        ],
-        "recorded" : "2024-01-30T17:37:59Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "RelatedPerson/1706654279146481000.effcae76-7021-41fc-86b7-00f56818def6",
-      "resource" : {
-        "resourceType" : "RelatedPerson",
-        "id" : "1706654279146481000.effcae76-7021-41fc-86b7-00f56818def6",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "NK1"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-16-birth-date",
-            "valueString" : "20100622"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-employee-number"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              }
-            ],
-            "value" : "IDNumber"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-identifier"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme2"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit2"
-              }
-            ],
-            "value" : "IDNumber2"
-          },
-          {
-            "system" : "http://hl7.org/fhir/sid/us-ssn",
-            "value" : "111-11-1111"
-          }
-        ],
-        "patient" : {
-          "reference" : "Patient/1706654279131920000.d6dd85ba-ca01-435f-97fb-b46253b87630"
-        },
-        "relationship" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "relationship"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "OTH",
-                "display" : "Other"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "alt-coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "L"
-                  }
-                ],
-                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                "code" : "OT",
-                "display" : "OTHER RELATIONSHIP"
-              }
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-role"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "ASC",
-                "display" : "Associate"
-              }
-            ]
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.2",
-                    "valueString" : "GENARO"
-                  },
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "SURYAN",
-            "given" : [
-              "GENARO"
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "Plato"
-          }
-        ],
-        "telecom" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "555"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "4672293"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 555 467 2293"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "business-phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 555 467 2293",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telephone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "123"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013454"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013454"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 123 301 3454"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "next-of-kin-telecomm-info"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 123 301 3454",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "456"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013454"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013454"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 456 301 3454"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telecomm-info"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 456 301 3454",
-            "use" : "home"
-          }
-        ],
-        "gender" : "male",
-        "_gender" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      },
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                        "valueString" : "HL70001"
-                      }
-                    ],
-                    "code" : "M",
-                    "display" : "Male"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        "birthDate" : "2010-06-22",
-        "address" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "THUNDER MOUNTAIN",
-            "state" : "NV",
-            "postalCode" : "99999",
-            "country" : "USA"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "AURORA",
-            "state" : "IG",
-            "postalCode" : "99999",
-            "country" : "USA"
-          }
-        ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          "end" : "2023-05-01T10:25:31-04:00",
-          "_end" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20230501102531-0400"
-              }
-            ]
-          }
-        },
-        "communication" : [
-          {
-            "language" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "en",
-                  "display" : "English"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "RelatedPerson/1706654279151284000.16b4a61c-c7b4-42d6-88bd-aece4f26719a",
-      "resource" : {
-        "resourceType" : "RelatedPerson",
-        "id" : "1706654279151284000.16b4a61c-c7b4-42d6-88bd-aece4f26719a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "NK1"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-13-organization-name",
-            "valueReference" : {
-              "reference" : "Organization/1706654279148898000.6539ab27-0c40-4fb0-87d0-f361011aa290"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-16-birth-date",
-            "valueString" : "20100622"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-employee-number"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              }
-            ],
-            "value" : "IDNumber"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "next-of-kin-identifier"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme2"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit2"
-              }
-            ],
-            "value" : "IDNumber2"
-          },
-          {
-            "system" : "http://hl7.org/fhir/sid/us-ssn",
-            "value" : "111-11-1111"
-          }
-        ],
-        "patient" : {
-          "reference" : "Patient/1706654279131920000.d6dd85ba-ca01-435f-97fb-b46253b87630"
-        },
-        "relationship" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "relationship"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "OTH",
-                "display" : "Other"
-              },
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "alt-coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "L"
-                  }
-                ],
-                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-                "code" : "OT",
-                "display" : "OTHER RELATIONSHIP"
-              }
-            ]
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-role"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "HL70063"
-                  }
-                ],
-                "code" : "ASC",
-                "display" : "Associate"
-              }
-            ]
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-name"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-                "extension" : [
-                  {
-                    "url" : "XPN.7",
-                    "valueString" : "L"
-                  }
-                ]
-              }
-            ],
-            "use" : "official",
-            "family" : "Plato"
-          }
-        ],
-        "telecom" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "PRN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "home"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "555"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "4672293"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "4672293"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 555 467 2293"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "business-phone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 555 467 2293",
-            "use" : "work"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-                "valueString" : "1"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-                "valueString" : "720"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-                "valueString" : "3013954"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-                "extension" : [
-                  {
-                    "url" : "XTN.2",
-                    "valueString" : "WPN"
-                  },
-                  {
-                    "url" : "XTN.3",
-                    "valueString" : "PH"
-                  },
-                  {
-                    "url" : "XTN.7",
-                    "valueString" : "3013954"
-                  },
-                  {
-                    "url" : "XTN.12",
-                    "valueString" : "+1 720 301 3954"
-                  }
-                ]
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-telephone-number"
-              }
-            ],
-            "system" : "phone",
-            "value" : "+1 720 301 3954",
-            "use" : "work"
-          }
-        ],
-        "birthDate" : "2010-06-22",
-        "address" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "THUNDER MOUNTAIN",
-            "state" : "NV",
-            "postalCode" : "99999",
-            "country" : "USA"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "contact-person-address"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-                    "extension" : [
-                      {
-                        "url" : "SAD.1",
-                        "valueString" : "4861 20TH AVE"
-                      }
-                    ]
-                  },
-                  {
-                    "url" : "XAD.7",
-                    "valueCode" : "H"
-                  }
-                ]
-              }
-            ],
-            "use" : "home",
-            "line" : [
-              "4861 20TH AVE"
-            ],
-            "city" : "AURORA",
-            "state" : "IG",
-            "postalCode" : "99999",
-            "country" : "USA"
-          }
-        ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          "end" : "2023-05-01T10:25:31-04:00",
-          "_end" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20230501102531-0400"
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654279148898000.6539ab27-0c40-4fb0-87d0-f361011aa290",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654279148898000.6539ab27-0c40-4fb0-87d0-f361011aa290",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
-            }
-          }
-        ],
-        "name" : "Org2"
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714052283666000.3160820e-41e6-457b-b357-20043019be35",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714052283666000.3160820e-41e6-457b-b357-20043019be35",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714052291179000.a092c19a-e427-477f-8f17-9c9b5a25b14a",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714052291179000.a092c19a-e427-477f-8f17-9c9b5a25b14a",
+      "recorded" : "2024-01-31T10:14:12Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e",
+      "contact" : [ {
+        "extension" : [ {
+          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "HL70063"
+              } ],
+              "code" : "OTH",
+              "display" : "Other"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "L"
+              } ],
+              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+              "code" : "OT",
+              "display" : "OTHER RELATIONSHIP"
+            } ]
+          }
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "HL70063"
+              } ],
+              "code" : "OTH",
+              "display" : "Other"
+            }, {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "alt-coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "L"
+              } ],
+              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+              "code" : "OT",
+              "display" : "OTHER RELATIONSHIP"
+            } ]
+          }
+        } ],
+        "relationship" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+              "valueString" : "HL70063"
+            } ],
+            "code" : "ASC",
+            "display" : "Associate"
+          } ]
+        } ],
+        "name" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+            "extension" : [ {
+              "url" : "XPN.2",
+              "valueString" : "GENARO"
+            }, {
+              "url" : "XPN.7",
+              "valueString" : "L"
+            } ]
+          } ],
+          "use" : "official",
+          "family" : "SURYAN",
+          "given" : [ "GENARO" ]
+        },
+        "telecom" : [ {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013954"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "PRN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013954"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3954"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3954",
+          "use" : "home"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013954"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "PRN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013954"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3954"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3954",
+          "use" : "home"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "555"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "4672293"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "4672293"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 555 467 2293"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 555 467 2293",
+          "use" : "work"
+        }, {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "555"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "4672293"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "4672293"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 555 467 2293"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 555 467 2293",
+          "use" : "work"
+        } ],
+        "address" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+              "extension" : [ {
+                "url" : "SAD.1",
+                "valueString" : "4861 20TH AVE"
+              } ]
+            }, {
+              "url" : "XAD.7",
+              "valueCode" : "H"
+            } ]
+          } ],
+          "use" : "home",
+          "line" : [ "4861 20TH AVE" ],
+          "city" : "THUNDER MOUNTAIN",
+          "state" : "NV",
+          "postalCode" : "99999",
+          "country" : "USA"
+        },
+        "gender" : "male",
+        "organization" : {
+          "reference" : "Organization/1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7"
+        },
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20220501102531-0400"
+            } ]
+          },
+          "end" : "2023-05-01T10:25:31-04:00",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20230501102531-0400"
+            } ]
+          }
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      } ],
+      "name" : "Org2",
+      "contact" : [ {
+        "name" : { },
+        "telecom" : [ {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            "valueString" : "1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            "valueString" : "720"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            "valueString" : "3013954"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+            "extension" : [ {
+              "url" : "XTN.2",
+              "valueString" : "WPN"
+            }, {
+              "url" : "XTN.3",
+              "valueString" : "PH"
+            }, {
+              "url" : "XTN.7",
+              "valueString" : "3013954"
+            }, {
+              "url" : "XTN.12",
+              "valueString" : "+1 720 301 3954"
+            } ]
+          } ],
+          "system" : "phone",
+          "value" : "+1 720 301 3954",
+          "use" : "work"
+        } ],
+        "address" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+              "extension" : [ {
+                "url" : "SAD.1",
+                "valueString" : "4861 20TH AVE"
+              } ]
+            }, {
+              "url" : "XAD.7",
+              "valueCode" : "H"
+            } ]
+          } ],
+          "use" : "home",
+          "line" : [ "4861 20TH AVE" ],
+          "city" : "AURORA",
+          "state" : "IG",
+          "postalCode" : "99999",
+          "country" : "USA"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714052323402000.16701dcb-e279-4593-aad9-5c4346f056fc",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714052323402000.16701dcb-e279-4593-aad9-5c4346f056fc",
+      "target" : [ {
+        "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
+      } ],
+      "recorded" : "2024-01-31T10:14:12Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "RelatedPerson/1706714052330913000.c9826e01-89ae-4315-85f3-c015db8630ef",
+    "resource" : {
+      "resourceType" : "RelatedPerson",
+      "id" : "1706714052330913000.c9826e01-89ae-4315-85f3-c015db8630ef",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "NK1"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+        "extension" : [ {
+          "url" : "NK1.16",
+          "valueString" : "20100622"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-employee-number"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        } ],
+        "value" : "IDNumber"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-identifier"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme2"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit2"
+        } ],
+        "value" : "IDNumber2"
+      }, {
+        "system" : "http://hl7.org/fhir/sid/us-ssn",
+        "value" : "111-11-1111"
+      } ],
+      "patient" : {
+        "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
+      },
+      "relationship" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "relationship"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "OTH",
+          "display" : "Other"
+        }, {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "alt-coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "L"
+          } ],
+          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+          "code" : "OT",
+          "display" : "OTHER RELATIONSHIP"
+        } ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-role"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "ASC",
+          "display" : "Associate"
+        } ]
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.2",
+            "valueString" : "GENARO"
+          }, {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "SURYAN",
+        "given" : [ "GENARO" ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "Plato"
+      } ],
+      "telecom" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "555"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "4672293"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "4672293"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 555 467 2293"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "business-phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 555 467 2293",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telephone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "123"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013454"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013454"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 123 301 3454"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "next-of-kin-telecomm-info"
+        } ],
+        "system" : "phone",
+        "value" : "+1 123 301 3454",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "456"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013454"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013454"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 456 301 3454"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telecomm-info"
+        } ],
+        "system" : "phone",
+        "value" : "+1 456 301 3454",
+        "use" : "home"
+      } ],
+      "gender" : "male",
+      "_gender" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "HL70001"
+              } ],
+              "code" : "M",
+              "display" : "Male"
+            } ]
+          }
+        } ]
+      },
+      "birthDate" : "2010-06-22",
+      "address" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "THUNDER MOUNTAIN",
+        "state" : "NV",
+        "postalCode" : "99999",
+        "country" : "USA"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "AURORA",
+        "state" : "IG",
+        "postalCode" : "99999",
+        "country" : "USA"
+      } ],
+      "period" : {
+        "start" : "2022-05-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20220501102531-0400"
+          } ]
+        },
+        "end" : "2023-05-01T10:25:31-04:00",
+        "_end" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230501102531-0400"
+          } ]
+        }
+      },
+      "communication" : [ {
+        "language" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "en",
+            "display" : "English"
+          } ]
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "RelatedPerson/1706714052336813000.1d8a6982-d48b-4bdd-aafc-14f227ede96c",
+    "resource" : {
+      "resourceType" : "RelatedPerson",
+      "id" : "1706714052336813000.1d8a6982-d48b-4bdd-aafc-14f227ede96c",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "NK1"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+        "extension" : [ {
+          "url" : "NK1.13",
+          "valueReference" : {
+            "reference" : "Organization/1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413"
+          }
+        }, {
+          "url" : "NK1.16",
+          "valueString" : "20100622"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-employee-number"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        } ],
+        "value" : "IDNumber"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "next-of-kin-identifier"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme2"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit2"
+        } ],
+        "value" : "IDNumber2"
+      }, {
+        "system" : "http://hl7.org/fhir/sid/us-ssn",
+        "value" : "111-11-1111"
+      } ],
+      "patient" : {
+        "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
+      },
+      "relationship" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "relationship"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "OTH",
+          "display" : "Other"
+        }, {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "alt-coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "L"
+          } ],
+          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+          "code" : "OT",
+          "display" : "OTHER RELATIONSHIP"
+        } ]
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-role"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "HL70063"
+          } ],
+          "code" : "ASC",
+          "display" : "Associate"
+        } ]
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-name"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+          "extension" : [ {
+            "url" : "XPN.7",
+            "valueString" : "L"
+          } ]
+        } ],
+        "use" : "official",
+        "family" : "Plato"
+      } ],
+      "telecom" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "PRN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "home"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "555"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "4672293"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "4672293"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 555 467 2293"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "business-phone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 555 467 2293",
+        "use" : "work"
+      }, {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+          "valueString" : "1"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+          "valueString" : "720"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+          "valueString" : "3013954"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+          "extension" : [ {
+            "url" : "XTN.2",
+            "valueString" : "WPN"
+          }, {
+            "url" : "XTN.3",
+            "valueString" : "PH"
+          }, {
+            "url" : "XTN.7",
+            "valueString" : "3013954"
+          }, {
+            "url" : "XTN.12",
+            "valueString" : "+1 720 301 3954"
+          } ]
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-telephone-number"
+        } ],
+        "system" : "phone",
+        "value" : "+1 720 301 3954",
+        "use" : "work"
+      } ],
+      "birthDate" : "2010-06-22",
+      "address" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "THUNDER MOUNTAIN",
+        "state" : "NV",
+        "postalCode" : "99999",
+        "country" : "USA"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "contact-person-address"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+            "extension" : [ {
+              "url" : "SAD.1",
+              "valueString" : "4861 20TH AVE"
+            } ]
+          }, {
+            "url" : "XAD.7",
+            "valueCode" : "H"
+          } ]
+        } ],
+        "use" : "home",
+        "line" : [ "4861 20TH AVE" ],
+        "city" : "AURORA",
+        "state" : "IG",
+        "postalCode" : "99999",
+        "country" : "USA"
+      } ],
+      "period" : {
+        "start" : "2022-05-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20220501102531-0400"
+          } ]
+        },
+        "end" : "2023-05-01T10:25:31-04:00",
+        "_end" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230501102531-0400"
+          } ]
+        }
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      } ],
+      "name" : "Org2"
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nk1/NK1-to-RelatedPerson.fhir
@@ -10,1158 +10,1610 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714052283666000.3160820e-41e6-457b-b357-20043019be35",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714052283666000.3160820e-41e6-457b-b357-20043019be35",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714052291179000.a092c19a-e427-477f-8f17-9c9b5a25b14a",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714052291179000.a092c19a-e427-477f-8f17-9c9b5a25b14a",
-      "recorded" : "2024-01-31T10:14:12Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e",
-      "contact" : [ {
-        "extension" : [ {
-          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "HL70063"
-              } ],
-              "code" : "OTH",
-              "display" : "Other"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "L"
-              } ],
-              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-              "code" : "OT",
-              "display" : "OTHER RELATIONSHIP"
-            } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714052283666000.3160820e-41e6-457b-b357-20043019be35",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714052283666000.3160820e-41e6-457b-b357-20043019be35",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
           }
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "HL70063"
-              } ],
-              "code" : "OTH",
-              "display" : "Other"
-            }, {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "alt-coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "L"
-              } ],
-              "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-              "code" : "OT",
-              "display" : "OTHER RELATIONSHIP"
-            } ]
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714052291179000.a092c19a-e427-477f-8f17-9c9b5a25b14a",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714052291179000.a092c19a-e427-477f-8f17-9c9b5a25b14a",
+        "recorded" : "2024-01-31T10:14:12Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74"
+            }
           }
-        } ],
-        "relationship" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-              "valueString" : "HL70063"
-            } ],
-            "code" : "ASC",
-            "display" : "Associate"
-          } ]
-        } ],
-        "name" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-            "extension" : [ {
-              "url" : "XPN.2",
-              "valueString" : "GENARO"
-            }, {
-              "url" : "XPN.7",
-              "valueString" : "L"
-            } ]
-          } ],
-          "use" : "official",
-          "family" : "SURYAN",
-          "given" : [ "GENARO" ]
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714052290743000.59823c93-7ce5-494d-bbb5-3c3e8c596b74",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e",
+        "contact" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "HL70063"
+                        }
+                      ],
+                      "code" : "OTH",
+                      "display" : "Other"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "L"
+                        }
+                      ],
+                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                      "code" : "OT",
+                      "display" : "OTHER RELATIONSHIP"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/relationship",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "HL70063"
+                        }
+                      ],
+                      "code" : "OTH",
+                      "display" : "Other"
+                    },
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "alt-coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "L"
+                        }
+                      ],
+                      "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                      "code" : "OT",
+                      "display" : "OTHER RELATIONSHIP"
+                    }
+                  ]
+                }
+              }
+            ],
+            "relationship" : [
+              {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      },
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                        "valueString" : "HL70063"
+                      }
+                    ],
+                    "code" : "ASC",
+                    "display" : "Associate"
+                  }
+                ]
+              }
+            ],
+            "name" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                  "extension" : [
+                    {
+                      "url" : "XPN.2",
+                      "valueString" : "GENARO"
+                    },
+                    {
+                      "url" : "XPN.7",
+                      "valueString" : "L"
+                    }
+                  ]
+                }
+              ],
+              "use" : "official",
+              "family" : "SURYAN",
+              "given" : [
+                "GENARO"
+              ]
+            },
+            "telecom" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "PRN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013954"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3954"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3954",
+                "use" : "home"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "PRN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013954"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3954"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3954",
+                "use" : "home"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "555"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "4672293"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 555 467 2293"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 555 467 2293",
+                "use" : "work"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "555"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "4672293"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 555 467 2293"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 555 467 2293",
+                "use" : "work"
+              }
+            ],
+            "address" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                      "extension" : [
+                        {
+                          "url" : "SAD.1",
+                          "valueString" : "4861 20TH AVE"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.7",
+                      "valueCode" : "H"
+                    }
+                  ]
+                }
+              ],
+              "use" : "home",
+              "line" : [
+                "4861 20TH AVE"
+              ],
+              "city" : "THUNDER MOUNTAIN",
+              "state" : "NV",
+              "postalCode" : "99999",
+              "country" : "USA"
+            },
+            "gender" : "male",
+            "organization" : {
+              "reference" : "Organization/1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7"
+            },
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20220501102531-0400"
+                  }
+                ]
+              },
+              "end" : "2023-05-01T10:25:31-04:00",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20230501102531-0400"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          }
+        ],
+        "name" : "Org2",
+        "contact" : [
+          {
+            "name" : {},
+            "telecom" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                    "valueString" : "1"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                    "valueString" : "720"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                    "extension" : [
+                      {
+                        "url" : "XTN.2",
+                        "valueString" : "WPN"
+                      },
+                      {
+                        "url" : "XTN.3",
+                        "valueString" : "PH"
+                      },
+                      {
+                        "url" : "XTN.7",
+                        "valueString" : "3013954"
+                      },
+                      {
+                        "url" : "XTN.12",
+                        "valueString" : "+1 720 301 3954"
+                      }
+                    ]
+                  }
+                ],
+                "system" : "phone",
+                "value" : "+1 720 301 3954",
+                "use" : "work"
+              }
+            ],
+            "address" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                      "extension" : [
+                        {
+                          "url" : "SAD.1",
+                          "valueString" : "4861 20TH AVE"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.7",
+                      "valueCode" : "H"
+                    }
+                  ]
+                }
+              ],
+              "use" : "home",
+              "line" : [
+                "4861 20TH AVE"
+              ],
+              "city" : "AURORA",
+              "state" : "IG",
+              "postalCode" : "99999",
+              "country" : "USA"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714052323402000.16701dcb-e279-4593-aad9-5c4346f056fc",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714052323402000.16701dcb-e279-4593-aad9-5c4346f056fc",
+        "target" : [
+          {
+            "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
+          }
+        ],
+        "recorded" : "2024-01-31T10:14:12Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706714052330913000.c9826e01-89ae-4315-85f3-c015db8630ef",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706714052330913000.c9826e01-89ae-4315-85f3-c015db8630ef",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+            "extension" : [
+              {
+                "url" : "NK1.16",
+                "valueString" : "20100622"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-employee-number"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              }
+            ],
+            "value" : "IDNumber"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-identifier"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme2"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit2"
+              }
+            ],
+            "value" : "IDNumber2"
+          },
+          {
+            "system" : "http://hl7.org/fhir/sid/us-ssn",
+            "value" : "111-11-1111"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
         },
-        "telecom" : [ {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013954"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "PRN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013954"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3954"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3954",
-          "use" : "home"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013954"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "PRN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013954"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3954"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3954",
-          "use" : "home"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "555"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "4672293"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "4672293"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 555 467 2293"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 555 467 2293",
-          "use" : "work"
-        }, {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "555"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "4672293"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "4672293"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 555 467 2293"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 555 467 2293",
-          "use" : "work"
-        } ],
-        "address" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-              "extension" : [ {
-                "url" : "SAD.1",
-                "valueString" : "4861 20TH AVE"
-              } ]
-            }, {
-              "url" : "XAD.7",
-              "valueCode" : "H"
-            } ]
-          } ],
-          "use" : "home",
-          "line" : [ "4861 20TH AVE" ],
-          "city" : "THUNDER MOUNTAIN",
-          "state" : "NV",
-          "postalCode" : "99999",
-          "country" : "USA"
-        },
+        "relationship" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "relationship"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "OTH",
+                "display" : "Other"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "alt-coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "L"
+                  }
+                ],
+                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                "code" : "OT",
+                "display" : "OTHER RELATIONSHIP"
+              }
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-role"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "ASC",
+                "display" : "Associate"
+              }
+            ]
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "GENARO"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "SURYAN",
+            "given" : [
+              "GENARO"
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Plato"
+          }
+        ],
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "555"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "4672293"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 555 467 2293"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "business-phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 555 467 2293",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telephone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "123"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013454"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013454"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 123 301 3454"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "next-of-kin-telecomm-info"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 123 301 3454",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "456"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013454"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013454"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 456 301 3454"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telecomm-info"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 456 301 3454",
+            "use" : "home"
+          }
+        ],
         "gender" : "male",
-        "organization" : {
-          "reference" : "Organization/1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7"
+        "_gender" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      },
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                        "valueString" : "HL70001"
+                      }
+                    ],
+                    "code" : "M",
+                    "display" : "Male"
+                  }
+                ]
+              }
+            }
+          ]
         },
+        "birthDate" : "2010-06-22",
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "state" : "NV",
+            "postalCode" : "99999",
+            "country" : "USA"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "AURORA",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA"
+          }
+        ],
         "period" : {
           "start" : "2022-05-01T10:25:31-04:00",
           "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20220501102531-0400"
-            } ]
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
           },
           "end" : "2023-05-01T10:25:31-04:00",
           "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20230501102531-0400"
-            } ]
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714052315387000.e78528cc-329e-4a05-827a-5a0b4b4e96f7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+        },
+        "communication" : [
+          {
+            "language" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "en",
+                  "display" : "English"
+                }
+              ]
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      } ],
-      "name" : "Org2",
-      "contact" : [ {
-        "name" : { },
-        "telecom" : [ {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-            "valueString" : "1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-            "valueString" : "720"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-            "valueString" : "3013954"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-            "extension" : [ {
-              "url" : "XTN.2",
-              "valueString" : "WPN"
-            }, {
-              "url" : "XTN.3",
-              "valueString" : "PH"
-            }, {
-              "url" : "XTN.7",
-              "valueString" : "3013954"
-            }, {
-              "url" : "XTN.12",
-              "valueString" : "+1 720 301 3954"
-            } ]
-          } ],
-          "system" : "phone",
-          "value" : "+1 720 301 3954",
-          "use" : "work"
-        } ],
-        "address" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-              "extension" : [ {
-                "url" : "SAD.1",
-                "valueString" : "4861 20TH AVE"
-              } ]
-            }, {
-              "url" : "XAD.7",
-              "valueCode" : "H"
-            } ]
-          } ],
-          "use" : "home",
-          "line" : [ "4861 20TH AVE" ],
-          "city" : "AURORA",
-          "state" : "IG",
-          "postalCode" : "99999",
-          "country" : "USA"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714052323402000.16701dcb-e279-4593-aad9-5c4346f056fc",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714052323402000.16701dcb-e279-4593-aad9-5c4346f056fc",
-      "target" : [ {
-        "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
-      } ],
-      "recorded" : "2024-01-31T10:14:12Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+          }
+        ]
       }
-    }
-  }, {
-    "fullUrl" : "RelatedPerson/1706714052330913000.c9826e01-89ae-4315-85f3-c015db8630ef",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706714052330913000.c9826e01-89ae-4315-85f3-c015db8630ef",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
-        "extension" : [ {
-          "url" : "NK1.16",
-          "valueString" : "20100622"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-employee-number"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        } ],
-        "value" : "IDNumber"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-identifier"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme2"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit2"
-        } ],
-        "value" : "IDNumber2"
-      }, {
-        "system" : "http://hl7.org/fhir/sid/us-ssn",
-        "value" : "111-11-1111"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
-      },
-      "relationship" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "relationship"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "OTH",
-          "display" : "Other"
-        }, {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "alt-coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "L"
-          } ],
-          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-          "code" : "OT",
-          "display" : "OTHER RELATIONSHIP"
-        } ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-role"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "ASC",
-          "display" : "Associate"
-        } ]
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "GENARO"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "SURYAN",
-        "given" : [ "GENARO" ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Plato"
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "555"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "4672293"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "4672293"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 555 467 2293"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "business-phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 555 467 2293",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telephone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "123"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013454"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013454"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 123 301 3454"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "next-of-kin-telecomm-info"
-        } ],
-        "system" : "phone",
-        "value" : "+1 123 301 3454",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "456"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013454"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013454"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 456 301 3454"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telecomm-info"
-        } ],
-        "system" : "phone",
-        "value" : "+1 456 301 3454",
-        "use" : "home"
-      } ],
-      "gender" : "male",
-      "_gender" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-15-administrative-sex",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "HL70001"
-              } ],
-              "code" : "M",
-              "display" : "Male"
-            } ]
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706714052336813000.1d8a6982-d48b-4bdd-aafc-14f227ede96c",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706714052336813000.1d8a6982-d48b-4bdd-aafc-14f227ede96c",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
+            "extension" : [
+              {
+                "url" : "NK1.13",
+                "valueReference" : {
+                  "reference" : "Organization/1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413"
+                }
+              },
+              {
+                "url" : "NK1.16",
+                "valueString" : "20100622"
+              }
+            ]
           }
-        } ]
-      },
-      "birthDate" : "2010-06-22",
-      "address" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "THUNDER MOUNTAIN",
-        "state" : "NV",
-        "postalCode" : "99999",
-        "country" : "USA"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "AURORA",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA"
-      } ],
-      "period" : {
-        "start" : "2022-05-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20220501102531-0400"
-          } ]
-        },
-        "end" : "2023-05-01T10:25:31-04:00",
-        "_end" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230501102531-0400"
-          } ]
-        }
-      },
-      "communication" : [ {
-        "language" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "en",
-            "display" : "English"
-          } ]
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "RelatedPerson/1706714052336813000.1d8a6982-d48b-4bdd-aafc-14f227ede96c",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706714052336813000.1d8a6982-d48b-4bdd-aafc-14f227ede96c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/nk1-related-person",
-        "extension" : [ {
-          "url" : "NK1.13",
-          "valueReference" : {
-            "reference" : "Organization/1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413"
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-employee-number"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              }
+            ],
+            "value" : "IDNumber"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "next-of-kin-identifier"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme2"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit2"
+              }
+            ],
+            "value" : "IDNumber2"
+          },
+          {
+            "system" : "http://hl7.org/fhir/sid/us-ssn",
+            "value" : "111-11-1111"
           }
-        }, {
-          "url" : "NK1.16",
-          "valueString" : "20100622"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-employee-number"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        } ],
-        "value" : "IDNumber"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "next-of-kin-identifier"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme2"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit2"
-        } ],
-        "value" : "IDNumber2"
-      }, {
-        "system" : "http://hl7.org/fhir/sid/us-ssn",
-        "value" : "111-11-1111"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
-      },
-      "relationship" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "relationship"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "OTH",
-          "display" : "Other"
-        }, {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "alt-coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "L"
-          } ],
-          "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
-          "code" : "OT",
-          "display" : "OTHER RELATIONSHIP"
-        } ]
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-role"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "HL70063"
-          } ],
-          "code" : "ASC",
-          "display" : "Associate"
-        } ]
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Plato"
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "home"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "555"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "4672293"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "4672293"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 555 467 2293"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "business-phone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 555 467 2293",
-        "use" : "work"
-      }, {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "720"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "3013954"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "WPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "3013954"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 720 301 3954"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-telephone-number"
-        } ],
-        "system" : "phone",
-        "value" : "+1 720 301 3954",
-        "use" : "work"
-      } ],
-      "birthDate" : "2010-06-22",
-      "address" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "THUNDER MOUNTAIN",
-        "state" : "NV",
-        "postalCode" : "99999",
-        "country" : "USA"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861 20TH AVE"
-            } ]
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861 20TH AVE" ],
-        "city" : "AURORA",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA"
-      } ],
-      "period" : {
-        "start" : "2022-05-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20220501102531-0400"
-          } ]
+        ],
+        "patient" : {
+          "reference" : "Patient/1706714052319597000.c054a10b-6835-42b3-b3e5-605be375101e"
         },
-        "end" : "2023-05-01T10:25:31-04:00",
-        "_end" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230501102531-0400"
-          } ]
+        "relationship" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "relationship"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "OTH",
+                "display" : "Other"
+              },
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "alt-coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "L"
+                  }
+                ],
+                "system" : "https://terminology.hl7.org/CodeSystem-v2-0396.html#v2-0396-99zzzorL",
+                "code" : "OT",
+                "display" : "OTHER RELATIONSHIP"
+              }
+            ]
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-role"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "HL70063"
+                  }
+                ],
+                "code" : "ASC",
+                "display" : "Associate"
+              }
+            ]
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-name"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Plato"
+          }
+        ],
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "home"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "555"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "4672293"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "4672293"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 555 467 2293"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "business-phone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 555 467 2293",
+            "use" : "work"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "720"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "3013954"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "WPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "3013954"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 720 301 3954"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-telephone-number"
+              }
+            ],
+            "system" : "phone",
+            "value" : "+1 720 301 3954",
+            "use" : "work"
+          }
+        ],
+        "birthDate" : "2010-06-22",
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "state" : "NV",
+            "postalCode" : "99999",
+            "country" : "USA"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861 20TH AVE"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861 20TH AVE"
+            ],
+            "city" : "AURORA",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA"
+          }
+        ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          "end" : "2023-05-01T10:25:31-04:00",
+          "_end" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
         }
       }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
+    },
+    {
+      "fullUrl" : "Organization/1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714052333726000.e803dbfd-d9bd-46cf-8946-fc5e96d8b413",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      } ],
-      "name" : "Org2"
+          }
+        ],
+        "name" : "Org2"
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nm/nm-to-quantity.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nm/nm-to-quantity.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311356017326000.866881c1-7928-4f0c-8031-d065e9ec43c4",
+  "id" : "1706815209910328000.790f75f9-0e80-4717-bda4-dd5290cdef76",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:22:36.030-06:00"
+    "lastUpdated" : "2024-02-01T14:20:09.917-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311356398209000.1c0c46d6-5b93-44ce-8b8d-dd4e40440e7d",
+      "fullUrl" : "Provenance/1706815210333780000.4ce7695a-fa00-4099-9ee8-10eddf20dc46",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311356398209000.1c0c46d6-5b93-44ce-8b8d-dd4e40440e7d",
+        "id" : "1706815210333780000.4ce7695a-fa00-4099-9ee8-10eddf20dc46",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311356405492000.100c1ae9-3a59-4824-b9a8-189a538980d4",
+      "fullUrl" : "Provenance/1706815210341789000.8feca696-afa4-4191-9687-6c1700714829",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311356405492000.100c1ae9-3a59-4824-b9a8-189a538980d4",
-        "recorded" : "2024-01-26T17:22:36Z",
+        "id" : "1706815210341789000.8feca696-afa4-4191-9687-6c1700714829",
+        "recorded" : "2024-02-01T14:20:10Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311356404573000.30e6a6b7-9bf0-40ac-a1ce-b43a7570c2eb"
+              "reference" : "Organization/1706815210341280000.dd579891-b55c-412b-bdf1-71a01ccd00cc"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311356404573000.30e6a6b7-9bf0-40ac-a1ce-b43a7570c2eb",
+      "fullUrl" : "Organization/1706815210341280000.dd579891-b55c-412b-bdf1-71a01ccd00cc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311356404573000.30e6a6b7-9bf0-40ac-a1ce-b43a7570c2eb",
+        "id" : "1706815210341280000.dd579891-b55c-412b-bdf1-71a01ccd00cc",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,23 +125,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311356418689000.55a6f72f-746d-44c2-bf56-cc6d80b968be",
+      "fullUrl" : "Patient/1706815210357853000.99eee773-13e4-4455-bc39-c20d7c7b7b48",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311356418689000.55a6f72f-746d-44c2-bf56-cc6d80b968be"
+        "id" : "1706815210357853000.99eee773-13e4-4455-bc39-c20d7c7b7b48"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311356419246000.9072c455-b258-4195-980f-13f1959d8f4e",
+      "fullUrl" : "Provenance/1706815210358638000.dfce6548-f533-49aa-9432-15efa30f52b3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311356419246000.9072c455-b258-4195-980f-13f1959d8f4e",
+        "id" : "1706815210358638000.dfce6548-f533-49aa-9432-15efa30f52b3",
         "target" : [
           {
-            "reference" : "Patient/1706311356418689000.55a6f72f-746d-44c2-bf56-cc6d80b968be"
+            "reference" : "Patient/1706815210357853000.99eee773-13e4-4455-bc39-c20d7c7b7b48"
           }
         ],
-        "recorded" : "2024-01-26T17:22:36Z",
+        "recorded" : "2024-02-01T14:20:10Z",
         "activity" : {
           "coding" : [
             {
@@ -148,10 +153,10 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311356421791000.3b23478b-5b05-4641-bd45-e6a7e2b09efb",
+      "fullUrl" : "Encounter/1706815210361586000.bc29372f-2309-4679-b3db-3ab1eff6a13a",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311356421791000.3b23478b-5b05-4641-bd45-e6a7e2b09efb",
+        "id" : "1706815210361586000.bc29372f-2309-4679-b3db-3ab1eff6a13a",
         "meta" : {
           "security" : [
             {
@@ -160,11 +165,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311356418689000.55a6f72f-746d-44c2-bf56-cc6d80b968be"
+          "reference" : "Patient/1706815210357853000.99eee773-13e4-4455-bc39-c20d7c7b7b48"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311356422095000.093d73c5-a6f2-43c2-b765-fa3631183169"
+            "reference" : "EpisodeOfCare/1706815210361843000.a1ac7cd2-9137-4060-8a94-ae703dbe3b9f"
           }
         ],
         "length" : {
@@ -176,10 +181,10 @@
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311356422095000.093d73c5-a6f2-43c2-b765-fa3631183169",
+      "fullUrl" : "EpisodeOfCare/1706815210361843000.a1ac7cd2-9137-4060-8a94-ae703dbe3b9f",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311356422095000.093d73c5-a6f2-43c2-b765-fa3631183169",
+        "id" : "1706815210361843000.a1ac7cd2-9137-4060-8a94-ae703dbe3b9f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nte/NTE-to-annotation.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nte/NTE-to-annotation.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654327162552000.0b98452d-4d05-406a-8eff-25c1ad6f280e",
+  "id" : "1706815300744624000.5a677bab-5a9b-453d-aff3-42d251ed322a",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:38:47.168-05:00"
+    "lastUpdated" : "2024-02-01T14:21:40.759-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654327600920000.bb9d17aa-3c44-4aea-b234-f00892a24de4",
+      "fullUrl" : "Provenance/1706815301176086000.84fdb2a7-ef43-4f36-a137-031e5aebf56f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654327600920000.bb9d17aa-3c44-4aea-b234-f00892a24de4",
+        "id" : "1706815301176086000.84fdb2a7-ef43-4f36-a137-031e5aebf56f",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
           },
           {
-            "reference" : "DiagnosticReport/1706654327818429000.673cf651-ff17-4253-84b1-19b2c97e32dd"
+            "reference" : "DiagnosticReport/1706815301402621000.53c4b24e-8b18-419f-a061-3a542eb87f2c"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654327609360000.7150b9f4-7d03-45d3-8dfe-db4a82e867c9",
+      "fullUrl" : "Provenance/1706815301187041000.8136b21a-5cbc-4b10-bda3-c408bb9d6405",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654327609360000.7150b9f4-7d03-45d3-8dfe-db4a82e867c9",
-        "recorded" : "2024-01-30T17:38:47Z",
+        "id" : "1706815301187041000.8136b21a-5cbc-4b10-bda3-c408bb9d6405",
+        "recorded" : "2024-02-01T14:21:41Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654327607920000.e11694c9-f588-43d8-bbb8-81a9d7ac0418"
+              "reference" : "Organization/1706815301186405000.e99791a3-9d62-4b46-9fe8-75215eb37809"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654327607920000.e11694c9-f588-43d8-bbb8-81a9d7ac0418",
+      "fullUrl" : "Organization/1706815301186405000.e99791a3-9d62-4b46-9fe8-75215eb37809",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654327607920000.e11694c9-f588-43d8-bbb8-81a9d7ac0418",
+        "id" : "1706815301186405000.e99791a3-9d62-4b46-9fe8-75215eb37809",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,10 +128,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654327624300000.9f6ef194-b63f-4b74-9629-5b8bb7e051cc",
+      "fullUrl" : "Patient/1706815301202760000.c7ae1b19-538d-49b6-9a7e-2000aac08b2a",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654327624300000.9f6ef194-b63f-4b74-9629-5b8bb7e051cc",
+        "id" : "1706815301202760000.c7ae1b19-538d-49b6-9a7e-2000aac08b2a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/patient-notes",
@@ -166,7 +171,7 @@
                 }
               ],
               "authorReference" : {
-                "reference" : "Practitioner/1706654327619643000.8d151cb4-e6e0-44b2-96d9-246f727b493c"
+                "reference" : "Practitioner/1706815301197773000.b14d5911-c33b-4a23-a363-e18470b881d8"
               },
               "text" : "Patient Note"
             }
@@ -175,10 +180,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654327619643000.8d151cb4-e6e0-44b2-96d9-246f727b493c",
+      "fullUrl" : "Practitioner/1706815301197773000.b14d5911-c33b-4a23-a363-e18470b881d8",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654327619643000.8d151cb4-e6e0-44b2-96d9-246f727b493c",
+        "id" : "1706815301197773000.b14d5911-c33b-4a23-a363-e18470b881d8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -237,16 +242,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654327625800000.d3396ccb-18a6-4a3e-8d70-9ab03a3a6d40",
+      "fullUrl" : "Provenance/1706815301204206000.0f782438-918b-4182-a314-7459f97b67be",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654327625800000.d3396ccb-18a6-4a3e-8d70-9ab03a3a6d40",
+        "id" : "1706815301204206000.0f782438-918b-4182-a314-7459f97b67be",
         "target" : [
           {
-            "reference" : "Patient/1706654327624300000.9f6ef194-b63f-4b74-9629-5b8bb7e051cc"
+            "reference" : "Patient/1706815301202760000.c7ae1b19-538d-49b6-9a7e-2000aac08b2a"
           }
         ],
-        "recorded" : "2024-01-30T17:38:47Z",
+        "recorded" : "2024-02-01T14:21:41Z",
         "activity" : {
           "coding" : [
             {
@@ -258,10 +263,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706654327632499000.b7697df0-d62a-4865-b69f-4e0f2e32352e",
+      "fullUrl" : "Observation/1706815301216870000.8a44c5b4-671e-47a4-9b3c-cfc983fee2b9",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706654327632499000.b7697df0-d62a-4865-b69f-4e0f2e32352e",
+        "id" : "1706815301216870000.8a44c5b4-671e-47a4-9b3c-cfc983fee2b9",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -299,14 +304,14 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654327624300000.9f6ef194-b63f-4b74-9629-5b8bb7e051cc"
+          "reference" : "Patient/1706815301202760000.c7ae1b19-538d-49b6-9a7e-2000aac08b2a"
         },
         "performer" : [
           {
-            "reference" : "Organization/1706654327633192000.d0d3cc85-943b-4666-a671-dd614d75d4d3"
+            "reference" : "Organization/1706815301217656000.a5b3aaa8-6da6-4960-9607-9bbaa52fe75f"
           },
           {
-            "reference" : "Organization/1706654327636481000.1e6dca1e-6fa9-48ff-8d43-81874c80de19"
+            "reference" : "Organization/1706815301220344000.951257ee-7e69-4020-a8c8-ce49a116ea57"
           }
         ],
         "valueDateTime" : "2023-02-01",
@@ -355,7 +360,7 @@
               }
             ],
             "authorReference" : {
-              "reference" : "Practitioner/1706654327638211000.2a344801-f572-427d-bd17-49e8d16bf165"
+              "reference" : "Practitioner/1706815301222690000.9d4f64e9-5165-4948-b649-effcb9be374a"
             },
             "text" : "OBX Note"
           }
@@ -363,10 +368,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654327633192000.d0d3cc85-943b-4666-a671-dd614d75d4d3",
+      "fullUrl" : "Organization/1706815301217656000.a5b3aaa8-6da6-4960-9607-9bbaa52fe75f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654327633192000.d0d3cc85-943b-4666-a671-dd614d75d4d3",
+        "id" : "1706815301217656000.a5b3aaa8-6da6-4960-9607-9bbaa52fe75f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-organization",
@@ -397,10 +402,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654327636481000.1e6dca1e-6fa9-48ff-8d43-81874c80de19",
+      "fullUrl" : "Organization/1706815301220344000.951257ee-7e69-4020-a8c8-ce49a116ea57",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654327636481000.1e6dca1e-6fa9-48ff-8d43-81874c80de19",
+        "id" : "1706815301220344000.951257ee-7e69-4020-a8c8-ce49a116ea57",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -520,10 +525,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654327638211000.2a344801-f572-427d-bd17-49e8d16bf165",
+      "fullUrl" : "Practitioner/1706815301222690000.9d4f64e9-5165-4948-b649-effcb9be374a",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654327638211000.2a344801-f572-427d-bd17-49e8d16bf165",
+        "id" : "1706815301222690000.9d4f64e9-5165-4948-b649-effcb9be374a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -582,10 +587,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654327814866000.f113ccc4-a75e-4b6e-989f-b52c41c1ad70",
+      "fullUrl" : "ServiceRequest/1706815301397566000.dbb41008-c266-45e4-a8da-f06f7ae7d3ed",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654327814866000.f113ccc4-a75e-4b6e-989f-b52c41c1ad70",
+        "id" : "1706815301397566000.dbb41008-c266-45e4-a8da-f06f7ae7d3ed",
         "identifier" : [
           {
             "extension" : [
@@ -683,10 +688,10 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654327624300000.9f6ef194-b63f-4b74-9629-5b8bb7e051cc"
+          "reference" : "Patient/1706815301202760000.c7ae1b19-538d-49b6-9a7e-2000aac08b2a"
         },
         "requester" : {
-          "reference" : "Practitioner/1706654327811425000.5fb24a2d-f2a8-486d-9aef-7b237d2c02e5"
+          "reference" : "Practitioner/1706815301392463000.bdaf3a1d-655d-4aba-a8e8-06482a3d9bae"
         },
         "note" : [
           {
@@ -730,10 +735,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654327811425000.5fb24a2d-f2a8-486d-9aef-7b237d2c02e5",
+      "fullUrl" : "Practitioner/1706815301392463000.bdaf3a1d-655d-4aba-a8e8-06482a3d9bae",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654327811425000.5fb24a2d-f2a8-486d-9aef-7b237d2c02e5",
+        "id" : "1706815301392463000.bdaf3a1d-655d-4aba-a8e8-06482a3d9bae",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -784,10 +789,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654327818429000.673cf651-ff17-4253-84b1-19b2c97e32dd",
+      "fullUrl" : "DiagnosticReport/1706815301402621000.53c4b24e-8b18-419f-a061-3a542eb87f2c",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654327818429000.673cf651-ff17-4253-84b1-19b2c97e32dd",
+        "id" : "1706815301402621000.53c4b24e-8b18-419f-a061-3a542eb87f2c",
         "identifier" : [
           {
             "extension" : [
@@ -856,7 +861,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654327814866000.f113ccc4-a75e-4b6e-989f-b52c41c1ad70"
+            "reference" : "ServiceRequest/1706815301397566000.dbb41008-c266-45e4-a8da-f06f7ae7d3ed"
           }
         ],
         "status" : "final",
@@ -886,11 +891,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654327624300000.9f6ef194-b63f-4b74-9629-5b8bb7e051cc"
+          "reference" : "Patient/1706815301202760000.c7ae1b19-538d-49b6-9a7e-2000aac08b2a"
         },
         "result" : [
           {
-            "reference" : "Observation/1706654327632499000.b7697df0-d62a-4865-b69f-4e0f2e32352e"
+            "reference" : "Observation/1706815301216870000.8a44c5b4-671e-47a4-9b3c-cfc983fee2b9"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/nte/annotation_author_string_resource_test_file.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/nte/annotation_author_string_resource_test_file.fhir
@@ -30,29 +30,47 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230405133610-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-            "valueString" : "NE"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-            "valueString" : "NE"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.11"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230405133610-0400"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id",
+                          "valueString" : "PHIN"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.11"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "system" : "PHIN",
+                  "value" : "PHLabReport-NoAck"
                 }
-              ],
-              "system" : "PHIN",
-              "value" : "PHLabReport-NoAck"
-            }
+              }
+            ]
           }
         ],
         "eventCoding" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-ce-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-ce-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709384859406000.1d6a2e4a-3e71-4813-80a3-1fe776a8a502",
+  "id" : "1706815456453386000.308a7f19-0be5-4d9b-a5fd-0598624e5b93",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:56:24.866-05:00"
+    "lastUpdated" : "2024-02-01T14:24:16.460-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,162 +10,219 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706709384928376000.2eedfdbc-e2d8-4d87-9848-be40687c56c8"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706709384928376000.2eedfdbc-e2d8-4d87-9848-be40687c56c8",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709384928376000.2eedfdbc-e2d8-4d87-9848-be40687c56c8",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709385251443000.b65a2fd2-2857-40b3-b262-0d440fd1170a",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709385251443000.b65a2fd2-2857-40b3-b262-0d440fd1170a",
-      "target" : [ {
-        "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
-      }, {
-        "reference" : "DiagnosticReport/1706709385441297000.a9bf8732-00c0-4d0b-b351-c6ddc6a31f34"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709385258570000.2674d626-9e77-498d-8e16-204e9f4d4912",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709385258570000.2674d626-9e77-498d-8e16-204e9f4d4912",
-      "recorded" : "2024-01-31T08:56:25Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706709385257682000.bfa0d807-48b3-456a-9ba5-0a931f887b66"
+        "sender" : {
+          "reference" : "Organization/1706815456503807000.9b8e1be9-c27b-4947-b470-d65c8a11a83d"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706709385257682000.bfa0d807-48b3-456a-9ba5-0a931f887b66",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709385257682000.bfa0d807-48b3-456a-9ba5-0a931f887b66",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815456503807000.9b8e1be9-c27b-4947-b470-d65c8a11a83d",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815456503807000.9b8e1be9-c27b-4947-b470-d65c8a11a83d",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815456872432000.88cf03d3-38d2-4ad6-a052-3259e42a4252",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815456872432000.88cf03d3-38d2-4ad6-a052-3259e42a4252",
+        "target" : [
+          {
+            "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815457058637000.f7ee86e1-ba28-487a-a60a-5b8dd0ce110a"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815456880345000.b665d99e-07e9-4c66-afc6-2960ed89f8eb",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815456880345000.b665d99e-07e9-4c66-afc6-2960ed89f8eb",
+        "recorded" : "2024-02-01T14:24:16Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Observation/1706709385273894000.2ab4a8c7-efee-4ab4-a43e-070d10059b05",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1706709385273894000.2ab4a8c7-efee-4ab4-a43e-070d10059b05",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
-        "extension" : [ {
-          "url" : "obx-2-value-type",
-          "valueId" : "CE"
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ce-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ce-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "8675-3",
-          "display" : "Fake"
-        } ]
-      },
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ce-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "1",
-          "display" : "Display"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815456879924000.8a194ad2-f315-4ede-9f30-46277960c19f"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815456879924000.8a194ad2-f315-4ede-9f30-46277960c19f",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815456879924000.8a194ad2-f315-4ede-9f30-46277960c19f",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Observation/1706815456892129000.9d7662ec-a1d9-47e5-8b9d-e557d4229fc4",
+      "resource" : {
+        "resourceType" : "Observation",
+        "id" : "1706815456892129000.9d7662ec-a1d9-47e5-8b9d-e557d4229fc4",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+            "extension" : [
+              {
+                "url" : "obx-2-value-type",
+                "valueId" : "CE"
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ce-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ce-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "8675-3",
+              "display" : "Fake"
+            }
+          ]
+        },
+        "valueCodeableConcept" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ce-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "1",
+              "display" : "Display"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815457056413000.5087be9e-b2ad-4fc0-b64f-864fb61bc405",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815457056413000.5087be9e-b2ad-4fc0-b64f-864fb61bc405",
+        "status" : "unknown"
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815457058637000.f7ee86e1-ba28-487a-a60a-5b8dd0ce110a",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815457058637000.f7ee86e1-ba28-487a-a60a-5b8dd0ce110a",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815457056413000.5087be9e-b2ad-4fc0-b64f-864fb61bc405"
+          }
+        ],
+        "status" : "final",
+        "result" : [
+          {
+            "reference" : "Observation/1706815456892129000.9d7662ec-a1d9-47e5-8b9d-e557d4229fc4"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "ServiceRequest/1706709385439329000.1648aab5-d292-498c-ad76-3bea4193d7d0",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706709385439329000.1648aab5-d292-498c-ad76-3bea4193d7d0",
-      "status" : "unknown"
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706709385441297000.a9bf8732-00c0-4d0b-b351-c6ddc6a31f34",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706709385441297000.a9bf8732-00c0-4d0b-b351-c6ddc6a31f34",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706709385439329000.1648aab5-d292-498c-ad76-3bea4193d7d0"
-      } ],
-      "status" : "final",
-      "result" : [ {
-        "reference" : "Observation/1706709385273894000.2ab4a8c7-efee-4ab4-a43e-070d10059b05"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-cwe-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-cwe-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709394162909000.a8fed36b-715e-4972-9f47-8ac148350ad7",
+  "id" : "1706815466367339000.f545450a-a519-4351-b2fb-56e04d03b5f1",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:56:34.169-05:00"
+    "lastUpdated" : "2024-02-01T14:24:26.374-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,190 +10,257 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706709394232544000.0b013955-b74c-47e1-b42f-164e0611d1ee"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706709394232544000.0b013955-b74c-47e1-b42f-164e0611d1ee",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709394232544000.0b013955-b74c-47e1-b42f-164e0611d1ee",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709394544347000.ee4ab043-555f-476e-85f2-ca435f13f231",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709394544347000.ee4ab043-555f-476e-85f2-ca435f13f231",
-      "target" : [ {
-        "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
-      }, {
-        "reference" : "DiagnosticReport/1706709394732919000.3e4bd656-aca8-43ee-aa6d-2731d7bbdb8a"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709394551558000.538ca7a6-fe32-40d2-b2f9-e164ce1991dd",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709394551558000.538ca7a6-fe32-40d2-b2f9-e164ce1991dd",
-      "recorded" : "2024-01-31T08:56:34Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706709394551068000.92365eea-4bfe-433a-bacc-d7f933d8904b"
+        "sender" : {
+          "reference" : "Organization/1706815466416962000.7af57d73-b8b8-4381-9256-6f08500a6f49"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706709394551068000.92365eea-4bfe-433a-bacc-d7f933d8904b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709394551068000.92365eea-4bfe-433a-bacc-d7f933d8904b",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815466416962000.7af57d73-b8b8-4381-9256-6f08500a6f49",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815466416962000.7af57d73-b8b8-4381-9256-6f08500a6f49",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815466773416000.f394bb6e-5881-4456-8027-bfb59b7074ce",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815466773416000.f394bb6e-5881-4456-8027-bfb59b7074ce",
+        "target" : [
+          {
+            "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815466971869000.78240c3a-e62f-4e32-aff7-549b89a4307e"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815466780911000.75608777-ab5d-4409-9644-b2c6bbf8847d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815466780911000.75608777-ab5d-4409-9644-b2c6bbf8847d",
+        "recorded" : "2024-02-01T14:24:26Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Observation/1706709394566890000.e6e1b826-1901-40bd-ac50-5c91d52fb92d",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1706709394566890000.e6e1b826-1901-40bd-ac50-5c91d52fb92d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
-        "extension" : [ {
-          "url" : "obx-2-value-type",
-          "valueId" : "CWE"
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "8675-3",
-          "display" : "Fake"
-        } ]
-      },
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "1",
-          "display" : "Display"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815466780423000.43e6bad2-8879-4f00-9783-abe0e5ec020d"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815466780423000.43e6bad2-8879-4f00-9783-abe0e5ec020d",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815466780423000.43e6bad2-8879-4f00-9783-abe0e5ec020d",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Observation/1706815466798236000.ce375398-1f0d-454b-8b44-ed8cd51573bd",
+      "resource" : {
+        "resourceType" : "Observation",
+        "id" : "1706815466798236000.ce375398-1f0d-454b-8b44-ed8cd51573bd",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+            "extension" : [
+              {
+                "url" : "obx-2-value-type",
+                "valueId" : "CWE"
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "8675-3",
+              "display" : "Fake"
+            }
+          ]
+        },
+        "valueCodeableConcept" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "1",
+              "display" : "Display"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815466969429000.ac0ac496-460a-491b-b1ce-650abb14ca7c",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815466969429000.ac0ac496-460a-491b-b1ce-650abb14ca7c",
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815466971869000.78240c3a-e62f-4e32-aff7-549b89a4307e",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815466971869000.78240c3a-e62f-4e32-aff7-549b89a4307e",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815466969429000.ac0ac496-460a-491b-b1ce-650abb14ca7c"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        },
+        "result" : [
+          {
+            "reference" : "Observation/1706815466798236000.ce375398-1f0d-454b-8b44-ed8cd51573bd"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "ServiceRequest/1706709394730798000.f1593023-5fa5-429b-9de6-30e38fb284ed",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706709394730798000.f1593023-5fa5-429b-9de6-30e38fb284ed",
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706709394732919000.3e4bd656-aca8-43ee-aa6d-2731d7bbdb8a",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706709394732919000.3e4bd656-aca8-43ee-aa6d-2731d7bbdb8a",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706709394730798000.f1593023-5fa5-429b-9de6-30e38fb284ed"
-      } ],
-      "status" : "final",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      },
-      "result" : [ {
-        "reference" : "Observation/1706709394566890000.e6e1b826-1901-40bd-ac50-5c91d52fb92d"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-data-absent-n-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-data-absent-n-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709403342249000.035f56ae-6526-491c-baeb-07218d760759",
+  "id" : "1706815476094690000.32c3ba11-880a-4fe4-a650-26ad92730580",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:56:43.351-05:00"
+    "lastUpdated" : "2024-02-01T14:24:36.101-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709403420117000.dc5dfc83-d197-4f96-92e4-a86875055ec2"
+          "reference" : "Organization/1706815476145164000.65117ddc-40b7-48d6-bebe-5e14c6243ece"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709403420117000.dc5dfc83-d197-4f96-92e4-a86875055ec2",
+      "fullUrl" : "Organization/1706815476145164000.65117ddc-40b7-48d6-bebe-5e14c6243ece",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709403420117000.dc5dfc83-d197-4f96-92e4-a86875055ec2",
+        "id" : "1706815476145164000.65117ddc-40b7-48d6-bebe-5e14c6243ece",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709403725819000.02408709-3d81-48f3-9565-64b52f72209f",
+      "fullUrl" : "Provenance/1706815476537555000.35b5e19a-c58e-4e97-8211-d1b9516d7c56",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709403725819000.02408709-3d81-48f3-9565-64b52f72209f",
+        "id" : "1706815476537555000.35b5e19a-c58e-4e97-8211-d1b9516d7c56",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709403911274000.6d53b3b0-86ff-4614-9b16-9e11f6735b6d"
+            "reference" : "DiagnosticReport/1706815476725235000.21642f96-66fb-4184-a89d-1a83525ce343"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709403733145000.1521eaf9-92dd-4e4a-b498-64906af81713",
+      "fullUrl" : "Provenance/1706815476545340000.a266a077-a3a2-4490-9638-09f3e8e3b525",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709403733145000.1521eaf9-92dd-4e4a-b498-64906af81713",
-        "recorded" : "2024-01-31T08:56:43Z",
+        "id" : "1706815476545340000.a266a077-a3a2-4490-9638-09f3e8e3b525",
+        "recorded" : "2024-02-01T14:24:36Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709403732757000.b3b53db8-fe65-495b-b1c5-affb58fec391"
+              "reference" : "Organization/1706815476544902000.ad28e6f8-6c47-4799-9aa4-94f5015c0d7e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709403732757000.b3b53db8-fe65-495b-b1c5-affb58fec391",
+      "fullUrl" : "Organization/1706815476544902000.ad28e6f8-6c47-4799-9aa4-94f5015c0d7e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709403732757000.b3b53db8-fe65-495b-b1c5-affb58fec391",
+        "id" : "1706815476544902000.ad28e6f8-6c47-4799-9aa4-94f5015c0d7e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709403749250000.c36455b8-0f9a-4f47-ab40-b68fa6f0be31",
+      "fullUrl" : "Observation/1706815476559046000.0a738a32-c5d7-4795-bfdc-01534803a111",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709403749250000.c36455b8-0f9a-4f47-ab40-b68fa6f0be31",
+        "id" : "1706815476559046000.0a738a32-c5d7-4795-bfdc-01534803a111",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709403909153000.bd5dccf7-d511-4f6f-9eba-4836214d4fd4",
+      "fullUrl" : "ServiceRequest/1706815476721198000.85e9955a-8f82-4911-ac4d-df03c2753eaa",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709403909153000.bd5dccf7-d511-4f6f-9eba-4836214d4fd4",
+        "id" : "1706815476721198000.85e9955a-8f82-4911-ac4d-df03c2753eaa",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -215,13 +220,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709403911274000.6d53b3b0-86ff-4614-9b16-9e11f6735b6d",
+      "fullUrl" : "DiagnosticReport/1706815476725235000.21642f96-66fb-4184-a89d-1a83525ce343",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709403911274000.6d53b3b0-86ff-4614-9b16-9e11f6735b6d",
+        "id" : "1706815476725235000.21642f96-66fb-4184-a89d-1a83525ce343",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709403909153000.bd5dccf7-d511-4f6f-9eba-4836214d4fd4"
+            "reference" : "ServiceRequest/1706815476721198000.85e9955a-8f82-4911-ac4d-df03c2753eaa"
           }
         ],
         "status" : "final",
@@ -246,7 +251,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709403749250000.c36455b8-0f9a-4f47-ab40-b68fa6f0be31"
+            "reference" : "Observation/1706815476559046000.0a738a32-c5d7-4795-bfdc-01534803a111"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-data-absent-st-but-empty-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-data-absent-st-but-empty-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709412561190000.edfdb256-d39c-4a99-8566-f29327718e70",
+  "id" : "1706815485925357000.34bf113b-fcba-4c2b-9235-7a231592cc54",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:56:52.567-05:00"
+    "lastUpdated" : "2024-02-01T14:24:45.932-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709412630048000.9841fa5f-b34a-4695-82c7-fd76a73edb78"
+          "reference" : "Organization/1706815485979578000.bcd2bd8d-46b6-4ea2-91d3-08f0288d3476"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709412630048000.9841fa5f-b34a-4695-82c7-fd76a73edb78",
+      "fullUrl" : "Organization/1706815485979578000.bcd2bd8d-46b6-4ea2-91d3-08f0288d3476",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709412630048000.9841fa5f-b34a-4695-82c7-fd76a73edb78",
+        "id" : "1706815485979578000.bcd2bd8d-46b6-4ea2-91d3-08f0288d3476",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709412940527000.41e4f9a5-8233-4241-b5b1-3265f3a582ad",
+      "fullUrl" : "Provenance/1706815486344041000.67989cd9-e47f-404b-8e18-b974c0105c82",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709412940527000.41e4f9a5-8233-4241-b5b1-3265f3a582ad",
+        "id" : "1706815486344041000.67989cd9-e47f-404b-8e18-b974c0105c82",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709413140196000.cf620865-f0b0-4603-98cc-bf99eb0837c9"
+            "reference" : "DiagnosticReport/1706815486552149000.bb832716-7674-4c9b-8bb4-3bd6f584642d"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709412948118000.8f9afd25-2601-446e-8cae-64743a125c9d",
+      "fullUrl" : "Provenance/1706815486353790000.9aa3d395-1d09-4752-9f07-12a21a6e5325",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709412948118000.8f9afd25-2601-446e-8cae-64743a125c9d",
-        "recorded" : "2024-01-31T08:56:52Z",
+        "id" : "1706815486353790000.9aa3d395-1d09-4752-9f07-12a21a6e5325",
+        "recorded" : "2024-02-01T14:24:46Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709412947494000.ab9e1e2a-518b-43fc-a463-8b8a63a394c3"
+              "reference" : "Organization/1706815486353192000.6677c0ff-4ff2-4c94-ba56-8650bea743dd"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709412947494000.ab9e1e2a-518b-43fc-a463-8b8a63a394c3",
+      "fullUrl" : "Organization/1706815486353192000.6677c0ff-4ff2-4c94-ba56-8650bea743dd",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709412947494000.ab9e1e2a-518b-43fc-a463-8b8a63a394c3",
+        "id" : "1706815486353192000.6677c0ff-4ff2-4c94-ba56-8650bea743dd",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709412961172000.94465d2a-4333-4735-8800-f479207928a2",
+      "fullUrl" : "Observation/1706815486370841000.1cff3ae3-7384-444e-b2dd-9c7980cd5234",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709412961172000.94465d2a-4333-4735-8800-f479207928a2",
+        "id" : "1706815486370841000.1cff3ae3-7384-444e-b2dd-9c7980cd5234",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -192,10 +197,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709413137628000.6ea13bd6-bd53-4989-8478-48ff13a18f36",
+      "fullUrl" : "ServiceRequest/1706815486549778000.24e632d4-5f49-4b42-953b-daf08af8266d",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709413137628000.6ea13bd6-bd53-4989-8478-48ff13a18f36",
+        "id" : "1706815486549778000.24e632d4-5f49-4b42-953b-daf08af8266d",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -219,13 +224,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709413140196000.cf620865-f0b0-4603-98cc-bf99eb0837c9",
+      "fullUrl" : "DiagnosticReport/1706815486552149000.bb832716-7674-4c9b-8bb4-3bd6f584642d",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709413140196000.cf620865-f0b0-4603-98cc-bf99eb0837c9",
+        "id" : "1706815486552149000.bb832716-7674-4c9b-8bb4-3bd6f584642d",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709413137628000.6ea13bd6-bd53-4989-8478-48ff13a18f36"
+            "reference" : "ServiceRequest/1706815486549778000.24e632d4-5f49-4b42-953b-daf08af8266d"
           }
         ],
         "status" : "final",
@@ -250,7 +255,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709412961172000.94465d2a-4333-4735-8800-f479207928a2"
+            "reference" : "Observation/1706815486370841000.1cff3ae3-7384-444e-b2dd-9c7980cd5234"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-data-absent-x-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-data-absent-x-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709421926182000.f644c64d-51ef-4a58-b482-2873cbcab9db",
+  "id" : "1706815496262910000.cfce379c-a7fa-4a98-aecb-94063f4a8837",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:01.933-05:00"
+    "lastUpdated" : "2024-02-01T14:24:56.269-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709421997413000.06fd0837-5903-4fd4-9b30-440ff704e28d"
+          "reference" : "Organization/1706815496312531000.1e4b36fd-be2f-42f6-ba52-a4e91069f1ec"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709421997413000.06fd0837-5903-4fd4-9b30-440ff704e28d",
+      "fullUrl" : "Organization/1706815496312531000.1e4b36fd-be2f-42f6-ba52-a4e91069f1ec",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709421997413000.06fd0837-5903-4fd4-9b30-440ff704e28d",
+        "id" : "1706815496312531000.1e4b36fd-be2f-42f6-ba52-a4e91069f1ec",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709422322360000.ce6e302c-a846-469b-811f-5481ae9c5b42",
+      "fullUrl" : "Provenance/1706815496684590000.e3263f4c-5a9f-4d78-bf87-be0f14bad148",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709422322360000.ce6e302c-a846-469b-811f-5481ae9c5b42",
+        "id" : "1706815496684590000.e3263f4c-5a9f-4d78-bf87-be0f14bad148",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709422507230000.c6b2f638-4aca-48bd-9d0f-869d581b5e2b"
+            "reference" : "DiagnosticReport/1706815496875206000.0c86c7ce-4606-4665-94c2-e9092314edc2"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709422329242000.d26d87be-a8bd-4480-a3aa-99e4a3a389c5",
+      "fullUrl" : "Provenance/1706815496692393000.07c8b809-ad73-431a-972b-e0471877bb84",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709422329242000.d26d87be-a8bd-4480-a3aa-99e4a3a389c5",
-        "recorded" : "2024-01-31T08:57:02Z",
+        "id" : "1706815496692393000.07c8b809-ad73-431a-972b-e0471877bb84",
+        "recorded" : "2024-02-01T14:24:56Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709422328737000.28a71dfd-bf5e-4387-b51c-6c3599e6edb4"
+              "reference" : "Organization/1706815496691956000.46b762f6-2f47-4ff0-bf90-ae75ae58c000"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709422328737000.28a71dfd-bf5e-4387-b51c-6c3599e6edb4",
+      "fullUrl" : "Organization/1706815496691956000.46b762f6-2f47-4ff0-bf90-ae75ae58c000",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709422328737000.28a71dfd-bf5e-4387-b51c-6c3599e6edb4",
+        "id" : "1706815496691956000.46b762f6-2f47-4ff0-bf90-ae75ae58c000",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709422346696000.021ec212-8107-4067-b092-487b27455ca1",
+      "fullUrl" : "Observation/1706815496703598000.aafa145e-3616-4005-8521-46ec19f8254a",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709422346696000.021ec212-8107-4067-b092-487b27455ca1",
+        "id" : "1706815496703598000.aafa145e-3616-4005-8521-46ec19f8254a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -188,10 +193,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709422505083000.ee7fe501-2be8-4c2e-b493-862acbc57b14",
+      "fullUrl" : "ServiceRequest/1706815496872932000.61e9dece-41c4-463c-a62f-185e15ba525b",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709422505083000.ee7fe501-2be8-4c2e-b493-862acbc57b14",
+        "id" : "1706815496872932000.61e9dece-41c4-463c-a62f-185e15ba525b",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -215,13 +220,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709422507230000.c6b2f638-4aca-48bd-9d0f-869d581b5e2b",
+      "fullUrl" : "DiagnosticReport/1706815496875206000.0c86c7ce-4606-4665-94c2-e9092314edc2",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709422507230000.c6b2f638-4aca-48bd-9d0f-869d581b5e2b",
+        "id" : "1706815496875206000.0c86c7ce-4606-4665-94c2-e9092314edc2",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709422505083000.ee7fe501-2be8-4c2e-b493-862acbc57b14"
+            "reference" : "ServiceRequest/1706815496872932000.61e9dece-41c4-463c-a62f-185e15ba525b"
           }
         ],
         "status" : "final",
@@ -246,7 +251,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709422346696000.021ec212-8107-4067-b092-487b27455ca1"
+            "reference" : "Observation/1706815496703598000.aafa145e-3616-4005-8521-46ec19f8254a"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-dr-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-dr-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709431308297000.58b5d08a-628b-41e1-9ed0-e0325f3678e6",
+  "id" : "1706815507452583000.dbc9eba2-88cd-42b6-856c-0f1c49201873",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:11.314-05:00"
+    "lastUpdated" : "2024-02-01T14:25:07.459-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709431379763000.b390108e-6a28-44e0-8ab5-c3afe45a7294"
+          "reference" : "Organization/1706815507504277000.e2ceed4c-ff7a-4425-930f-43c2ffd3f4d9"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709431379763000.b390108e-6a28-44e0-8ab5-c3afe45a7294",
+      "fullUrl" : "Organization/1706815507504277000.e2ceed4c-ff7a-4425-930f-43c2ffd3f4d9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709431379763000.b390108e-6a28-44e0-8ab5-c3afe45a7294",
+        "id" : "1706815507504277000.e2ceed4c-ff7a-4425-930f-43c2ffd3f4d9",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709431694280000.2332a9a5-8694-4a58-bb13-173ff8422217",
+      "fullUrl" : "Provenance/1706815507885941000.b44ccc8b-62fb-49ae-b244-1acac69526da",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709431694280000.2332a9a5-8694-4a58-bb13-173ff8422217",
+        "id" : "1706815507885941000.b44ccc8b-62fb-49ae-b244-1acac69526da",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709431882412000.408c92f0-ff63-4263-a42a-0ffa512ccf0b"
+            "reference" : "DiagnosticReport/1706815508141359000.3f33e471-f61d-446e-99d2-4169ffcd9d06"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709431702139000.1da281a3-6e62-44eb-9982-d9867b4b131e",
+      "fullUrl" : "Provenance/1706815507894007000.7bfdfdf6-39c5-4409-bf3b-86962aa28316",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709431702139000.1da281a3-6e62-44eb-9982-d9867b4b131e",
-        "recorded" : "2024-01-31T08:57:11Z",
+        "id" : "1706815507894007000.7bfdfdf6-39c5-4409-bf3b-86962aa28316",
+        "recorded" : "2024-02-01T14:25:07Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709431701651000.5d0f5127-4c50-439e-820e-8874f4b235f0"
+              "reference" : "Organization/1706815507893544000.b2b10aa2-396e-45ee-920c-4f1f0b879bbc"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709431701651000.5d0f5127-4c50-439e-820e-8874f4b235f0",
+      "fullUrl" : "Organization/1706815507893544000.b2b10aa2-396e-45ee-920c-4f1f0b879bbc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709431701651000.5d0f5127-4c50-439e-820e-8874f4b235f0",
+        "id" : "1706815507893544000.b2b10aa2-396e-45ee-920c-4f1f0b879bbc",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709431717110000.6fffdd75-b013-4c87-b1d1-b5db0928efeb",
+      "fullUrl" : "Observation/1706815507914130000.827812a2-77cd-4d5e-8048-c132959635f8",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709431717110000.6fffdd75-b013-4c87-b1d1-b5db0928efeb",
+        "id" : "1706815507914130000.827812a2-77cd-4d5e-8048-c132959635f8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -200,10 +205,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709431880510000.aaea43b8-a212-4682-81fd-514ed3e2c719",
+      "fullUrl" : "ServiceRequest/1706815508138978000.4db94e3c-f28c-4831-8def-ba472d150899",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709431880510000.aaea43b8-a212-4682-81fd-514ed3e2c719",
+        "id" : "1706815508138978000.4db94e3c-f28c-4831-8def-ba472d150899",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -227,13 +232,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709431882412000.408c92f0-ff63-4263-a42a-0ffa512ccf0b",
+      "fullUrl" : "DiagnosticReport/1706815508141359000.3f33e471-f61d-446e-99d2-4169ffcd9d06",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709431882412000.408c92f0-ff63-4263-a42a-0ffa512ccf0b",
+        "id" : "1706815508141359000.3f33e471-f61d-446e-99d2-4169ffcd9d06",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709431880510000.aaea43b8-a212-4682-81fd-514ed3e2c719"
+            "reference" : "ServiceRequest/1706815508138978000.4db94e3c-f28c-4831-8def-ba472d150899"
           }
         ],
         "status" : "final",
@@ -258,7 +263,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709431717110000.6fffdd75-b013-4c87-b1d1-b5db0928efeb"
+            "reference" : "Observation/1706815507914130000.827812a2-77cd-4d5e-8048-c132959635f8"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-dt-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-dt-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709440548973000.e34261ec-298d-4ba1-8d61-f66a9fc81472",
+  "id" : "1706815517491846000.8cf15fe1-40b7-4f00-9564-770ab6ef79d4",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:20.554-05:00"
+    "lastUpdated" : "2024-02-01T14:25:17.498-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709440619698000.56c136df-7fc7-4b90-8296-fe6169283dd3"
+          "reference" : "Organization/1706815517544770000.5fa358b0-fe31-4537-b3a6-164310514735"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709440619698000.56c136df-7fc7-4b90-8296-fe6169283dd3",
+      "fullUrl" : "Organization/1706815517544770000.5fa358b0-fe31-4537-b3a6-164310514735",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709440619698000.56c136df-7fc7-4b90-8296-fe6169283dd3",
+        "id" : "1706815517544770000.5fa358b0-fe31-4537-b3a6-164310514735",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709440928389000.2a43ab57-bf01-4836-a3a8-6996738e3ac2",
+      "fullUrl" : "Provenance/1706815517894767000.e81c1fdc-16af-4d34-b1ef-76057e6518e4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709440928389000.2a43ab57-bf01-4836-a3a8-6996738e3ac2",
+        "id" : "1706815517894767000.e81c1fdc-16af-4d34-b1ef-76057e6518e4",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709441112609000.cd1b0444-d265-43f3-8ec7-df2e70a32e94"
+            "reference" : "DiagnosticReport/1706815518084642000.01076350-d8cf-4cb8-9e22-ea5f0deec302"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709440936227000.1047b517-2389-4635-b083-214459d9950b",
+      "fullUrl" : "Provenance/1706815517902842000.5688d730-1fa4-4b88-a388-36ed0cbe87cf",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709440936227000.1047b517-2389-4635-b083-214459d9950b",
-        "recorded" : "2024-01-31T08:57:20Z",
+        "id" : "1706815517902842000.5688d730-1fa4-4b88-a388-36ed0cbe87cf",
+        "recorded" : "2024-02-01T14:25:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709440935172000.bd69766e-a2cc-41cc-8f4a-f447b2ad83bf"
+              "reference" : "Organization/1706815517902358000.44255b09-e878-4b34-94a1-9dc12934bc57"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709440935172000.bd69766e-a2cc-41cc-8f4a-f447b2ad83bf",
+      "fullUrl" : "Organization/1706815517902358000.44255b09-e878-4b34-94a1-9dc12934bc57",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709440935172000.bd69766e-a2cc-41cc-8f4a-f447b2ad83bf",
+        "id" : "1706815517902358000.44255b09-e878-4b34-94a1-9dc12934bc57",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709440953550000.6b14a472-4fd6-4adb-a445-647fb9debfca",
+      "fullUrl" : "Observation/1706815517915386000.12ddcea3-9e4f-4908-96a1-34db049441e6",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709440953550000.6b14a472-4fd6-4adb-a445-647fb9debfca",
+        "id" : "1706815517915386000.12ddcea3-9e4f-4908-96a1-34db049441e6",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -189,10 +194,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709441110115000.672a6f33-285d-43c0-8797-1260c70d2d18",
+      "fullUrl" : "ServiceRequest/1706815518082016000.8d662a5e-03ba-4c37-9be6-cd74b4ee87fa",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709441110115000.672a6f33-285d-43c0-8797-1260c70d2d18",
+        "id" : "1706815518082016000.8d662a5e-03ba-4c37-9be6-cd74b4ee87fa",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -216,13 +221,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709441112609000.cd1b0444-d265-43f3-8ec7-df2e70a32e94",
+      "fullUrl" : "DiagnosticReport/1706815518084642000.01076350-d8cf-4cb8-9e22-ea5f0deec302",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709441112609000.cd1b0444-d265-43f3-8ec7-df2e70a32e94",
+        "id" : "1706815518084642000.01076350-d8cf-4cb8-9e22-ea5f0deec302",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709441110115000.672a6f33-285d-43c0-8797-1260c70d2d18"
+            "reference" : "ServiceRequest/1706815518082016000.8d662a5e-03ba-4c37-9be6-cd74b4ee87fa"
           }
         ],
         "status" : "final",
@@ -247,7 +252,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709440953550000.6b14a472-4fd6-4adb-a445-647fb9debfca"
+            "reference" : "Observation/1706815517915386000.12ddcea3-9e4f-4908-96a1-34db049441e6"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-dtm-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-dtm-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709449892845000.8413cea7-c1a9-4a01-9c01-a9600ea8fd4f",
+  "id" : "1706815527346353000.a3138e3e-b376-4dc0-bf31-bcbd0c4e0ca7",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:29.899-05:00"
+    "lastUpdated" : "2024-02-01T14:25:27.353-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709449966653000.d02aaf9e-52fe-490a-b8ec-fed54c446abb"
+          "reference" : "Organization/1706815527402582000.eeaf6d3e-48da-4850-b2de-d326fda2e0af"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709449966653000.d02aaf9e-52fe-490a-b8ec-fed54c446abb",
+      "fullUrl" : "Organization/1706815527402582000.eeaf6d3e-48da-4850-b2de-d326fda2e0af",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709449966653000.d02aaf9e-52fe-490a-b8ec-fed54c446abb",
+        "id" : "1706815527402582000.eeaf6d3e-48da-4850-b2de-d326fda2e0af",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709450268673000.5e7c165d-f984-4b53-bd1c-793a1373f26e",
+      "fullUrl" : "Provenance/1706815527780248000.272468aa-6d0c-4fc7-bf2d-d3c81ff4b500",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709450268673000.5e7c165d-f984-4b53-bd1c-793a1373f26e",
+        "id" : "1706815527780248000.272468aa-6d0c-4fc7-bf2d-d3c81ff4b500",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709450459164000.6f7ac92f-c7e2-4081-96fc-bd2721a32c38"
+            "reference" : "DiagnosticReport/1706815527977985000.211aca01-6979-46ac-b25b-95f15ca00123"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709450276313000.7821ebb2-5dec-4b08-a2ff-1adca3a8f232",
+      "fullUrl" : "Provenance/1706815527789040000.4a4fd7d3-bf19-4e6c-b2c2-351ee8d46680",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709450276313000.7821ebb2-5dec-4b08-a2ff-1adca3a8f232",
-        "recorded" : "2024-01-31T08:57:30Z",
+        "id" : "1706815527789040000.4a4fd7d3-bf19-4e6c-b2c2-351ee8d46680",
+        "recorded" : "2024-02-01T14:25:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709450275868000.ebc7b3e4-d19b-43ad-be07-2412c251aa99"
+              "reference" : "Organization/1706815527788578000.608d2503-353b-49fa-bb9f-05d816ece878"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709450275868000.ebc7b3e4-d19b-43ad-be07-2412c251aa99",
+      "fullUrl" : "Organization/1706815527788578000.608d2503-353b-49fa-bb9f-05d816ece878",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709450275868000.ebc7b3e4-d19b-43ad-be07-2412c251aa99",
+        "id" : "1706815527788578000.608d2503-353b-49fa-bb9f-05d816ece878",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709450289981000.5528f303-7321-4b09-8a54-27f788d839c9",
+      "fullUrl" : "Observation/1706815527804668000.afdc1d51-b10e-4ea7-b606-4ba85f20a605",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709450289981000.5528f303-7321-4b09-8a54-27f788d839c9",
+        "id" : "1706815527804668000.afdc1d51-b10e-4ea7-b606-4ba85f20a605",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -189,10 +194,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709450456702000.58b3ac67-dabb-4afc-a708-199f633a412c",
+      "fullUrl" : "ServiceRequest/1706815527975012000.e722de17-47a6-42e9-a17e-9b496bf0dc1b",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709450456702000.58b3ac67-dabb-4afc-a708-199f633a412c",
+        "id" : "1706815527975012000.e722de17-47a6-42e9-a17e-9b496bf0dc1b",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -216,13 +221,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709450459164000.6f7ac92f-c7e2-4081-96fc-bd2721a32c38",
+      "fullUrl" : "DiagnosticReport/1706815527977985000.211aca01-6979-46ac-b25b-95f15ca00123",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709450459164000.6f7ac92f-c7e2-4081-96fc-bd2721a32c38",
+        "id" : "1706815527977985000.211aca01-6979-46ac-b25b-95f15ca00123",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709450456702000.58b3ac67-dabb-4afc-a708-199f633a412c"
+            "reference" : "ServiceRequest/1706815527975012000.e722de17-47a6-42e9-a17e-9b496bf0dc1b"
           }
         ],
         "status" : "final",
@@ -247,7 +252,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709450289981000.5528f303-7321-4b09-8a54-27f788d839c9"
+            "reference" : "Observation/1706815527804668000.afdc1d51-b10e-4ea7-b606-4ba85f20a605"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-ed-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-ed-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709459444929000.9bc3bcbd-1291-4f95-839f-1da41b341dc6",
+  "id" : "1706815537699943000.22b33f6f-1d48-4727-aeb7-c3afc67c6a37",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:39.451-05:00"
+    "lastUpdated" : "2024-02-01T14:25:37.706-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709459527195000.e8910acd-3f59-4870-ab93-615dec157aeb"
+          "reference" : "Organization/1706815537749162000.5e95bd8a-f4b9-4e5e-9019-f8ed2167eb38"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709459527195000.e8910acd-3f59-4870-ab93-615dec157aeb",
+      "fullUrl" : "Organization/1706815537749162000.5e95bd8a-f4b9-4e5e-9019-f8ed2167eb38",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709459527195000.e8910acd-3f59-4870-ab93-615dec157aeb",
+        "id" : "1706815537749162000.5e95bd8a-f4b9-4e5e-9019-f8ed2167eb38",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709459913263000.852c095d-bd2c-4f3b-aa9b-0aaae1a2d080",
+      "fullUrl" : "Provenance/1706815538095008000.d938cc32-d5c9-4ea9-9181-efe4c000da0a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709459913263000.852c095d-bd2c-4f3b-aa9b-0aaae1a2d080",
+        "id" : "1706815538095008000.d938cc32-d5c9-4ea9-9181-efe4c000da0a",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709460170598000.fd8a4f3b-8661-4cce-9f71-5ac77ec4fb73"
+            "reference" : "DiagnosticReport/1706815538281518000.18c69fe6-a47c-44a9-9c54-0a8fe876d2d2"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709459924964000.1318d4bf-ebd2-4087-bb0f-0762c57eca1f",
+      "fullUrl" : "Provenance/1706815538102049000.efb23e79-bb50-435d-bd2f-07cc959cec75",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709459924964000.1318d4bf-ebd2-4087-bb0f-0762c57eca1f",
-        "recorded" : "2024-01-31T08:57:39Z",
+        "id" : "1706815538102049000.efb23e79-bb50-435d-bd2f-07cc959cec75",
+        "recorded" : "2024-02-01T14:25:38Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709459924208000.2e58a225-b9bd-4979-b39b-07f85e40046d"
+              "reference" : "Organization/1706815538101108000.e8ea62ba-87c5-480c-998b-de9f48fbf01d"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709459924208000.2e58a225-b9bd-4979-b39b-07f85e40046d",
+      "fullUrl" : "Organization/1706815538101108000.e8ea62ba-87c5-480c-998b-de9f48fbf01d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709459924208000.2e58a225-b9bd-4979-b39b-07f85e40046d",
+        "id" : "1706815538101108000.e8ea62ba-87c5-480c-998b-de9f48fbf01d",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709459945263000.09baea31-2e50-4f34-9952-5ac767685bab",
+      "fullUrl" : "Observation/1706815538115816000.c88babc4-5bfa-4118-b2d0-622922513816",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709459945263000.09baea31-2e50-4f34-9952-5ac767685bab",
+        "id" : "1706815538115816000.c88babc4-5bfa-4118-b2d0-622922513816",
         "extension" : [
           {
             "url" : "https://hl7.org/fhir/R5/StructureDefinition/observation-value-attachment",
@@ -235,10 +240,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709460166738000.72adb79c-ad3e-4fb6-a54e-beeb740556fc",
+      "fullUrl" : "ServiceRequest/1706815538278213000.58cf3b03-c846-4327-81ec-b822a039d959",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709460166738000.72adb79c-ad3e-4fb6-a54e-beeb740556fc",
+        "id" : "1706815538278213000.58cf3b03-c846-4327-81ec-b822a039d959",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -262,13 +267,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709460170598000.fd8a4f3b-8661-4cce-9f71-5ac77ec4fb73",
+      "fullUrl" : "DiagnosticReport/1706815538281518000.18c69fe6-a47c-44a9-9c54-0a8fe876d2d2",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709460170598000.fd8a4f3b-8661-4cce-9f71-5ac77ec4fb73",
+        "id" : "1706815538281518000.18c69fe6-a47c-44a9-9c54-0a8fe876d2d2",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709460166738000.72adb79c-ad3e-4fb6-a54e-beeb740556fc"
+            "reference" : "ServiceRequest/1706815538278213000.58cf3b03-c846-4327-81ec-b822a039d959"
           }
         ],
         "status" : "final",
@@ -293,7 +298,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709459945263000.09baea31-2e50-4f34-9952-5ac767685bab"
+            "reference" : "Observation/1706815538115816000.c88babc4-5bfa-4118-b2d0-622922513816"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-ft-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-ft-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709469193154000.50ceb338-77f7-4472-8c08-e2cd7fba6a88",
+  "id" : "1706815547917518000.099e2a74-9c1b-4ceb-8c80-33273e4c6e06",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:49.199-05:00"
+    "lastUpdated" : "2024-02-01T14:25:47.923-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709469262789000.db41c9ac-0391-4203-a30c-8628350da178"
+          "reference" : "Organization/1706815547967951000.8e250dcd-7175-45e8-859c-1e41f7ed7d40"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709469262789000.db41c9ac-0391-4203-a30c-8628350da178",
+      "fullUrl" : "Organization/1706815547967951000.8e250dcd-7175-45e8-859c-1e41f7ed7d40",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709469262789000.db41c9ac-0391-4203-a30c-8628350da178",
+        "id" : "1706815547967951000.8e250dcd-7175-45e8-859c-1e41f7ed7d40",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709469574121000.8a5cb742-ea46-4d3a-86c8-668de2eda0bd",
+      "fullUrl" : "Provenance/1706815548448260000.3486d654-3ed3-4f81-b2bc-f090a32b8340",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709469574121000.8a5cb742-ea46-4d3a-86c8-668de2eda0bd",
+        "id" : "1706815548448260000.3486d654-3ed3-4f81-b2bc-f090a32b8340",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709469758989000.67c68ff0-d42a-4e2f-900e-5b2321f6004a"
+            "reference" : "DiagnosticReport/1706815548674135000.8eacf261-aea0-42b5-8aa9-15b7c58df44b"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709469581957000.d94564d5-9b6b-48e2-810c-93e9fbb53a7b",
+      "fullUrl" : "Provenance/1706815548459431000.bb070d81-0095-416e-a647-c66bd54944db",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709469581957000.d94564d5-9b6b-48e2-810c-93e9fbb53a7b",
-        "recorded" : "2024-01-31T08:57:49Z",
+        "id" : "1706815548459431000.bb070d81-0095-416e-a647-c66bd54944db",
+        "recorded" : "2024-02-01T14:25:48Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709469581438000.2a040af7-bc58-405f-bd95-6d6b606df5b0"
+              "reference" : "Organization/1706815548457900000.2118d6be-fdd2-46e8-bf25-3869a4d56201"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709469581438000.2a040af7-bc58-405f-bd95-6d6b606df5b0",
+      "fullUrl" : "Organization/1706815548457900000.2118d6be-fdd2-46e8-bf25-3869a4d56201",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709469581438000.2a040af7-bc58-405f-bd95-6d6b606df5b0",
+        "id" : "1706815548457900000.2118d6be-fdd2-46e8-bf25-3869a4d56201",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709469595139000.e2da99da-53e6-4380-87a9-ad06361d924d",
+      "fullUrl" : "Observation/1706815548478248000.f23cf4ac-baa9-4a5b-a9d5-91c6e5cb0958",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709469595139000.e2da99da-53e6-4380-87a9-ad06361d924d",
+        "id" : "1706815548478248000.f23cf4ac-baa9-4a5b-a9d5-91c6e5cb0958",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -181,10 +186,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709469752484000.d397acd9-679e-4328-be6d-30f40470f40a",
+      "fullUrl" : "ServiceRequest/1706815548671379000.5a470d0d-62be-4cb9-9899-71766189f15e",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709469752484000.d397acd9-679e-4328-be6d-30f40470f40a",
+        "id" : "1706815548671379000.5a470d0d-62be-4cb9-9899-71766189f15e",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -208,13 +213,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709469758989000.67c68ff0-d42a-4e2f-900e-5b2321f6004a",
+      "fullUrl" : "DiagnosticReport/1706815548674135000.8eacf261-aea0-42b5-8aa9-15b7c58df44b",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709469758989000.67c68ff0-d42a-4e2f-900e-5b2321f6004a",
+        "id" : "1706815548674135000.8eacf261-aea0-42b5-8aa9-15b7c58df44b",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709469752484000.d397acd9-679e-4328-be6d-30f40470f40a"
+            "reference" : "ServiceRequest/1706815548671379000.5a470d0d-62be-4cb9-9899-71766189f15e"
           }
         ],
         "status" : "final",
@@ -239,7 +244,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709469595139000.e2da99da-53e6-4380-87a9-ad06361d924d"
+            "reference" : "Observation/1706815548478248000.f23cf4ac-baa9-4a5b-a9d5-91c6e5cb0958"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-is-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-is-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709478482341000.af99e7bc-158e-461f-9a93-c2522435e06f",
+  "id" : "1706815559675748000.b7eca3cc-996a-49e6-940a-c6a093bd6ff0",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:57:58.487-05:00"
+    "lastUpdated" : "2024-02-01T14:25:59.686-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709478549332000.72853459-763e-447b-bc47-18b246f1bfbf"
+          "reference" : "Organization/1706815559740925000.a0c30b1b-1791-4559-9d0c-15a222e6d471"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709478549332000.72853459-763e-447b-bc47-18b246f1bfbf",
+      "fullUrl" : "Organization/1706815559740925000.a0c30b1b-1791-4559-9d0c-15a222e6d471",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709478549332000.72853459-763e-447b-bc47-18b246f1bfbf",
+        "id" : "1706815559740925000.a0c30b1b-1791-4559-9d0c-15a222e6d471",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709478856866000.a53b6f97-2a46-4208-87eb-7465102e1aa6",
+      "fullUrl" : "Provenance/1706815560099511000.ba643edf-e917-45a6-9802-9cbaa2946418",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709478856866000.a53b6f97-2a46-4208-87eb-7465102e1aa6",
+        "id" : "1706815560099511000.ba643edf-e917-45a6-9802-9cbaa2946418",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709479035199000.d9d99b52-fc30-41a8-9d91-2450e854ef79"
+            "reference" : "DiagnosticReport/1706815560300336000.703e8411-8809-43a0-b328-1d8b220b31a9"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709478864216000.afe17d53-2583-450e-b93b-06cedb5454f5",
+      "fullUrl" : "Provenance/1706815560105623000.1d6d3b63-1821-429d-8a09-1031208ea17f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709478864216000.afe17d53-2583-450e-b93b-06cedb5454f5",
-        "recorded" : "2024-01-31T08:57:58Z",
+        "id" : "1706815560105623000.1d6d3b63-1821-429d-8a09-1031208ea17f",
+        "recorded" : "2024-02-01T14:26:00Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709478863305000.3cffe872-ce65-498f-9d2f-a048d2b2507d"
+              "reference" : "Organization/1706815560105178000.a1719e0a-244e-4fa1-888a-db55a0b504d6"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709478863305000.3cffe872-ce65-498f-9d2f-a048d2b2507d",
+      "fullUrl" : "Organization/1706815560105178000.a1719e0a-244e-4fa1-888a-db55a0b504d6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709478863305000.3cffe872-ce65-498f-9d2f-a048d2b2507d",
+        "id" : "1706815560105178000.a1719e0a-244e-4fa1-888a-db55a0b504d6",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709478876481000.16230768-9dc9-4aa8-98c1-5fbbaccc30d2",
+      "fullUrl" : "Observation/1706815560116862000.505cb125-060d-42a2-9cc8-f218bc2681ec",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709478876481000.16230768-9dc9-4aa8-98c1-5fbbaccc30d2",
+        "id" : "1706815560116862000.505cb125-060d-42a2-9cc8-f218bc2681ec",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -187,10 +192,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709479032747000.2057340b-dc7a-4ced-9835-9e48e15f611c",
+      "fullUrl" : "ServiceRequest/1706815560297918000.b3d2cbe6-9f1a-4db9-96fa-35ddd1d68c99",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709479032747000.2057340b-dc7a-4ced-9835-9e48e15f611c",
+        "id" : "1706815560297918000.b3d2cbe6-9f1a-4db9-96fa-35ddd1d68c99",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -214,13 +219,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709479035199000.d9d99b52-fc30-41a8-9d91-2450e854ef79",
+      "fullUrl" : "DiagnosticReport/1706815560300336000.703e8411-8809-43a0-b328-1d8b220b31a9",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709479035199000.d9d99b52-fc30-41a8-9d91-2450e854ef79",
+        "id" : "1706815560300336000.703e8411-8809-43a0-b328-1d8b220b31a9",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709479032747000.2057340b-dc7a-4ced-9835-9e48e15f611c"
+            "reference" : "ServiceRequest/1706815560297918000.b3d2cbe6-9f1a-4db9-96fa-35ddd1d68c99"
           }
         ],
         "status" : "final",
@@ -245,7 +250,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709478876481000.16230768-9dc9-4aa8-98c1-5fbbaccc30d2"
+            "reference" : "Observation/1706815560116862000.505cb125-060d-42a2-9cc8-f218bc2681ec"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-nm-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-nm-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709487682007000.cc6a1ca4-ae7c-4636-bc7e-d8a78f492260",
+  "id" : "1706815571499373000.70bad19b-06fd-4d4f-ae45-e1c523f37c69",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:58:07.688-05:00"
+    "lastUpdated" : "2024-02-01T14:26:11.505-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709487754612000.5bd68eaa-97b7-4774-8cc1-24328fd575d8"
+          "reference" : "Organization/1706815571547588000.69a4466c-ed70-4151-9c7a-2821123d17a1"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709487754612000.5bd68eaa-97b7-4774-8cc1-24328fd575d8",
+      "fullUrl" : "Organization/1706815571547588000.69a4466c-ed70-4151-9c7a-2821123d17a1",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709487754612000.5bd68eaa-97b7-4774-8cc1-24328fd575d8",
+        "id" : "1706815571547588000.69a4466c-ed70-4151-9c7a-2821123d17a1",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709488057060000.d5b68afc-225d-4060-bcc6-7274b9e6a866",
+      "fullUrl" : "Provenance/1706815571889739000.4436d2f8-e7aa-4407-8549-c4f0d65e35e2",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709488057060000.d5b68afc-225d-4060-bcc6-7274b9e6a866",
+        "id" : "1706815571889739000.4436d2f8-e7aa-4407-8549-c4f0d65e35e2",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709488243016000.c407dc75-5c2b-4f31-b9e0-9c7e84f2e1e8"
+            "reference" : "DiagnosticReport/1706815572096425000.1addafcd-c369-4cd2-9cf6-cf245264fede"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709488067057000.459e6757-b4da-40b1-8514-57b35a178a18",
+      "fullUrl" : "Provenance/1706815571896823000.dcf13c31-70c1-4797-8787-323721f494a8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709488067057000.459e6757-b4da-40b1-8514-57b35a178a18",
-        "recorded" : "2024-01-31T08:58:08Z",
+        "id" : "1706815571896823000.dcf13c31-70c1-4797-8787-323721f494a8",
+        "recorded" : "2024-02-01T14:26:11Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709488066629000.f65200d4-d34c-47c3-af96-b58f784467ea"
+              "reference" : "Organization/1706815571896328000.c25a55e7-9c19-47ef-bbb4-7421975877b3"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709488066629000.f65200d4-d34c-47c3-af96-b58f784467ea",
+      "fullUrl" : "Organization/1706815571896328000.c25a55e7-9c19-47ef-bbb4-7421975877b3",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709488066629000.f65200d4-d34c-47c3-af96-b58f784467ea",
+        "id" : "1706815571896328000.c25a55e7-9c19-47ef-bbb4-7421975877b3",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709488079179000.3fafb3a6-a917-45bc-ab3f-b91aa6ff7abd",
+      "fullUrl" : "Observation/1706815571910415000.4c262a46-5906-419e-9c50-c3bc2017cdd0",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709488079179000.3fafb3a6-a917-45bc-ab3f-b91aa6ff7abd",
+        "id" : "1706815571910415000.4c262a46-5906-419e-9c50-c3bc2017cdd0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -207,10 +212,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709488240371000.f22a5242-bed3-44e9-ab61-d4309bbb22c7",
+      "fullUrl" : "ServiceRequest/1706815572094444000.a59a2654-53ec-4bdb-ac00-32d42547b5f3",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709488240371000.f22a5242-bed3-44e9-ab61-d4309bbb22c7",
+        "id" : "1706815572094444000.a59a2654-53ec-4bdb-ac00-32d42547b5f3",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -234,13 +239,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709488243016000.c407dc75-5c2b-4f31-b9e0-9c7e84f2e1e8",
+      "fullUrl" : "DiagnosticReport/1706815572096425000.1addafcd-c369-4cd2-9cf6-cf245264fede",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709488243016000.c407dc75-5c2b-4f31-b9e0-9c7e84f2e1e8",
+        "id" : "1706815572096425000.1addafcd-c369-4cd2-9cf6-cf245264fede",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709488240371000.f22a5242-bed3-44e9-ab61-d4309bbb22c7"
+            "reference" : "ServiceRequest/1706815572094444000.a59a2654-53ec-4bdb-ac00-32d42547b5f3"
           }
         ],
         "status" : "final",
@@ -265,7 +270,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709488079179000.3fafb3a6-a917-45bc-ab3f-b91aa6ff7abd"
+            "reference" : "Observation/1706815571910415000.4c262a46-5906-419e-9c50-c3bc2017cdd0"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-nr-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-nr-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709496997500000.2dc08ce8-36a6-4603-804c-9b07262a780f",
+  "id" : "1706815582568707000.c0918eb5-c025-49c7-97d0-3c05082a8b16",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:58:17.003-05:00"
+    "lastUpdated" : "2024-02-01T14:26:22.574-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,188 +10,251 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706709497068196000.bbb564fd-83c0-44f9-a404-ad8e446d5d80"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706709497068196000.bbb564fd-83c0-44f9-a404-ad8e446d5d80",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709497068196000.bbb564fd-83c0-44f9-a404-ad8e446d5d80",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709497367055000.0dc97f03-1220-497c-b4e8-c2715a418075",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709497367055000.0dc97f03-1220-497c-b4e8-c2715a418075",
-      "target" : [ {
-        "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
-      }, {
-        "reference" : "DiagnosticReport/1706709497545951000.5d80120d-99e8-42b4-8ca4-7621f285ad8a"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709497373930000.4263cf67-c003-474a-b2a8-f2746b92a7de",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709497373930000.4263cf67-c003-474a-b2a8-f2746b92a7de",
-      "recorded" : "2024-01-31T08:58:17Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706709497373492000.10747064-e971-4b36-aad3-2f4b815b476e"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706709497373492000.10747064-e971-4b36-aad3-2f4b815b476e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709497373492000.10747064-e971-4b36-aad3-2f4b815b476e",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+        "sender" : {
+          "reference" : "Organization/1706815582620367000.098e4fb3-88f6-4f22-9da4-7657e0671664"
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Observation/1706709497387220000.23f4c1a3-8ffe-4f46-b6d1-e74b5af128a7",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1706709497387220000.23f4c1a3-8ffe-4f46-b6d1-e74b5af128a7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
-        "extension" : [ {
-          "url" : "obx-2-value-type",
-          "valueId" : "NR"
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "8675-3",
-          "display" : "Fake"
-        } ]
-      },
-      "valueRange" : {
-        "low" : {
-          "value" : 1
-        },
-        "high" : {
-          "value" : 10
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
       }
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706709497543419000.49a1caea-ad8d-49bd-be2e-bc9d8dc63f0a",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706709497543419000.49a1caea-ad8d-49bd-be2e-bc9d8dc63f0a",
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
+    },
+    {
+      "fullUrl" : "Organization/1706815582620367000.098e4fb3-88f6-4f22-9da4-7657e0671664",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815582620367000.098e4fb3-88f6-4f22-9da4-7657e0671664",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815582979235000.a8364edc-f5ec-4d4a-baa1-fe99d9a7b561",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815582979235000.a8364edc-f5ec-4d4a-baa1-fe99d9a7b561",
+        "target" : [
+          {
+            "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815583169250000.efa6d52d-d23e-4532-8976-b7f873a1f481"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815582986416000.0f268d7b-596e-431c-b8ae-eb068d57ffcd",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815582986416000.0f268d7b-596e-431c-b8ae-eb068d57ffcd",
+        "recorded" : "2024-02-01T14:26:22Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815582985955000.976e7826-5d64-4607-98f1-5c38ce4ad9e4"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815582985955000.976e7826-5d64-4607-98f1-5c38ce4ad9e4",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815582985955000.976e7826-5d64-4607-98f1-5c38ce4ad9e4",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Observation/1706815583001490000.500544ed-db31-4527-887d-148333d10535",
+      "resource" : {
+        "resourceType" : "Observation",
+        "id" : "1706815583001490000.500544ed-db31-4527-887d-148333d10535",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+            "extension" : [
+              {
+                "url" : "obx-2-value-type",
+                "valueId" : "NR"
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "8675-3",
+              "display" : "Fake"
+            }
+          ]
+        },
+        "valueRange" : {
+          "low" : {
+            "value" : 1
+          },
+          "high" : {
+            "value" : 10
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815583166248000.01f77e56-9710-4e1c-9bdf-40bdea5b4fc6",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815583166248000.01f77e56-9710-4e1c-9bdf-40bdea5b4fc6",
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815583169250000.efa6d52d-d23e-4532-8976-b7f873a1f481",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815583169250000.efa6d52d-d23e-4532-8976-b7f873a1f481",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815583166248000.01f77e56-9710-4e1c-9bdf-40bdea5b4fc6"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        },
+        "result" : [
+          {
+            "reference" : "Observation/1706815583001490000.500544ed-db31-4527-887d-148333d10535"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706709497545951000.5d80120d-99e8-42b4-8ca4-7621f285ad8a",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706709497545951000.5d80120d-99e8-42b4-8ca4-7621f285ad8a",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706709497543419000.49a1caea-ad8d-49bd-be2e-bc9d8dc63f0a"
-      } ],
-      "status" : "final",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      },
-      "result" : [ {
-        "reference" : "Observation/1706709497387220000.23f4c1a3-8ffe-4f46-b6d1-e74b5af128a7"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-obx25-not-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-obx25-not-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709506265186000.2c264658-afac-47b1-ab2e-626a0b19b0aa",
+  "id" : "1706815593657217000.db188b52-a60f-4455-84bb-c6c751d7be9a",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:58:26.270-05:00"
+    "lastUpdated" : "2024-02-01T14:26:33.663-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,358 +10,491 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706709506337966000.b24a9537-56bf-4626-ad74-3c615c987e1e"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706709506337966000.b24a9537-56bf-4626-ad74-3c615c987e1e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709506337966000.b24a9537-56bf-4626-ad74-3c615c987e1e",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709506658164000.7cf1ce45-076c-425f-9567-627e382a94d2",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709506658164000.7cf1ce45-076c-425f-9567-627e382a94d2",
-      "target" : [ {
-        "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
-      }, {
-        "reference" : "DiagnosticReport/1706709506853200000.12114293-f450-413a-99e6-12d610e4b3a0"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706709506664897000.3cb1a2c0-0b38-48c7-9712-393c48991886",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706709506664897000.3cb1a2c0-0b38-48c7-9712-393c48991886",
-      "recorded" : "2024-01-31T08:58:26Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706709506664474000.95bb0230-4a47-4976-9557-15e8b2a6ebd5"
+        "sender" : {
+          "reference" : "Organization/1706815593712971000.4ec32475-3506-48c9-880e-fd00333b4389"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706709506664474000.95bb0230-4a47-4976-9557-15e8b2a6ebd5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709506664474000.95bb0230-4a47-4976-9557-15e8b2a6ebd5",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Observation/1706709506677493000.a4d84fee-5578-46ec-b481-52d8864eaaf6",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1706709506677493000.a4d84fee-5578-46ec-b481-52d8864eaaf6",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
-        "extension" : [ {
-          "url" : "obx-2-value-type",
-          "valueId" : "ST"
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "8675-3",
-          "display" : "Fake"
-        } ]
-      },
-      "performer" : [ {
-        "reference" : "Organization/1706709506682868000.25bb8174-aaef-4966-8fc2-a99abbe018a3"
-      } ],
-      "valueString" : "Some value"
-    }
-  }, {
-    "fullUrl" : "Location/1706709506679160000.ff307615-bf61-4d39-b17e-fc143898d618",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706709506679160000.ff307615-bf61-4d39-b17e-fc143898d618",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Organization/1706709506682868000.25bb8174-aaef-4966-8fc2-a99abbe018a3",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706709506682868000.25bb8174-aaef-4966-8fc2-a99abbe018a3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
+    },
+    {
+      "fullUrl" : "Organization/1706815593712971000.4ec32475-3506-48c9-880e-fd00333b4389",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815593712971000.4ec32475-3506-48c9-880e-fd00333b4389",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815594064258000.a4d2fc4f-ee83-4cd7-8cb0-4ef40a9c03c5",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815594064258000.a4d2fc4f-ee83-4cd7-8cb0-4ef40a9c03c5",
+        "target" : [
+          {
+            "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815594266329000.87f08342-893d-44d7-bd2a-45f84eb8b694"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815594072027000.0427d050-dd2b-4f7d-ba07-3a897ecbe058",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815594072027000.0427d050-dd2b-4f7d-ba07-3a897ecbe058",
+        "recorded" : "2024-02-01T14:26:34Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815594071550000.be74fff8-9baa-44a4-a76d-0f803c46e515"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815594071550000.be74fff8-9baa-44a4-a76d-0f803c46e515",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815594071550000.be74fff8-9baa-44a4-a76d-0f803c46e515",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Observation/1706815594084195000.05d4ec2b-9860-4699-a482-0aa23a1e1f12",
+      "resource" : {
+        "resourceType" : "Observation",
+        "id" : "1706815594084195000.05d4ec2b-9860-4699-a482-0aa23a1e1f12",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+            "extension" : [
+              {
+                "url" : "obx-2-value-type",
+                "valueId" : "ST"
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
                   "valueString" : "coding"
-                }, {
+                },
+                {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
                   "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "8675-3",
+              "display" : "Fake"
             }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "obx-25-performing-organization"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
+          ]
+        },
+        "performer" : [
+          {
+            "reference" : "Organization/1706815594089962000.5a8f291f-dbf1-4d4a-b5d1-e1299cacdf60"
+          }
+        ],
+        "valueString" : "Some value"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706815594086122000.8989d662-19dd-4974-b0cd-d51c239a4b99",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706815594086122000.8989d662-19dd-4974-b0cd-d51c239a4b99",
+        "extension" : [
+          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
             "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706709506679160000.ff307615-bf61-4d39-b17e-fc143898d618"
           }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org",
-      "address" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
-          "valueCode" : "6059"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861"
-            }, {
-              "url" : "SAD.2",
-              "valueString" : "20TH AVE"
-            }, {
-              "url" : "SAD.3",
-              "valueString" : "1"
-            } ]
-          }, {
-            "url" : "XAD.2",
-            "valueString" : "Other Designation"
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "B"
-          }, {
-            "url" : "XAD.8",
-            "valueString" : "Other Geographic Designation"
-          }, {
-            "url" : "XAD.11",
-            "valueCode" : "A"
-          }, {
-            "url" : "XAD.13",
-            "valueString" : "20220501102531-0400"
-          }, {
-            "url" : "XAD.14",
-            "valueString" : "20230501102531-0400"
-          }, {
-            "url" : "XAD.19",
-            "valueCode" : "Adressee"
-          } ]
-        } ],
-        "use" : "work",
-        "line" : [ "4861", "20TH AVE", "1", "Other Designation", "Adressee" ],
-        "city" : "THUNDER MOUNTAIN",
-        "district" : "County",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA",
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706709506850387000.7d5295db-2351-46ea-8f38-db576c4208f5",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706709506850387000.7d5295db-2351-46ea-8f38-db576c4208f5",
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815594089962000.5a8f291f-dbf1-4d4a-b5d1-e1299cacdf60",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815594089962000.5a8f291f-dbf1-4d4a-b5d1-e1299cacdf60",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "obx-25-performing-organization"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706815594086122000.8989d662-19dd-4974-b0cd-d51c239a4b99"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org",
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                "valueCode" : "6059"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861"
+                      },
+                      {
+                        "url" : "SAD.2",
+                        "valueString" : "20TH AVE"
+                      },
+                      {
+                        "url" : "SAD.3",
+                        "valueString" : "1"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.2",
+                    "valueString" : "Other Designation"
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "B"
+                  },
+                  {
+                    "url" : "XAD.8",
+                    "valueString" : "Other Geographic Designation"
+                  },
+                  {
+                    "url" : "XAD.11",
+                    "valueCode" : "A"
+                  },
+                  {
+                    "url" : "XAD.13",
+                    "valueString" : "20220501102531-0400"
+                  },
+                  {
+                    "url" : "XAD.14",
+                    "valueString" : "20230501102531-0400"
+                  },
+                  {
+                    "url" : "XAD.19",
+                    "valueCode" : "Adressee"
+                  }
+                ]
+              }
+            ],
+            "use" : "work",
+            "line" : [
+              "4861",
+              "20TH AVE",
+              "1",
+              "Other Designation",
+              "Adressee"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "district" : "County",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA",
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815594259732000.06a99074-e9f1-41d0-a81a-b34500d1215c",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815594259732000.06a99074-e9f1-41d0-a81a-b34500d1215c",
+        "status" : "unknown",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815594266329000.87f08342-893d-44d7-bd2a-45f84eb8b694",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815594266329000.87f08342-893d-44d7-bd2a-45f84eb8b694",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815594259732000.06a99074-e9f1-41d0-a81a-b34500d1215c"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        },
+        "result" : [
+          {
+            "reference" : "Observation/1706815594084195000.05d4ec2b-9860-4699-a482-0aa23a1e1f12"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706709506853200000.12114293-f450-413a-99e6-12d610e4b3a0",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706709506853200000.12114293-f450-413a-99e6-12d610e4b3a0",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706709506850387000.7d5295db-2351-46ea-8f38-db576c4208f5"
-      } ],
-      "status" : "final",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      },
-      "result" : [ {
-        "reference" : "Observation/1706709506677493000.a4d84fee-5578-46ec-b481-52d8864eaaf6"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-obx25-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-obx25-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709515606464000.eccb90cf-e639-4006-8a8d-db156ed7b07d",
+  "id" : "1706815604395373000.47da1a30-96c2-4ea3-8425-d10531ee6007",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:58:35.613-05:00"
+    "lastUpdated" : "2024-02-01T14:26:44.401-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709515678428000.825be011-355b-4a62-8fdf-cfe89b9472e1"
+          "reference" : "Organization/1706815604448384000.baf79a01-8a1e-4b68-8aa5-c7cc6988c821"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709515678428000.825be011-355b-4a62-8fdf-cfe89b9472e1",
+      "fullUrl" : "Organization/1706815604448384000.baf79a01-8a1e-4b68-8aa5-c7cc6988c821",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709515678428000.825be011-355b-4a62-8fdf-cfe89b9472e1",
+        "id" : "1706815604448384000.baf79a01-8a1e-4b68-8aa5-c7cc6988c821",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709515984101000.2aa7ab75-f035-4de8-8888-0b7fbb59eb9e",
+      "fullUrl" : "Provenance/1706815604813551000.d0ff844f-a455-4b5b-8df0-e31548c217c0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709515984101000.2aa7ab75-f035-4de8-8888-0b7fbb59eb9e",
+        "id" : "1706815604813551000.d0ff844f-a455-4b5b-8df0-e31548c217c0",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709516189195000.db30a7cd-bbeb-4842-8db2-5f21493acec4"
+            "reference" : "DiagnosticReport/1706815605054058000.fef26ee8-fee6-4b1f-aed5-bda910b43da2"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709515990604000.7c5f22da-6f1c-4630-8050-df18b6c5e09b",
+      "fullUrl" : "Provenance/1706815604820891000.7a876ed4-e66c-4406-8258-960ad54d82e2",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709515990604000.7c5f22da-6f1c-4630-8050-df18b6c5e09b",
-        "recorded" : "2024-01-31T08:58:35Z",
+        "id" : "1706815604820891000.7a876ed4-e66c-4406-8258-960ad54d82e2",
+        "recorded" : "2024-02-01T14:26:44Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709515989381000.3392b32b-d388-4853-a493-1ea33e562782"
+              "reference" : "Organization/1706815604820422000.7a357d8e-0ea0-4eb8-bde2-cd5734c49eac"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709515989381000.3392b32b-d388-4853-a493-1ea33e562782",
+      "fullUrl" : "Organization/1706815604820422000.7a357d8e-0ea0-4eb8-bde2-cd5734c49eac",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709515989381000.3392b32b-d388-4853-a493-1ea33e562782",
+        "id" : "1706815604820422000.7a357d8e-0ea0-4eb8-bde2-cd5734c49eac",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709516002574000.4e84c75e-679e-44c7-ac7c-301032dd9708",
+      "fullUrl" : "Observation/1706815604838736000.bb10221e-57b0-4bc5-ba61-5feadd29c119",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709516002574000.4e84c75e-679e-44c7-ac7c-301032dd9708",
+        "id" : "1706815604838736000.bb10221e-57b0-4bc5-ba61-5feadd29c119",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -179,17 +184,17 @@
         },
         "performer" : [
           {
-            "reference" : "PractitionerRole/1706709516003697000.6b24829c-094f-4c91-9bed-d02e42ca20c5"
+            "reference" : "PractitionerRole/1706815604839685000.17b1a1de-51ff-4bd5-9427-808aadd71750"
           }
         ],
         "valueString" : "Some value"
       }
     },
     {
-      "fullUrl" : "Practitioner/1706709516013504000.22d87874-31f5-45c7-9d07-2ada075e292d",
+      "fullUrl" : "Practitioner/1706815604852200000.54aa6943-fc53-4867-abdd-7904abb757b0",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706709516013504000.22d87874-31f5-45c7-9d07-2ada075e292d",
+        "id" : "1706815604852200000.54aa6943-fc53-4867-abdd-7904abb757b0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -394,10 +399,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706709516016906000.0ff52e29-e9da-450c-a091-b919a8a3c482",
+      "fullUrl" : "Location/1706815604853602000.b42c9694-e831-4717-bf52-d38a18d0be66",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706709516016906000.0ff52e29-e9da-450c-a091-b919a8a3c482",
+        "id" : "1706815604853602000.b42c9694-e831-4717-bf52-d38a18d0be66",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -427,10 +432,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709516020224000.7392fa5d-a6d7-42c6-8708-0112d7ed1600",
+      "fullUrl" : "Organization/1706815604857692000.7d0a5a15-0bc4-4f4c-82b5-a7489945b447",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709516020224000.7392fa5d-a6d7-42c6-8708-0112d7ed1600",
+        "id" : "1706815604857692000.7d0a5a15-0bc4-4f4c-82b5-a7489945b447",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -530,7 +535,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706709516016906000.0ff52e29-e9da-450c-a091-b919a8a3c482"
+                  "reference" : "Location/1706815604853602000.b42c9694-e831-4717-bf52-d38a18d0be66"
                 }
               }
             ],
@@ -632,15 +637,15 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706709516003697000.6b24829c-094f-4c91-9bed-d02e42ca20c5",
+      "fullUrl" : "PractitionerRole/1706815604839685000.17b1a1de-51ff-4bd5-9427-808aadd71750",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706709516003697000.6b24829c-094f-4c91-9bed-d02e42ca20c5",
+        "id" : "1706815604839685000.17b1a1de-51ff-4bd5-9427-808aadd71750",
         "practitioner" : {
-          "reference" : "Practitioner/1706709516013504000.22d87874-31f5-45c7-9d07-2ada075e292d"
+          "reference" : "Practitioner/1706815604852200000.54aa6943-fc53-4867-abdd-7904abb757b0"
         },
         "organization" : {
-          "reference" : "Organization/1706709516020224000.7392fa5d-a6d7-42c6-8708-0112d7ed1600"
+          "reference" : "Organization/1706815604857692000.7d0a5a15-0bc4-4f4c-82b5-a7489945b447"
         },
         "code" : [
           {
@@ -655,10 +660,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709516186235000.dac035d7-a925-4cbe-96eb-628bcf0cb7c3",
+      "fullUrl" : "ServiceRequest/1706815605041770000.44f20a94-8e78-41b8-94a5-464a9b4722aa",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709516186235000.dac035d7-a925-4cbe-96eb-628bcf0cb7c3",
+        "id" : "1706815605041770000.44f20a94-8e78-41b8-94a5-464a9b4722aa",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -682,13 +687,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709516189195000.db30a7cd-bbeb-4842-8db2-5f21493acec4",
+      "fullUrl" : "DiagnosticReport/1706815605054058000.fef26ee8-fee6-4b1f-aed5-bda910b43da2",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709516189195000.db30a7cd-bbeb-4842-8db2-5f21493acec4",
+        "id" : "1706815605054058000.fef26ee8-fee6-4b1f-aed5-bda910b43da2",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709516186235000.dac035d7-a925-4cbe-96eb-628bcf0cb7c3"
+            "reference" : "ServiceRequest/1706815605041770000.44f20a94-8e78-41b8-94a5-464a9b4722aa"
           }
         ],
         "status" : "final",
@@ -713,7 +718,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709516002574000.4e84c75e-679e-44c7-ac7c-301032dd9708"
+            "reference" : "Observation/1706815604838736000.bb10221e-57b0-4bc5-ba61-5feadd29c119"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-quantity-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-quantity-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709524988215000.60be1222-3809-4745-9b1b-d8abb1f367c8",
+  "id" : "1706815615124806000.3fee045a-db9b-4ad8-a278-a58cff7ac855",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:58:44.995-05:00"
+    "lastUpdated" : "2024-02-01T14:26:55.131-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709525059528000.b7f19fd5-d5d2-4704-9e96-dbeff0fc374b"
+          "reference" : "Organization/1706815615176214000.543612d2-b1dd-493e-906e-35cc06041eec"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709525059528000.b7f19fd5-d5d2-4704-9e96-dbeff0fc374b",
+      "fullUrl" : "Organization/1706815615176214000.543612d2-b1dd-493e-906e-35cc06041eec",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709525059528000.b7f19fd5-d5d2-4704-9e96-dbeff0fc374b",
+        "id" : "1706815615176214000.543612d2-b1dd-493e-906e-35cc06041eec",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709525366071000.cec9cd64-1186-4e65-834c-e037ba795072",
+      "fullUrl" : "Provenance/1706815615537749000.257da58f-e1ff-45c7-92dc-4a781d6a6eca",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709525366071000.cec9cd64-1186-4e65-834c-e037ba795072",
+        "id" : "1706815615537749000.257da58f-e1ff-45c7-92dc-4a781d6a6eca",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709525547530000.6209d535-1374-4f73-a5fc-768069e23a68"
+            "reference" : "DiagnosticReport/1706815615738587000.1242c562-fcb5-4dbd-b856-3bf48b037ffc"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709525374334000.2c5c8f30-82b5-4395-800c-538c0b1f1591",
+      "fullUrl" : "Provenance/1706815615545783000.af089669-ed9d-41a4-841e-5c808a75f6fd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709525374334000.2c5c8f30-82b5-4395-800c-538c0b1f1591",
-        "recorded" : "2024-01-31T08:58:45Z",
+        "id" : "1706815615545783000.af089669-ed9d-41a4-841e-5c808a75f6fd",
+        "recorded" : "2024-02-01T14:26:55Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709525373676000.d7f96b50-592b-462b-8632-18fc1c33b834"
+              "reference" : "Organization/1706815615545331000.23da99dc-f474-481b-9946-a7a6f8e1f7b7"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709525373676000.d7f96b50-592b-462b-8632-18fc1c33b834",
+      "fullUrl" : "Organization/1706815615545331000.23da99dc-f474-481b-9946-a7a6f8e1f7b7",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709525373676000.d7f96b50-592b-462b-8632-18fc1c33b834",
+        "id" : "1706815615545331000.23da99dc-f474-481b-9946-a7a6f8e1f7b7",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709525387987000.eeb6293a-4a79-45fe-93fb-ea0484e751c3",
+      "fullUrl" : "Observation/1706815615561964000.288a5b06-d342-44d2-9c29-239cb302b9b5",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709525387987000.eeb6293a-4a79-45fe-93fb-ea0484e751c3",
+        "id" : "1706815615561964000.288a5b06-d342-44d2-9c29-239cb302b9b5",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-5-value-sn",
@@ -239,10 +244,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709525545210000.d02ef779-32cf-4b16-8a2a-270383571ca6",
+      "fullUrl" : "ServiceRequest/1706815615735159000.1b7c9f8f-f08f-4ea4-96ff-a4e04e3b1137",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709525545210000.d02ef779-32cf-4b16-8a2a-270383571ca6",
+        "id" : "1706815615735159000.1b7c9f8f-f08f-4ea4-96ff-a4e04e3b1137",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -266,13 +271,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709525547530000.6209d535-1374-4f73-a5fc-768069e23a68",
+      "fullUrl" : "DiagnosticReport/1706815615738587000.1242c562-fcb5-4dbd-b856-3bf48b037ffc",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709525547530000.6209d535-1374-4f73-a5fc-768069e23a68",
+        "id" : "1706815615738587000.1242c562-fcb5-4dbd-b856-3bf48b037ffc",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709525545210000.d02ef779-32cf-4b16-8a2a-270383571ca6"
+            "reference" : "ServiceRequest/1706815615735159000.1b7c9f8f-f08f-4ea4-96ff-a4e04e3b1137"
           }
         ],
         "status" : "final",
@@ -297,7 +302,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709525387987000.eeb6293a-4a79-45fe-93fb-ea0484e751c3"
+            "reference" : "Observation/1706815615561964000.288a5b06-d342-44d2-9c29-239cb302b9b5"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-range-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-range-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709534537213000.51fedd91-5975-459e-85c9-b05cd3be6231",
+  "id" : "1706815625408755000.aef2f0c0-4fc5-47c3-9258-a98f97dc0364",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:58:54.544-05:00"
+    "lastUpdated" : "2024-02-01T14:27:05.415-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709534611457000.a0933e4d-bf51-4d00-aa2e-8bd17b732872"
+          "reference" : "Organization/1706815625462413000.391ee0cc-8243-4eaa-88c3-37a1538c00e9"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709534611457000.a0933e4d-bf51-4d00-aa2e-8bd17b732872",
+      "fullUrl" : "Organization/1706815625462413000.391ee0cc-8243-4eaa-88c3-37a1538c00e9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709534611457000.a0933e4d-bf51-4d00-aa2e-8bd17b732872",
+        "id" : "1706815625462413000.391ee0cc-8243-4eaa-88c3-37a1538c00e9",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709534922034000.8420b529-2eed-4b0b-9d63-7a6a95edb0ce",
+      "fullUrl" : "Provenance/1706815625815642000.860d8eb3-8702-4ea9-a0e7-e16c85126fae",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709534922034000.8420b529-2eed-4b0b-9d63-7a6a95edb0ce",
+        "id" : "1706815625815642000.860d8eb3-8702-4ea9-a0e7-e16c85126fae",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709535104653000.f9953018-bbac-4131-b3b5-e7d41d07c1dd"
+            "reference" : "DiagnosticReport/1706815626001509000.af57b1d1-0c26-410e-976d-b1af9513f10c"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709534929493000.cab4fb98-2d07-4fbf-8a8c-f3f2b6075701",
+      "fullUrl" : "Provenance/1706815625822706000.74f64ea8-9d20-442a-bb51-502e9879d994",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709534929493000.cab4fb98-2d07-4fbf-8a8c-f3f2b6075701",
-        "recorded" : "2024-01-31T08:58:54Z",
+        "id" : "1706815625822706000.74f64ea8-9d20-442a-bb51-502e9879d994",
+        "recorded" : "2024-02-01T14:27:05Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709534929050000.a9351fea-417f-4c53-9225-f71f0db4100e"
+              "reference" : "Organization/1706815625822241000.70b1523a-ca98-4b75-bdc3-0c8a26963ac7"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709534929050000.a9351fea-417f-4c53-9225-f71f0db4100e",
+      "fullUrl" : "Organization/1706815625822241000.70b1523a-ca98-4b75-bdc3-0c8a26963ac7",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709534929050000.a9351fea-417f-4c53-9225-f71f0db4100e",
+        "id" : "1706815625822241000.70b1523a-ca98-4b75-bdc3-0c8a26963ac7",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709534942810000.682bae54-67cd-4536-8158-ef013ca95522",
+      "fullUrl" : "Observation/1706815625836085000.c4db2c35-cadd-488f-bf1d-9bdc77f4e4e1",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709534942810000.682bae54-67cd-4536-8158-ef013ca95522",
+        "id" : "1706815625836085000.c4db2c35-cadd-488f-bf1d-9bdc77f4e4e1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-5-value-sn",
@@ -246,10 +251,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709535102107000.e676f12c-4c21-4aac-8ce0-4d56575dca85",
+      "fullUrl" : "ServiceRequest/1706815625999024000.e24ea02c-3a9e-4c44-9a94-26ad571d8a5c",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709535102107000.e676f12c-4c21-4aac-8ce0-4d56575dca85",
+        "id" : "1706815625999024000.e24ea02c-3a9e-4c44-9a94-26ad571d8a5c",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -273,13 +278,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709535104653000.f9953018-bbac-4131-b3b5-e7d41d07c1dd",
+      "fullUrl" : "DiagnosticReport/1706815626001509000.af57b1d1-0c26-410e-976d-b1af9513f10c",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709535104653000.f9953018-bbac-4131-b3b5-e7d41d07c1dd",
+        "id" : "1706815626001509000.af57b1d1-0c26-410e-976d-b1af9513f10c",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709535102107000.e676f12c-4c21-4aac-8ce0-4d56575dca85"
+            "reference" : "ServiceRequest/1706815625999024000.e24ea02c-3a9e-4c44-9a94-26ad571d8a5c"
           }
         ],
         "status" : "final",
@@ -304,7 +309,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709534942810000.682bae54-67cd-4536-8158-ef013ca95522"
+            "reference" : "Observation/1706815625836085000.c4db2c35-cadd-488f-bf1d-9bdc77f4e4e1"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-ratio-value-colon.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-ratio-value-colon.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709543758327000.7518655d-8b73-4c6d-b087-ad87ff9d230c",
+  "id" : "1706815635358999000.e4ae4527-30eb-4858-b6ac-a79b1c3c35c5",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:03.764-05:00"
+    "lastUpdated" : "2024-02-01T14:27:15.365-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709543832616000.012b5aec-3b94-42d6-9625-9a7dd57f9748"
+          "reference" : "Organization/1706815635408750000.d7d50d21-7a30-4de0-ac8e-78cd60b18741"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709543832616000.012b5aec-3b94-42d6-9625-9a7dd57f9748",
+      "fullUrl" : "Organization/1706815635408750000.d7d50d21-7a30-4de0-ac8e-78cd60b18741",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709543832616000.012b5aec-3b94-42d6-9625-9a7dd57f9748",
+        "id" : "1706815635408750000.d7d50d21-7a30-4de0-ac8e-78cd60b18741",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709544142599000.ea37772c-7842-401f-a06c-80c6951dfc5d",
+      "fullUrl" : "Provenance/1706815635767606000.57602fff-b804-427f-bf9c-356e82d6324e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709544142599000.ea37772c-7842-401f-a06c-80c6951dfc5d",
+        "id" : "1706815635767606000.57602fff-b804-427f-bf9c-356e82d6324e",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709544322341000.93a61c35-017b-4726-b622-02624efa6158"
+            "reference" : "DiagnosticReport/1706815635972972000.f4342263-4824-454a-b2fb-0f86d86fc668"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709544149170000.24ee9c7e-ae5e-41b4-95f9-9918aa9d3af8",
+      "fullUrl" : "Provenance/1706815635776494000.17c30e66-89c2-4672-ac72-3d6562a5cd24",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709544149170000.24ee9c7e-ae5e-41b4-95f9-9918aa9d3af8",
-        "recorded" : "2024-01-31T08:59:04Z",
+        "id" : "1706815635776494000.17c30e66-89c2-4672-ac72-3d6562a5cd24",
+        "recorded" : "2024-02-01T14:27:15Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709544148765000.67b236d7-21fb-4986-ba5d-069e766b5396"
+              "reference" : "Organization/1706815635775991000.a8138f9e-4c36-48b2-a304-0dc6983d09aa"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709544148765000.67b236d7-21fb-4986-ba5d-069e766b5396",
+      "fullUrl" : "Organization/1706815635775991000.a8138f9e-4c36-48b2-a304-0dc6983d09aa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709544148765000.67b236d7-21fb-4986-ba5d-069e766b5396",
+        "id" : "1706815635775991000.a8138f9e-4c36-48b2-a304-0dc6983d09aa",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709544164398000.9d2cfb0c-b041-4d27-914a-f45295e75db1",
+      "fullUrl" : "Observation/1706815635791240000.7825055d-6d49-4b96-905a-2f07d0bcb68c",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709544164398000.9d2cfb0c-b041-4d27-914a-f45295e75db1",
+        "id" : "1706815635791240000.7825055d-6d49-4b96-905a-2f07d0bcb68c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-5-value-sn",
@@ -246,10 +251,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709544320169000.5b8b1ed7-f2d7-4082-8566-855cad541465",
+      "fullUrl" : "ServiceRequest/1706815635969166000.e545d12b-bd01-4528-807a-d6c17b7f32a8",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709544320169000.5b8b1ed7-f2d7-4082-8566-855cad541465",
+        "id" : "1706815635969166000.e545d12b-bd01-4528-807a-d6c17b7f32a8",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -273,13 +278,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709544322341000.93a61c35-017b-4726-b622-02624efa6158",
+      "fullUrl" : "DiagnosticReport/1706815635972972000.f4342263-4824-454a-b2fb-0f86d86fc668",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709544322341000.93a61c35-017b-4726-b622-02624efa6158",
+        "id" : "1706815635972972000.f4342263-4824-454a-b2fb-0f86d86fc668",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709544320169000.5b8b1ed7-f2d7-4082-8566-855cad541465"
+            "reference" : "ServiceRequest/1706815635969166000.e545d12b-bd01-4528-807a-d6c17b7f32a8"
           }
         ],
         "status" : "final",
@@ -304,7 +309,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709544164398000.9d2cfb0c-b041-4d27-914a-f45295e75db1"
+            "reference" : "Observation/1706815635791240000.7825055d-6d49-4b96-905a-2f07d0bcb68c"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-ratio-value-division.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-ratio-value-division.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709553116731000.fc86c999-9722-492d-a610-61c299286fa5",
+  "id" : "1706815645295437000.d165fb90-9d0f-4c69-87f9-bd45955140e1",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:13.123-05:00"
+    "lastUpdated" : "2024-02-01T14:27:25.302-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709553189171000.731c8c17-6ed8-4c50-b327-d9eb0e1d9452"
+          "reference" : "Organization/1706815645358584000.3759f191-c957-4d47-a6ed-ec6fafdf634b"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709553189171000.731c8c17-6ed8-4c50-b327-d9eb0e1d9452",
+      "fullUrl" : "Organization/1706815645358584000.3759f191-c957-4d47-a6ed-ec6fafdf634b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709553189171000.731c8c17-6ed8-4c50-b327-d9eb0e1d9452",
+        "id" : "1706815645358584000.3759f191-c957-4d47-a6ed-ec6fafdf634b",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709553493390000.4723fb6e-7c08-4c34-80aa-7e88f2a066f6",
+      "fullUrl" : "Provenance/1706815645729779000.271ecedb-e57e-4173-ade6-fae8fd9b23b7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709553493390000.4723fb6e-7c08-4c34-80aa-7e88f2a066f6",
+        "id" : "1706815645729779000.271ecedb-e57e-4173-ade6-fae8fd9b23b7",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709553676210000.2a100ebc-2314-49e7-8715-95242c0fd6b4"
+            "reference" : "DiagnosticReport/1706815645940217000.3c45f16b-35cf-4f07-b9f9-84f8732a7a06"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709553500052000.73d4acd7-3482-4f0d-8f9d-d97b6dfe0c8e",
+      "fullUrl" : "Provenance/1706815645737500000.d66b2a3a-26c0-4a9f-bb40-7b12ae46496a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709553500052000.73d4acd7-3482-4f0d-8f9d-d97b6dfe0c8e",
-        "recorded" : "2024-01-31T08:59:13Z",
+        "id" : "1706815645737500000.d66b2a3a-26c0-4a9f-bb40-7b12ae46496a",
+        "recorded" : "2024-02-01T14:27:25Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709553498860000.944529ed-b1b6-4a50-9deb-ec0992dd262a"
+              "reference" : "Organization/1706815645737019000.9d21fc14-3566-44f0-8d46-95bfd0a41d39"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709553498860000.944529ed-b1b6-4a50-9deb-ec0992dd262a",
+      "fullUrl" : "Organization/1706815645737019000.9d21fc14-3566-44f0-8d46-95bfd0a41d39",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709553498860000.944529ed-b1b6-4a50-9deb-ec0992dd262a",
+        "id" : "1706815645737019000.9d21fc14-3566-44f0-8d46-95bfd0a41d39",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709553513761000.8f681bc8-1562-4f41-8b04-6a2f67ea1616",
+      "fullUrl" : "Observation/1706815645753802000.426f1df1-8916-434f-a04e-b8b9166f3e29",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709553513761000.8f681bc8-1562-4f41-8b04-6a2f67ea1616",
+        "id" : "1706815645753802000.426f1df1-8916-434f-a04e-b8b9166f3e29",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-5-value-sn",
@@ -246,10 +251,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709553672910000.376e0606-75a0-4781-95ed-1cbf3d700534",
+      "fullUrl" : "ServiceRequest/1706815645936153000.9eff12b0-d1bf-4c68-b0be-aa388699f41d",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709553672910000.376e0606-75a0-4781-95ed-1cbf3d700534",
+        "id" : "1706815645936153000.9eff12b0-d1bf-4c68-b0be-aa388699f41d",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -273,13 +278,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709553676210000.2a100ebc-2314-49e7-8715-95242c0fd6b4",
+      "fullUrl" : "DiagnosticReport/1706815645940217000.3c45f16b-35cf-4f07-b9f9-84f8732a7a06",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709553676210000.2a100ebc-2314-49e7-8715-95242c0fd6b4",
+        "id" : "1706815645940217000.3c45f16b-35cf-4f07-b9f9-84f8732a7a06",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709553672910000.376e0606-75a0-4781-95ed-1cbf3d700534"
+            "reference" : "ServiceRequest/1706815645936153000.9eff12b0-d1bf-4c68-b0be-aa388699f41d"
           }
         ],
         "status" : "final",
@@ -304,7 +309,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709553513761000.8f681bc8-1562-4f41-8b04-6a2f67ea1616"
+            "reference" : "Observation/1706815645753802000.426f1df1-8916-434f-a04e-b8b9166f3e29"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-string-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-sn-as-string-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709562455503000.2aaffc6f-b20e-4e99-937c-1b8a6509f574",
+  "id" : "1706815655863173000.667267bb-5369-4cb7-a326-9438e2fbc895",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:22.462-05:00"
+    "lastUpdated" : "2024-02-01T14:27:35.870-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709562527289000.d65c716d-4cda-45a0-b83c-f0417317b9a0"
+          "reference" : "Organization/1706815655921016000.f15369d9-68ae-4446-8ca8-1427ddfffecd"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709562527289000.d65c716d-4cda-45a0-b83c-f0417317b9a0",
+      "fullUrl" : "Organization/1706815655921016000.f15369d9-68ae-4446-8ca8-1427ddfffecd",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709562527289000.d65c716d-4cda-45a0-b83c-f0417317b9a0",
+        "id" : "1706815655921016000.f15369d9-68ae-4446-8ca8-1427ddfffecd",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709562835921000.b4a4935b-37f5-422d-9604-0c0f3d93c7fa",
+      "fullUrl" : "Provenance/1706815656350390000.2e310658-96d4-44ce-824c-8fb7ee7beaaf",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709562835921000.b4a4935b-37f5-422d-9604-0c0f3d93c7fa",
+        "id" : "1706815656350390000.2e310658-96d4-44ce-824c-8fb7ee7beaaf",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709563016759000.dcf4984a-4e42-4cb7-a6d7-561088894759"
+            "reference" : "DiagnosticReport/1706815656608957000.caeb4479-d510-449e-8dfd-e252ae752c90"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709562843802000.b9de6456-7531-408d-951b-2fda97da806e",
+      "fullUrl" : "Provenance/1706815656358591000.5de7b1d6-d85f-4006-91ce-803c77756b64",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709562843802000.b9de6456-7531-408d-951b-2fda97da806e",
-        "recorded" : "2024-01-31T08:59:22Z",
+        "id" : "1706815656358591000.5de7b1d6-d85f-4006-91ce-803c77756b64",
+        "recorded" : "2024-02-01T14:27:36Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709562843394000.2b38fa8b-0e9e-4dfe-8c38-94fe88ca9234"
+              "reference" : "Organization/1706815656358105000.3a232f0a-ce12-425d-9237-3a29011bce8a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709562843394000.2b38fa8b-0e9e-4dfe-8c38-94fe88ca9234",
+      "fullUrl" : "Organization/1706815656358105000.3a232f0a-ce12-425d-9237-3a29011bce8a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709562843394000.2b38fa8b-0e9e-4dfe-8c38-94fe88ca9234",
+        "id" : "1706815656358105000.3a232f0a-ce12-425d-9237-3a29011bce8a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709562854992000.1391d827-8227-41fd-b40e-e1029901688f",
+      "fullUrl" : "Observation/1706815656386454000.66105621-3e2c-4922-a3e0-ccd34598b559",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709562854992000.1391d827-8227-41fd-b40e-e1029901688f",
+        "id" : "1706815656386454000.66105621-3e2c-4922-a3e0-ccd34598b559",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-5-value-sn",
@@ -202,10 +207,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709563014258000.e1e2c9e2-3513-4e04-bc9e-482abeb41505",
+      "fullUrl" : "ServiceRequest/1706815656605880000.3dfea911-3a40-451f-8813-9deb850126c5",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709563014258000.e1e2c9e2-3513-4e04-bc9e-482abeb41505",
+        "id" : "1706815656605880000.3dfea911-3a40-451f-8813-9deb850126c5",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -229,13 +234,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709563016759000.dcf4984a-4e42-4cb7-a6d7-561088894759",
+      "fullUrl" : "DiagnosticReport/1706815656608957000.caeb4479-d510-449e-8dfd-e252ae752c90",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709563016759000.dcf4984a-4e42-4cb7-a6d7-561088894759",
+        "id" : "1706815656608957000.caeb4479-d510-449e-8dfd-e252ae752c90",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709563014258000.e1e2c9e2-3513-4e04-bc9e-482abeb41505"
+            "reference" : "ServiceRequest/1706815656605880000.3dfea911-3a40-451f-8813-9deb850126c5"
           }
         ],
         "status" : "final",
@@ -260,7 +265,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709562854992000.1391d827-8227-41fd-b40e-e1029901688f"
+            "reference" : "Observation/1706815656386454000.66105621-3e2c-4922-a3e0-ccd34598b559"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-st-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-st-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709571749452000.53750a33-b1c2-43a9-999a-d60ccd6afbc0",
+  "id" : "1706815667158967000.b6eb67a8-9147-444f-a0c1-d87f3b618911",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:31.755-05:00"
+    "lastUpdated" : "2024-02-01T14:27:47.164-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709571822477000.3c1e62a6-3d8c-4205-81ff-b6889243ec73"
+          "reference" : "Organization/1706815667205481000.740a944c-a068-44f1-b46d-c7b824cc5564"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709571822477000.3c1e62a6-3d8c-4205-81ff-b6889243ec73",
+      "fullUrl" : "Organization/1706815667205481000.740a944c-a068-44f1-b46d-c7b824cc5564",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709571822477000.3c1e62a6-3d8c-4205-81ff-b6889243ec73",
+        "id" : "1706815667205481000.740a944c-a068-44f1-b46d-c7b824cc5564",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709572132884000.e9457453-19a5-4428-98bd-e3466ecb32c0",
+      "fullUrl" : "Provenance/1706815667537017000.b432a096-0b3d-44f5-a5fe-e1ac7f142e65",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709572132884000.e9457453-19a5-4428-98bd-e3466ecb32c0",
+        "id" : "1706815667537017000.b432a096-0b3d-44f5-a5fe-e1ac7f142e65",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709572351809000.084df4a5-377d-43e9-811f-966a8129c2ab"
+            "reference" : "DiagnosticReport/1706815667778511000.3d972e08-5a61-44df-aebd-f1eeb336fa45"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709572140747000.1ca12019-6c31-4b99-b82d-d7a28745d1b3",
+      "fullUrl" : "Provenance/1706815667544131000.f857b49a-cd43-4325-84e1-7fdd7730674a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709572140747000.1ca12019-6c31-4b99-b82d-d7a28745d1b3",
-        "recorded" : "2024-01-31T08:59:32Z",
+        "id" : "1706815667544131000.f857b49a-cd43-4325-84e1-7fdd7730674a",
+        "recorded" : "2024-02-01T14:27:47Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709572140251000.1929c6e6-f6f7-4eb0-a3f1-6b5eb08b8504"
+              "reference" : "Organization/1706815667543695000.f1cd21b5-8a58-4164-b320-f3bdb30067c7"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709572140251000.1929c6e6-f6f7-4eb0-a3f1-6b5eb08b8504",
+      "fullUrl" : "Organization/1706815667543695000.f1cd21b5-8a58-4164-b320-f3bdb30067c7",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709572140251000.1929c6e6-f6f7-4eb0-a3f1-6b5eb08b8504",
+        "id" : "1706815667543695000.f1cd21b5-8a58-4164-b320-f3bdb30067c7",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709572155819000.c1f1c431-18cc-431b-a021-2d7849f7870f",
+      "fullUrl" : "Observation/1706815667559560000.d8f94f41-bd4b-465c-babf-4e837cd2a635",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709572155819000.c1f1c431-18cc-431b-a021-2d7849f7870f",
+        "id" : "1706815667559560000.d8f94f41-bd4b-465c-babf-4e837cd2a635",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
@@ -231,13 +236,13 @@
               {
                 "url" : "obx-18-equipment-instance-identifier",
                 "valueReference" : {
-                  "reference" : "Device/1706709572149232000.bc28e11f-6d14-494b-b409-5f96944017ef"
+                  "reference" : "Device/1706815667553632000.06bda4dc-a282-49be-a51d-44b0f9c706ca"
                 }
               },
               {
                 "url" : "obx-18-equipment-instance-identifier",
                 "valueReference" : {
-                  "reference" : "Device/1706709572149712000.1ad5b5f9-fef9-4bf9-8118-74ba3df8e8da"
+                  "reference" : "Device/1706815667554126000.c485b063-2253-46ee-b1af-5a2cf218d234"
                 }
               },
               {
@@ -343,16 +348,16 @@
         },
         "performer" : [
           {
-            "reference" : "Organization/1706709572156983000.5ecaf804-e5ee-46b1-848a-bfc1fbc8e525"
+            "reference" : "Organization/1706815667560632000.172f5f9b-662d-4135-81de-75fa488e5ccb"
           },
           {
-            "reference" : "PractitionerRole/1706709572157812000.653b193f-419f-4623-953e-a1298b939127"
+            "reference" : "PractitionerRole/1706815667561290000.3d67fe40-a0d4-4c78-bf91-dfd4a2dd193c"
           },
           {
-            "reference" : "PractitionerRole/1706709572166557000.ad4c50c6-23b7-4c58-9093-b01f08885e44"
+            "reference" : "PractitionerRole/1706815667569173000.7d928798-8a64-42bf-999e-1a8c9812f502"
           },
           {
-            "reference" : "PractitionerRole/1706709572170965000.f424ef4b-503b-4d71-83cf-8cb125b75dc9"
+            "reference" : "PractitionerRole/1706815667573114000.205d8e83-f617-4407-bfde-f14ac3a208e2"
           }
         ],
         "valueString" : "Some value",
@@ -415,7 +420,7 @@
           ]
         },
         "device" : {
-          "reference" : "Device/1706709572181314000.75e6a4ca-a3c0-40f2-9aff-7f8fde19a345"
+          "reference" : "Device/1706815667583090000.9fd99a9a-dfac-44f0-bf5c-d849af4e1260"
         },
         "referenceRange" : [
           {
@@ -425,10 +430,10 @@
       }
     },
     {
-      "fullUrl" : "Device/1706709572149232000.bc28e11f-6d14-494b-b409-5f96944017ef",
+      "fullUrl" : "Device/1706815667553632000.06bda4dc-a282-49be-a51d-44b0f9c706ca",
       "resource" : {
         "resourceType" : "Device",
-        "id" : "1706709572149232000.bc28e11f-6d14-494b-b409-5f96944017ef",
+        "id" : "1706815667553632000.06bda4dc-a282-49be-a51d-44b0f9c706ca",
         "identifier" : [
           {
             "extension" : [
@@ -456,10 +461,10 @@
       }
     },
     {
-      "fullUrl" : "Device/1706709572149712000.1ad5b5f9-fef9-4bf9-8118-74ba3df8e8da",
+      "fullUrl" : "Device/1706815667554126000.c485b063-2253-46ee-b1af-5a2cf218d234",
       "resource" : {
         "resourceType" : "Device",
-        "id" : "1706709572149712000.1ad5b5f9-fef9-4bf9-8118-74ba3df8e8da",
+        "id" : "1706815667554126000.c485b063-2253-46ee-b1af-5a2cf218d234",
         "identifier" : [
           {
             "extension" : [
@@ -487,10 +492,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709572156983000.5ecaf804-e5ee-46b1-848a-bfc1fbc8e525",
+      "fullUrl" : "Organization/1706815667560632000.172f5f9b-662d-4135-81de-75fa488e5ccb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709572156983000.5ecaf804-e5ee-46b1-848a-bfc1fbc8e525",
+        "id" : "1706815667560632000.172f5f9b-662d-4135-81de-75fa488e5ccb",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-organization",
@@ -528,10 +533,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706709572166014000.04c75a2b-834b-46c9-95e5-a93b4e7f23d8",
+      "fullUrl" : "Practitioner/1706815667568707000.bd83eb59-3f35-467e-b22a-a1c3c90ce3cc",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706709572166014000.04c75a2b-834b-46c9-95e5-a93b4e7f23d8",
+        "id" : "1706815667568707000.bd83eb59-3f35-467e-b22a-a1c3c90ce3cc",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -736,12 +741,12 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706709572157812000.653b193f-419f-4623-953e-a1298b939127",
+      "fullUrl" : "PractitionerRole/1706815667561290000.3d67fe40-a0d4-4c78-bf91-dfd4a2dd193c",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706709572157812000.653b193f-419f-4623-953e-a1298b939127",
+        "id" : "1706815667561290000.3d67fe40-a0d4-4c78-bf91-dfd4a2dd193c",
         "practitioner" : {
-          "reference" : "Practitioner/1706709572166014000.04c75a2b-834b-46c9-95e5-a93b4e7f23d8"
+          "reference" : "Practitioner/1706815667568707000.bd83eb59-3f35-467e-b22a-a1c3c90ce3cc"
         },
         "code" : [
           {
@@ -756,10 +761,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706709572170480000.e819229d-0e91-4e77-9df6-01d8456ba0a3",
+      "fullUrl" : "Practitioner/1706815667572632000.00ccee73-1b4c-4fba-9eeb-7ea78fcea3f9",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706709572170480000.e819229d-0e91-4e77-9df6-01d8456ba0a3",
+        "id" : "1706815667572632000.00ccee73-1b4c-4fba-9eeb-7ea78fcea3f9",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -964,12 +969,12 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706709572166557000.ad4c50c6-23b7-4c58-9093-b01f08885e44",
+      "fullUrl" : "PractitionerRole/1706815667569173000.7d928798-8a64-42bf-999e-1a8c9812f502",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706709572166557000.ad4c50c6-23b7-4c58-9093-b01f08885e44",
+        "id" : "1706815667569173000.7d928798-8a64-42bf-999e-1a8c9812f502",
         "practitioner" : {
-          "reference" : "Practitioner/1706709572170480000.e819229d-0e91-4e77-9df6-01d8456ba0a3"
+          "reference" : "Practitioner/1706815667572632000.00ccee73-1b4c-4fba-9eeb-7ea78fcea3f9"
         },
         "code" : [
           {
@@ -984,10 +989,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706709572175293000.116cd8ba-4386-49e2-aed5-c624237bb411",
+      "fullUrl" : "Practitioner/1706815667576346000.ce9db703-8caf-4fef-948b-7a8ff49fc53a",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706709572175293000.116cd8ba-4386-49e2-aed5-c624237bb411",
+        "id" : "1706815667576346000.ce9db703-8caf-4fef-948b-7a8ff49fc53a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1192,10 +1197,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706709572176157000.c3612d46-d077-4da8-89ae-f34ac5acf5b7",
+      "fullUrl" : "Location/1706815667577292000.0e61ed74-997f-4faf-bd34-30f13c86d313",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706709572176157000.c3612d46-d077-4da8-89ae-f34ac5acf5b7",
+        "id" : "1706815667577292000.0e61ed74-997f-4faf-bd34-30f13c86d313",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1225,10 +1230,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709572178369000.eb988c18-765b-40c9-88bb-d98c0fd3907b",
+      "fullUrl" : "Organization/1706815667579655000.4e419f3e-c6f5-4658-b8de-f4dadc6433f0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709572178369000.eb988c18-765b-40c9-88bb-d98c0fd3907b",
+        "id" : "1706815667579655000.4e419f3e-c6f5-4658-b8de-f4dadc6433f0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1328,7 +1333,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706709572176157000.c3612d46-d077-4da8-89ae-f34ac5acf5b7"
+                  "reference" : "Location/1706815667577292000.0e61ed74-997f-4faf-bd34-30f13c86d313"
                 }
               }
             ],
@@ -1430,15 +1435,15 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706709572170965000.f424ef4b-503b-4d71-83cf-8cb125b75dc9",
+      "fullUrl" : "PractitionerRole/1706815667573114000.205d8e83-f617-4407-bfde-f14ac3a208e2",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706709572170965000.f424ef4b-503b-4d71-83cf-8cb125b75dc9",
+        "id" : "1706815667573114000.205d8e83-f617-4407-bfde-f14ac3a208e2",
         "practitioner" : {
-          "reference" : "Practitioner/1706709572175293000.116cd8ba-4386-49e2-aed5-c624237bb411"
+          "reference" : "Practitioner/1706815667576346000.ce9db703-8caf-4fef-948b-7a8ff49fc53a"
         },
         "organization" : {
-          "reference" : "Organization/1706709572178369000.eb988c18-765b-40c9-88bb-d98c0fd3907b"
+          "reference" : "Organization/1706815667579655000.4e419f3e-c6f5-4658-b8de-f4dadc6433f0"
         },
         "code" : [
           {
@@ -1453,10 +1458,10 @@
       }
     },
     {
-      "fullUrl" : "Device/1706709572181314000.75e6a4ca-a3c0-40f2-9aff-7f8fde19a345",
+      "fullUrl" : "Device/1706815667583090000.9fd99a9a-dfac-44f0-bf5c-d849af4e1260",
       "resource" : {
         "resourceType" : "Device",
-        "id" : "1706709572181314000.75e6a4ca-a3c0-40f2-9aff-7f8fde19a345",
+        "id" : "1706815667583090000.9fd99a9a-dfac-44f0-bf5c-d849af4e1260",
         "identifier" : [
           {
             "extension" : [
@@ -1484,10 +1489,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709572349874000.cd4794c7-160b-4055-a601-feed37349d03",
+      "fullUrl" : "ServiceRequest/1706815667776628000.6e92253c-526f-4909-9f15-09932f80247b",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709572349874000.cd4794c7-160b-4055-a601-feed37349d03",
+        "id" : "1706815667776628000.6e92253c-526f-4909-9f15-09932f80247b",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -1511,13 +1516,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709572351809000.084df4a5-377d-43e9-811f-966a8129c2ab",
+      "fullUrl" : "DiagnosticReport/1706815667778511000.3d972e08-5a61-44df-aebd-f1eeb336fa45",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709572351809000.084df4a5-377d-43e9-811f-966a8129c2ab",
+        "id" : "1706815667778511000.3d972e08-5a61-44df-aebd-f1eeb336fa45",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709572349874000.cd4794c7-160b-4055-a601-feed37349d03"
+            "reference" : "ServiceRequest/1706815667776628000.6e92253c-526f-4909-9f15-09932f80247b"
           }
         ],
         "status" : "final",
@@ -1542,7 +1547,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709572155819000.c1f1c431-18cc-431b-a021-2d7849f7870f"
+            "reference" : "Observation/1706815667559560000.d8f94f41-bd4b-465c-babf-4e837cd2a635"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-tm-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-tm-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709581115515000.d58b3021-8bb5-4e19-ae4d-006a848cb9a0",
+  "id" : "1706815677835553000.2f9aa490-84ee-4666-884f-1e45786c0381",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:41.121-05:00"
+    "lastUpdated" : "2024-02-01T14:27:57.841-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709581190925000.b8574204-008b-4581-8e06-fa8d4e89c586"
+          "reference" : "Organization/1706815677889211000.68816bab-e78c-43ac-b07a-459cdf88526d"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709581190925000.b8574204-008b-4581-8e06-fa8d4e89c586",
+      "fullUrl" : "Organization/1706815677889211000.68816bab-e78c-43ac-b07a-459cdf88526d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709581190925000.b8574204-008b-4581-8e06-fa8d4e89c586",
+        "id" : "1706815677889211000.68816bab-e78c-43ac-b07a-459cdf88526d",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709581497055000.9997540d-953d-46f7-8c07-476456d1f9d3",
+      "fullUrl" : "Provenance/1706815678256063000.502da348-ef47-4692-af2d-bc49a5f3288a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709581497055000.9997540d-953d-46f7-8c07-476456d1f9d3",
+        "id" : "1706815678256063000.502da348-ef47-4692-af2d-bc49a5f3288a",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709581690116000.30cf6863-94ef-4d20-9168-fd3f3b54601a"
+            "reference" : "DiagnosticReport/1706815678447035000.30e395e4-7e35-452d-b172-987e46cb1eae"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709581504800000.97517cee-9bf1-4173-bfae-14b2adbc9f5b",
+      "fullUrl" : "Provenance/1706815678265233000.43af6fe3-dc6c-4017-bf6a-fb994c827b56",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709581504800000.97517cee-9bf1-4173-bfae-14b2adbc9f5b",
-        "recorded" : "2024-01-31T08:59:41Z",
+        "id" : "1706815678265233000.43af6fe3-dc6c-4017-bf6a-fb994c827b56",
+        "recorded" : "2024-02-01T14:27:58Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709581504069000.e31d0fbb-d349-4be3-b5b8-cf0435f5bd94"
+              "reference" : "Organization/1706815678264711000.ae1a4aab-f5f1-4e74-9766-3b7ff8efa5e7"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709581504069000.e31d0fbb-d349-4be3-b5b8-cf0435f5bd94",
+      "fullUrl" : "Organization/1706815678264711000.ae1a4aab-f5f1-4e74-9766-3b7ff8efa5e7",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709581504069000.e31d0fbb-d349-4be3-b5b8-cf0435f5bd94",
+        "id" : "1706815678264711000.ae1a4aab-f5f1-4e74-9766-3b7ff8efa5e7",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709581518392000.a18d5934-3fab-405e-801b-ef2f35ceba9d",
+      "fullUrl" : "Observation/1706815678277328000.e7b6d4c0-6e41-474f-99fa-b5316d6d9663",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709581518392000.a18d5934-3fab-405e-801b-ef2f35ceba9d",
+        "id" : "1706815678277328000.e7b6d4c0-6e41-474f-99fa-b5316d6d9663",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -189,10 +194,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709581687697000.cc9b59a3-8c0b-42a6-a55a-8af160701112",
+      "fullUrl" : "ServiceRequest/1706815678444421000.c20cc2db-6e85-4def-90ce-ef82a932de07",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709581687697000.cc9b59a3-8c0b-42a6-a55a-8af160701112",
+        "id" : "1706815678444421000.c20cc2db-6e85-4def-90ce-ef82a932de07",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -216,13 +221,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709581690116000.30cf6863-94ef-4d20-9168-fd3f3b54601a",
+      "fullUrl" : "DiagnosticReport/1706815678447035000.30e395e4-7e35-452d-b172-987e46cb1eae",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709581690116000.30cf6863-94ef-4d20-9168-fd3f3b54601a",
+        "id" : "1706815678447035000.30e395e4-7e35-452d-b172-987e46cb1eae",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709581687697000.cc9b59a3-8c0b-42a6-a55a-8af160701112"
+            "reference" : "ServiceRequest/1706815678444421000.c20cc2db-6e85-4def-90ce-ef82a932de07"
           }
         ],
         "status" : "final",
@@ -247,7 +252,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709581518392000.a18d5934-3fab-405e-801b-ef2f35ceba9d"
+            "reference" : "Observation/1706815678277328000.e7b6d4c0-6e41-474f-99fa-b5316d6d9663"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-tx-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-tx-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709590395813000.95c4db39-9486-479d-9b52-d79f92d1d222",
+  "id" : "1706815688183161000.befc0bb7-4250-4b67-b9e9-eca71996a164",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:50.401-05:00"
+    "lastUpdated" : "2024-02-01T14:28:08.194-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709590464883000.1e05c31b-fcb8-4d29-bdb7-abcd63a271f1"
+          "reference" : "Organization/1706815688249902000.9e2fc0fd-20c2-40f2-8d2a-eb5eca7534f8"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709590464883000.1e05c31b-fcb8-4d29-bdb7-abcd63a271f1",
+      "fullUrl" : "Organization/1706815688249902000.9e2fc0fd-20c2-40f2-8d2a-eb5eca7534f8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709590464883000.1e05c31b-fcb8-4d29-bdb7-abcd63a271f1",
+        "id" : "1706815688249902000.9e2fc0fd-20c2-40f2-8d2a-eb5eca7534f8",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709590772035000.d8db24c1-9491-41dd-a3bf-088fc59dd561",
+      "fullUrl" : "Provenance/1706815688623925000.90a0d1ae-2fc6-4541-a337-e9ca4970cf74",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709590772035000.d8db24c1-9491-41dd-a3bf-088fc59dd561",
+        "id" : "1706815688623925000.90a0d1ae-2fc6-4541-a337-e9ca4970cf74",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709590962012000.a7c5ab73-688d-4e3f-a506-dd468f0b8d9b"
+            "reference" : "DiagnosticReport/1706815688840518000.21a99514-1a97-4094-8d37-66af5ebcac71"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709590779388000.9251b21e-10cd-47b1-a7c9-c54313d37c59",
+      "fullUrl" : "Provenance/1706815688633172000.abd7b801-39d0-4ebb-bc15-e656d78b6586",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709590779388000.9251b21e-10cd-47b1-a7c9-c54313d37c59",
-        "recorded" : "2024-01-31T08:59:50Z",
+        "id" : "1706815688633172000.abd7b801-39d0-4ebb-bc15-e656d78b6586",
+        "recorded" : "2024-02-01T14:28:08Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709590778965000.0382acba-7719-4f56-bad8-d159d87b48b8"
+              "reference" : "Organization/1706815688632703000.f96c1d20-d619-4b62-91f7-637c8e02e34b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709590778965000.0382acba-7719-4f56-bad8-d159d87b48b8",
+      "fullUrl" : "Organization/1706815688632703000.f96c1d20-d619-4b62-91f7-637c8e02e34b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709590778965000.0382acba-7719-4f56-bad8-d159d87b48b8",
+        "id" : "1706815688632703000.f96c1d20-d619-4b62-91f7-637c8e02e34b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709590791781000.94d18844-72c6-4f14-9e76-edf9146cd791",
+      "fullUrl" : "Observation/1706815688649338000.3bdb73ee-ee5a-4e18-bc45-21ca8c475e38",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709590791781000.94d18844-72c6-4f14-9e76-edf9146cd791",
+        "id" : "1706815688649338000.3bdb73ee-ee5a-4e18-bc45-21ca8c475e38",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -181,10 +186,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709590959906000.4ddf38bc-5480-4b5c-b564-2b540859481c",
+      "fullUrl" : "ServiceRequest/1706815688837742000.79415a3d-944f-4939-8b3b-b642e5914f00",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709590959906000.4ddf38bc-5480-4b5c-b564-2b540859481c",
+        "id" : "1706815688837742000.79415a3d-944f-4939-8b3b-b642e5914f00",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -208,13 +213,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709590962012000.a7c5ab73-688d-4e3f-a506-dd468f0b8d9b",
+      "fullUrl" : "DiagnosticReport/1706815688840518000.21a99514-1a97-4094-8d37-66af5ebcac71",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709590962012000.a7c5ab73-688d-4e3f-a506-dd468f0b8d9b",
+        "id" : "1706815688840518000.21a99514-1a97-4094-8d37-66af5ebcac71",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709590959906000.4ddf38bc-5480-4b5c-b564-2b540859481c"
+            "reference" : "ServiceRequest/1706815688837742000.79415a3d-944f-4939-8b3b-b642e5914f00"
           }
         ],
         "status" : "final",
@@ -239,7 +244,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709590791781000.94d18844-72c6-4f14-9e76-edf9146cd791"
+            "reference" : "Observation/1706815688649338000.3bdb73ee-ee5a-4e18-bc45-21ca8c475e38"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-vr-value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/obx/OBX-to-Observation-vr-value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706709599874444000.ec2db21f-e04a-4721-9e3a-9e3e861e7c25",
+  "id" : "1706815698246767000.763475d1-233f-4ee9-9982-4bb71e83bdaf",
   "meta" : {
-    "lastUpdated" : "2024-01-31T08:59:59.882-05:00"
+    "lastUpdated" : "2024-02-01T14:28:18.253-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706709599948622000.5490ded5-b495-4006-b58f-d5d1c2676fb6"
+          "reference" : "Organization/1706815698303316000.1b0e407f-36e2-4b6c-9562-c65f5bcc719a"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706709599948622000.5490ded5-b495-4006-b58f-d5d1c2676fb6",
+      "fullUrl" : "Organization/1706815698303316000.1b0e407f-36e2-4b6c-9562-c65f5bcc719a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709599948622000.5490ded5-b495-4006-b58f-d5d1c2676fb6",
+        "id" : "1706815698303316000.1b0e407f-36e2-4b6c-9562-c65f5bcc719a",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709600262607000.cbb54337-f039-4f71-991a-424acc24f9d0",
+      "fullUrl" : "Provenance/1706815698662777000.c7fc70ba-7ebd-4931-86ef-36417b9d19e7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709600262607000.cbb54337-f039-4f71-991a-424acc24f9d0",
+        "id" : "1706815698662777000.c7fc70ba-7ebd-4931-86ef-36417b9d19e7",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706709600438339000.c9a6954c-93cd-4f4a-825c-a4d99e89c4dd"
+            "reference" : "DiagnosticReport/1706815698860144000.87e6a736-1ecd-4caa-944b-3e6708db82c8"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706709600270326000.2dcebfbd-17f5-4e74-b360-e3f74f62014b",
+      "fullUrl" : "Provenance/1706815698670885000.e35b9496-7971-401d-bf8d-3f69ba7500c4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706709600270326000.2dcebfbd-17f5-4e74-b360-e3f74f62014b",
-        "recorded" : "2024-01-31T09:00:00Z",
+        "id" : "1706815698670885000.e35b9496-7971-401d-bf8d-3f69ba7500c4",
+        "recorded" : "2024-02-01T14:28:18Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706709600269678000.21680cf8-dfea-4c4f-b071-214e417092bc"
+              "reference" : "Organization/1706815698670383000.a3b1da36-10bf-4994-8127-b6080d45729a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706709600269678000.21680cf8-dfea-4c4f-b071-214e417092bc",
+      "fullUrl" : "Organization/1706815698670383000.a3b1da36-10bf-4994-8127-b6080d45729a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706709600269678000.21680cf8-dfea-4c4f-b071-214e417092bc",
+        "id" : "1706815698670383000.a3b1da36-10bf-4994-8127-b6080d45729a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Observation/1706709600284943000.d29742ad-07f8-4281-b70a-9a695d27ffda",
+      "fullUrl" : "Observation/1706815698686282000.17b47eb7-aa80-4755-8fe6-adc713b20537",
       "resource" : {
         "resourceType" : "Observation",
-        "id" : "1706709600284943000.d29742ad-07f8-4281-b70a-9a695d27ffda",
+        "id" : "1706815698686282000.17b47eb7-aa80-4755-8fe6-adc713b20537",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
@@ -181,10 +186,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706709600435663000.db901deb-baaf-4ab9-add4-8b519b24d12a",
+      "fullUrl" : "ServiceRequest/1706815698857485000.c12e0e23-bf79-4c05-8587-5e9791d30f7d",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706709600435663000.db901deb-baaf-4ab9-add4-8b519b24d12a",
+        "id" : "1706815698857485000.c12e0e23-bf79-4c05-8587-5e9791d30f7d",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -208,13 +213,13 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706709600438339000.c9a6954c-93cd-4f4a-825c-a4d99e89c4dd",
+      "fullUrl" : "DiagnosticReport/1706815698860144000.87e6a736-1ecd-4caa-944b-3e6708db82c8",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706709600438339000.c9a6954c-93cd-4f4a-825c-a4d99e89c4dd",
+        "id" : "1706815698860144000.87e6a736-1ecd-4caa-944b-3e6708db82c8",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706709600435663000.db901deb-baaf-4ab9-add4-8b519b24d12a"
+            "reference" : "ServiceRequest/1706815698857485000.c12e0e23-bf79-4c05-8587-5e9791d30f7d"
           }
         ],
         "status" : "final",
@@ -239,7 +244,7 @@
         },
         "result" : [
           {
-            "reference" : "Observation/1706709600284943000.d29742ad-07f8-4281-b70a-9a695d27ffda"
+            "reference" : "Observation/1706815698686282000.17b47eb7-aa80-4755-8fe6-adc713b20537"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654677248396000.a1a8ea76-23eb-4ff7-aa03-9f0f6d611fe4",
+  "id" : "1706815769533763000.f5a2aa13-7d31-46ca-a28e-6354e2e8d7bb",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:44:37.254-05:00"
+    "lastUpdated" : "2024-02-01T14:29:29.539-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654677656199000.501e6a9e-8059-4821-96a6-a577c6d75c90",
+      "fullUrl" : "Provenance/1706815769931005000.5815b33d-e26c-441d-ad60-12674976e86e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654677656199000.501e6a9e-8059-4821-96a6-a577c6d75c90",
+        "id" : "1706815769931005000.5815b33d-e26c-441d-ad60-12674976e86e",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654677899523000.080a0d6f-6ebc-4c43-9013-cab5f1695b41"
+            "reference" : "DiagnosticReport/1706815770189967000.cabac1a4-b4da-4e6d-a1e0-51e6992da9e7"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654677663973000.f6f7851d-96c1-487d-bf25-62b5c684c674",
+      "fullUrl" : "Provenance/1706815769939123000.a54e7134-c439-42de-9014-38504f219147",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654677663973000.f6f7851d-96c1-487d-bf25-62b5c684c674",
-        "recorded" : "2024-01-30T17:44:37Z",
+        "id" : "1706815769939123000.a54e7134-c439-42de-9014-38504f219147",
+        "recorded" : "2024-02-01T14:29:29Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654677663470000.91245720-15ac-4246-93d0-a8f658d18364"
+              "reference" : "Organization/1706815769938622000.1720b8e6-1719-4eab-9aec-6770ecab5d41"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654677663470000.91245720-15ac-4246-93d0-a8f658d18364",
+      "fullUrl" : "Organization/1706815769938622000.1720b8e6-1719-4eab-9aec-6770ecab5d41",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654677663470000.91245720-15ac-4246-93d0-a8f658d18364",
+        "id" : "1706815769938622000.1720b8e6-1719-4eab-9aec-6770ecab5d41",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654677683265000.988643eb-577f-47b5-a0ca-895a76faabe9",
+      "fullUrl" : "Patient/1706815769957258000.d72f92f8-cc34-4852-9b63-a39b4c275cd5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654677683265000.988643eb-577f-47b5-a0ca-895a76faabe9"
+        "id" : "1706815769957258000.d72f92f8-cc34-4852-9b63-a39b4c275cd5"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654677684099000.5287be71-6204-4647-acc4-324c46ac4acf",
+      "fullUrl" : "Provenance/1706815769957900000.cc75f341-071b-4c79-b157-82a6b9b5fd2e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654677684099000.5287be71-6204-4647-acc4-324c46ac4acf",
+        "id" : "1706815769957900000.cc75f341-071b-4c79-b157-82a6b9b5fd2e",
         "target" : [
           {
-            "reference" : "Patient/1706654677683265000.988643eb-577f-47b5-a0ca-895a76faabe9"
+            "reference" : "Patient/1706815769957258000.d72f92f8-cc34-4852-9b63-a39b4c275cd5"
           }
         ],
-        "recorded" : "2024-01-30T17:44:37Z",
+        "recorded" : "2024-02-01T14:29:29Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654677729600000.45c0a1d2-ca79-4fa6-be1a-8d944942eb5e",
+      "fullUrl" : "ServiceRequest/1706815770007653000.fff18fff-da6b-4c2a-ba8c-fcc1a0759255",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654677729600000.45c0a1d2-ca79-4fa6-be1a-8d944942eb5e",
+        "id" : "1706815770007653000.fff18fff-da6b-4c2a-ba8c-fcc1a0759255",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -238,7 +243,7 @@
               {
                 "url" : "obr-28-result-copies-to",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654677708765000.6efe4397-cc83-4361-8943-b979bb03f4d3"
+                  "reference" : "Practitioner/1706815769982961000.fb4c14db-a8ae-4329-88a5-3a7c2dca3318"
                 }
               },
               {
@@ -293,7 +298,7 @@
               {
                 "url" : "obr-33-assistant-result-interpreter",
                 "valueReference" : {
-                  "reference" : "PractitionerRole/1706654677722715000.ac166af8-d565-4482-9983-092442408489"
+                  "reference" : "PractitionerRole/1706815769997869000.940d7037-4bf7-47f3-83f6-399ce84adc12"
                 }
               },
               {
@@ -303,7 +308,7 @@
               {
                 "url" : "obr-10-collector-identifier",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654677726295000.b4d26c21-04d1-4fee-9e69-7a1d1316f1b6"
+                  "reference" : "Practitioner/1706815770001893000.3d8176e1-e031-48c8-85e8-5e2cd319d714"
                 }
               },
               {
@@ -581,7 +586,7 @@
           }
         ],
         "subject" : {
-          "reference" : "Patient/1706654677683265000.988643eb-577f-47b5-a0ca-895a76faabe9"
+          "reference" : "Patient/1706815769957258000.d72f92f8-cc34-4852-9b63-a39b4c275cd5"
         },
         "requester" : {
           "extension" : [
@@ -664,7 +669,7 @@
               }
             }
           ],
-          "reference" : "Practitioner/1706654677697968000.c9c90d3b-47cc-42d8-b3ec-6ce057a0e8ff"
+          "reference" : "Practitioner/1706815769970000000.b577fb72-ed25-4cc7-96c5-dc74ccbc0e1e"
         },
         "reasonCode" : [
           {
@@ -685,10 +690,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677697968000.c9c90d3b-47cc-42d8-b3ec-6ce057a0e8ff",
+      "fullUrl" : "Practitioner/1706815769970000000.b577fb72-ed25-4cc7-96c5-dc74ccbc0e1e",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677697968000.c9c90d3b-47cc-42d8-b3ec-6ce057a0e8ff",
+        "id" : "1706815769970000000.b577fb72-ed25-4cc7-96c5-dc74ccbc0e1e",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -896,10 +901,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677708765000.6efe4397-cc83-4361-8943-b979bb03f4d3",
+      "fullUrl" : "Practitioner/1706815769982961000.fb4c14db-a8ae-4329-88a5-3a7c2dca3318",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677708765000.6efe4397-cc83-4361-8943-b979bb03f4d3",
+        "id" : "1706815769982961000.fb4c14db-a8ae-4329-88a5-3a7c2dca3318",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1103,10 +1108,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677710603000.82c20ade-106a-4238-9c06-d42d84e04635",
+      "fullUrl" : "Practitioner/1706815769985430000.d653931d-7a87-4cf5-bdb2-e3dd4e8c8891",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677710603000.82c20ade-106a-4238-9c06-d42d84e04635",
+        "id" : "1706815769985430000.d653931d-7a87-4cf5-bdb2-e3dd4e8c8891",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -1173,10 +1178,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677711360000.98b64692-73b1-4275-a77b-16a17adc5e2e",
+      "fullUrl" : "Location/1706815769986291000.38f3dae5-6f77-4883-914e-311a9a544369",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677711360000.98b64692-73b1-4275-a77b-16a17adc5e2e",
+        "id" : "1706815769986291000.38f3dae5-6f77-4883-914e-311a9a544369",
         "identifier" : [
           {
             "extension" : [
@@ -1223,10 +1228,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677720927000.857fa651-f6b7-4261-b340-0cb0ba91faf8",
+      "fullUrl" : "Location/1706815769995845000.8dd184f5-5a50-4806-84de-32aaca3c323b",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677720927000.857fa651-f6b7-4261-b340-0cb0ba91faf8",
+        "id" : "1706815769995845000.8dd184f5-5a50-4806-84de-32aaca3c323b",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -1245,10 +1250,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677721438000.468837f1-bc30-430c-988f-4e0966ec2cee",
+      "fullUrl" : "Location/1706815769996439000.a28ac9e3-665b-4033-8d3f-270f1b72dcc9",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677721438000.468837f1-bc30-430c-988f-4e0966ec2cee",
+        "id" : "1706815769996439000.a28ac9e3-665b-4033-8d3f-270f1b72dcc9",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -1274,10 +1279,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677721828000.95aab8a2-1dfa-4081-bef0-28820ffdb96b",
+      "fullUrl" : "Location/1706815769996788000.6d8bff8a-9ef9-4383-8f61-f609415c6fc6",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677721828000.95aab8a2-1dfa-4081-bef0-28820ffdb96b",
+        "id" : "1706815769996788000.6d8bff8a-9ef9-4383-8f61-f609415c6fc6",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -1296,10 +1301,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677722259000.4d43079f-87c3-48d1-a270-8a9c2390d311",
+      "fullUrl" : "Location/1706815769997339000.f0c9fe14-13a6-40ad-a930-1bf7e8c6e5ef",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677722259000.4d43079f-87c3-48d1-a270-8a9c2390d311",
+        "id" : "1706815769997339000.f0c9fe14-13a6-40ad-a930-1bf7e8c6e5ef",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -1318,10 +1323,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677722587000.4988df5e-48ad-4704-b192-4d5647e2fea4",
+      "fullUrl" : "Location/1706815769997724000.20ec935b-411d-4748-a613-6c0bbcdc9411",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677722587000.4988df5e-48ad-4704-b192-4d5647e2fea4",
+        "id" : "1706815769997724000.20ec935b-411d-4748-a613-6c0bbcdc9411",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -1340,10 +1345,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654677722715000.ac166af8-d565-4482-9983-092442408489",
+      "fullUrl" : "PractitionerRole/1706815769997869000.940d7037-4bf7-47f3-83f6-399ce84adc12",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654677722715000.ac166af8-d565-4482-9983-092442408489",
+        "id" : "1706815769997869000.940d7037-4bf7-47f3-83f6-399ce84adc12",
         "period" : {
           "start" : "2023-04-01T10:25:31-04:00",
           "_start" : {
@@ -1365,35 +1370,35 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654677710603000.82c20ade-106a-4238-9c06-d42d84e04635"
+          "reference" : "Practitioner/1706815769985430000.d653931d-7a87-4cf5-bdb2-e3dd4e8c8891"
         },
         "location" : [
           {
-            "reference" : "Location/1706654677711360000.98b64692-73b1-4275-a77b-16a17adc5e2e"
+            "reference" : "Location/1706815769986291000.38f3dae5-6f77-4883-914e-311a9a544369"
           },
           {
-            "reference" : "Location/1706654677720927000.857fa651-f6b7-4261-b340-0cb0ba91faf8"
+            "reference" : "Location/1706815769995845000.8dd184f5-5a50-4806-84de-32aaca3c323b"
           },
           {
-            "reference" : "Location/1706654677721438000.468837f1-bc30-430c-988f-4e0966ec2cee"
+            "reference" : "Location/1706815769996439000.a28ac9e3-665b-4033-8d3f-270f1b72dcc9"
           },
           {
-            "reference" : "Location/1706654677721828000.95aab8a2-1dfa-4081-bef0-28820ffdb96b"
+            "reference" : "Location/1706815769996788000.6d8bff8a-9ef9-4383-8f61-f609415c6fc6"
           },
           {
-            "reference" : "Location/1706654677722259000.4d43079f-87c3-48d1-a270-8a9c2390d311"
+            "reference" : "Location/1706815769997339000.f0c9fe14-13a6-40ad-a930-1bf7e8c6e5ef"
           },
           {
-            "reference" : "Location/1706654677722587000.4988df5e-48ad-4704-b192-4d5647e2fea4"
+            "reference" : "Location/1706815769997724000.20ec935b-411d-4748-a613-6c0bbcdc9411"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677726295000.b4d26c21-04d1-4fee-9e69-7a1d1316f1b6",
+      "fullUrl" : "Practitioner/1706815770001893000.3d8176e1-e031-48c8-85e8-5e2cd319d714",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677726295000.b4d26c21-04d1-4fee-9e69-7a1d1316f1b6",
+        "id" : "1706815770001893000.3d8176e1-e031-48c8-85e8-5e2cd319d714",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1597,10 +1602,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654677899523000.080a0d6f-6ebc-4c43-9013-cab5f1695b41",
+      "fullUrl" : "DiagnosticReport/1706815770189967000.cabac1a4-b4da-4e6d-a1e0-51e6992da9e7",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654677899523000.080a0d6f-6ebc-4c43-9013-cab5f1695b41",
+        "id" : "1706815770189967000.cabac1a4-b4da-4e6d-a1e0-51e6992da9e7",
         "identifier" : [
           {
             "extension" : [
@@ -1669,7 +1674,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654677729600000.45c0a1d2-ca79-4fa6-be1a-8d944942eb5e"
+            "reference" : "ServiceRequest/1706815770007653000.fff18fff-da6b-4c2a-ba8c-fcc1a0759255"
           }
         ],
         "status" : "final",
@@ -1703,7 +1708,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654677683265000.988643eb-577f-47b5-a0ca-895a76faabe9"
+          "reference" : "Patient/1706815769957258000.d72f92f8-cc34-4852-9b63-a39b4c275cd5"
         },
         "effectivePeriod" : {
           "start" : "2023-08-16T12:33:58-05:00",
@@ -1736,24 +1741,24 @@
         },
         "performer" : [
           {
-            "reference" : "PractitionerRole/1706654677895434000.1300cb0a-894a-4881-9f79-946a633c4af6"
+            "reference" : "PractitionerRole/1706815770185274000.2f79a26f-a74a-49ea-b4ff-b90d386d513e"
           },
           {
-            "reference" : "PractitionerRole/1706654677898847000.2ba58ff2-e31d-45b5-99fe-b5529f5f034e"
+            "reference" : "PractitionerRole/1706815770189732000.880b99ee-e578-4ad6-8760-2448cb6d0568"
           }
         ],
         "resultsInterpreter" : [
           {
-            "reference" : "PractitionerRole/1706654677892394000.feb91b56-2242-47f0-aa6c-818d6c7e62c0"
+            "reference" : "PractitionerRole/1706815770182372000.cfd93c06-c54b-4e22-83cf-5b49ae5ccf87"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677890221000.e418499e-d1bb-4313-bf4a-4844f8d617e7",
+      "fullUrl" : "Practitioner/1706815770179852000.8e9ed5ad-1646-48c8-b45d-a3bc31411197",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677890221000.e418499e-d1bb-4313-bf4a-4844f8d617e7",
+        "id" : "1706815770179852000.8e9ed5ad-1646-48c8-b45d-a3bc31411197",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -1820,10 +1825,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677890627000.d16eba71-045f-49ee-a24b-386053519fb6",
+      "fullUrl" : "Location/1706815770180419000.eeff3bb7-56df-4421-aee5-4c49c30bbc87",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677890627000.d16eba71-045f-49ee-a24b-386053519fb6",
+        "id" : "1706815770180419000.eeff3bb7-56df-4421-aee5-4c49c30bbc87",
         "identifier" : [
           {
             "extension" : [
@@ -1870,10 +1875,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677890958000.1bf363f8-bc40-462d-a019-cbd135bcdf46",
+      "fullUrl" : "Location/1706815770180792000.1505106f-8e1a-450b-9a5b-159a8afd63b0",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677890958000.1bf363f8-bc40-462d-a019-cbd135bcdf46",
+        "id" : "1706815770180792000.1505106f-8e1a-450b-9a5b-159a8afd63b0",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -1892,10 +1897,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677891377000.f018937a-4b88-4811-8023-113628298d87",
+      "fullUrl" : "Location/1706815770181252000.8cb6aed2-36b0-47e8-9329-9bc8ea00e486",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677891377000.f018937a-4b88-4811-8023-113628298d87",
+        "id" : "1706815770181252000.8cb6aed2-36b0-47e8-9329-9bc8ea00e486",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -1921,10 +1926,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677891667000.eb6b8a82-9453-4b98-b0b3-391bef455eda",
+      "fullUrl" : "Location/1706815770181553000.ded25cf5-87bf-4ed4-8f03-3a344f1a0276",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677891667000.eb6b8a82-9453-4b98-b0b3-391bef455eda",
+        "id" : "1706815770181553000.ded25cf5-87bf-4ed4-8f03-3a344f1a0276",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -1943,10 +1948,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677891980000.dd5cb3da-cd84-489c-b095-c3ce7144bf38",
+      "fullUrl" : "Location/1706815770181860000.b4caaaa9-210d-4010-b30e-47b91e2fc3b6",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677891980000.dd5cb3da-cd84-489c-b095-c3ce7144bf38",
+        "id" : "1706815770181860000.b4caaaa9-210d-4010-b30e-47b91e2fc3b6",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -1965,10 +1970,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677892288000.0f781c11-10db-429e-aaca-e171b2319062",
+      "fullUrl" : "Location/1706815770182249000.8753822d-0539-437a-9f2a-e40429b5e801",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677892288000.0f781c11-10db-429e-aaca-e171b2319062",
+        "id" : "1706815770182249000.8753822d-0539-437a-9f2a-e40429b5e801",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -1987,10 +1992,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654677892394000.feb91b56-2242-47f0-aa6c-818d6c7e62c0",
+      "fullUrl" : "PractitionerRole/1706815770182372000.cfd93c06-c54b-4e22-83cf-5b49ae5ccf87",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654677892394000.feb91b56-2242-47f0-aa6c-818d6c7e62c0",
+        "id" : "1706815770182372000.cfd93c06-c54b-4e22-83cf-5b49ae5ccf87",
         "period" : {
           "start" : "2023-04-01T10:25:31-04:00",
           "_start" : {
@@ -2012,35 +2017,35 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654677890221000.e418499e-d1bb-4313-bf4a-4844f8d617e7"
+          "reference" : "Practitioner/1706815770179852000.8e9ed5ad-1646-48c8-b45d-a3bc31411197"
         },
         "location" : [
           {
-            "reference" : "Location/1706654677890627000.d16eba71-045f-49ee-a24b-386053519fb6"
+            "reference" : "Location/1706815770180419000.eeff3bb7-56df-4421-aee5-4c49c30bbc87"
           },
           {
-            "reference" : "Location/1706654677890958000.1bf363f8-bc40-462d-a019-cbd135bcdf46"
+            "reference" : "Location/1706815770180792000.1505106f-8e1a-450b-9a5b-159a8afd63b0"
           },
           {
-            "reference" : "Location/1706654677891377000.f018937a-4b88-4811-8023-113628298d87"
+            "reference" : "Location/1706815770181252000.8cb6aed2-36b0-47e8-9329-9bc8ea00e486"
           },
           {
-            "reference" : "Location/1706654677891667000.eb6b8a82-9453-4b98-b0b3-391bef455eda"
+            "reference" : "Location/1706815770181553000.ded25cf5-87bf-4ed4-8f03-3a344f1a0276"
           },
           {
-            "reference" : "Location/1706654677891980000.dd5cb3da-cd84-489c-b095-c3ce7144bf38"
+            "reference" : "Location/1706815770181860000.b4caaaa9-210d-4010-b30e-47b91e2fc3b6"
           },
           {
-            "reference" : "Location/1706654677892288000.0f781c11-10db-429e-aaca-e171b2319062"
+            "reference" : "Location/1706815770182249000.8753822d-0539-437a-9f2a-e40429b5e801"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677893139000.75b3d663-aaeb-40c5-87fa-3e20192a104b",
+      "fullUrl" : "Practitioner/1706815770183333000.0be3cf52-3f43-4a9c-a707-d2684f47bd9d",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677893139000.75b3d663-aaeb-40c5-87fa-3e20192a104b",
+        "id" : "1706815770183333000.0be3cf52-3f43-4a9c-a707-d2684f47bd9d",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -2107,10 +2112,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677893437000.b3572272-cc9a-427c-b591-743b91698618",
+      "fullUrl" : "Location/1706815770183681000.561b7480-ddf8-4c3c-9e55-07a43302c2e5",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677893437000.b3572272-cc9a-427c-b591-743b91698618",
+        "id" : "1706815770183681000.561b7480-ddf8-4c3c-9e55-07a43302c2e5",
         "identifier" : [
           {
             "extension" : [
@@ -2157,10 +2162,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677893705000.11eadd17-ca8a-400a-97bb-bf8735eebdb2",
+      "fullUrl" : "Location/1706815770183997000.84623096-56c9-4490-a8cb-56b7f70fcc87",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677893705000.11eadd17-ca8a-400a-97bb-bf8735eebdb2",
+        "id" : "1706815770183997000.84623096-56c9-4490-a8cb-56b7f70fcc87",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -2179,10 +2184,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677893975000.398da21f-d4d8-4c69-9524-d8cd84bff9fb",
+      "fullUrl" : "Location/1706815770184292000.c445d5a3-2607-44b7-96cd-5876de7bda2c",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677893975000.398da21f-d4d8-4c69-9524-d8cd84bff9fb",
+        "id" : "1706815770184292000.c445d5a3-2607-44b7-96cd-5876de7bda2c",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -2208,10 +2213,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677894247000.fa5ee436-ef66-4b24-a960-b11f21962a34",
+      "fullUrl" : "Location/1706815770184583000.6f1f310f-79b9-41bc-afd7-a92dce783635",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677894247000.fa5ee436-ef66-4b24-a960-b11f21962a34",
+        "id" : "1706815770184583000.6f1f310f-79b9-41bc-afd7-a92dce783635",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -2230,10 +2235,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677895041000.e494de75-ed0a-4b7d-9c27-b834f3fbf446",
+      "fullUrl" : "Location/1706815770184870000.b594a644-9f8d-4bbc-bd32-7d0c02867afc",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677895041000.e494de75-ed0a-4b7d-9c27-b834f3fbf446",
+        "id" : "1706815770184870000.b594a644-9f8d-4bbc-bd32-7d0c02867afc",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -2252,10 +2257,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677895328000.00653ff5-8236-432c-aa0b-d8746aaef7db",
+      "fullUrl" : "Location/1706815770185152000.c4dc9607-b89e-4fdb-b3c8-874ab6d6c26d",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677895328000.00653ff5-8236-432c-aa0b-d8746aaef7db",
+        "id" : "1706815770185152000.c4dc9607-b89e-4fdb-b3c8-874ab6d6c26d",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -2274,10 +2279,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654677895434000.1300cb0a-894a-4881-9f79-946a633c4af6",
+      "fullUrl" : "PractitionerRole/1706815770185274000.2f79a26f-a74a-49ea-b4ff-b90d386d513e",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654677895434000.1300cb0a-894a-4881-9f79-946a633c4af6",
+        "id" : "1706815770185274000.2f79a26f-a74a-49ea-b4ff-b90d386d513e",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/event-performerFunction",
@@ -2318,35 +2323,35 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654677893139000.75b3d663-aaeb-40c5-87fa-3e20192a104b"
+          "reference" : "Practitioner/1706815770183333000.0be3cf52-3f43-4a9c-a707-d2684f47bd9d"
         },
         "location" : [
           {
-            "reference" : "Location/1706654677893437000.b3572272-cc9a-427c-b591-743b91698618"
+            "reference" : "Location/1706815770183681000.561b7480-ddf8-4c3c-9e55-07a43302c2e5"
           },
           {
-            "reference" : "Location/1706654677893705000.11eadd17-ca8a-400a-97bb-bf8735eebdb2"
+            "reference" : "Location/1706815770183997000.84623096-56c9-4490-a8cb-56b7f70fcc87"
           },
           {
-            "reference" : "Location/1706654677893975000.398da21f-d4d8-4c69-9524-d8cd84bff9fb"
+            "reference" : "Location/1706815770184292000.c445d5a3-2607-44b7-96cd-5876de7bda2c"
           },
           {
-            "reference" : "Location/1706654677894247000.fa5ee436-ef66-4b24-a960-b11f21962a34"
+            "reference" : "Location/1706815770184583000.6f1f310f-79b9-41bc-afd7-a92dce783635"
           },
           {
-            "reference" : "Location/1706654677895041000.e494de75-ed0a-4b7d-9c27-b834f3fbf446"
+            "reference" : "Location/1706815770184870000.b594a644-9f8d-4bbc-bd32-7d0c02867afc"
           },
           {
-            "reference" : "Location/1706654677895328000.00653ff5-8236-432c-aa0b-d8746aaef7db"
+            "reference" : "Location/1706815770185152000.c4dc9607-b89e-4fdb-b3c8-874ab6d6c26d"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654677896881000.cafa55a2-4335-432a-9423-69ae6ab3e205",
+      "fullUrl" : "Practitioner/1706815770187193000.9932a125-a3a0-4ebb-8345-b09426c23230",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654677896881000.cafa55a2-4335-432a-9423-69ae6ab3e205",
+        "id" : "1706815770187193000.9932a125-a3a0-4ebb-8345-b09426c23230",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -2413,10 +2418,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677897284000.fbbaa958-e8bc-4e95-a9dd-913b9da62da1",
+      "fullUrl" : "Location/1706815770187635000.b325ddb3-7c73-48d5-961b-1082cb0e76e2",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677897284000.fbbaa958-e8bc-4e95-a9dd-913b9da62da1",
+        "id" : "1706815770187635000.b325ddb3-7c73-48d5-961b-1082cb0e76e2",
         "identifier" : [
           {
             "extension" : [
@@ -2463,10 +2468,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677897752000.6ca8de27-8174-482c-b76e-3fb100363b9a",
+      "fullUrl" : "Location/1706815770188356000.1e0a2091-9347-4c9f-8006-24d69932e6a7",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677897752000.6ca8de27-8174-482c-b76e-3fb100363b9a",
+        "id" : "1706815770188356000.1e0a2091-9347-4c9f-8006-24d69932e6a7",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -2485,10 +2490,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677898012000.885dcb8f-49b0-4fbb-9a3e-644cab856f39",
+      "fullUrl" : "Location/1706815770188690000.485edf17-4d41-4b05-9bec-381435cbe3b4",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677898012000.885dcb8f-49b0-4fbb-9a3e-644cab856f39",
+        "id" : "1706815770188690000.485edf17-4d41-4b05-9bec-381435cbe3b4",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -2514,10 +2519,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677898257000.fae62a09-998f-4e18-b0bf-02bc98967e7f",
+      "fullUrl" : "Location/1706815770189075000.e8de8b2e-821a-426b-ac2a-dad3e2b99bd3",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677898257000.fae62a09-998f-4e18-b0bf-02bc98967e7f",
+        "id" : "1706815770189075000.e8de8b2e-821a-426b-ac2a-dad3e2b99bd3",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -2536,10 +2541,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677898504000.b3ae5a29-44d7-4aed-aa6e-ba726ec47515",
+      "fullUrl" : "Location/1706815770189344000.a9e8a5d5-b4e2-4882-bf3e-53152a9b468b",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677898504000.b3ae5a29-44d7-4aed-aa6e-ba726ec47515",
+        "id" : "1706815770189344000.a9e8a5d5-b4e2-4882-bf3e-53152a9b468b",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -2558,10 +2563,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654677898745000.496b8167-59b5-4f28-950f-a1717bc6630a",
+      "fullUrl" : "Location/1706815770189613000.f1080992-a6cd-452c-a5eb-f7de3514f283",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654677898745000.496b8167-59b5-4f28-950f-a1717bc6630a",
+        "id" : "1706815770189613000.f1080992-a6cd-452c-a5eb-f7de3514f283",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -2580,10 +2585,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654677898847000.2ba58ff2-e31d-45b5-99fe-b5529f5f034e",
+      "fullUrl" : "PractitionerRole/1706815770189732000.880b99ee-e578-4ad6-8760-2448cb6d0568",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654677898847000.2ba58ff2-e31d-45b5-99fe-b5529f5f034e",
+        "id" : "1706815770189732000.880b99ee-e578-4ad6-8760-2448cb6d0568",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/event-performerFunction",
@@ -2624,26 +2629,26 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654677896881000.cafa55a2-4335-432a-9423-69ae6ab3e205"
+          "reference" : "Practitioner/1706815770187193000.9932a125-a3a0-4ebb-8345-b09426c23230"
         },
         "location" : [
           {
-            "reference" : "Location/1706654677897284000.fbbaa958-e8bc-4e95-a9dd-913b9da62da1"
+            "reference" : "Location/1706815770187635000.b325ddb3-7c73-48d5-961b-1082cb0e76e2"
           },
           {
-            "reference" : "Location/1706654677897752000.6ca8de27-8174-482c-b76e-3fb100363b9a"
+            "reference" : "Location/1706815770188356000.1e0a2091-9347-4c9f-8006-24d69932e6a7"
           },
           {
-            "reference" : "Location/1706654677898012000.885dcb8f-49b0-4fbb-9a3e-644cab856f39"
+            "reference" : "Location/1706815770188690000.485edf17-4d41-4b05-9bec-381435cbe3b4"
           },
           {
-            "reference" : "Location/1706654677898257000.fae62a09-998f-4e18-b0bf-02bc98967e7f"
+            "reference" : "Location/1706815770189075000.e8de8b2e-821a-426b-ac2a-dad3e2b99bd3"
           },
           {
-            "reference" : "Location/1706654677898504000.b3ae5a29-44d7-4aed-aa6e-ba726ec47515"
+            "reference" : "Location/1706815770189344000.a9e8a5d5-b4e2-4882-bf3e-53152a9b468b"
           },
           {
-            "reference" : "Location/1706654677898745000.496b8167-59b5-4f28-950f-a1717bc6630a"
+            "reference" : "Location/1706815770189613000.f1080992-a6cd-452c-a5eb-f7de3514f283"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr11-a.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr11-a.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654686856169000.da0a668b-befe-42fe-a2c8-35cf1a63b247",
+  "id" : "1706815780057258000.c811ff3e-5598-4911-88de-6198002a28a5",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:44:46.862-05:00"
+    "lastUpdated" : "2024-02-01T14:29:40.065-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654687256369000.1111911a-6213-4683-b069-3471a8220769",
+      "fullUrl" : "Provenance/1706815780470846000.baa83b81-b7df-4982-a2a1-04fa09ebe2e3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654687256369000.1111911a-6213-4683-b069-3471a8220769",
+        "id" : "1706815780470846000.baa83b81-b7df-4982-a2a1-04fa09ebe2e3",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654687450253000.5562dc52-eeb0-4373-a54a-7ea9b9bdd49b"
+            "reference" : "DiagnosticReport/1706815780649145000.52f165ea-da3f-4f99-9325-fdd5240e9f90"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654687264766000.fead868c-b96d-4c0b-aa6d-42893223acb4",
+      "fullUrl" : "Provenance/1706815780478842000.d9fafd54-c685-4c6d-9e80-7239790e80de",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654687264766000.fead868c-b96d-4c0b-aa6d-42893223acb4",
-        "recorded" : "2024-01-30T17:44:47Z",
+        "id" : "1706815780478842000.d9fafd54-c685-4c6d-9e80-7239790e80de",
+        "recorded" : "2024-02-01T14:29:40Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654687264256000.b166cbc6-22af-4756-a83e-4c8d7aa6245d"
+              "reference" : "Organization/1706815780478327000.325e7de8-d660-40bf-8276-cb3897b1f4d1"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654687264256000.b166cbc6-22af-4756-a83e-4c8d7aa6245d",
+      "fullUrl" : "Organization/1706815780478327000.325e7de8-d660-40bf-8276-cb3897b1f4d1",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654687264256000.b166cbc6-22af-4756-a83e-4c8d7aa6245d",
+        "id" : "1706815780478327000.325e7de8-d660-40bf-8276-cb3897b1f4d1",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654687280255000.6619c0ab-884c-4a88-92e4-a1d434ed0475",
+      "fullUrl" : "Patient/1706815780495249000.7148066e-84ff-448b-87b8-63f742b09629",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654687280255000.6619c0ab-884c-4a88-92e4-a1d434ed0475"
+        "id" : "1706815780495249000.7148066e-84ff-448b-87b8-63f742b09629"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654687280867000.f9b366ea-8b3b-4f8e-b154-3a42cb938f51",
+      "fullUrl" : "Provenance/1706815780495932000.6f5a68f7-6fd9-4fff-87de-2668177c27ad",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654687280867000.f9b366ea-8b3b-4f8e-b154-3a42cb938f51",
+        "id" : "1706815780495932000.6f5a68f7-6fd9-4fff-87de-2668177c27ad",
         "target" : [
           {
-            "reference" : "Patient/1706654687280255000.6619c0ab-884c-4a88-92e4-a1d434ed0475"
+            "reference" : "Patient/1706815780495249000.7148066e-84ff-448b-87b8-63f742b09629"
           }
         ],
-        "recorded" : "2024-01-30T17:44:47Z",
+        "recorded" : "2024-02-01T14:29:40Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654687285842000.b593e0d0-5a1a-4738-9b31-bbfa519ff697",
+      "fullUrl" : "ServiceRequest/1706815780501081000.49ea7a91-9aec-48fd-8552-fa32e0ca2d33",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654687285842000.b593e0d0-5a1a-4738-9b31-bbfa519ff697",
+        "id" : "1706815780501081000.49ea7a91-9aec-48fd-8552-fa32e0ca2d33",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -169,23 +174,23 @@
         "status" : "unknown",
         "intent" : "order",
         "subject" : {
-          "reference" : "Patient/1706654687280255000.6619c0ab-884c-4a88-92e4-a1d434ed0475"
+          "reference" : "Patient/1706815780495249000.7148066e-84ff-448b-87b8-63f742b09629"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654687450253000.5562dc52-eeb0-4373-a54a-7ea9b9bdd49b",
+      "fullUrl" : "DiagnosticReport/1706815780649145000.52f165ea-da3f-4f99-9325-fdd5240e9f90",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654687450253000.5562dc52-eeb0-4373-a54a-7ea9b9bdd49b",
+        "id" : "1706815780649145000.52f165ea-da3f-4f99-9325-fdd5240e9f90",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654687285842000.b593e0d0-5a1a-4738-9b31-bbfa519ff697"
+            "reference" : "ServiceRequest/1706815780501081000.49ea7a91-9aec-48fd-8552-fa32e0ca2d33"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654687280255000.6619c0ab-884c-4a88-92e4-a1d434ed0475"
+          "reference" : "Patient/1706815780495249000.7148066e-84ff-448b-87b8-63f742b09629"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr11-g.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr11-g.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654696335940000.3d2716e3-639c-4da9-a49e-8413e6791a13",
+  "id" : "1706815790629284000.837f8d23-5bb3-4c84-88d1-8144b3d68d73",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:44:56.342-05:00"
+    "lastUpdated" : "2024-02-01T14:29:50.636-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654696723031000.c0cc414d-d815-46ea-9eeb-bc6e1a0cf98f",
+      "fullUrl" : "Provenance/1706815791012534000.992e1e93-8a30-4cc2-bcd0-21919fc186da",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654696723031000.c0cc414d-d815-46ea-9eeb-bc6e1a0cf98f",
+        "id" : "1706815791012534000.992e1e93-8a30-4cc2-bcd0-21919fc186da",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654696900806000.da4746e5-7de6-49d3-8e8f-ff59712474a3"
+            "reference" : "DiagnosticReport/1706815791215199000.dab64a1d-2cb6-4776-a92a-811ae3e7f447"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654696730777000.d231880b-63bb-4848-b897-932f77d8848c",
+      "fullUrl" : "Provenance/1706815791019435000.546c6367-7a69-4032-b244-8bfa9c8a5502",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654696730777000.d231880b-63bb-4848-b897-932f77d8848c",
-        "recorded" : "2024-01-30T17:44:56Z",
+        "id" : "1706815791019435000.546c6367-7a69-4032-b244-8bfa9c8a5502",
+        "recorded" : "2024-02-01T14:29:51Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654696730245000.bb0fdc6f-b140-48bb-a33a-d65127b0071b"
+              "reference" : "Organization/1706815791018955000.78516ae2-7ee8-472f-aea4-0f9aa8050d3f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654696730245000.bb0fdc6f-b140-48bb-a33a-d65127b0071b",
+      "fullUrl" : "Organization/1706815791018955000.78516ae2-7ee8-472f-aea4-0f9aa8050d3f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654696730245000.bb0fdc6f-b140-48bb-a33a-d65127b0071b",
+        "id" : "1706815791018955000.78516ae2-7ee8-472f-aea4-0f9aa8050d3f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654696746178000.8a7ebfd5-f351-4a68-8882-92259cd8c601",
+      "fullUrl" : "Patient/1706815791033601000.61b926dd-9347-45f4-aa6c-f6adac4fd5b2",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654696746178000.8a7ebfd5-f351-4a68-8882-92259cd8c601"
+        "id" : "1706815791033601000.61b926dd-9347-45f4-aa6c-f6adac4fd5b2"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654696746947000.2fa0fda1-edd9-47e0-a93b-c8cfcf591a19",
+      "fullUrl" : "Provenance/1706815791034203000.a0e2ad56-d1e4-41f1-9589-1499b68be2fa",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654696746947000.2fa0fda1-edd9-47e0-a93b-c8cfcf591a19",
+        "id" : "1706815791034203000.a0e2ad56-d1e4-41f1-9589-1499b68be2fa",
         "target" : [
           {
-            "reference" : "Patient/1706654696746178000.8a7ebfd5-f351-4a68-8882-92259cd8c601"
+            "reference" : "Patient/1706815791033601000.61b926dd-9347-45f4-aa6c-f6adac4fd5b2"
           }
         ],
-        "recorded" : "2024-01-30T17:44:56Z",
+        "recorded" : "2024-02-01T14:29:51Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654696752143000.2f83197a-6dc8-4c2e-80a5-0e702f2b190a",
+      "fullUrl" : "ServiceRequest/1706815791038768000.c684e1b2-56b2-435c-9c36-290a460fe5f4",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654696752143000.2f83197a-6dc8-4c2e-80a5-0e702f2b190a",
+        "id" : "1706815791038768000.c684e1b2-56b2-435c-9c36-290a460fe5f4",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -169,23 +174,23 @@
         "status" : "unknown",
         "intent" : "order",
         "subject" : {
-          "reference" : "Patient/1706654696746178000.8a7ebfd5-f351-4a68-8882-92259cd8c601"
+          "reference" : "Patient/1706815791033601000.61b926dd-9347-45f4-aa6c-f6adac4fd5b2"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654696900806000.da4746e5-7de6-49d3-8e8f-ff59712474a3",
+      "fullUrl" : "DiagnosticReport/1706815791215199000.dab64a1d-2cb6-4776-a92a-811ae3e7f447",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654696900806000.da4746e5-7de6-49d3-8e8f-ff59712474a3",
+        "id" : "1706815791215199000.dab64a1d-2cb6-4776-a92a-811ae3e7f447",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654696752143000.2f83197a-6dc8-4c2e-80a5-0e702f2b190a"
+            "reference" : "ServiceRequest/1706815791038768000.c684e1b2-56b2-435c-9c36-290a460fe5f4"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654696746178000.8a7ebfd5-f351-4a68-8882-92259cd8c601"
+          "reference" : "Patient/1706815791033601000.61b926dd-9347-45f4-aa6c-f6adac4fd5b2"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr11-l.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr11-l.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654705962410000.1825affc-ec68-41c4-b7f5-888b10d29056",
+  "id" : "1706815801929347000.4e0eae35-2b58-44ac-82ba-11c5fe84e465",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:45:05.969-05:00"
+    "lastUpdated" : "2024-02-01T14:30:01.936-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654706369167000.a2894e97-5e5b-447b-8cff-707b118016c4",
+      "fullUrl" : "Provenance/1706815802326724000.c6b3ecaf-9624-4905-abb5-75ba1c213489",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654706369167000.a2894e97-5e5b-447b-8cff-707b118016c4",
+        "id" : "1706815802326724000.c6b3ecaf-9624-4905-abb5-75ba1c213489",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654706560058000.3956cf28-5507-4d5f-887a-149e8555dd2b"
+            "reference" : "DiagnosticReport/1706815802569376000.33f6425c-92d4-421d-998f-2b3574687f7d"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654706376402000.c6839a0e-1a26-46dc-8aff-aed6f7b5811b",
+      "fullUrl" : "Provenance/1706815802336124000.7ed224cb-4aa9-4556-b4cd-875611fecd75",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654706376402000.c6839a0e-1a26-46dc-8aff-aed6f7b5811b",
-        "recorded" : "2024-01-30T17:45:06Z",
+        "id" : "1706815802336124000.7ed224cb-4aa9-4556-b4cd-875611fecd75",
+        "recorded" : "2024-02-01T14:30:02Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654706375964000.080f7fb3-5aad-477e-aad2-b482f197f0e7"
+              "reference" : "Organization/1706815802335463000.5e8a691a-6291-4626-98b3-2aaeaad39227"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654706375964000.080f7fb3-5aad-477e-aad2-b482f197f0e7",
+      "fullUrl" : "Organization/1706815802335463000.5e8a691a-6291-4626-98b3-2aaeaad39227",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654706375964000.080f7fb3-5aad-477e-aad2-b482f197f0e7",
+        "id" : "1706815802335463000.5e8a691a-6291-4626-98b3-2aaeaad39227",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654706392169000.1891d913-7e73-497d-b1f8-b6f1e89e1498",
+      "fullUrl" : "Patient/1706815802355124000.4c0fc68d-385c-4acd-b364-2d15902453af",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654706392169000.1891d913-7e73-497d-b1f8-b6f1e89e1498"
+        "id" : "1706815802355124000.4c0fc68d-385c-4acd-b364-2d15902453af"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654706393360000.38197431-ca2b-42cb-ab7d-22b027065a2c",
+      "fullUrl" : "Provenance/1706815802356004000.231df7b1-647c-4967-92b2-69bfcbe2a686",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654706393360000.38197431-ca2b-42cb-ab7d-22b027065a2c",
+        "id" : "1706815802356004000.231df7b1-647c-4967-92b2-69bfcbe2a686",
         "target" : [
           {
-            "reference" : "Patient/1706654706392169000.1891d913-7e73-497d-b1f8-b6f1e89e1498"
+            "reference" : "Patient/1706815802355124000.4c0fc68d-385c-4acd-b364-2d15902453af"
           }
         ],
-        "recorded" : "2024-01-30T17:45:06Z",
+        "recorded" : "2024-02-01T14:30:02Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654706399984000.73647170-5ef8-4b48-b392-cef772bd5258",
+      "fullUrl" : "ServiceRequest/1706815802364848000.3e2771e2-edc3-4c58-af86-3cfb14141ffe",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654706399984000.73647170-5ef8-4b48-b392-cef772bd5258",
+        "id" : "1706815802364848000.3e2771e2-edc3-4c58-af86-3cfb14141ffe",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
@@ -169,23 +174,23 @@
         "status" : "unknown",
         "intent" : "order",
         "subject" : {
-          "reference" : "Patient/1706654706392169000.1891d913-7e73-497d-b1f8-b6f1e89e1498"
+          "reference" : "Patient/1706815802355124000.4c0fc68d-385c-4acd-b364-2d15902453af"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654706560058000.3956cf28-5507-4d5f-887a-149e8555dd2b",
+      "fullUrl" : "DiagnosticReport/1706815802569376000.33f6425c-92d4-421d-998f-2b3574687f7d",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654706560058000.3956cf28-5507-4d5f-887a-149e8555dd2b",
+        "id" : "1706815802569376000.33f6425c-92d4-421d-998f-2b3574687f7d",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654706399984000.73647170-5ef8-4b48-b392-cef772bd5258"
+            "reference" : "ServiceRequest/1706815802364848000.3e2771e2-edc3-4c58-af86-3cfb14141ffe"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654706392169000.1891d913-7e73-497d-b1f8-b6f1e89e1498"
+          "reference" : "Patient/1706815802355124000.4c0fc68d-385c-4acd-b364-2d15902453af"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr8-not-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-obr8-not-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654715724493000.febef832-cc57-4c5c-aff7-33e06164fdc7",
+  "id" : "1706815812459004000.d9f25626-5e6d-4410-b7d3-2e0dbe0a6bf6",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:45:15.732-05:00"
+    "lastUpdated" : "2024-02-01T14:30:12.469-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,141 +10,186 @@
   },
   "type" : "message",
   "timestamp" : "2023-08-16T13:33:58.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230816123358-0500"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654716122417000.0ef5b14d-5128-43fe-b4c7-5f399decc2e3",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654716122417000.0ef5b14d-5128-43fe-b4c7-5f399decc2e3",
-      "target" : [ {
-        "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
-      }, {
-        "reference" : "DiagnosticReport/1706654716301541000.fb849660-d159-4a80-a7cf-02c70e01b7b7"
-      } ],
-      "recorded" : "2023-08-16T12:33:58-05:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654716130893000.543889fe-c3c6-4572-b781-89c9a63949db",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654716130893000.543889fe-c3c6-4572-b781-89c9a63949db",
-      "recorded" : "2024-01-30T17:45:16Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706654716130406000.9b5bc8a4-95fa-499e-8f13-186711ff8b6e"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654716130406000.9b5bc8a4-95fa-499e-8f13-186711ff8b6e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654716130406000.9b5bc8a4-95fa-499e-8f13-186711ff8b6e",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815812864973000.2698d0c7-69ad-4859-ab94-0bd521f3c081",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815812864973000.2698d0c7-69ad-4859-ab94-0bd521f3c081",
+        "target" : [
+          {
+            "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815813044903000.66f98096-c728-46bc-b59f-59706d4a445c"
+          }
+        ],
+        "recorded" : "2023-08-16T12:33:58-05:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815812873959000.684d2ff7-572d-4eaa-83ff-da0f25d07447",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815812873959000.684d2ff7-572d-4eaa-83ff-da0f25d07447",
+        "recorded" : "2024-02-01T14:30:12Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706654716146917000.06f1793e-39b9-481d-ab3a-0ef3725f295e",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706654716146917000.06f1793e-39b9-481d-ab3a-0ef3725f295e"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654716147557000.98b0a00e-980e-41b2-8834-80b4b6df495b",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654716147557000.98b0a00e-980e-41b2-8834-80b4b6df495b",
-      "target" : [ {
-        "reference" : "Patient/1706654716146917000.06f1793e-39b9-481d-ab3a-0ef3725f295e"
-      } ],
-      "recorded" : "2024-01-30T17:45:16Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815812873208000.4c63c9f5-87ed-4f24-b12c-e95026550197"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815812873208000.4c63c9f5-87ed-4f24-b12c-e95026550197",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815812873208000.4c63c9f5-87ed-4f24-b12c-e95026550197",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706815812889469000.8d17e5f5-9e7d-4489-ace9-6dc0172cf7c9",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706815812889469000.8d17e5f5-9e7d-4489-ace9-6dc0172cf7c9"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815812890040000.fd52f2c3-630d-488b-96f0-c93a27621dec",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815812890040000.fd52f2c3-630d-488b-96f0-c93a27621dec",
+        "target" : [
+          {
+            "reference" : "Patient/1706815812889469000.8d17e5f5-9e7d-4489-ace9-6dc0172cf7c9"
+          }
+        ],
+        "recorded" : "2024-02-01T14:30:12Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815812894637000.b96fd66c-3476-46cf-a452-efb4de5f0bde",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815812894637000.b96fd66c-3476-46cf-a452-efb4de5f0bde",
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815812889469000.8d17e5f5-9e7d-4489-ace9-6dc0172cf7c9"
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815813044903000.66f98096-c728-46bc-b59f-59706d4a445c",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815813044903000.66f98096-c728-46bc-b59f-59706d4a445c",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815812894637000.b96fd66c-3476-46cf-a452-efb4de5f0bde"
+          }
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815812889469000.8d17e5f5-9e7d-4489-ace9-6dc0172cf7c9"
+        },
+        "effectiveDateTime" : "2023-08-16T12:33:58-05:00",
+        "_effectiveDateTime" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20230816123358-0500"
+            }
+          ]
+        }
       }
     }
-  }, {
-    "fullUrl" : "ServiceRequest/1706654716153765000.9c3b1a94-be47-4262-a92e-6fbeb85f1653",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706654716153765000.9c3b1a94-be47-4262-a92e-6fbeb85f1653",
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654716146917000.06f1793e-39b9-481d-ab3a-0ef3725f295e"
-      }
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706654716301541000.fb849660-d159-4a80-a7cf-02c70e01b7b7",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706654716301541000.fb849660-d159-4a80-a7cf-02c70e01b7b7",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706654716153765000.9c3b1a94-be47-4262-a92e-6fbeb85f1653"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654716146917000.06f1793e-39b9-481d-ab3a-0ef3725f295e"
-      },
-      "effectiveDateTime" : "2023-08-16T12:33:58-05:00",
-      "_effectiveDateTime" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-          "valueString" : "20230816123358-0500"
-        } ]
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-orc-obr-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-orc-obr-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654725647123000.0a2d4f5e-e07d-4fd1-aec8-4afb5460ccbe",
+  "id" : "1706815823019998000.106a6cfe-3d52-4dc8-aa27-f401f73ab5ce",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:45:25.653-05:00"
+    "lastUpdated" : "2024-02-01T14:30:23.025-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654726041673000.c37a0c95-c021-4e01-a213-9319f1cfcda3",
+      "fullUrl" : "Provenance/1706815823425195000.78d5ff87-61e3-403c-93f3-54a521e89150",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654726041673000.c37a0c95-c021-4e01-a213-9319f1cfcda3",
+        "id" : "1706815823425195000.78d5ff87-61e3-403c-93f3-54a521e89150",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654726317886000.595b2009-987a-4378-8011-5d51370a1d29"
+            "reference" : "DiagnosticReport/1706815823711227000.92d65855-2f79-4e33-9534-5e7d8a2489a4"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654726049266000.c619dfea-f20b-478c-9fe7-0f1983fe02fa",
+      "fullUrl" : "Provenance/1706815823434977000.3d7f746f-f279-4672-a7f0-5aedcbff23af",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654726049266000.c619dfea-f20b-478c-9fe7-0f1983fe02fa",
-        "recorded" : "2024-01-30T17:45:26Z",
+        "id" : "1706815823434977000.3d7f746f-f279-4672-a7f0-5aedcbff23af",
+        "recorded" : "2024-02-01T14:30:23Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654726048816000.1b17a662-dcb2-4cf4-afdb-879431ff0dc6"
+              "reference" : "Organization/1706815823434437000.097fc419-c9c3-414b-a8b3-2909d1aebc79"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654726048816000.1b17a662-dcb2-4cf4-afdb-879431ff0dc6",
+      "fullUrl" : "Organization/1706815823434437000.097fc419-c9c3-414b-a8b3-2909d1aebc79",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654726048816000.1b17a662-dcb2-4cf4-afdb-879431ff0dc6",
+        "id" : "1706815823434437000.097fc419-c9c3-414b-a8b3-2909d1aebc79",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654726064391000.20cfdef4-e8d2-45a0-b3a9-3521e49a6295",
+      "fullUrl" : "Patient/1706815823456502000.e1fb6d7b-4f15-44fc-bdc2-014267dd9f35",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654726064391000.20cfdef4-e8d2-45a0-b3a9-3521e49a6295"
+        "id" : "1706815823456502000.e1fb6d7b-4f15-44fc-bdc2-014267dd9f35"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654726065025000.bb625d31-1cad-4cef-b522-4a5e49442b6d",
+      "fullUrl" : "Provenance/1706815823457362000.e6e23491-50e1-43c9-9610-2aa19a27644e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654726065025000.bb625d31-1cad-4cef-b522-4a5e49442b6d",
+        "id" : "1706815823457362000.e6e23491-50e1-43c9-9610-2aa19a27644e",
         "target" : [
           {
-            "reference" : "Patient/1706654726064391000.20cfdef4-e8d2-45a0-b3a9-3521e49a6295"
+            "reference" : "Patient/1706815823456502000.e1fb6d7b-4f15-44fc-bdc2-014267dd9f35"
           }
         ],
-        "recorded" : "2024-01-30T17:45:26Z",
+        "recorded" : "2024-02-01T14:30:23Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654726131443000.2bc20595-eea9-4e74-b9a1-d30430557e58",
+      "fullUrl" : "ServiceRequest/1706815823531126000.ae1d0754-0abe-4ada-8b38-8e7efa8fc2d5",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654726131443000.2bc20595-eea9-4e74-b9a1-d30430557e58",
+        "id" : "1706815823531126000.ae1d0754-0abe-4ada-8b38-8e7efa8fc2d5",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -298,19 +303,19 @@
               {
                 "url" : "orc-10-entered-by",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654726098268000.12281305-87b5-4f8a-9090-1556cefb9fd1"
+                  "reference" : "Practitioner/1706815823491169000.d083209f-dc76-401f-bf6f-ae758c696569"
                 }
               },
               {
                 "url" : "orc-11-verified-by",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654726101513000.438df2f6-ada0-41dc-a58b-7441edf161a8"
+                  "reference" : "Practitioner/1706815823494870000.3e3e9fbd-0c69-4157-ae90-e4a3a6fcdb37"
                 }
               },
               {
                 "url" : "orc-13-enterers-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654726103566000.d39cacd1-48cf-408c-a11a-e765f0804bb4"
+                  "reference" : "Location/1706815823497198000.55dcd02c-3ae4-4e56-a174-d1fec5daafc2"
                 }
               },
               {
@@ -353,7 +358,7 @@
               {
                 "url" : "orc-19-action-by",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654726106908000.69a59678-c3ad-48d7-90c5-df1955cbda32"
+                  "reference" : "Practitioner/1706815823502208000.7f3dd1ff-6e45-4d6e-885d-65a5b73cd648"
                 }
               }
             ]
@@ -490,7 +495,7 @@
               {
                 "url" : "obr-28-result-copies-to",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654726110122000.7a736f4e-135e-4851-9469-90044829c040"
+                  "reference" : "Practitioner/1706815823506032000.1455f723-c80c-4a3e-8b84-6b5d8c287c80"
                 }
               },
               {
@@ -545,7 +550,7 @@
               {
                 "url" : "obr-33-assistant-result-interpreter",
                 "valueReference" : {
-                  "reference" : "PractitionerRole/1706654726123733000.ab7048b4-3556-432c-8de4-5a2b9490dc10"
+                  "reference" : "PractitionerRole/1706815823521856000.4e54f26e-dabd-4522-bcf4-4937dcfca388"
                 }
               },
               {
@@ -555,7 +560,7 @@
               {
                 "url" : "obr-10-collector-identifier",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654726125805000.b469265e-c6cd-4c73-bdf4-fe212324a610"
+                  "reference" : "Practitioner/1706815823524323000.aa7b76bc-42a9-4238-8800-a9dd5d49c531"
                 }
               },
               {
@@ -691,7 +696,7 @@
               {
                 "url" : "obr-16-ordering-provider",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654726129066000.c7ab76d7-b208-4515-ad77-efca11fcd1cd"
+                  "reference" : "Practitioner/1706815823528403000.9d3d24a0-8c8e-40a4-a705-332fe0d6fd4f"
                 }
               },
               {
@@ -1001,7 +1006,7 @@
           }
         ],
         "subject" : {
-          "reference" : "Patient/1706654726064391000.20cfdef4-e8d2-45a0-b3a9-3521e49a6295"
+          "reference" : "Patient/1706815823456502000.e1fb6d7b-4f15-44fc-bdc2-014267dd9f35"
         },
         "requester" : {
           "extension" : [
@@ -1084,7 +1089,7 @@
               }
             }
           ],
-          "reference" : "PractitionerRole/1706654726067392000.38164ae9-172e-4374-bf12-f55f7dc48da9"
+          "reference" : "PractitionerRole/1706815823460307000.e96911dc-9740-45fc-b48c-24ab3ffe041d"
         },
         "locationCode" : [
           {
@@ -1121,10 +1126,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726080047000.4db8a548-14e3-4218-8d77-fd29635c3e43",
+      "fullUrl" : "Practitioner/1706815823473671000.e3fd8d76-9a93-497f-a648-ee3770c25d8f",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726080047000.4db8a548-14e3-4218-8d77-fd29635c3e43",
+        "id" : "1706815823473671000.e3fd8d76-9a93-497f-a648-ee3770c25d8f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1410,10 +1415,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726082676000.7acb141c-2ce4-46ed-8606-e00beca0f719",
+      "fullUrl" : "Location/1706815823474993000.c25b57c3-94a7-4445-a527-04075d863530",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726082676000.7acb141c-2ce4-46ed-8606-e00beca0f719",
+        "id" : "1706815823474993000.c25b57c3-94a7-4445-a527-04075d863530",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1443,10 +1448,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654726087442000.385d8408-1806-4e9e-b078-3eb88735e364",
+      "fullUrl" : "Organization/1706815823480440000.b5878114-d0ae-4d27-8e6b-609953475055",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654726087442000.385d8408-1806-4e9e-b078-3eb88735e364",
+        "id" : "1706815823480440000.b5878114-d0ae-4d27-8e6b-609953475055",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1546,7 +1551,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654726082676000.7acb141c-2ce4-46ed-8606-e00beca0f719"
+                  "reference" : "Location/1706815823474993000.c25b57c3-94a7-4445-a527-04075d863530"
                 }
               }
             ],
@@ -1714,23 +1719,23 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654726067392000.38164ae9-172e-4374-bf12-f55f7dc48da9",
+      "fullUrl" : "PractitionerRole/1706815823460307000.e96911dc-9740-45fc-b48c-24ab3ffe041d",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654726067392000.38164ae9-172e-4374-bf12-f55f7dc48da9",
+        "id" : "1706815823460307000.e96911dc-9740-45fc-b48c-24ab3ffe041d",
         "practitioner" : {
-          "reference" : "Practitioner/1706654726080047000.4db8a548-14e3-4218-8d77-fd29635c3e43"
+          "reference" : "Practitioner/1706815823473671000.e3fd8d76-9a93-497f-a648-ee3770c25d8f"
         },
         "organization" : {
-          "reference" : "Organization/1706654726087442000.385d8408-1806-4e9e-b078-3eb88735e364"
+          "reference" : "Organization/1706815823480440000.b5878114-d0ae-4d27-8e6b-609953475055"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726098268000.12281305-87b5-4f8a-9090-1556cefb9fd1",
+      "fullUrl" : "Practitioner/1706815823491169000.d083209f-dc76-401f-bf6f-ae758c696569",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726098268000.12281305-87b5-4f8a-9090-1556cefb9fd1",
+        "id" : "1706815823491169000.d083209f-dc76-401f-bf6f-ae758c696569",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1935,10 +1940,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726101513000.438df2f6-ada0-41dc-a58b-7441edf161a8",
+      "fullUrl" : "Practitioner/1706815823494870000.3e3e9fbd-0c69-4157-ae90-e4a3a6fcdb37",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726101513000.438df2f6-ada0-41dc-a58b-7441edf161a8",
+        "id" : "1706815823494870000.3e3e9fbd-0c69-4157-ae90-e4a3a6fcdb37",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -2143,10 +2148,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654726102012000.7d5c21f0-bba1-472c-baea-42a291a8264d",
+      "fullUrl" : "Organization/1706815823495392000.1515bab9-2d93-494f-ae2c-662db3608918",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654726102012000.7d5c21f0-bba1-472c-baea-42a291a8264d",
+        "id" : "1706815823495392000.1515bab9-2d93-494f-ae2c-662db3608918",
         "identifier" : [
           {
             "extension" : [
@@ -2179,10 +2184,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726103179000.ec38e20e-466b-4718-bf3e-c3f472bb2022",
+      "fullUrl" : "Location/1706815823496756000.48d92355-79a1-4b96-a96e-5cc0605b6324",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726103179000.ec38e20e-466b-4718-bf3e-c3f472bb2022",
+        "id" : "1706815823496756000.48d92355-79a1-4b96-a96e-5cc0605b6324",
         "identifier" : [
           {
             "extension" : [
@@ -2227,10 +2232,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726103309000.2a0158a0-b319-4d28-ac40-750b631f4063",
+      "fullUrl" : "Location/1706815823496913000.5d0a42e4-85bc-4f39-94fc-1dc306ee11be",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726103309000.2a0158a0-b319-4d28-ac40-750b631f4063",
+        "id" : "1706815823496913000.5d0a42e4-85bc-4f39-94fc-1dc306ee11be",
         "identifier" : [
           {
             "extension" : [
@@ -2280,15 +2285,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706654726103179000.ec38e20e-466b-4718-bf3e-c3f472bb2022"
+          "reference" : "Location/1706815823496756000.48d92355-79a1-4b96-a96e-5cc0605b6324"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706654726103566000.d39cacd1-48cf-408c-a11a-e765f0804bb4",
+      "fullUrl" : "Location/1706815823497198000.55dcd02c-3ae4-4e56-a174-d1fec5daafc2",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726103566000.d39cacd1-48cf-408c-a11a-e765f0804bb4",
+        "id" : "1706815823497198000.55dcd02c-3ae4-4e56-a174-d1fec5daafc2",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -2348,7 +2353,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706654726102012000.7d5c21f0-bba1-472c-baea-42a291a8264d"
+              "reference" : "Organization/1706815823495392000.1515bab9-2d93-494f-ae2c-662db3608918"
             }
           }
         ],
@@ -2364,15 +2369,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706654726103309000.2a0158a0-b319-4d28-ac40-750b631f4063"
+          "reference" : "Location/1706815823496913000.5d0a42e4-85bc-4f39-94fc-1dc306ee11be"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726106908000.69a59678-c3ad-48d7-90c5-df1955cbda32",
+      "fullUrl" : "Practitioner/1706815823502208000.7f3dd1ff-6e45-4d6e-885d-65a5b73cd648",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726106908000.69a59678-c3ad-48d7-90c5-df1955cbda32",
+        "id" : "1706815823502208000.7f3dd1ff-6e45-4d6e-885d-65a5b73cd648",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -2577,10 +2582,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726110122000.7a736f4e-135e-4851-9469-90044829c040",
+      "fullUrl" : "Practitioner/1706815823506032000.1455f723-c80c-4a3e-8b84-6b5d8c287c80",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726110122000.7a736f4e-135e-4851-9469-90044829c040",
+        "id" : "1706815823506032000.1455f723-c80c-4a3e-8b84-6b5d8c287c80",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -2784,10 +2789,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726111639000.6938f8d2-875a-46fb-915c-ee5e73d9cf56",
+      "fullUrl" : "Practitioner/1706815823507548000.d76a834c-6aab-4a8e-9330-1c0838982f79",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726111639000.6938f8d2-875a-46fb-915c-ee5e73d9cf56",
+        "id" : "1706815823507548000.d76a834c-6aab-4a8e-9330-1c0838982f79",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -2854,10 +2859,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726112386000.fa29a24b-6283-4ef4-a75e-49800c573cf8",
+      "fullUrl" : "Location/1706815823508342000.9a88c92e-c420-41a4-9797-1ccb5ed7e552",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726112386000.fa29a24b-6283-4ef4-a75e-49800c573cf8",
+        "id" : "1706815823508342000.9a88c92e-c420-41a4-9797-1ccb5ed7e552",
         "identifier" : [
           {
             "extension" : [
@@ -2904,10 +2909,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726122571000.b2ba1a3e-c683-4d11-8d07-6ec60cf7172c",
+      "fullUrl" : "Location/1706815823520516000.13219a15-3669-498e-ac44-2af647afaf0a",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726122571000.b2ba1a3e-c683-4d11-8d07-6ec60cf7172c",
+        "id" : "1706815823520516000.13219a15-3669-498e-ac44-2af647afaf0a",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -2926,10 +2931,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726122921000.fc6026f7-1c24-4774-81c6-87be8ad4d5d9",
+      "fullUrl" : "Location/1706815823520927000.e61935fd-f8da-4746-9898-6d4310949ff6",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726122921000.fc6026f7-1c24-4774-81c6-87be8ad4d5d9",
+        "id" : "1706815823520927000.e61935fd-f8da-4746-9898-6d4310949ff6",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -2955,10 +2960,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726123143000.943db74f-1e92-4f92-ad38-343979f40d1c",
+      "fullUrl" : "Location/1706815823521204000.6f2e9e2e-4699-40fe-897b-164ab75b6439",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726123143000.943db74f-1e92-4f92-ad38-343979f40d1c",
+        "id" : "1706815823521204000.6f2e9e2e-4699-40fe-897b-164ab75b6439",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -2977,10 +2982,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726123385000.40abc3fb-9741-463b-a500-4d2c0616364b",
+      "fullUrl" : "Location/1706815823521472000.a14bf98c-12ae-4f7d-83c8-a34e7d36b946",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726123385000.40abc3fb-9741-463b-a500-4d2c0616364b",
+        "id" : "1706815823521472000.a14bf98c-12ae-4f7d-83c8-a34e7d36b946",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -2999,10 +3004,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726123622000.dedaa809-ab7d-44bb-8c3f-f21916205b97",
+      "fullUrl" : "Location/1706815823521744000.45f225e9-a3ea-4b32-b013-e17e645f8484",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726123622000.dedaa809-ab7d-44bb-8c3f-f21916205b97",
+        "id" : "1706815823521744000.45f225e9-a3ea-4b32-b013-e17e645f8484",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -3021,10 +3026,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654726123733000.ab7048b4-3556-432c-8de4-5a2b9490dc10",
+      "fullUrl" : "PractitionerRole/1706815823521856000.4e54f26e-dabd-4522-bcf4-4937dcfca388",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654726123733000.ab7048b4-3556-432c-8de4-5a2b9490dc10",
+        "id" : "1706815823521856000.4e54f26e-dabd-4522-bcf4-4937dcfca388",
         "period" : {
           "start" : "2023-04-01T10:25:31-04:00",
           "_start" : {
@@ -3046,35 +3051,35 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654726111639000.6938f8d2-875a-46fb-915c-ee5e73d9cf56"
+          "reference" : "Practitioner/1706815823507548000.d76a834c-6aab-4a8e-9330-1c0838982f79"
         },
         "location" : [
           {
-            "reference" : "Location/1706654726112386000.fa29a24b-6283-4ef4-a75e-49800c573cf8"
+            "reference" : "Location/1706815823508342000.9a88c92e-c420-41a4-9797-1ccb5ed7e552"
           },
           {
-            "reference" : "Location/1706654726122571000.b2ba1a3e-c683-4d11-8d07-6ec60cf7172c"
+            "reference" : "Location/1706815823520516000.13219a15-3669-498e-ac44-2af647afaf0a"
           },
           {
-            "reference" : "Location/1706654726122921000.fc6026f7-1c24-4774-81c6-87be8ad4d5d9"
+            "reference" : "Location/1706815823520927000.e61935fd-f8da-4746-9898-6d4310949ff6"
           },
           {
-            "reference" : "Location/1706654726123143000.943db74f-1e92-4f92-ad38-343979f40d1c"
+            "reference" : "Location/1706815823521204000.6f2e9e2e-4699-40fe-897b-164ab75b6439"
           },
           {
-            "reference" : "Location/1706654726123385000.40abc3fb-9741-463b-a500-4d2c0616364b"
+            "reference" : "Location/1706815823521472000.a14bf98c-12ae-4f7d-83c8-a34e7d36b946"
           },
           {
-            "reference" : "Location/1706654726123622000.dedaa809-ab7d-44bb-8c3f-f21916205b97"
+            "reference" : "Location/1706815823521744000.45f225e9-a3ea-4b32-b013-e17e645f8484"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726125805000.b469265e-c6cd-4c73-bdf4-fe212324a610",
+      "fullUrl" : "Practitioner/1706815823524323000.aa7b76bc-42a9-4238-8800-a9dd5d49c531",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726125805000.b469265e-c6cd-4c73-bdf4-fe212324a610",
+        "id" : "1706815823524323000.aa7b76bc-42a9-4238-8800-a9dd5d49c531",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -3278,10 +3283,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726129066000.c7ab76d7-b208-4515-ad77-efca11fcd1cd",
+      "fullUrl" : "Practitioner/1706815823528403000.9d3d24a0-8c8e-40a4-a705-332fe0d6fd4f",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726129066000.c7ab76d7-b208-4515-ad77-efca11fcd1cd",
+        "id" : "1706815823528403000.9d3d24a0-8c8e-40a4-a705-332fe0d6fd4f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -3485,10 +3490,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654726317886000.595b2009-987a-4378-8011-5d51370a1d29",
+      "fullUrl" : "DiagnosticReport/1706815823711227000.92d65855-2f79-4e33-9534-5e7d8a2489a4",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654726317886000.595b2009-987a-4378-8011-5d51370a1d29",
+        "id" : "1706815823711227000.92d65855-2f79-4e33-9534-5e7d8a2489a4",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/event-statusReason",
@@ -3625,7 +3630,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654726131443000.2bc20595-eea9-4e74-b9a1-d30430557e58"
+            "reference" : "ServiceRequest/1706815823531126000.ae1d0754-0abe-4ada-8b38-8e7efa8fc2d5"
           }
         ],
         "status" : "final",
@@ -3659,7 +3664,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654726064391000.20cfdef4-e8d2-45a0-b3a9-3521e49a6295"
+          "reference" : "Patient/1706815823456502000.e1fb6d7b-4f15-44fc-bdc2-014267dd9f35"
         },
         "effectivePeriod" : {
           "start" : "2023-08-16T12:33:58-05:00",
@@ -3692,24 +3697,24 @@
         },
         "performer" : [
           {
-            "reference" : "PractitionerRole/1706654726314466000.4e826700-78f7-4a53-9b5b-2529d2e6e8cc"
+            "reference" : "PractitionerRole/1706815823707166000.ba0c8fa8-aa39-461c-8004-fe1237bbbb25"
           },
           {
-            "reference" : "PractitionerRole/1706654726317672000.5d72a97a-9e2c-428a-b264-4edb9ee5b982"
+            "reference" : "PractitionerRole/1706815823711001000.71cb2713-0a84-4223-8551-18db9d72eb99"
           }
         ],
         "resultsInterpreter" : [
           {
-            "reference" : "PractitionerRole/1706654726312280000.12aecf94-4125-4ce7-a62e-99defc4863ea"
+            "reference" : "PractitionerRole/1706815823704881000.4a4a922e-eeea-4590-b0a8-0fed3e7f62ed"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726310550000.9cbe9c68-a7e8-4f88-8b60-f847088904ec",
+      "fullUrl" : "Practitioner/1706815823702636000.1f134b50-2ab0-4934-ae57-c102745fed33",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726310550000.9cbe9c68-a7e8-4f88-8b60-f847088904ec",
+        "id" : "1706815823702636000.1f134b50-2ab0-4934-ae57-c102745fed33",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -3776,10 +3781,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726310868000.aa001302-c4d4-45c5-936e-b1d76c102e51",
+      "fullUrl" : "Location/1706815823703060000.6e55c215-ab86-464c-bfa7-dd8f1d6a91fc",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726310868000.aa001302-c4d4-45c5-936e-b1d76c102e51",
+        "id" : "1706815823703060000.6e55c215-ab86-464c-bfa7-dd8f1d6a91fc",
         "identifier" : [
           {
             "extension" : [
@@ -3826,10 +3831,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726311146000.46104c05-3187-4011-8915-1dfb105b8025",
+      "fullUrl" : "Location/1706815823703418000.e24e6392-b92c-47ad-82df-d2c63cb76eb2",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726311146000.46104c05-3187-4011-8915-1dfb105b8025",
+        "id" : "1706815823703418000.e24e6392-b92c-47ad-82df-d2c63cb76eb2",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -3848,10 +3853,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726311498000.06afd56f-0c3f-4b76-9495-49230cba34ae",
+      "fullUrl" : "Location/1706815823703821000.369b5970-c2d1-431f-ac40-7607097441c0",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726311498000.06afd56f-0c3f-4b76-9495-49230cba34ae",
+        "id" : "1706815823703821000.369b5970-c2d1-431f-ac40-7607097441c0",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -3877,10 +3882,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726311736000.6bcba44a-fe81-4c12-acad-438baf5a0524",
+      "fullUrl" : "Location/1706815823704158000.cc637ee1-251a-45d7-9ca0-3406fbc95e59",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726311736000.6bcba44a-fe81-4c12-acad-438baf5a0524",
+        "id" : "1706815823704158000.cc637ee1-251a-45d7-9ca0-3406fbc95e59",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -3899,10 +3904,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726311962000.60849cd0-ac69-447a-b42a-60f351952035",
+      "fullUrl" : "Location/1706815823704475000.85a5e2d9-0c2b-4be3-ac86-705f28b1c227",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726311962000.60849cd0-ac69-447a-b42a-60f351952035",
+        "id" : "1706815823704475000.85a5e2d9-0c2b-4be3-ac86-705f28b1c227",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -3921,10 +3926,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726312184000.7acfbd23-3928-408b-933a-62dbb72367c4",
+      "fullUrl" : "Location/1706815823704778000.534940a0-bd5c-4a30-8bee-b1434de8fb7c",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726312184000.7acfbd23-3928-408b-933a-62dbb72367c4",
+        "id" : "1706815823704778000.534940a0-bd5c-4a30-8bee-b1434de8fb7c",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -3943,10 +3948,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654726312280000.12aecf94-4125-4ce7-a62e-99defc4863ea",
+      "fullUrl" : "PractitionerRole/1706815823704881000.4a4a922e-eeea-4590-b0a8-0fed3e7f62ed",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654726312280000.12aecf94-4125-4ce7-a62e-99defc4863ea",
+        "id" : "1706815823704881000.4a4a922e-eeea-4590-b0a8-0fed3e7f62ed",
         "period" : {
           "start" : "2023-04-01T10:25:31-04:00",
           "_start" : {
@@ -3968,35 +3973,35 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654726310550000.9cbe9c68-a7e8-4f88-8b60-f847088904ec"
+          "reference" : "Practitioner/1706815823702636000.1f134b50-2ab0-4934-ae57-c102745fed33"
         },
         "location" : [
           {
-            "reference" : "Location/1706654726310868000.aa001302-c4d4-45c5-936e-b1d76c102e51"
+            "reference" : "Location/1706815823703060000.6e55c215-ab86-464c-bfa7-dd8f1d6a91fc"
           },
           {
-            "reference" : "Location/1706654726311146000.46104c05-3187-4011-8915-1dfb105b8025"
+            "reference" : "Location/1706815823703418000.e24e6392-b92c-47ad-82df-d2c63cb76eb2"
           },
           {
-            "reference" : "Location/1706654726311498000.06afd56f-0c3f-4b76-9495-49230cba34ae"
+            "reference" : "Location/1706815823703821000.369b5970-c2d1-431f-ac40-7607097441c0"
           },
           {
-            "reference" : "Location/1706654726311736000.6bcba44a-fe81-4c12-acad-438baf5a0524"
+            "reference" : "Location/1706815823704158000.cc637ee1-251a-45d7-9ca0-3406fbc95e59"
           },
           {
-            "reference" : "Location/1706654726311962000.60849cd0-ac69-447a-b42a-60f351952035"
+            "reference" : "Location/1706815823704475000.85a5e2d9-0c2b-4be3-ac86-705f28b1c227"
           },
           {
-            "reference" : "Location/1706654726312184000.7acfbd23-3928-408b-933a-62dbb72367c4"
+            "reference" : "Location/1706815823704778000.534940a0-bd5c-4a30-8bee-b1434de8fb7c"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726312906000.6759c4e2-1853-4d98-9829-00681c997c5b",
+      "fullUrl" : "Practitioner/1706815823705486000.45392073-1d9b-461b-a936-5400bddb4a02",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726312906000.6759c4e2-1853-4d98-9829-00681c997c5b",
+        "id" : "1706815823705486000.45392073-1d9b-461b-a936-5400bddb4a02",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -4063,10 +4068,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726313183000.ff343a9c-f2b1-408e-b25f-00f8bd4cb397",
+      "fullUrl" : "Location/1706815823705742000.b0fd565b-1bfb-42d1-abd0-eb1762d66798",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726313183000.ff343a9c-f2b1-408e-b25f-00f8bd4cb397",
+        "id" : "1706815823705742000.b0fd565b-1bfb-42d1-abd0-eb1762d66798",
         "identifier" : [
           {
             "extension" : [
@@ -4113,10 +4118,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726313452000.93b465f5-01e7-4a08-aacf-1fd9d905be3f",
+      "fullUrl" : "Location/1706815823705995000.6e0e0061-cd6e-435f-9c52-62128ec7690e",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726313452000.93b465f5-01e7-4a08-aacf-1fd9d905be3f",
+        "id" : "1706815823705995000.6e0e0061-cd6e-435f-9c52-62128ec7690e",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -4135,10 +4140,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726313716000.5f4fca0c-8817-4e7f-a3b9-50833a38ff15",
+      "fullUrl" : "Location/1706815823706287000.d5ba247d-d585-4821-9fd0-14112855785e",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726313716000.5f4fca0c-8817-4e7f-a3b9-50833a38ff15",
+        "id" : "1706815823706287000.d5ba247d-d585-4821-9fd0-14112855785e",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -4164,10 +4169,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726313932000.8b894a6f-6df0-4bc4-bdd7-c9cf260a270d",
+      "fullUrl" : "Location/1706815823706533000.d58b75e1-b3ac-49f2-acdf-d904b3ef3f27",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726313932000.8b894a6f-6df0-4bc4-bdd7-c9cf260a270d",
+        "id" : "1706815823706533000.d58b75e1-b3ac-49f2-acdf-d904b3ef3f27",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -4186,10 +4191,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726314153000.fbcf9df0-bddf-464b-b006-622fd260bd22",
+      "fullUrl" : "Location/1706815823706813000.1807c4b9-0e14-4bdf-ab45-3227eed0c2a1",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726314153000.fbcf9df0-bddf-464b-b006-622fd260bd22",
+        "id" : "1706815823706813000.1807c4b9-0e14-4bdf-ab45-3227eed0c2a1",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -4208,10 +4213,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726314374000.bad3a3f4-09e0-47e3-948e-67f45d445bb6",
+      "fullUrl" : "Location/1706815823707071000.2eaaacad-ec33-4195-aa06-0dcb3890fe79",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726314374000.bad3a3f4-09e0-47e3-948e-67f45d445bb6",
+        "id" : "1706815823707071000.2eaaacad-ec33-4195-aa06-0dcb3890fe79",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -4230,10 +4235,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654726314466000.4e826700-78f7-4a53-9b5b-2529d2e6e8cc",
+      "fullUrl" : "PractitionerRole/1706815823707166000.ba0c8fa8-aa39-461c-8004-fe1237bbbb25",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654726314466000.4e826700-78f7-4a53-9b5b-2529d2e6e8cc",
+        "id" : "1706815823707166000.ba0c8fa8-aa39-461c-8004-fe1237bbbb25",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/event-performerFunction",
@@ -4274,35 +4279,35 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654726312906000.6759c4e2-1853-4d98-9829-00681c997c5b"
+          "reference" : "Practitioner/1706815823705486000.45392073-1d9b-461b-a936-5400bddb4a02"
         },
         "location" : [
           {
-            "reference" : "Location/1706654726313183000.ff343a9c-f2b1-408e-b25f-00f8bd4cb397"
+            "reference" : "Location/1706815823705742000.b0fd565b-1bfb-42d1-abd0-eb1762d66798"
           },
           {
-            "reference" : "Location/1706654726313452000.93b465f5-01e7-4a08-aacf-1fd9d905be3f"
+            "reference" : "Location/1706815823705995000.6e0e0061-cd6e-435f-9c52-62128ec7690e"
           },
           {
-            "reference" : "Location/1706654726313716000.5f4fca0c-8817-4e7f-a3b9-50833a38ff15"
+            "reference" : "Location/1706815823706287000.d5ba247d-d585-4821-9fd0-14112855785e"
           },
           {
-            "reference" : "Location/1706654726313932000.8b894a6f-6df0-4bc4-bdd7-c9cf260a270d"
+            "reference" : "Location/1706815823706533000.d58b75e1-b3ac-49f2-acdf-d904b3ef3f27"
           },
           {
-            "reference" : "Location/1706654726314153000.fbcf9df0-bddf-464b-b006-622fd260bd22"
+            "reference" : "Location/1706815823706813000.1807c4b9-0e14-4bdf-ab45-3227eed0c2a1"
           },
           {
-            "reference" : "Location/1706654726314374000.bad3a3f4-09e0-47e3-948e-67f45d445bb6"
+            "reference" : "Location/1706815823707071000.2eaaacad-ec33-4195-aa06-0dcb3890fe79"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654726315614000.0d9522a0-f1a0-4d27-b8db-2e93bb9c6451",
+      "fullUrl" : "Practitioner/1706815823708751000.3e7bda4a-59ad-45f5-a38c-3bc2f36898b9",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654726315614000.0d9522a0-f1a0-4d27-b8db-2e93bb9c6451",
+        "id" : "1706815823708751000.3e7bda4a-59ad-45f5-a38c-3bc2f36898b9",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cnn-practitioner",
@@ -4369,10 +4374,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726316020000.3861e1d1-1bfe-444b-83da-a0404f8c6056",
+      "fullUrl" : "Location/1706815823709146000.4d8e08cc-7fe0-43e7-bee0-412e06b37640",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726316020000.3861e1d1-1bfe-444b-83da-a0404f8c6056",
+        "id" : "1706815823709146000.4d8e08cc-7fe0-43e7-bee0-412e06b37640",
         "identifier" : [
           {
             "extension" : [
@@ -4419,10 +4424,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726316485000.8bdacbf5-80c1-4191-862f-2a96c34974b8",
+      "fullUrl" : "Location/1706815823709753000.157e6bd8-28f0-4299-8a7d-7bba6af796c9",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726316485000.8bdacbf5-80c1-4191-862f-2a96c34974b8",
+        "id" : "1706815823709753000.157e6bd8-28f0-4299-8a7d-7bba6af796c9",
         "identifier" : [
           {
             "value" : "Building 123"
@@ -4441,10 +4446,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726316846000.f1a319b9-a96c-4d04-8d06-3d1545e050fb",
+      "fullUrl" : "Location/1706815823710100000.c20b4bd9-e00c-4879-8925-fca5da9920d2",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726316846000.f1a319b9-a96c-4d04-8d06-3d1545e050fb",
+        "id" : "1706815823710100000.c20b4bd9-e00c-4879-8925-fca5da9920d2",
         "identifier" : [
           {
             "value" : "Point of Care"
@@ -4470,10 +4475,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726317120000.f101cc07-f359-410d-9810-de156fba0efa",
+      "fullUrl" : "Location/1706815823710391000.61ad06e7-719e-4309-b88c-da1a7b26b764",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726317120000.f101cc07-f359-410d-9810-de156fba0efa",
+        "id" : "1706815823710391000.61ad06e7-719e-4309-b88c-da1a7b26b764",
         "identifier" : [
           {
             "value" : "Floor A"
@@ -4492,10 +4497,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726317361000.c2bb413d-6abe-468c-a145-2cfcbf8d69a4",
+      "fullUrl" : "Location/1706815823710655000.06a7ae42-7bb0-446e-be01-4670184b5016",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726317361000.c2bb413d-6abe-468c-a145-2cfcbf8d69a4",
+        "id" : "1706815823710655000.06a7ae42-7bb0-446e-be01-4670184b5016",
         "identifier" : [
           {
             "value" : "Room 101"
@@ -4514,10 +4519,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654726317590000.b2bd0a01-ffc8-4a7e-8c1b-71f6ecec75b3",
+      "fullUrl" : "Location/1706815823710909000.cdb8938f-9eea-4fdb-9de9-b246a0bd4e1a",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654726317590000.b2bd0a01-ffc8-4a7e-8c1b-71f6ecec75b3",
+        "id" : "1706815823710909000.cdb8938f-9eea-4fdb-9de9-b246a0bd4e1a",
         "identifier" : [
           {
             "value" : "Bed A"
@@ -4536,10 +4541,10 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654726317672000.5d72a97a-9e2c-428a-b264-4edb9ee5b982",
+      "fullUrl" : "PractitionerRole/1706815823711001000.71cb2713-0a84-4223-8551-18db9d72eb99",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654726317672000.5d72a97a-9e2c-428a-b264-4edb9ee5b982",
+        "id" : "1706815823711001000.71cb2713-0a84-4223-8551-18db9d72eb99",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/event-performerFunction",
@@ -4580,26 +4585,26 @@
           }
         },
         "practitioner" : {
-          "reference" : "Practitioner/1706654726315614000.0d9522a0-f1a0-4d27-b8db-2e93bb9c6451"
+          "reference" : "Practitioner/1706815823708751000.3e7bda4a-59ad-45f5-a38c-3bc2f36898b9"
         },
         "location" : [
           {
-            "reference" : "Location/1706654726316020000.3861e1d1-1bfe-444b-83da-a0404f8c6056"
+            "reference" : "Location/1706815823709146000.4d8e08cc-7fe0-43e7-bee0-412e06b37640"
           },
           {
-            "reference" : "Location/1706654726316485000.8bdacbf5-80c1-4191-862f-2a96c34974b8"
+            "reference" : "Location/1706815823709753000.157e6bd8-28f0-4299-8a7d-7bba6af796c9"
           },
           {
-            "reference" : "Location/1706654726316846000.f1a319b9-a96c-4d04-8d06-3d1545e050fb"
+            "reference" : "Location/1706815823710100000.c20b4bd9-e00c-4879-8925-fca5da9920d2"
           },
           {
-            "reference" : "Location/1706654726317120000.f101cc07-f359-410d-9810-de156fba0efa"
+            "reference" : "Location/1706815823710391000.61ad06e7-719e-4309-b88c-da1a7b26b764"
           },
           {
-            "reference" : "Location/1706654726317361000.c2bb413d-6abe-468c-a145-2cfcbf8d69a4"
+            "reference" : "Location/1706815823710655000.06a7ae42-7bb0-446e-be01-4670184b5016"
           },
           {
-            "reference" : "Location/1706654726317590000.b2bd0a01-ffc8-4a7e-8c1b-71f6ecec75b3"
+            "reference" : "Location/1706815823710909000.cdb8938f-9eea-4fdb-9de9-b246a0bd4e1a"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-orc-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-orc-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654735786546000.20ac10cf-5910-4a64-b2b7-3cb23cf70e6d",
+  "id" : "1706815833446080000.5e96b60d-b0a9-4786-87c4-e706437757ee",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:45:35.792-05:00"
+    "lastUpdated" : "2024-02-01T14:30:33.453-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654736179204000.e22f4060-642c-4ae6-92d1-7913faacb954",
+      "fullUrl" : "Provenance/1706815833842637000.03b1c308-50d4-4ef9-8f00-62c27b9d028b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654736179204000.e22f4060-642c-4ae6-92d1-7913faacb954",
+        "id" : "1706815833842637000.03b1c308-50d4-4ef9-8f00-62c27b9d028b",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654736422009000.9aaeb80f-6450-4ab3-b588-c0285aab9831"
+            "reference" : "DiagnosticReport/1706815834098426000.9f35c841-6e26-4718-b26b-94365d4fce05"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654736186723000.42480d4f-d917-4a2e-b504-c236f58fc2f0",
+      "fullUrl" : "Provenance/1706815833851696000.3d0eefeb-034d-4037-87fc-d48fc0e5fff4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654736186723000.42480d4f-d917-4a2e-b504-c236f58fc2f0",
-        "recorded" : "2024-01-30T17:45:36Z",
+        "id" : "1706815833851696000.3d0eefeb-034d-4037-87fc-d48fc0e5fff4",
+        "recorded" : "2024-02-01T14:30:33Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654736186229000.425e8b11-189e-4b4c-a332-d861c6cb1140"
+              "reference" : "Organization/1706815833850529000.8b48ac5d-2ca3-4d5a-9074-8e1226fd4054"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654736186229000.425e8b11-189e-4b4c-a332-d861c6cb1140",
+      "fullUrl" : "Organization/1706815833850529000.8b48ac5d-2ca3-4d5a-9074-8e1226fd4054",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654736186229000.425e8b11-189e-4b4c-a332-d861c6cb1140",
+        "id" : "1706815833850529000.8b48ac5d-2ca3-4d5a-9074-8e1226fd4054",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654736202028000.fe45826d-9e2b-4f53-998f-57958a556796",
+      "fullUrl" : "Patient/1706815833867494000.562f90ae-09a3-45b1-8a1f-7498f7636466",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654736202028000.fe45826d-9e2b-4f53-998f-57958a556796"
+        "id" : "1706815833867494000.562f90ae-09a3-45b1-8a1f-7498f7636466"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654736202671000.f89488e2-271b-4f22-bf53-a89323e3c213",
+      "fullUrl" : "Provenance/1706815833868122000.dd90d4a4-89d0-4429-a14a-25ac5a6ed3c9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654736202671000.f89488e2-271b-4f22-bf53-a89323e3c213",
+        "id" : "1706815833868122000.dd90d4a4-89d0-4429-a14a-25ac5a6ed3c9",
         "target" : [
           {
-            "reference" : "Patient/1706654736202028000.fe45826d-9e2b-4f53-998f-57958a556796"
+            "reference" : "Patient/1706815833867494000.562f90ae-09a3-45b1-8a1f-7498f7636466"
           }
         ],
-        "recorded" : "2024-01-30T17:45:36Z",
+        "recorded" : "2024-02-01T14:30:33Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654736244395000.5bd07bb3-f3a8-414d-9de6-7b9005b2c63e",
+      "fullUrl" : "ServiceRequest/1706815833914854000.e2ad1b55-6c24-436b-a9de-67dde925f973",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654736244395000.5bd07bb3-f3a8-414d-9de6-7b9005b2c63e",
+        "id" : "1706815833914854000.e2ad1b55-6c24-436b-a9de-67dde925f973",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -298,19 +303,19 @@
               {
                 "url" : "orc-10-entered-by",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654736235410000.b0951da0-d727-41e3-88b9-c0b3f80e8c71"
+                  "reference" : "Practitioner/1706815833903733000.f87ab10c-3053-4008-bce6-25022de86da6"
                 }
               },
               {
                 "url" : "orc-11-verified-by",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654736238268000.e2ef9f38-a70a-4718-907a-054b6d7352f0"
+                  "reference" : "Practitioner/1706815833908243000.743b9cd4-b406-44e5-b8e3-7d086b029159"
                 }
               },
               {
                 "url" : "orc-13-enterers-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654736240103000.99c3f423-5467-4810-a18e-4fee18c06f6e"
+                  "reference" : "Location/1706815833910502000.76b842cd-1e75-4408-b4c9-dcb975c4ee12"
                 }
               },
               {
@@ -353,7 +358,7 @@
               {
                 "url" : "orc-19-action-by",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654736243184000.fb528e21-1d9c-42de-bd27-dc5f528f99d0"
+                  "reference" : "Practitioner/1706815833913721000.2cbd7c5e-1d5c-4623-96e4-edb5cf1e6b5c"
                 }
               }
             ]
@@ -548,7 +553,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654736202028000.fe45826d-9e2b-4f53-998f-57958a556796"
+          "reference" : "Patient/1706815833867494000.562f90ae-09a3-45b1-8a1f-7498f7636466"
         },
         "requester" : {
           "extension" : [
@@ -631,7 +636,7 @@
               }
             }
           ],
-          "reference" : "PractitionerRole/1706654736205108000.1cf514fb-22e0-4077-a65d-976704e1a237"
+          "reference" : "PractitionerRole/1706815833870139000.9efa789f-1d6a-4e13-8c9b-33caa8701f30"
         },
         "locationCode" : [
           {
@@ -652,10 +657,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654736219090000.2e6d9c71-aa95-460e-9d6b-ada7fd30dc37",
+      "fullUrl" : "Practitioner/1706815833885744000.0e6e615e-b3e8-4a6e-8bc7-837175b5fed5",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654736219090000.2e6d9c71-aa95-460e-9d6b-ada7fd30dc37",
+        "id" : "1706815833885744000.0e6e615e-b3e8-4a6e-8bc7-837175b5fed5",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -941,10 +946,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654736220848000.ce07b32f-1466-464f-a55a-25976126c439",
+      "fullUrl" : "Location/1706815833887237000.a76c5696-9ea0-49f3-91f9-e4fc41906399",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654736220848000.ce07b32f-1466-464f-a55a-25976126c439",
+        "id" : "1706815833887237000.a76c5696-9ea0-49f3-91f9-e4fc41906399",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -974,10 +979,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654736226935000.67799fc7-5ebc-4413-8ee7-926e92213172",
+      "fullUrl" : "Organization/1706815833893056000.5433e720-c36b-45f2-9db3-d59025c8d4bb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654736226935000.67799fc7-5ebc-4413-8ee7-926e92213172",
+        "id" : "1706815833893056000.5433e720-c36b-45f2-9db3-d59025c8d4bb",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1077,7 +1082,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654736220848000.ce07b32f-1466-464f-a55a-25976126c439"
+                  "reference" : "Location/1706815833887237000.a76c5696-9ea0-49f3-91f9-e4fc41906399"
                 }
               }
             ],
@@ -1245,23 +1250,23 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654736205108000.1cf514fb-22e0-4077-a65d-976704e1a237",
+      "fullUrl" : "PractitionerRole/1706815833870139000.9efa789f-1d6a-4e13-8c9b-33caa8701f30",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654736205108000.1cf514fb-22e0-4077-a65d-976704e1a237",
+        "id" : "1706815833870139000.9efa789f-1d6a-4e13-8c9b-33caa8701f30",
         "practitioner" : {
-          "reference" : "Practitioner/1706654736219090000.2e6d9c71-aa95-460e-9d6b-ada7fd30dc37"
+          "reference" : "Practitioner/1706815833885744000.0e6e615e-b3e8-4a6e-8bc7-837175b5fed5"
         },
         "organization" : {
-          "reference" : "Organization/1706654736226935000.67799fc7-5ebc-4413-8ee7-926e92213172"
+          "reference" : "Organization/1706815833893056000.5433e720-c36b-45f2-9db3-d59025c8d4bb"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654736235410000.b0951da0-d727-41e3-88b9-c0b3f80e8c71",
+      "fullUrl" : "Practitioner/1706815833903733000.f87ab10c-3053-4008-bce6-25022de86da6",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654736235410000.b0951da0-d727-41e3-88b9-c0b3f80e8c71",
+        "id" : "1706815833903733000.f87ab10c-3053-4008-bce6-25022de86da6",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1466,10 +1471,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654736238268000.e2ef9f38-a70a-4718-907a-054b6d7352f0",
+      "fullUrl" : "Practitioner/1706815833908243000.743b9cd4-b406-44e5-b8e3-7d086b029159",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654736238268000.e2ef9f38-a70a-4718-907a-054b6d7352f0",
+        "id" : "1706815833908243000.743b9cd4-b406-44e5-b8e3-7d086b029159",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -1674,10 +1679,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654736238837000.552190da-74db-4145-b3ff-67fd6d0e128e",
+      "fullUrl" : "Organization/1706815833908995000.8e704820-be24-42d8-a1a8-5df421d7ac38",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654736238837000.552190da-74db-4145-b3ff-67fd6d0e128e",
+        "id" : "1706815833908995000.8e704820-be24-42d8-a1a8-5df421d7ac38",
         "identifier" : [
           {
             "extension" : [
@@ -1710,10 +1715,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654736239746000.a052b94a-772d-45cf-b851-be94e0925fc0",
+      "fullUrl" : "Location/1706815833910130000.dc92e616-d78a-4156-abfa-d505214bb956",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654736239746000.a052b94a-772d-45cf-b851-be94e0925fc0",
+        "id" : "1706815833910130000.dc92e616-d78a-4156-abfa-d505214bb956",
         "identifier" : [
           {
             "extension" : [
@@ -1758,10 +1763,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654736239882000.7202c4be-0f82-4c8c-910a-a45d6fc27506",
+      "fullUrl" : "Location/1706815833910255000.52887cfa-f10a-4dd9-9a78-ec0a1e77a999",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654736239882000.7202c4be-0f82-4c8c-910a-a45d6fc27506",
+        "id" : "1706815833910255000.52887cfa-f10a-4dd9-9a78-ec0a1e77a999",
         "identifier" : [
           {
             "extension" : [
@@ -1811,15 +1816,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706654736239746000.a052b94a-772d-45cf-b851-be94e0925fc0"
+          "reference" : "Location/1706815833910130000.dc92e616-d78a-4156-abfa-d505214bb956"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706654736240103000.99c3f423-5467-4810-a18e-4fee18c06f6e",
+      "fullUrl" : "Location/1706815833910502000.76b842cd-1e75-4408-b4c9-dcb975c4ee12",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654736240103000.99c3f423-5467-4810-a18e-4fee18c06f6e",
+        "id" : "1706815833910502000.76b842cd-1e75-4408-b4c9-dcb975c4ee12",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -1879,7 +1884,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706654736238837000.552190da-74db-4145-b3ff-67fd6d0e128e"
+              "reference" : "Organization/1706815833908995000.8e704820-be24-42d8-a1a8-5df421d7ac38"
             }
           }
         ],
@@ -1895,15 +1900,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706654736239882000.7202c4be-0f82-4c8c-910a-a45d6fc27506"
+          "reference" : "Location/1706815833910255000.52887cfa-f10a-4dd9-9a78-ec0a1e77a999"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654736243184000.fb528e21-1d9c-42de-bd27-dc5f528f99d0",
+      "fullUrl" : "Practitioner/1706815833913721000.2cbd7c5e-1d5c-4623-96e4-edb5cf1e6b5c",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654736243184000.fb528e21-1d9c-42de-bd27-dc5f528f99d0",
+        "id" : "1706815833913721000.2cbd7c5e-1d5c-4623-96e4-edb5cf1e6b5c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -2108,10 +2113,10 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654736422009000.9aaeb80f-6450-4ab3-b588-c0285aab9831",
+      "fullUrl" : "DiagnosticReport/1706815834098426000.9f35c841-6e26-4718-b26b-94365d4fce05",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654736422009000.9aaeb80f-6450-4ab3-b588-c0285aab9831",
+        "id" : "1706815834098426000.9f35c841-6e26-4718-b26b-94365d4fce05",
         "extension" : [
           {
             "url" : "http://hl7.org/fhir/StructureDefinition/event-statusReason",
@@ -2248,7 +2253,7 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654736244395000.5bd07bb3-f3a8-414d-9de6-7b9005b2c63e"
+            "reference" : "ServiceRequest/1706815833914854000.e2ad1b55-6c24-436b-a9de-67dde925f973"
           }
         ],
         "status" : "final",
@@ -2272,7 +2277,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654736202028000.fe45826d-9e2b-4f53-998f-57958a556796"
+          "reference" : "Patient/1706815833867494000.562f90ae-09a3-45b1-8a1f-7498f7636466"
         },
         "issued" : "2023",
         "_issued" : {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-prefers-orc-12-for-requester.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-prefers-orc-12-for-requester.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654745547124000.7ca7fb82-c0e1-4d31-a67f-848fe5a26cc9",
+  "id" : "1706815843718023000.2366344c-5698-46cc-bfdb-ece5ca4fc51e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:45:45.554-05:00"
+    "lastUpdated" : "2024-02-01T14:30:43.725-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654745947867000.f04e5468-440a-44e1-9442-cec61e9f8d4d",
+      "fullUrl" : "Provenance/1706815844153324000.e7526339-8d81-4e5a-bdf4-4615dded85af",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654745947867000.f04e5468-440a-44e1-9442-cec61e9f8d4d",
+        "id" : "1706815844153324000.e7526339-8d81-4e5a-bdf4-4615dded85af",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654746152036000.169d1d32-5adb-45ba-9bf3-4c2658ba13e2"
+            "reference" : "DiagnosticReport/1706815844345682000.d8cf5cd6-ebca-4756-9305-026b6ec47631"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654745956051000.6e9e8655-54ea-47f3-ae20-6db161a924cc",
+      "fullUrl" : "Provenance/1706815844161637000.0deda38b-a8a6-4000-b6eb-04a7a365e345",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654745956051000.6e9e8655-54ea-47f3-ae20-6db161a924cc",
-        "recorded" : "2024-01-30T17:45:45Z",
+        "id" : "1706815844161637000.0deda38b-a8a6-4000-b6eb-04a7a365e345",
+        "recorded" : "2024-02-01T14:30:44Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654745955636000.7316d218-fc8f-4045-bf49-404f0c882fb4"
+              "reference" : "Organization/1706815844161123000.17452cb1-caf1-4444-8bef-552e6b81887f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654745955636000.7316d218-fc8f-4045-bf49-404f0c882fb4",
+      "fullUrl" : "Organization/1706815844161123000.17452cb1-caf1-4444-8bef-552e6b81887f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654745955636000.7316d218-fc8f-4045-bf49-404f0c882fb4",
+        "id" : "1706815844161123000.17452cb1-caf1-4444-8bef-552e6b81887f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654745972157000.7b226561-f484-497d-9f77-f446a82e1306",
+      "fullUrl" : "Patient/1706815844176700000.4935672e-5b26-4e4d-ace6-44c5d649cac5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654745972157000.7b226561-f484-497d-9f77-f446a82e1306"
+        "id" : "1706815844176700000.4935672e-5b26-4e4d-ace6-44c5d649cac5"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654745972770000.422230f1-5839-4774-b37f-cd8e3165fc41",
+      "fullUrl" : "Provenance/1706815844177250000.697da418-fb51-4dcc-a4c8-21a11d37d3f1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654745972770000.422230f1-5839-4774-b37f-cd8e3165fc41",
+        "id" : "1706815844177250000.697da418-fb51-4dcc-a4c8-21a11d37d3f1",
         "target" : [
           {
-            "reference" : "Patient/1706654745972157000.7b226561-f484-497d-9f77-f446a82e1306"
+            "reference" : "Patient/1706815844176700000.4935672e-5b26-4e4d-ace6-44c5d649cac5"
           }
         ],
-        "recorded" : "2024-01-30T17:45:45Z",
+        "recorded" : "2024-02-01T14:30:44Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654745991338000.8292a2ce-5770-4951-bbb6-06907cf19261",
+      "fullUrl" : "ServiceRequest/1706815844196999000.0ce16b72-e36e-4d4f-9793-4c1d1c30e60e",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654745991338000.8292a2ce-5770-4951-bbb6-06907cf19261",
+        "id" : "1706815844196999000.0ce16b72-e36e-4d4f-9793-4c1d1c30e60e",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -166,7 +171,7 @@
               {
                 "url" : "obr-16-ordering-provider",
                 "valueReference" : {
-                  "reference" : "Practitioner/1706654745990605000.79023f88-1742-4225-8f09-0975a16a6b2e"
+                  "reference" : "Practitioner/1706815844196202000.f9ffac94-c8b0-43e9-996e-3a1568e4bd4c"
                 }
               }
             ]
@@ -174,18 +179,18 @@
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654745972157000.7b226561-f484-497d-9f77-f446a82e1306"
+          "reference" : "Patient/1706815844176700000.4935672e-5b26-4e4d-ace6-44c5d649cac5"
         },
         "requester" : {
-          "reference" : "Practitioner/1706654745984356000.aa8077e3-42f9-4814-8bfa-de5fdba050ff"
+          "reference" : "Practitioner/1706815844187851000.4716f1fe-96f3-4049-b416-af73c051857b"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654745984356000.aa8077e3-42f9-4814-8bfa-de5fdba050ff",
+      "fullUrl" : "Practitioner/1706815844187851000.4716f1fe-96f3-4049-b416-af73c051857b",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654745984356000.aa8077e3-42f9-4814-8bfa-de5fdba050ff",
+        "id" : "1706815844187851000.4716f1fe-96f3-4049-b416-af73c051857b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -394,10 +399,10 @@
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654745990605000.79023f88-1742-4225-8f09-0975a16a6b2e",
+      "fullUrl" : "Practitioner/1706815844196202000.f9ffac94-c8b0-43e9-996e-3a1568e4bd4c",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654745990605000.79023f88-1742-4225-8f09-0975a16a6b2e",
+        "id" : "1706815844196202000.f9ffac94-c8b0-43e9-996e-3a1568e4bd4c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -601,18 +606,18 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654746152036000.169d1d32-5adb-45ba-9bf3-4c2658ba13e2",
+      "fullUrl" : "DiagnosticReport/1706815844345682000.d8cf5cd6-ebca-4756-9305-026b6ec47631",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654746152036000.169d1d32-5adb-45ba-9bf3-4c2658ba13e2",
+        "id" : "1706815844345682000.d8cf5cd6-ebca-4756-9305-026b6ec47631",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654745991338000.8292a2ce-5770-4951-bbb6-06907cf19261"
+            "reference" : "ServiceRequest/1706815844196999000.0ce16b72-e36e-4d4f-9793-4c1d1c30e60e"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654745972157000.7b226561-f484-497d-9f77-f446a82e1306"
+          "reference" : "Patient/1706815844176700000.4935672e-5b26-4e4d-ace6-44c5d649cac5"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-prefers-orc-for-identifiers.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-prefers-orc-for-identifiers.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654755135125000.4770e9c4-605f-41b8-94b8-ac5e887e2867",
+  "id" : "1706815853651275000.a535ad93-ae2b-4b6a-8b03-0ffb1e0fc253",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:45:55.142-05:00"
+    "lastUpdated" : "2024-02-01T14:30:53.658-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654755523532000.96eab5b0-b3fa-4705-81bc-6a9c382cf142",
+      "fullUrl" : "Provenance/1706815854065726000.9a660013-263d-4942-b70e-2a3aefd01ad9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654755523532000.96eab5b0-b3fa-4705-81bc-6a9c382cf142",
+        "id" : "1706815854065726000.9a660013-263d-4942-b70e-2a3aefd01ad9",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654755716943000.78f13701-60e6-4393-8d54-61801ea5e12f"
+            "reference" : "DiagnosticReport/1706815854279436000.71b57780-3a35-44e4-9b3a-6222b3f4f6b2"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654755535790000.8ef26e2b-200a-45ea-b8e6-5069579f747e",
+      "fullUrl" : "Provenance/1706815854075662000.a44771f3-9c6f-4016-95d6-c9c03520fd54",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654755535790000.8ef26e2b-200a-45ea-b8e6-5069579f747e",
-        "recorded" : "2024-01-30T17:45:55Z",
+        "id" : "1706815854075662000.a44771f3-9c6f-4016-95d6-c9c03520fd54",
+        "recorded" : "2024-02-01T14:30:54Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654755535248000.a5d3e65a-7e08-48a8-950b-5275c76e0677"
+              "reference" : "Organization/1706815854075175000.aeb2a6c5-214c-4a24-8646-1ef6a8d36719"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654755535248000.a5d3e65a-7e08-48a8-950b-5275c76e0677",
+      "fullUrl" : "Organization/1706815854075175000.aeb2a6c5-214c-4a24-8646-1ef6a8d36719",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654755535248000.a5d3e65a-7e08-48a8-950b-5275c76e0677",
+        "id" : "1706815854075175000.aeb2a6c5-214c-4a24-8646-1ef6a8d36719",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654755551372000.f2114064-b18d-4e12-bf01-639c27bcfe04",
+      "fullUrl" : "Patient/1706815854092113000.033699b3-a01a-41ed-baa8-8b01500b4586",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654755551372000.f2114064-b18d-4e12-bf01-639c27bcfe04"
+        "id" : "1706815854092113000.033699b3-a01a-41ed-baa8-8b01500b4586"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654755552260000.404282b4-5cc0-40ba-9c5c-8d331dc86fd5",
+      "fullUrl" : "Provenance/1706815854092898000.b00d0a3d-f99b-4b9d-ba31-19f734148c52",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654755552260000.404282b4-5cc0-40ba-9c5c-8d331dc86fd5",
+        "id" : "1706815854092898000.b00d0a3d-f99b-4b9d-ba31-19f734148c52",
         "target" : [
           {
-            "reference" : "Patient/1706654755551372000.f2114064-b18d-4e12-bf01-639c27bcfe04"
+            "reference" : "Patient/1706815854092113000.033699b3-a01a-41ed-baa8-8b01500b4586"
           }
         ],
-        "recorded" : "2024-01-30T17:45:55Z",
+        "recorded" : "2024-02-01T14:30:54Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654755559789000.e2cb27ad-3f73-44e9-b36c-4b575205af24",
+      "fullUrl" : "ServiceRequest/1706815854101892000.ffbb0dec-cfe2-48cc-9026-225af5aeefda",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654755559789000.e2cb27ad-3f73-44e9-b36c-4b575205af24",
+        "id" : "1706815854101892000.ffbb0dec-cfe2-48cc-9026-225af5aeefda",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -325,15 +330,15 @@
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654755551372000.f2114064-b18d-4e12-bf01-639c27bcfe04"
+          "reference" : "Patient/1706815854092113000.033699b3-a01a-41ed-baa8-8b01500b4586"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654755716943000.78f13701-60e6-4393-8d54-61801ea5e12f",
+      "fullUrl" : "DiagnosticReport/1706815854279436000.71b57780-3a35-44e4-9b3a-6222b3f4f6b2",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654755716943000.78f13701-60e6-4393-8d54-61801ea5e12f",
+        "id" : "1706815854279436000.71b57780-3a35-44e4-9b3a-6222b3f4f6b2",
         "identifier" : [
           {
             "extension" : [
@@ -402,12 +407,12 @@
         ],
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654755559789000.e2cb27ad-3f73-44e9-b36c-4b575205af24"
+            "reference" : "ServiceRequest/1706815854101892000.ffbb0dec-cfe2-48cc-9026-225af5aeefda"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654755551372000.f2114064-b18d-4e12-bf01-639c27bcfe04"
+          "reference" : "Patient/1706815854092113000.033699b3-a01a-41ed-baa8-8b01500b4586"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitioner-missing-orc212223.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitioner-missing-orc212223.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654765064252000.25134bb9-d239-4e4a-b44b-3b87b72f485d",
+  "id" : "1706815863706107000.62b158d5-628b-48c3-864b-b2e806849e97",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:46:05.069-05:00"
+    "lastUpdated" : "2024-02-01T14:31:03.713-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654765479434000.f4216df5-e34a-4a23-9bb7-60181563e82f",
+      "fullUrl" : "Provenance/1706815864096942000.18000c02-5c1c-485d-a940-54d97f0fee4b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654765479434000.f4216df5-e34a-4a23-9bb7-60181563e82f",
+        "id" : "1706815864096942000.18000c02-5c1c-485d-a940-54d97f0fee4b",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654765681138000.ef6ee99c-a913-4541-88ef-fbec64a013e3"
+            "reference" : "DiagnosticReport/1706815864303846000.f4af05dc-a43c-4770-ad1e-47a8886e81cd"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654765487698000.8fcf5006-900e-4c56-8f06-30ea8b8d7958",
+      "fullUrl" : "Provenance/1706815864105235000.8db7823e-4fca-49e7-80c3-dcd31febfa2c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654765487698000.8fcf5006-900e-4c56-8f06-30ea8b8d7958",
-        "recorded" : "2024-01-30T17:46:05Z",
+        "id" : "1706815864105235000.8db7823e-4fca-49e7-80c3-dcd31febfa2c",
+        "recorded" : "2024-02-01T14:31:04Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654765487118000.f1c02938-1210-4f95-b3a1-53a926025801"
+              "reference" : "Organization/1706815864104501000.cb6d9e96-a7b3-4a8f-bea2-66efb1fac123"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654765487118000.f1c02938-1210-4f95-b3a1-53a926025801",
+      "fullUrl" : "Organization/1706815864104501000.cb6d9e96-a7b3-4a8f-bea2-66efb1fac123",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654765487118000.f1c02938-1210-4f95-b3a1-53a926025801",
+        "id" : "1706815864104501000.cb6d9e96-a7b3-4a8f-bea2-66efb1fac123",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654765504080000.bb61f8c3-a4c3-4d59-92f4-d154bcc04d64",
+      "fullUrl" : "Patient/1706815864121139000.72318f5c-5f8d-443b-9fcd-a41d89e1db17",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654765504080000.bb61f8c3-a4c3-4d59-92f4-d154bcc04d64"
+        "id" : "1706815864121139000.72318f5c-5f8d-443b-9fcd-a41d89e1db17"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654765504684000.62f8d43f-d58f-4793-b75d-05a86c3bfff7",
+      "fullUrl" : "Provenance/1706815864121963000.a16155ff-cd2b-42a2-b792-3746737eb501",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654765504684000.62f8d43f-d58f-4793-b75d-05a86c3bfff7",
+        "id" : "1706815864121963000.a16155ff-cd2b-42a2-b792-3746737eb501",
         "target" : [
           {
-            "reference" : "Patient/1706654765504080000.bb61f8c3-a4c3-4d59-92f4-d154bcc04d64"
+            "reference" : "Patient/1706815864121139000.72318f5c-5f8d-443b-9fcd-a41d89e1db17"
           }
         ],
-        "recorded" : "2024-01-30T17:46:05Z",
+        "recorded" : "2024-02-01T14:31:04Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654765517887000.db90df25-df71-45f2-ae1d-6def13a2034e",
+      "fullUrl" : "ServiceRequest/1706815864135566000.47507c70-7f20-43ac-86d9-7edb7a4990cf",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654765517887000.db90df25-df71-45f2-ae1d-6def13a2034e",
+        "id" : "1706815864135566000.47507c70-7f20-43ac-86d9-7edb7a4990cf",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -163,18 +168,18 @@
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654765504080000.bb61f8c3-a4c3-4d59-92f4-d154bcc04d64"
+          "reference" : "Patient/1706815864121139000.72318f5c-5f8d-443b-9fcd-a41d89e1db17"
         },
         "requester" : {
-          "reference" : "Practitioner/1706654765515260000.1b623e10-829b-4067-a162-0f1aa4ea0fac"
+          "reference" : "Practitioner/1706815864132582000.8817fdba-a1b1-49d4-8fba-026587716cca"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654765515260000.1b623e10-829b-4067-a162-0f1aa4ea0fac",
+      "fullUrl" : "Practitioner/1706815864132582000.8817fdba-a1b1-49d4-8fba-026587716cca",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654765515260000.1b623e10-829b-4067-a162-0f1aa4ea0fac",
+        "id" : "1706815864132582000.8817fdba-a1b1-49d4-8fba-026587716cca",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -382,18 +387,18 @@
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654765681138000.ef6ee99c-a913-4541-88ef-fbec64a013e3",
+      "fullUrl" : "DiagnosticReport/1706815864303846000.f4af05dc-a43c-4770-ad1e-47a8886e81cd",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654765681138000.ef6ee99c-a913-4541-88ef-fbec64a013e3",
+        "id" : "1706815864303846000.f4af05dc-a43c-4770-ad1e-47a8886e81cd",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654765517887000.db90df25-df71-45f2-ae1d-6def13a2034e"
+            "reference" : "ServiceRequest/1706815864135566000.47507c70-7f20-43ac-86d9-7edb7a4990cf"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654765504080000.bb61f8c3-a4c3-4d59-92f4-d154bcc04d64"
+          "reference" : "Patient/1706815864121139000.72318f5c-5f8d-443b-9fcd-a41d89e1db17"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitionerrole-orc21-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitionerrole-orc21-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654774822586000.a046f4dd-1194-4948-901c-2e0c8a7b2ef6",
+  "id" : "1706815874061536000.d44c5be2-b93b-4502-aaa3-10ef77690e11",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:46:14.828-05:00"
+    "lastUpdated" : "2024-02-01T14:31:14.069-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230816123358-0500"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,16 +49,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654775209506000.afd804c3-594e-4c2b-996f-d98607e79b9a",
+      "fullUrl" : "Provenance/1706815874492104000.1dd93df9-27d5-49e7-a79c-63c005557ef4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654775209506000.afd804c3-594e-4c2b-996f-d98607e79b9a",
+        "id" : "1706815874492104000.1dd93df9-27d5-49e7-a79c-63c005557ef4",
         "target" : [
           {
             "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
           },
           {
-            "reference" : "DiagnosticReport/1706654775426554000.9e814a65-8468-4ff2-a7e9-ba5172ec2bca"
+            "reference" : "DiagnosticReport/1706815874698938000.3e833c04-0bd0-46b2-afd4-d98721f0b4b2"
           }
         ],
         "recorded" : "2023-08-16T12:33:58-05:00",
@@ -67,11 +72,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654775217846000.2d4c88ef-647b-4b08-8f0f-058e3ea73258",
+      "fullUrl" : "Provenance/1706815874501909000.15c9e0bb-06d3-42f8-810d-cc350aa26709",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654775217846000.2d4c88ef-647b-4b08-8f0f-058e3ea73258",
-        "recorded" : "2024-01-30T17:46:15Z",
+        "id" : "1706815874501909000.15c9e0bb-06d3-42f8-810d-cc350aa26709",
+        "recorded" : "2024-02-01T14:31:14Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -93,17 +98,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654775217108000.7fedd129-f77b-4d10-9eac-5dd5e9d2cc56"
+              "reference" : "Organization/1706815874501425000.433ac498-0bac-424e-84f4-d6466e525c3b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654775217108000.7fedd129-f77b-4d10-9eac-5dd5e9d2cc56",
+      "fullUrl" : "Organization/1706815874501425000.433ac498-0bac-424e-84f4-d6466e525c3b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654775217108000.7fedd129-f77b-4d10-9eac-5dd5e9d2cc56",
+        "id" : "1706815874501425000.433ac498-0bac-424e-84f4-d6466e525c3b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -123,23 +128,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654775237322000.d6a66089-5581-464d-8302-831af2143e2d",
+      "fullUrl" : "Patient/1706815874519703000.39937fc1-4d91-4f2f-acfa-4841d8030331",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654775237322000.d6a66089-5581-464d-8302-831af2143e2d"
+        "id" : "1706815874519703000.39937fc1-4d91-4f2f-acfa-4841d8030331"
       }
     },
     {
-      "fullUrl" : "Provenance/1706654775237969000.ba10d4f2-aaaf-4261-9dfb-2884bee94cfe",
+      "fullUrl" : "Provenance/1706815874520359000.d418799b-f0f5-42de-a97c-f668da8c316d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654775237969000.ba10d4f2-aaaf-4261-9dfb-2884bee94cfe",
+        "id" : "1706815874520359000.d418799b-f0f5-42de-a97c-f668da8c316d",
         "target" : [
           {
-            "reference" : "Patient/1706654775237322000.d6a66089-5581-464d-8302-831af2143e2d"
+            "reference" : "Patient/1706815874519703000.39937fc1-4d91-4f2f-acfa-4841d8030331"
           }
         ],
-        "recorded" : "2024-01-30T17:46:15Z",
+        "recorded" : "2024-02-01T14:31:14Z",
         "activity" : {
           "coding" : [
             {
@@ -151,10 +156,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654775256840000.dcfd15a4-03f5-4f71-bee1-b33cdaee78c1",
+      "fullUrl" : "ServiceRequest/1706815874541460000.dabad312-5197-4e3b-9ba0-b8661025a0aa",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654775256840000.dcfd15a4-03f5-4f71-bee1-b33cdaee78c1",
+        "id" : "1706815874541460000.dabad312-5197-4e3b-9ba0-b8661025a0aa",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
@@ -163,18 +168,18 @@
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654775237322000.d6a66089-5581-464d-8302-831af2143e2d"
+          "reference" : "Patient/1706815874519703000.39937fc1-4d91-4f2f-acfa-4841d8030331"
         },
         "requester" : {
-          "reference" : "PractitionerRole/1706654775241132000.2e7bebe2-77a8-4230-ae6a-33beeebf5171"
+          "reference" : "PractitionerRole/1706815874522448000.bdaa2fff-cf99-4498-bd5f-31402b1caf8c"
         }
       }
     },
     {
-      "fullUrl" : "Practitioner/1706654775250032000.dceb93d5-ec3e-418f-8159-563b4bca2393",
+      "fullUrl" : "Practitioner/1706815874535538000.7a3ffc29-c39f-402b-bc55-99bb4ff240a0",
       "resource" : {
         "resourceType" : "Practitioner",
-        "id" : "1706654775250032000.dceb93d5-ec3e-418f-8159-563b4bca2393",
+        "id" : "1706815874535538000.7a3ffc29-c39f-402b-bc55-99bb4ff240a0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
@@ -382,10 +387,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654775251295000.303abf1e-c05c-4054-9d33-1dfe180929c0",
+      "fullUrl" : "Location/1706815874536871000.1f7bf9fb-1819-47af-bd3a-d3eabf5309b6",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654775251295000.303abf1e-c05c-4054-9d33-1dfe180929c0",
+        "id" : "1706815874536871000.1f7bf9fb-1819-47af-bd3a-d3eabf5309b6",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -415,10 +420,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654775253951000.cb8f6166-7981-460f-bf07-b83cb29e383c",
+      "fullUrl" : "Organization/1706815874538439000.1d00f15f-142a-4640-981f-38c88ad1945a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654775253951000.cb8f6166-7981-460f-bf07-b83cb29e383c",
+        "id" : "1706815874538439000.1d00f15f-142a-4640-981f-38c88ad1945a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -518,7 +523,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654775251295000.303abf1e-c05c-4054-9d33-1dfe180929c0"
+                  "reference" : "Location/1706815874536871000.1f7bf9fb-1819-47af-bd3a-d3eabf5309b6"
                 }
               }
             ],
@@ -555,31 +560,31 @@
       }
     },
     {
-      "fullUrl" : "PractitionerRole/1706654775241132000.2e7bebe2-77a8-4230-ae6a-33beeebf5171",
+      "fullUrl" : "PractitionerRole/1706815874522448000.bdaa2fff-cf99-4498-bd5f-31402b1caf8c",
       "resource" : {
         "resourceType" : "PractitionerRole",
-        "id" : "1706654775241132000.2e7bebe2-77a8-4230-ae6a-33beeebf5171",
+        "id" : "1706815874522448000.bdaa2fff-cf99-4498-bd5f-31402b1caf8c",
         "practitioner" : {
-          "reference" : "Practitioner/1706654775250032000.dceb93d5-ec3e-418f-8159-563b4bca2393"
+          "reference" : "Practitioner/1706815874535538000.7a3ffc29-c39f-402b-bc55-99bb4ff240a0"
         },
         "organization" : {
-          "reference" : "Organization/1706654775253951000.cb8f6166-7981-460f-bf07-b83cb29e383c"
+          "reference" : "Organization/1706815874538439000.1d00f15f-142a-4640-981f-38c88ad1945a"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654775426554000.9e814a65-8468-4ff2-a7e9-ba5172ec2bca",
+      "fullUrl" : "DiagnosticReport/1706815874698938000.3e833c04-0bd0-46b2-afd4-d98721f0b4b2",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654775426554000.9e814a65-8468-4ff2-a7e9-ba5172ec2bca",
+        "id" : "1706815874698938000.3e833c04-0bd0-46b2-afd4-d98721f0b4b2",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654775256840000.dcfd15a4-03f5-4f71-bee1-b33cdaee78c1"
+            "reference" : "ServiceRequest/1706815874541460000.dabad312-5197-4e3b-9ba0-b8661025a0aa"
           }
         ],
         "status" : "unknown",
         "subject" : {
-          "reference" : "Patient/1706654775237322000.d6a66089-5581-464d-8302-831af2143e2d"
+          "reference" : "Patient/1706815874519703000.39937fc1-4d91-4f2f-acfa-4841d8030331"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitionerrole-orc22-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitionerrole-orc22-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654784330638000.09721d3e-e736-4e01-8f4f-26bc20421753",
+  "id" : "1706815884397856000.15f0f176-9801-486c-b086-01aa8237c414",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:46:24.336-05:00"
+    "lastUpdated" : "2024-02-01T14:31:24.404-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,365 +10,506 @@
   },
   "type" : "message",
   "timestamp" : "2023-08-16T13:33:58.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230816123358-0500"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654784718934000.f8786030-ac4d-4276-b6d9-56ca40953996",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654784718934000.f8786030-ac4d-4276-b6d9-56ca40953996",
-      "target" : [ {
-        "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
-      }, {
-        "reference" : "DiagnosticReport/1706654784915912000.fdb37686-59a5-4a0e-9449-07a933ce7969"
-      } ],
-      "recorded" : "2023-08-16T12:33:58-05:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654784727273000.e59c615a-a806-4b58-a7e1-1ce2ff2b1ff6",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654784727273000.e59c615a-a806-4b58-a7e1-1ce2ff2b1ff6",
-      "recorded" : "2024-01-30T17:46:24Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706654784726746000.7842344e-accb-4d2f-9d9b-de8e9e389760"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654784726746000.7842344e-accb-4d2f-9d9b-de8e9e389760",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654784726746000.7842344e-accb-4d2f-9d9b-de8e9e389760",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815884781533000.12b05531-5b26-48c0-8e82-167358a53920",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815884781533000.12b05531-5b26-48c0-8e82-167358a53920",
+        "target" : [
+          {
+            "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815884994024000.b78a8c1d-ea12-4a85-8d95-b1c3a618b326"
+          }
+        ],
+        "recorded" : "2023-08-16T12:33:58-05:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815884789911000.d1efcb4c-c0c9-4043-92a9-aaa706333a72",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815884789911000.d1efcb4c-c0c9-4043-92a9-aaa706333a72",
+        "recorded" : "2024-02-01T14:31:24Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706654784742234000.e555fc29-8007-43d1-aea6-d89616271ecf",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706654784742234000.e555fc29-8007-43d1-aea6-d89616271ecf"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654784742927000.5414aa76-7692-4ced-98f5-dd87d38e95bc",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654784742927000.5414aa76-7692-4ced-98f5-dd87d38e95bc",
-      "target" : [ {
-        "reference" : "Patient/1706654784742234000.e555fc29-8007-43d1-aea6-d89616271ecf"
-      } ],
-      "recorded" : "2024-01-30T17:46:24Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815884789425000.7a95c031-3549-4166-9d19-ee9f564c6bcb"
+            }
+          }
+        ]
       }
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706654784762169000.9f2df7cb-deb4-454c-9643-9984c6ec4417",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706654784762169000.9f2df7cb-deb4-454c-9643-9984c6ec4417",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
-        "valueCode" : "RE"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654784742234000.e555fc29-8007-43d1-aea6-d89616271ecf"
-      },
-      "requester" : {
-        "reference" : "PractitionerRole/1706654784745029000.86bc1503-24d5-47bd-9691-ee7d6edbffef"
+    },
+    {
+      "fullUrl" : "Organization/1706815884789425000.7a95c031-3549-4166-9d19-ee9f564c6bcb",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815884789425000.7a95c031-3549-4166-9d19-ee9f564c6bcb",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
       }
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706654784754176000.eee19c69-d745-4f27-a905-c7d84b797088",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706654784754176000.eee19c69-d745-4f27-a905-c7d84b797088",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+    },
+    {
+      "fullUrl" : "Patient/1706815884806859000.dbce81cf-c551-4ce5-8afa-dd16b67682e8",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706815884806859000.dbce81cf-c551-4ce5-8afa-dd16b67682e8"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815884807603000.e37bfd0a-ecf5-47d1-9474-3ddb9174c993",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815884807603000.e37bfd0a-ecf5-47d1-9474-3ddb9174c993",
+        "target" : [
+          {
+            "reference" : "Patient/1706815884806859000.dbce81cf-c551-4ce5-8afa-dd16b67682e8"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
+        ],
+        "recorded" : "2024-02-01T14:31:24Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815884824523000.47180764-e878-4f7f-a2d3-a0b36aa370f0",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815884824523000.47180764-e878-4f7f-a2d3-a0b36aa370f0",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+            "valueCode" : "RE"
           }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "obr-16-ordering-provider"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815884806859000.dbce81cf-c551-4ce5-8afa-dd16b67682e8"
         },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "OBR",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Provider"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
+        "requester" : {
+          "reference" : "PractitionerRole/1706815884809528000.961da3b0-2fb7-4dd2-858a-f75323deebb2"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706815884819832000.79bdba7a-8aaf-47e5-b62d-69343c428e28",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706815884819832000.79bdba7a-8aaf-47e5-b62d-69343c428e28",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "obr-16-ordering-provider"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "OBR",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Provider"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815884822151000.499afe6a-9f17-4f97-8f31-6cb4ad3f6735",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815884822151000.499afe6a-9f17-4f97-8f31-6cb4ad3f6735",
+        "telecom" : [
+          {
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                  "valueCode" : "unknown"
+                }
+              ]
+            }
+          }
+        ],
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                "valueCode" : "6059"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861"
+                      },
+                      {
+                        "url" : "SAD.2",
+                        "valueString" : "20TH AVE"
+                      },
+                      {
+                        "url" : "SAD.3",
+                        "valueString" : "1"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.2",
+                    "valueString" : "Ordering Facility Address"
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  },
+                  {
+                    "url" : "XAD.8",
+                    "valueString" : "Other Geographic Designation"
+                  },
+                  {
+                    "url" : "XAD.11",
+                    "valueCode" : "A"
+                  },
+                  {
+                    "url" : "XAD.13",
+                    "valueString" : "20220501102531-0400"
+                  },
+                  {
+                    "url" : "XAD.14",
+                    "valueString" : "20230501102531-0400"
+                  },
+                  {
+                    "url" : "XAD.19",
+                    "valueCode" : "Adressee"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861",
+              "20TH AVE",
+              "1",
+              "Ordering Facility Address",
+              "Adressee"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "district" : "County",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA",
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "PractitionerRole/1706815884809528000.961da3b0-2fb7-4dd2-858a-f75323deebb2",
+      "resource" : {
+        "resourceType" : "PractitionerRole",
+        "id" : "1706815884809528000.961da3b0-2fb7-4dd2-858a-f75323deebb2",
+        "practitioner" : {
+          "reference" : "Practitioner/1706815884819832000.79bdba7a-8aaf-47e5-b62d-69343c428e28"
         },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        "organization" : {
+          "reference" : "Organization/1706815884822151000.499afe6a-9f17-4f97-8f31-6cb4ad3f6735"
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654784756657000.32c98309-98a8-4af9-8e1a-158aa0f893cf",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654784756657000.32c98309-98a8-4af9-8e1a-158aa0f893cf",
-      "telecom" : [ {
-        "_system" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815884994024000.b78a8c1d-ea12-4a85-8d95-b1c3a618b326",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815884994024000.b78a8c1d-ea12-4a85-8d95-b1c3a618b326",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815884824523000.47180764-e878-4f7f-a2d3-a0b36aa370f0"
+          }
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815884806859000.dbce81cf-c551-4ce5-8afa-dd16b67682e8"
         }
-      } ],
-      "address" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
-          "valueCode" : "6059"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861"
-            }, {
-              "url" : "SAD.2",
-              "valueString" : "20TH AVE"
-            }, {
-              "url" : "SAD.3",
-              "valueString" : "1"
-            } ]
-          }, {
-            "url" : "XAD.2",
-            "valueString" : "Ordering Facility Address"
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          }, {
-            "url" : "XAD.8",
-            "valueString" : "Other Geographic Designation"
-          }, {
-            "url" : "XAD.11",
-            "valueCode" : "A"
-          }, {
-            "url" : "XAD.13",
-            "valueString" : "20220501102531-0400"
-          }, {
-            "url" : "XAD.14",
-            "valueString" : "20230501102531-0400"
-          }, {
-            "url" : "XAD.19",
-            "valueCode" : "Adressee"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861", "20TH AVE", "1", "Ordering Facility Address", "Adressee" ],
-        "city" : "THUNDER MOUNTAIN",
-        "district" : "County",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA",
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "PractitionerRole/1706654784745029000.86bc1503-24d5-47bd-9691-ee7d6edbffef",
-    "resource" : {
-      "resourceType" : "PractitionerRole",
-      "id" : "1706654784745029000.86bc1503-24d5-47bd-9691-ee7d6edbffef",
-      "practitioner" : {
-        "reference" : "Practitioner/1706654784754176000.eee19c69-d745-4f27-a905-c7d84b797088"
-      },
-      "organization" : {
-        "reference" : "Organization/1706654784756657000.32c98309-98a8-4af9-8e1a-158aa0f893cf"
       }
     }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706654784915912000.fdb37686-59a5-4a0e-9449-07a933ce7969",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706654784915912000.fdb37686-59a5-4a0e-9449-07a933ce7969",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706654784762169000.9f2df7cb-deb4-454c-9643-9984c6ec4417"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654784742234000.e555fc29-8007-43d1-aea6-d89616271ecf"
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitionerrole-orc23-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-requester-practitionerrole-orc23-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654794285271000.443839eb-a03c-4cdf-a0d9-9ff2b99a6f41",
+  "id" : "1706815895152306000.3be5e6d2-4063-4efc-9d22-be281e11f245",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:46:34.292-05:00"
+    "lastUpdated" : "2024-02-01T14:31:35.159-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,334 +10,459 @@
   },
   "type" : "message",
   "timestamp" : "2023-08-16T13:33:58.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230816123358-0500"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654794670894000.034b24e8-83aa-4bdc-917d-a4c55ab3451d",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654794670894000.034b24e8-83aa-4bdc-917d-a4c55ab3451d",
-      "target" : [ {
-        "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
-      }, {
-        "reference" : "DiagnosticReport/1706654794872062000.c4a04b6f-a988-4fd3-9e5c-084022b6506a"
-      } ],
-      "recorded" : "2023-08-16T12:33:58-05:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654794678397000.14825a57-ab9a-47ec-9b31-62721221c8bf",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654794678397000.14825a57-ab9a-47ec-9b31-62721221c8bf",
-      "recorded" : "2024-01-30T17:46:34Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706654794677470000.5793a5d9-d23b-4980-8657-13e16a2663ad"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654794677470000.5793a5d9-d23b-4980-8657-13e16a2663ad",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654794677470000.5793a5d9-d23b-4980-8657-13e16a2663ad",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706654794695189000.5d48cf07-d797-4941-9a6f-16ef62155612",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706654794695189000.5d48cf07-d797-4941-9a6f-16ef62155612"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654794699614000.09578f1b-4127-4f3a-85d7-b38d5934fd05",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654794699614000.09578f1b-4127-4f3a-85d7-b38d5934fd05",
-      "target" : [ {
-        "reference" : "Patient/1706654794695189000.5d48cf07-d797-4941-9a6f-16ef62155612"
-      } ],
-      "recorded" : "2024-01-30T17:46:34Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706654794718367000.b029bb05-5593-4ee7-aa45-943a0d1ac175",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706654794718367000.b029bb05-5593-4ee7-aa45-943a0d1ac175",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
-        "valueCode" : "RE"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654794695189000.5d48cf07-d797-4941-9a6f-16ef62155612"
-      },
-      "requester" : {
-        "reference" : "PractitionerRole/1706654794702036000.146df178-476b-4a43-a7a8-e11451408e15"
-      }
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706654794713192000.bdcf8b07-a229-46f7-a757-09190f429da7",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706654794713192000.bdcf8b07-a229-46f7-a757-09190f429da7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706815895545113000.6eef8a94-6557-49ce-bf55-8633fb5982fa",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815895545113000.6eef8a94-6557-49ce-bf55-8633fb5982fa",
+        "target" : [
+          {
+            "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815895880701000.9bf6e22a-27d3-4c36-979e-a206ab21ffea"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "obr-16-ordering-provider"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "OBR",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Provider"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "recorded" : "2023-08-16T12:33:58-05:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654794714660000.1d662543-c6c7-402e-a0b9-dde6b77f614f",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654794714660000.1d662543-c6c7-402e-a0b9-dde6b77f614f",
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "260"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "7595016"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "PRN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "BP"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "7595016"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 260 759 5016"
-          } ]
-        } ],
-        "system" : "pager",
-        "value" : "+1 260 759 5016",
-        "use" : "home"
-      } ]
-    }
-  }, {
-    "fullUrl" : "PractitionerRole/1706654794702036000.146df178-476b-4a43-a7a8-e11451408e15",
-    "resource" : {
-      "resourceType" : "PractitionerRole",
-      "id" : "1706654794702036000.146df178-476b-4a43-a7a8-e11451408e15",
-      "practitioner" : {
-        "reference" : "Practitioner/1706654794713192000.bdcf8b07-a229-46f7-a757-09190f429da7"
-      },
-      "organization" : {
-        "reference" : "Organization/1706654794714660000.1d662543-c6c7-402e-a0b9-dde6b77f614f"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815895553014000.06f3539b-ec06-4912-9d00-5f6c8d83613f",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815895553014000.06f3539b-ec06-4912-9d00-5f6c8d83613f",
+        "recorded" : "2024-02-01T14:31:35Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815895552384000.d82549b4-dc8d-4b99-a6f6-cb02214b8388"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815895552384000.d82549b4-dc8d-4b99-a6f6-cb02214b8388",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815895552384000.d82549b4-dc8d-4b99-a6f6-cb02214b8388",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706815895568572000.dd45c07a-4c66-432a-94c5-f46c5a5160a7",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706815895568572000.dd45c07a-4c66-432a-94c5-f46c5a5160a7"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815895569241000.e9cb0ff7-5d1d-47ad-b353-4791767b392e",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815895569241000.e9cb0ff7-5d1d-47ad-b353-4791767b392e",
+        "target" : [
+          {
+            "reference" : "Patient/1706815895568572000.dd45c07a-4c66-432a-94c5-f46c5a5160a7"
+          }
+        ],
+        "recorded" : "2024-02-01T14:31:35Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815895590254000.c817a54c-6f1a-4a1f-a0dc-aac360897006",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815895590254000.c817a54c-6f1a-4a1f-a0dc-aac360897006",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+            "valueCode" : "RE"
+          }
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815895568572000.dd45c07a-4c66-432a-94c5-f46c5a5160a7"
+        },
+        "requester" : {
+          "reference" : "PractitionerRole/1706815895571370000.7ebf496b-7061-43f6-96c4-70c77cf18d42"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706815895584761000.a55ff984-d496-401b-bfab-feb82af25472",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706815895584761000.a55ff984-d496-401b-bfab-feb82af25472",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "obr-16-ordering-provider"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "OBR",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Provider"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815895586681000.b94aad3e-480e-4edd-9b4e-579af6f04c15",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815895586681000.b94aad3e-480e-4edd-9b4e-579af6f04c15",
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "260"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "7595016"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "PRN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "BP"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "7595016"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 260 759 5016"
+                  }
+                ]
+              }
+            ],
+            "system" : "pager",
+            "value" : "+1 260 759 5016",
+            "use" : "home"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "PractitionerRole/1706815895571370000.7ebf496b-7061-43f6-96c4-70c77cf18d42",
+      "resource" : {
+        "resourceType" : "PractitionerRole",
+        "id" : "1706815895571370000.7ebf496b-7061-43f6-96c4-70c77cf18d42",
+        "practitioner" : {
+          "reference" : "Practitioner/1706815895584761000.a55ff984-d496-401b-bfab-feb82af25472"
+        },
+        "organization" : {
+          "reference" : "Organization/1706815895586681000.b94aad3e-480e-4edd-9b4e-579af6f04c15"
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815895880701000.9bf6e22a-27d3-4c36-979e-a206ab21ffea",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815895880701000.9bf6e22a-27d3-4c36-979e-a206ab21ffea",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815895590254000.c817a54c-6f1a-4a1f-a0dc-aac360897006"
+          }
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815895568572000.dd45c07a-4c66-432a-94c5-f46c5a5160a7"
+        }
       }
     }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706654794872062000.c4a04b6f-a988-4fd3-9e5c-084022b6506a",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706654794872062000.c4a04b6f-a988-4fd3-9e5c-084022b6506a",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706654794718367000.b029bb05-5593-4ee7-aa45-943a0d1ac175"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654794695189000.5d48cf07-d797-4941-9a6f-16ef62155612"
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-sets-authored-on.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/orcobr/orc_obr-to-servicerequest_diagnosticreport-sets-authored-on.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654803644710000.a6a40bbf-2b26-48cd-b46e-748ba580c7a2",
+  "id" : "1706815906204735000.a12fb3be-c450-4def-8f29-851fac705e35",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:46:43.652-05:00"
+    "lastUpdated" : "2024-02-01T14:31:46.214-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,148 +10,196 @@
   },
   "type" : "message",
   "timestamp" : "2023-08-16T13:33:58.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230816123358-0500"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654804033361000.6b87dfb3-b8b4-4def-9ef2-65e2d49f0386",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654804033361000.6b87dfb3-b8b4-4def-9ef2-65e2d49f0386",
-      "target" : [ {
-        "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
-      }, {
-        "reference" : "DiagnosticReport/1706654804223637000.04433f1b-146e-4f02-9b1d-a413fd9d1bad"
-      } ],
-      "recorded" : "2023-08-16T12:33:58-05:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "bb504ecd-c2ab-3be3-91d8-6065e2bce435",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230816123358-0500"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654804039994000.2dc34fee-defe-4161-ad03-db0d7eab6d0c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654804039994000.2dc34fee-defe-4161-ad03-db0d7eab6d0c",
-      "recorded" : "2024-01-30T17:46:44Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706654804038866000.b7ac73f7-301e-4a26-bc22-137b858a58d1"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706654804038866000.b7ac73f7-301e-4a26-bc22-137b858a58d1",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706654804038866000.b7ac73f7-301e-4a26-bc22-137b858a58d1",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815906787460000.2d4cab62-4167-4e31-af1e-60bea37682b8",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815906787460000.2d4cab62-4167-4e31-af1e-60bea37682b8",
+        "target" : [
+          {
+            "reference" : "MessageHeader/bb504ecd-c2ab-3be3-91d8-6065e2bce435"
+          },
+          {
+            "reference" : "DiagnosticReport/1706815906998070000.7f6eb9db-68d4-4a79-925d-6d595491915e"
+          }
+        ],
+        "recorded" : "2023-08-16T12:33:58-05:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815906797955000.ea8f3820-689b-42c6-9282-fd2cf1f2f5c2",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815906797955000.ea8f3820-689b-42c6-9282-fd2cf1f2f5c2",
+        "recorded" : "2024-02-01T14:31:46Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706654804054720000.73ea86a4-f862-41d1-af18-15db8894d2b8",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706654804054720000.73ea86a4-f862-41d1-af18-15db8894d2b8"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706654804055340000.5e452fbe-e490-4302-9f18-4cef89012f54",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706654804055340000.5e452fbe-e490-4302-9f18-4cef89012f54",
-      "target" : [ {
-        "reference" : "Patient/1706654804054720000.73ea86a4-f862-41d1-af18-15db8894d2b8"
-      } ],
-      "recorded" : "2024-01-30T17:46:44Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706815906797058000.736581d1-7c94-41aa-be01-f22a8a1982f7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706815906797058000.736581d1-7c94-41aa-be01-f22a8a1982f7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706815906797058000.736581d1-7c94-41aa-be01-f22a8a1982f7",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706815906830668000.67c1d542-a8a4-467c-a2f7-6a8e113698ce",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706815906830668000.67c1d542-a8a4-467c-a2f7-6a8e113698ce"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706815906831766000.5e23151e-0f07-4846-b691-277c9787c09b",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706815906831766000.5e23151e-0f07-4846-b691-277c9787c09b",
+        "target" : [
+          {
+            "reference" : "Patient/1706815906830668000.67c1d542-a8a4-467c-a2f7-6a8e113698ce"
+          }
+        ],
+        "recorded" : "2024-02-01T14:31:46Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706815906837152000.33e62303-3d1a-47d6-92cf-41eefe316f47",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706815906837152000.33e62303-3d1a-47d6-92cf-41eefe316f47",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+            "valueCode" : "NW"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+            "valueString" : "20230816123358-0500"
+          }
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815906830668000.67c1d542-a8a4-467c-a2f7-6a8e113698ce"
+        },
+        "authoredOn" : "2023-08-16T12:33:58-05:00",
+        "_authoredOn" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20230816123358-0500"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706815906998070000.7f6eb9db-68d4-4a79-925d-6d595491915e",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706815906998070000.7f6eb9db-68d4-4a79-925d-6d595491915e",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706815906837152000.33e62303-3d1a-47d6-92cf-41eefe316f47"
+          }
+        ],
+        "status" : "unknown",
+        "subject" : {
+          "reference" : "Patient/1706815906830668000.67c1d542-a8a4-467c-a2f7-6a8e113698ce"
+        }
       }
     }
-  }, {
-    "fullUrl" : "ServiceRequest/1706654804059589000.55821272-fe10-43d5-a16b-412e1b2d7d99",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706654804059589000.55821272-fe10-43d5-a16b-412e1b2d7d99",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
-        "valueCode" : "NW"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
-        "valueString" : "20230816123358-0500"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654804054720000.73ea86a4-f862-41d1-af18-15db8894d2b8"
-      },
-      "authoredOn" : "2023-08-16T12:33:58-05:00",
-      "_authoredOn" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-          "valueString" : "20230816123358-0500"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706654804223637000.04433f1b-146e-4f02-9b1d-a413fd9d1bad",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706654804223637000.04433f1b-146e-4f02-9b1d-a413fd9d1bad",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706654804059589000.55821272-fe10-43d5-a16b-412e1b2d7d99"
-      } ],
-      "status" : "unknown",
-      "subject" : {
-        "reference" : "Patient/1706654804054720000.73ea86a4-f862-41d1-af18-15db8894d2b8"
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pd1/pd1-to-patient-pd1-14-1-blank-14-10-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pd1/pd1-to-patient-pd1-14-1-blank-14-10-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654844841223000.1caae910-775e-45d4-b3d4-6fac80d7f00a",
+  "id" : "1706815971087188000.553ecf95-f1a5-4500-a807-d27afdfb2bb1",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:47:24.848-05:00"
+    "lastUpdated" : "2024-02-01T14:32:51.092-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706654844920243000.318648a0-51a4-4015-87bd-ef6a1c099fb9"
+          "reference" : "Organization/1706815971135545000.099bb0a0-1a93-425a-97bb-601bfb246f9e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654844920243000.318648a0-51a4-4015-87bd-ef6a1c099fb9",
+      "fullUrl" : "Organization/1706815971135545000.099bb0a0-1a93-425a-97bb-601bfb246f9e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654844920243000.318648a0-51a4-4015-87bd-ef6a1c099fb9",
+        "id" : "1706815971135545000.099bb0a0-1a93-425a-97bb-601bfb246f9e",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654845247732000.cac28e82-c697-4809-8dee-547f8bbe0284",
+      "fullUrl" : "Provenance/1706815971483229000.0b3061fb-762e-4824-8efe-773d76f947bb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654845247732000.cac28e82-c697-4809-8dee-547f8bbe0284",
+        "id" : "1706815971483229000.0b3061fb-762e-4824-8efe-773d76f947bb",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706654845478499000.7dae398d-befa-41c6-8994-1e00448683bf"
+            "reference" : "DiagnosticReport/1706815971717547000.9b5c4c52-b6fb-4dc3-8b43-9745c1d80ede"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654845256451000.7cb8788f-0ecd-40dc-8f7e-ece063e16b61",
+      "fullUrl" : "Provenance/1706815971492350000.4f526e21-9ad1-4526-b484-26836a269a24",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654845256451000.7cb8788f-0ecd-40dc-8f7e-ece063e16b61",
-        "recorded" : "2024-01-30T17:47:25Z",
+        "id" : "1706815971492350000.4f526e21-9ad1-4526-b484-26836a269a24",
+        "recorded" : "2024-02-01T14:32:51Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654845255933000.0b786017-d7ff-4164-9fb3-530e445f80b3"
+              "reference" : "Organization/1706815971491703000.7ad29f92-6ea2-42ec-bef7-7a8299b48e90"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654845255933000.0b786017-d7ff-4164-9fb3-530e445f80b3",
+      "fullUrl" : "Organization/1706815971491703000.7ad29f92-6ea2-42ec-bef7-7a8299b48e90",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845255933000.0b786017-d7ff-4164-9fb3-530e445f80b3",
+        "id" : "1706815971491703000.7ad29f92-6ea2-42ec-bef7-7a8299b48e90",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654845303959000.35891464-1baa-42d2-a6ef-0ff2f3c61c19",
+      "fullUrl" : "Patient/1706815971530669000.2e4906f5-0bc6-42b2-b320-16c1bdd2ebc5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654845303959000.35891464-1baa-42d2-a6ef-0ff2f3c61c19",
+        "id" : "1706815971530669000.2e4906f5-0bc6-42b2-b320-16c1bdd2ebc5",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/studentStatus",
@@ -830,7 +835,7 @@
                     {
                       "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                       "valueReference" : {
-                        "reference" : "Organization/1706654845293071000.316e52d6-3ada-46d3-a69b-ebbe6afac61d"
+                        "reference" : "Organization/1706815971521172000.63c40d62-4d5d-4b68-afa2-fd4d5579bdf0"
                       }
                     },
                     {
@@ -876,7 +881,7 @@
                     {
                       "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                       "valueReference" : {
-                        "reference" : "Organization/1706654845294999000.1e09a613-3bf0-412b-8cdd-17d2ad4497e8"
+                        "reference" : "Organization/1706815971522265000.012d6840-f603-4e34-85da-7a2e9a49702b"
                       }
                     },
                     {
@@ -985,13 +990,13 @@
               {
                 "url" : "pd1-14-patient-congregation",
                 "valueReference" : {
-                  "reference" : "Organization/1706654845298869000.4a4253d2-e215-4d31-b10b-a62158651ed5"
+                  "reference" : "Organization/1706815971526038000.96097944-ebbe-476d-82e1-c7dfc233e443"
                 }
               },
               {
                 "url" : "pd1-14-patient-congregation",
                 "valueReference" : {
-                  "reference" : "Organization/1706654845301288000.c1c5ef35-b8e5-44ea-8fad-45a5b11d5d1e"
+                  "reference" : "Organization/1706815971528053000.ebbecb3d-7df2-4251-991a-63d4a800b646"
                 }
               },
               {
@@ -1117,19 +1122,19 @@
         ],
         "generalPractitioner" : [
           {
-            "reference" : "Organization/1706654845268149000.5785bfc4-5045-4901-a27b-da4f72bb7c48"
+            "reference" : "Organization/1706815971502678000.cbec276b-2b81-4b6a-83c6-fde75c651c56"
           },
           {
-            "reference" : "Organization/1706654845271023000.b11eb146-8218-453a-a668-d7d0c0d7a6cb"
+            "reference" : "Organization/1706815971505718000.174ca4d8-0a79-48a5-9c93-0acc9e7b10c2"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706654845265630000.43225cbc-fdef-4e46-a913-ac38b6fcf9d6",
+      "fullUrl" : "Location/1706815971500832000.323ae094-f1a9-42c4-96be-df5abb8608ad",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654845265630000.43225cbc-fdef-4e46-a913-ac38b6fcf9d6",
+        "id" : "1706815971500832000.323ae094-f1a9-42c4-96be-df5abb8608ad",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1159,10 +1164,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654845268149000.5785bfc4-5045-4901-a27b-da4f72bb7c48",
+      "fullUrl" : "Organization/1706815971502678000.cbec276b-2b81-4b6a-83c6-fde75c651c56",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845268149000.5785bfc4-5045-4901-a27b-da4f72bb7c48",
+        "id" : "1706815971502678000.cbec276b-2b81-4b6a-83c6-fde75c651c56",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1262,7 +1267,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654845265630000.43225cbc-fdef-4e46-a913-ac38b6fcf9d6"
+                  "reference" : "Location/1706815971500832000.323ae094-f1a9-42c4-96be-df5abb8608ad"
                 }
               }
             ],
@@ -1287,10 +1292,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654845269723000.a9f90811-af61-459a-a8af-9c20443ab084",
+      "fullUrl" : "Location/1706815971504044000.4eda9d99-77f3-4ebf-930e-30e9166de115",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654845269723000.a9f90811-af61-459a-a8af-9c20443ab084",
+        "id" : "1706815971504044000.4eda9d99-77f3-4ebf-930e-30e9166de115",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1320,10 +1325,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654845271023000.b11eb146-8218-453a-a668-d7d0c0d7a6cb",
+      "fullUrl" : "Organization/1706815971505718000.174ca4d8-0a79-48a5-9c93-0acc9e7b10c2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845271023000.b11eb146-8218-453a-a668-d7d0c0d7a6cb",
+        "id" : "1706815971505718000.174ca4d8-0a79-48a5-9c93-0acc9e7b10c2",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1423,7 +1428,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654845269723000.a9f90811-af61-459a-a8af-9c20443ab084"
+                  "reference" : "Location/1706815971504044000.4eda9d99-77f3-4ebf-930e-30e9166de115"
                 }
               }
             ],
@@ -1448,10 +1453,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654845293071000.316e52d6-3ada-46d3-a69b-ebbe6afac61d",
+      "fullUrl" : "Organization/1706815971521172000.63c40d62-4d5d-4b68-afa2-fd4d5579bdf0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845293071000.316e52d6-3ada-46d3-a69b-ebbe6afac61d",
+        "id" : "1706815971521172000.63c40d62-4d5d-4b68-afa2-fd4d5579bdf0",
         "identifier" : [
           {
             "extension" : [
@@ -1484,10 +1489,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654845294999000.1e09a613-3bf0-412b-8cdd-17d2ad4497e8",
+      "fullUrl" : "Organization/1706815971522265000.012d6840-f603-4e34-85da-7a2e9a49702b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845294999000.1e09a613-3bf0-412b-8cdd-17d2ad4497e8",
+        "id" : "1706815971522265000.012d6840-f603-4e34-85da-7a2e9a49702b",
         "identifier" : [
           {
             "extension" : [
@@ -1520,10 +1525,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654845297504000.a220fdbf-61fb-4bfa-accc-c174f88fa122",
+      "fullUrl" : "Location/1706815971525119000.27dc0bea-bfb2-4e88-b8e6-6a0ddc1dae4a",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654845297504000.a220fdbf-61fb-4bfa-accc-c174f88fa122",
+        "id" : "1706815971525119000.27dc0bea-bfb2-4e88-b8e6-6a0ddc1dae4a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1553,10 +1558,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654845298869000.4a4253d2-e215-4d31-b10b-a62158651ed5",
+      "fullUrl" : "Organization/1706815971526038000.96097944-ebbe-476d-82e1-c7dfc233e443",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845298869000.4a4253d2-e215-4d31-b10b-a62158651ed5",
+        "id" : "1706815971526038000.96097944-ebbe-476d-82e1-c7dfc233e443",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1664,7 +1669,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654845297504000.a220fdbf-61fb-4bfa-accc-c174f88fa122"
+                  "reference" : "Location/1706815971525119000.27dc0bea-bfb2-4e88-b8e6-6a0ddc1dae4a"
                 }
               }
             ],
@@ -1688,10 +1693,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654845300178000.020b92d2-4e25-461c-9d26-fa07fa212ee1",
+      "fullUrl" : "Location/1706815971527147000.8222f6a2-7376-4d49-bf30-4738626b3815",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654845300178000.020b92d2-4e25-461c-9d26-fa07fa212ee1",
+        "id" : "1706815971527147000.8222f6a2-7376-4d49-bf30-4738626b3815",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1721,10 +1726,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654845301288000.c1c5ef35-b8e5-44ea-8fad-45a5b11d5d1e",
+      "fullUrl" : "Organization/1706815971528053000.ebbecb3d-7df2-4251-991a-63d4a800b646",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654845301288000.c1c5ef35-b8e5-44ea-8fad-45a5b11d5d1e",
+        "id" : "1706815971528053000.ebbecb3d-7df2-4251-991a-63d4a800b646",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1832,7 +1837,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654845300178000.020b92d2-4e25-461c-9d26-fa07fa212ee1"
+                  "reference" : "Location/1706815971527147000.8222f6a2-7376-4d49-bf30-4738626b3815"
                 }
               }
             ],
@@ -1856,16 +1861,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654845313234000.42d4dcff-4b2b-48bf-853e-06c3b0a43fe5",
+      "fullUrl" : "Provenance/1706815971539875000.bdb84560-0a6c-4f6e-9762-f92162e5928e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654845313234000.42d4dcff-4b2b-48bf-853e-06c3b0a43fe5",
+        "id" : "1706815971539875000.bdb84560-0a6c-4f6e-9762-f92162e5928e",
         "target" : [
           {
-            "reference" : "Patient/1706654845303959000.35891464-1baa-42d2-a6ef-0ff2f3c61c19"
+            "reference" : "Patient/1706815971530669000.2e4906f5-0bc6-42b2-b320-16c1bdd2ebc5"
           }
         ],
-        "recorded" : "2024-01-30T17:47:25Z",
+        "recorded" : "2024-02-01T14:32:51Z",
         "activity" : {
           "coding" : [
             {
@@ -1877,10 +1882,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654845317360000.40ae77cf-29ba-4147-9208-0625f1658c5c",
+      "fullUrl" : "ServiceRequest/1706815971543774000.cd14ae0d-f005-488a-8b9d-fb1cf273f2a7",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654845317360000.40ae77cf-29ba-4147-9208-0625f1658c5c",
+        "id" : "1706815971543774000.cd14ae0d-f005-488a-8b9d-fb1cf273f2a7",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -1896,18 +1901,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654845303959000.35891464-1baa-42d2-a6ef-0ff2f3c61c19"
+          "reference" : "Patient/1706815971530669000.2e4906f5-0bc6-42b2-b320-16c1bdd2ebc5"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654845478499000.7dae398d-befa-41c6-8994-1e00448683bf",
+      "fullUrl" : "DiagnosticReport/1706815971717547000.9b5c4c52-b6fb-4dc3-8b43-9745c1d80ede",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654845478499000.7dae398d-befa-41c6-8994-1e00448683bf",
+        "id" : "1706815971717547000.9b5c4c52-b6fb-4dc3-8b43-9745c1d80ede",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654845317360000.40ae77cf-29ba-4147-9208-0625f1658c5c"
+            "reference" : "ServiceRequest/1706815971543774000.cd14ae0d-f005-488a-8b9d-fb1cf273f2a7"
           }
         ],
         "status" : "final",
@@ -1925,7 +1930,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654845303959000.35891464-1baa-42d2-a6ef-0ff2f3c61c19"
+          "reference" : "Patient/1706815971530669000.2e4906f5-0bc6-42b2-b320-16c1bdd2ebc5"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pd1/pd1-to-patient-pd1-14-1-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pd1/pd1-to-patient-pd1-14-1-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654854649606000.3fd8fdaa-7d89-40d1-93f0-009eb1016616",
+  "id" : "1706815980987291000.c7f77196-2f10-4b19-821d-8928c03ef291",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:47:34.656-05:00"
+    "lastUpdated" : "2024-02-01T14:33:00.994-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706654854729599000.f266cc81-48f4-49dd-b620-4662d2e7b957"
+          "reference" : "Organization/1706815981040142000.fbe2940a-b7ae-4d95-b496-b2796a4e83f2"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654854729599000.f266cc81-48f4-49dd-b620-4662d2e7b957",
+      "fullUrl" : "Organization/1706815981040142000.fbe2940a-b7ae-4d95-b496-b2796a4e83f2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654854729599000.f266cc81-48f4-49dd-b620-4662d2e7b957",
+        "id" : "1706815981040142000.fbe2940a-b7ae-4d95-b496-b2796a4e83f2",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654855067247000.8cc047a7-cf07-4948-8701-3fb714ce5cd8",
+      "fullUrl" : "Provenance/1706815981402360000.0d5ede7f-76af-45c6-aeda-9977f1eea539",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654855067247000.8cc047a7-cf07-4948-8701-3fb714ce5cd8",
+        "id" : "1706815981402360000.0d5ede7f-76af-45c6-aeda-9977f1eea539",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706654855283261000.cb41cdfa-193f-42ee-b6a2-496e380e5105"
+            "reference" : "DiagnosticReport/1706815981623838000.a5a817d4-7b56-4147-a774-d8e1075221fd"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654855075587000.83ad5c17-6945-4eda-8df5-bff7131a56c1",
+      "fullUrl" : "Provenance/1706815981411258000.ca9dcbc3-437c-4c04-bd43-8961c0f971a5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654855075587000.83ad5c17-6945-4eda-8df5-bff7131a56c1",
-        "recorded" : "2024-01-30T17:47:35Z",
+        "id" : "1706815981411258000.ca9dcbc3-437c-4c04-bd43-8961c0f971a5",
+        "recorded" : "2024-02-01T14:33:01Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706654855075150000.766c1150-38d2-4306-9434-b6245a65fb61"
+              "reference" : "Organization/1706815981410584000.b422143f-32d0-4c62-bd07-0d411ad5e410"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706654855075150000.766c1150-38d2-4306-9434-b6245a65fb61",
+      "fullUrl" : "Organization/1706815981410584000.b422143f-32d0-4c62-bd07-0d411ad5e410",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855075150000.766c1150-38d2-4306-9434-b6245a65fb61",
+        "id" : "1706815981410584000.b422143f-32d0-4c62-bd07-0d411ad5e410",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706654855112256000.35e0c79d-9540-4336-a12b-649ce35f01d2",
+      "fullUrl" : "Patient/1706815981453421000.ad33e552-65dc-47b6-9654-60ac77ec84b6",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706654855112256000.35e0c79d-9540-4336-a12b-649ce35f01d2",
+        "id" : "1706815981453421000.ad33e552-65dc-47b6-9654-60ac77ec84b6",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/studentStatus",
@@ -830,7 +835,7 @@
                     {
                       "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                       "valueReference" : {
-                        "reference" : "Organization/1706654855102770000.95189a37-059b-4a62-b035-01564e16d4be"
+                        "reference" : "Organization/1706815981443805000.7d4a61eb-5148-4bd6-a4a0-3097d8a4cf2b"
                       }
                     },
                     {
@@ -876,7 +881,7 @@
                     {
                       "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                       "valueReference" : {
-                        "reference" : "Organization/1706654855104075000.89b12471-85cd-4482-a47e-d01151b7d2d3"
+                        "reference" : "Organization/1706815981445762000.8eb7bebd-ff51-4534-9136-c6742c306583"
                       }
                     },
                     {
@@ -985,13 +990,13 @@
               {
                 "url" : "pd1-14-patient-congregation",
                 "valueReference" : {
-                  "reference" : "Organization/1706654855108055000.2ff6c2a2-9716-4c21-978a-c18caa7c9d4a"
+                  "reference" : "Organization/1706815981448982000.30ba6ab1-eb4e-48e3-9968-99925f85b3e7"
                 }
               },
               {
                 "url" : "pd1-14-patient-congregation",
                 "valueReference" : {
-                  "reference" : "Organization/1706654855109752000.8bc1044d-ae72-4db3-ac08-9da755b3cf1d"
+                  "reference" : "Organization/1706815981450938000.deb2cf78-5cb7-43e2-a0cc-b17948a81896"
                 }
               },
               {
@@ -1117,19 +1122,19 @@
         ],
         "generalPractitioner" : [
           {
-            "reference" : "Organization/1706654855085257000.ae11483f-6e9f-4e7e-9ee2-75786e041451"
+            "reference" : "Organization/1706815981421619000.0eb29054-f114-49d2-8287-ad637e54152d"
           },
           {
-            "reference" : "Organization/1706654855087581000.27e27e12-cbe2-4003-95dc-958133641bf1"
+            "reference" : "Organization/1706815981425235000.480319a3-a024-4c3e-ad4b-3135b95db0d8"
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706654855083434000.1d892fe9-2574-4a87-864e-ea36f8335665",
+      "fullUrl" : "Location/1706815981419360000.411743da-a62d-4b14-9235-f4396760b003",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654855083434000.1d892fe9-2574-4a87-864e-ea36f8335665",
+        "id" : "1706815981419360000.411743da-a62d-4b14-9235-f4396760b003",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1159,10 +1164,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654855085257000.ae11483f-6e9f-4e7e-9ee2-75786e041451",
+      "fullUrl" : "Organization/1706815981421619000.0eb29054-f114-49d2-8287-ad637e54152d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855085257000.ae11483f-6e9f-4e7e-9ee2-75786e041451",
+        "id" : "1706815981421619000.0eb29054-f114-49d2-8287-ad637e54152d",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1270,7 +1275,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654855083434000.1d892fe9-2574-4a87-864e-ea36f8335665"
+                  "reference" : "Location/1706815981419360000.411743da-a62d-4b14-9235-f4396760b003"
                 }
               }
             ],
@@ -1295,10 +1300,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654855086433000.e483ab2f-a4d1-4391-92ac-12592d31427c",
+      "fullUrl" : "Location/1706815981423072000.41d7818b-83dc-4a6e-91ae-da68fdf8be67",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654855086433000.e483ab2f-a4d1-4391-92ac-12592d31427c",
+        "id" : "1706815981423072000.41d7818b-83dc-4a6e-91ae-da68fdf8be67",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1328,10 +1333,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654855087581000.27e27e12-cbe2-4003-95dc-958133641bf1",
+      "fullUrl" : "Organization/1706815981425235000.480319a3-a024-4c3e-ad4b-3135b95db0d8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855087581000.27e27e12-cbe2-4003-95dc-958133641bf1",
+        "id" : "1706815981425235000.480319a3-a024-4c3e-ad4b-3135b95db0d8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1439,7 +1444,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654855086433000.e483ab2f-a4d1-4391-92ac-12592d31427c"
+                  "reference" : "Location/1706815981423072000.41d7818b-83dc-4a6e-91ae-da68fdf8be67"
                 }
               }
             ],
@@ -1464,10 +1469,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654855102770000.95189a37-059b-4a62-b035-01564e16d4be",
+      "fullUrl" : "Organization/1706815981443805000.7d4a61eb-5148-4bd6-a4a0-3097d8a4cf2b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855102770000.95189a37-059b-4a62-b035-01564e16d4be",
+        "id" : "1706815981443805000.7d4a61eb-5148-4bd6-a4a0-3097d8a4cf2b",
         "identifier" : [
           {
             "extension" : [
@@ -1500,10 +1505,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654855104075000.89b12471-85cd-4482-a47e-d01151b7d2d3",
+      "fullUrl" : "Organization/1706815981445762000.8eb7bebd-ff51-4534-9136-c6742c306583",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855104075000.89b12471-85cd-4482-a47e-d01151b7d2d3",
+        "id" : "1706815981445762000.8eb7bebd-ff51-4534-9136-c6742c306583",
         "identifier" : [
           {
             "extension" : [
@@ -1536,10 +1541,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654855107084000.00c31d75-4c02-41c6-97f3-288806ee475b",
+      "fullUrl" : "Location/1706815981448010000.2c103de7-f202-4e1a-aa2c-29313b5aa997",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654855107084000.00c31d75-4c02-41c6-97f3-288806ee475b",
+        "id" : "1706815981448010000.2c103de7-f202-4e1a-aa2c-29313b5aa997",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1569,10 +1574,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654855108055000.2ff6c2a2-9716-4c21-978a-c18caa7c9d4a",
+      "fullUrl" : "Organization/1706815981448982000.30ba6ab1-eb4e-48e3-9968-99925f85b3e7",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855108055000.2ff6c2a2-9716-4c21-978a-c18caa7c9d4a",
+        "id" : "1706815981448982000.30ba6ab1-eb4e-48e3-9968-99925f85b3e7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1680,7 +1685,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654855107084000.00c31d75-4c02-41c6-97f3-288806ee475b"
+                  "reference" : "Location/1706815981448010000.2c103de7-f202-4e1a-aa2c-29313b5aa997"
                 }
               }
             ],
@@ -1705,10 +1710,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706654855108881000.824d326a-9104-4d17-aed4-2cbd119e2437",
+      "fullUrl" : "Location/1706815981450014000.b00fc0cc-0e1e-4004-b945-cba16c9d8b8a",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706654855108881000.824d326a-9104-4d17-aed4-2cbd119e2437",
+        "id" : "1706815981450014000.b00fc0cc-0e1e-4004-b945-cba16c9d8b8a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -1738,10 +1743,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706654855109752000.8bc1044d-ae72-4db3-ac08-9da755b3cf1d",
+      "fullUrl" : "Organization/1706815981450938000.deb2cf78-5cb7-43e2-a0cc-b17948a81896",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706654855109752000.8bc1044d-ae72-4db3-ac08-9da755b3cf1d",
+        "id" : "1706815981450938000.deb2cf78-5cb7-43e2-a0cc-b17948a81896",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -1849,7 +1854,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706654855108881000.824d326a-9104-4d17-aed4-2cbd119e2437"
+                  "reference" : "Location/1706815981450014000.b00fc0cc-0e1e-4004-b945-cba16c9d8b8a"
                 }
               }
             ],
@@ -1874,16 +1879,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706654855122529000.e1d21416-c3b3-46a2-be68-5daf1759d686",
+      "fullUrl" : "Provenance/1706815981464111000.27279ee4-3516-4614-afe4-5ff440e0f86c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706654855122529000.e1d21416-c3b3-46a2-be68-5daf1759d686",
+        "id" : "1706815981464111000.27279ee4-3516-4614-afe4-5ff440e0f86c",
         "target" : [
           {
-            "reference" : "Patient/1706654855112256000.35e0c79d-9540-4336-a12b-649ce35f01d2"
+            "reference" : "Patient/1706815981453421000.ad33e552-65dc-47b6-9654-60ac77ec84b6"
           }
         ],
-        "recorded" : "2024-01-30T17:47:35Z",
+        "recorded" : "2024-02-01T14:33:01Z",
         "activity" : {
           "coding" : [
             {
@@ -1895,10 +1900,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706654855126680000.3bccbf00-a954-45de-a9cd-e456eddb2548",
+      "fullUrl" : "ServiceRequest/1706815981467353000.ed9550a0-2992-4eed-afda-70e79ac1f3b3",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706654855126680000.3bccbf00-a954-45de-a9cd-e456eddb2548",
+        "id" : "1706815981467353000.ed9550a0-2992-4eed-afda-70e79ac1f3b3",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -1914,18 +1919,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654855112256000.35e0c79d-9540-4336-a12b-649ce35f01d2"
+          "reference" : "Patient/1706815981453421000.ad33e552-65dc-47b6-9654-60ac77ec84b6"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706654855283261000.cb41cdfa-193f-42ee-b6a2-496e380e5105",
+      "fullUrl" : "DiagnosticReport/1706815981623838000.a5a817d4-7b56-4147-a774-d8e1075221fd",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706654855283261000.cb41cdfa-193f-42ee-b6a2-496e380e5105",
+        "id" : "1706815981623838000.a5a817d4-7b56-4147-a774-d8e1075221fd",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706654855126680000.3bccbf00-a954-45de-a9cd-e456eddb2548"
+            "reference" : "ServiceRequest/1706815981467353000.ed9550a0-2992-4eed-afda-70e79ac1f3b3"
           }
         ],
         "status" : "final",
@@ -1943,7 +1948,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706654855112256000.35e0c79d-9540-4336-a12b-649ce35f01d2"
+          "reference" : "Patient/1706815981453421000.ad33e552-65dc-47b6-9654-60ac77ec84b6"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-25-not-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-25-not-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655727227304000.ba6bda19-a54a-4bb4-a374-d813743efc1d",
+  "id" : "1706816206695402000.484b9231-dd7b-4c04-8060-fd1b911bb08e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T18:02:07.234-05:00"
+    "lastUpdated" : "2024-02-01T14:36:46.703-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655727296483000.7cb4bb98-f4a3-4325-a14e-4a92c3a80365"
+          "reference" : "Organization/1706816206747234000.d07d2b8c-c93e-4d41-a21e-9ba662cc3d84"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655727296483000.7cb4bb98-f4a3-4325-a14e-4a92c3a80365",
+      "fullUrl" : "Organization/1706816206747234000.d07d2b8c-c93e-4d41-a21e-9ba662cc3d84",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655727296483000.7cb4bb98-f4a3-4325-a14e-4a92c3a80365",
+        "id" : "1706816206747234000.d07d2b8c-c93e-4d41-a21e-9ba662cc3d84",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655727610339000.39f9ba31-f3c7-4afd-86e5-0f317fce399f",
+      "fullUrl" : "Provenance/1706816207096777000.d18d8865-4ab5-436e-b1d1-6f18635328eb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655727610339000.39f9ba31-f3c7-4afd-86e5-0f317fce399f",
+        "id" : "1706816207096777000.d18d8865-4ab5-436e-b1d1-6f18635328eb",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706655727801250000.c2699acb-d6a6-41ed-bf05-a2cee25b3968"
+            "reference" : "DiagnosticReport/1706816207297849000.ee6c5c54-d669-4e3b-baec-3952c9a0d411"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655727617598000.61218fad-d4c3-4432-be10-012903174d69",
+      "fullUrl" : "Provenance/1706816207105630000.79662823-5329-431c-a3ea-2ff6495377f0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655727617598000.61218fad-d4c3-4432-be10-012903174d69",
-        "recorded" : "2024-01-30T18:02:07Z",
+        "id" : "1706816207105630000.79662823-5329-431c-a3ea-2ff6495377f0",
+        "recorded" : "2024-02-01T14:36:47Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655727616406000.fd0709c6-e6a8-41a9-9295-2edc088244fe"
+              "reference" : "Organization/1706816207105174000.c0b2b443-6e32-4c66-a937-006ff4b187da"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655727616406000.fd0709c6-e6a8-41a9-9295-2edc088244fe",
+      "fullUrl" : "Organization/1706816207105174000.c0b2b443-6e32-4c66-a937-006ff4b187da",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655727616406000.fd0709c6-e6a8-41a9-9295-2edc088244fe",
+        "id" : "1706816207105174000.c0b2b443-6e32-4c66-a937-006ff4b187da",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655727631995000.c67b96a3-01ac-4359-9ebc-489b8dc788b7",
+      "fullUrl" : "Patient/1706816207121555000.7666a78b-4962-41c1-b814-c612177b9c90",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655727631995000.c67b96a3-01ac-4359-9ebc-489b8dc788b7",
+        "id" : "1706816207121555000.7666a78b-4962-41c1-b814-c612177b9c90",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -161,16 +166,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655727632784000.ce45a4a9-cc20-4c4c-a007-df5a10af610d",
+      "fullUrl" : "Provenance/1706816207122354000.6f61861b-746c-4817-895b-c139230732ca",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655727632784000.ce45a4a9-cc20-4c4c-a007-df5a10af610d",
+        "id" : "1706816207122354000.6f61861b-746c-4817-895b-c139230732ca",
         "target" : [
           {
-            "reference" : "Patient/1706655727631995000.c67b96a3-01ac-4359-9ebc-489b8dc788b7"
+            "reference" : "Patient/1706816207121555000.7666a78b-4962-41c1-b814-c612177b9c90"
           }
         ],
-        "recorded" : "2024-01-30T18:02:07Z",
+        "recorded" : "2024-02-01T14:36:47Z",
         "activity" : {
           "coding" : [
             {
@@ -182,10 +187,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706655727637669000.03850fa6-5c81-4e87-8df0-996ed4672396",
+      "fullUrl" : "ServiceRequest/1706816207128264000.7dc24c20-e8ad-476b-bc0e-83e1f5afc4ae",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706655727637669000.03850fa6-5c81-4e87-8df0-996ed4672396",
+        "id" : "1706816207128264000.7dc24c20-e8ad-476b-bc0e-83e1f5afc4ae",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -201,18 +206,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655727631995000.c67b96a3-01ac-4359-9ebc-489b8dc788b7"
+          "reference" : "Patient/1706816207121555000.7666a78b-4962-41c1-b814-c612177b9c90"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706655727801250000.c2699acb-d6a6-41ed-bf05-a2cee25b3968",
+      "fullUrl" : "DiagnosticReport/1706816207297849000.ee6c5c54-d669-4e3b-baec-3952c9a0d411",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706655727801250000.c2699acb-d6a6-41ed-bf05-a2cee25b3968",
+        "id" : "1706816207297849000.ee6c5c54-d669-4e3b-baec-3952c9a0d411",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706655727637669000.03850fa6-5c81-4e87-8df0-996ed4672396"
+            "reference" : "ServiceRequest/1706816207128264000.7dc24c20-e8ad-476b-bc0e-83e1f5afc4ae"
           }
         ],
         "status" : "final",
@@ -230,7 +235,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655727631995000.c67b96a3-01ac-4359-9ebc-489b8dc788b7"
+          "reference" : "Patient/1706816207121555000.7666a78b-4962-41c1-b814-c612177b9c90"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-25-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-25-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655736809601000.1ca1d9f0-2cdb-4bad-b859-322c2032f0cf",
+  "id" : "1706816216589078000.b7b08cab-b7f1-44ff-8e58-a6947406ed03",
   "meta" : {
-    "lastUpdated" : "2024-01-30T18:02:16.817-05:00"
+    "lastUpdated" : "2024-02-01T14:36:56.596-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655736880053000.95f77049-c774-47a7-bbd5-ae6c2b7c7ae1"
+          "reference" : "Organization/1706816216640895000.a4bce726-b93a-4485-bbb5-4d188944233d"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655736880053000.95f77049-c774-47a7-bbd5-ae6c2b7c7ae1",
+      "fullUrl" : "Organization/1706816216640895000.a4bce726-b93a-4485-bbb5-4d188944233d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655736880053000.95f77049-c774-47a7-bbd5-ae6c2b7c7ae1",
+        "id" : "1706816216640895000.a4bce726-b93a-4485-bbb5-4d188944233d",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655737215835000.81b445c3-15a7-4517-8cf7-ae7c897b9a98",
+      "fullUrl" : "Provenance/1706816217002125000.2f55d256-845b-40be-897f-a29a1e3ff5e5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655737215835000.81b445c3-15a7-4517-8cf7-ae7c897b9a98",
+        "id" : "1706816217002125000.2f55d256-845b-40be-897f-a29a1e3ff5e5",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706655737397154000.451b3413-2ef0-42ba-8842-c1c05914c19b"
+            "reference" : "DiagnosticReport/1706816217188279000.b740e58f-ab16-4d69-be3a-6cbe5f58bb07"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655737224265000.2b4b0c5c-3434-4a45-b227-e5e4f0e957fc",
+      "fullUrl" : "Provenance/1706816217010449000.dc72584b-82a6-4bf9-be5f-a42e3054fd54",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655737224265000.2b4b0c5c-3434-4a45-b227-e5e4f0e957fc",
-        "recorded" : "2024-01-30T18:02:17Z",
+        "id" : "1706816217010449000.dc72584b-82a6-4bf9-be5f-a42e3054fd54",
+        "recorded" : "2024-02-01T14:36:57Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655737223843000.e6687680-f7a5-4a27-a38e-3a87468a3d3b"
+              "reference" : "Organization/1706816217009991000.d9f2d314-1096-44da-99e8-f318cdd30d90"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655737223843000.e6687680-f7a5-4a27-a38e-3a87468a3d3b",
+      "fullUrl" : "Organization/1706816217009991000.d9f2d314-1096-44da-99e8-f318cdd30d90",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655737223843000.e6687680-f7a5-4a27-a38e-3a87468a3d3b",
+        "id" : "1706816217009991000.d9f2d314-1096-44da-99e8-f318cdd30d90",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655737239658000.f8afaa1f-1025-4e28-9d05-943da7cf6ac6",
+      "fullUrl" : "Patient/1706816217026051000.2f95e53e-fd09-46fe-ad78-eb3350ae8eb8",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655737239658000.f8afaa1f-1025-4e28-9d05-943da7cf6ac6",
+        "id" : "1706816217026051000.2f95e53e-fd09-46fe-ad78-eb3350ae8eb8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -161,16 +166,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655737241463000.37ab0f80-1c00-4cb6-b5dd-3bc0e6f7779b",
+      "fullUrl" : "Provenance/1706816217027668000.e8a60051-a4d9-45da-a15c-4331dba8ec59",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655737241463000.37ab0f80-1c00-4cb6-b5dd-3bc0e6f7779b",
+        "id" : "1706816217027668000.e8a60051-a4d9-45da-a15c-4331dba8ec59",
         "target" : [
           {
-            "reference" : "Patient/1706655737239658000.f8afaa1f-1025-4e28-9d05-943da7cf6ac6"
+            "reference" : "Patient/1706816217026051000.2f95e53e-fd09-46fe-ad78-eb3350ae8eb8"
           }
         ],
-        "recorded" : "2024-01-30T18:02:17Z",
+        "recorded" : "2024-02-01T14:36:57Z",
         "activity" : {
           "coding" : [
             {
@@ -182,10 +187,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706655737246199000.291d9102-538d-4f5c-a9e9-63ab5da35f20",
+      "fullUrl" : "ServiceRequest/1706816217032716000.91f58673-ca06-4442-9b65-beeaf4cf10b3",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706655737246199000.291d9102-538d-4f5c-a9e9-63ab5da35f20",
+        "id" : "1706816217032716000.91f58673-ca06-4442-9b65-beeaf4cf10b3",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -201,18 +206,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655737239658000.f8afaa1f-1025-4e28-9d05-943da7cf6ac6"
+          "reference" : "Patient/1706816217026051000.2f95e53e-fd09-46fe-ad78-eb3350ae8eb8"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706655737397154000.451b3413-2ef0-42ba-8842-c1c05914c19b",
+      "fullUrl" : "DiagnosticReport/1706816217188279000.b740e58f-ab16-4d69-be3a-6cbe5f58bb07",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706655737397154000.451b3413-2ef0-42ba-8842-c1c05914c19b",
+        "id" : "1706816217188279000.b740e58f-ab16-4d69-be3a-6cbe5f58bb07",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706655737246199000.291d9102-538d-4f5c-a9e9-63ab5da35f20"
+            "reference" : "ServiceRequest/1706816217032716000.91f58673-ca06-4442-9b65-beeaf4cf10b3"
           }
         ],
         "status" : "final",
@@ -230,7 +235,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655737239658000.f8afaa1f-1025-4e28-9d05-943da7cf6ac6"
+          "reference" : "Patient/1706816217026051000.2f95e53e-fd09-46fe-ad78-eb3350ae8eb8"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-29-not-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-29-not-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655746580697000.5e8039ef-63e2-438f-bef0-ebec8e333468",
+  "id" : "1706816226345610000.24474a5d-63fb-490b-948c-bdc55b478af9",
   "meta" : {
-    "lastUpdated" : "2024-01-30T18:02:26.586-05:00"
+    "lastUpdated" : "2024-02-01T14:37:06.352-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655746651527000.7e5c1170-76bb-477b-a397-9dd06cc1d0b1"
+          "reference" : "Organization/1706816226399913000.edd53a0e-8b90-4492-addb-5866f6526211"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655746651527000.7e5c1170-76bb-477b-a397-9dd06cc1d0b1",
+      "fullUrl" : "Organization/1706816226399913000.edd53a0e-8b90-4492-addb-5866f6526211",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655746651527000.7e5c1170-76bb-477b-a397-9dd06cc1d0b1",
+        "id" : "1706816226399913000.edd53a0e-8b90-4492-addb-5866f6526211",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655746981186000.a0aef82d-ee69-4ffd-b5a3-7e55edc05495",
+      "fullUrl" : "Provenance/1706816226769018000.418ec5ec-7643-4d22-80d3-8a1e53f879ca",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655746981186000.a0aef82d-ee69-4ffd-b5a3-7e55edc05495",
+        "id" : "1706816226769018000.418ec5ec-7643-4d22-80d3-8a1e53f879ca",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706655747169424000.f085fd98-0da9-435c-be87-d992d2cf18fa"
+            "reference" : "DiagnosticReport/1706816226980488000.003821c3-eb01-442f-8417-1ac197637950"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655746989063000.875367a4-a360-492a-ace0-5180115a6071",
+      "fullUrl" : "Provenance/1706816226776753000.26ddaa34-de1c-4219-88df-216a5b1c6892",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655746989063000.875367a4-a360-492a-ace0-5180115a6071",
-        "recorded" : "2024-01-30T18:02:26Z",
+        "id" : "1706816226776753000.26ddaa34-de1c-4219-88df-216a5b1c6892",
+        "recorded" : "2024-02-01T14:37:06Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655746988332000.93923b22-75ac-4269-9ea7-7f19ea0a77f0"
+              "reference" : "Organization/1706816226776213000.ddefc226-a578-43eb-9e88-6fe9e118810c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655746988332000.93923b22-75ac-4269-9ea7-7f19ea0a77f0",
+      "fullUrl" : "Organization/1706816226776213000.ddefc226-a578-43eb-9e88-6fe9e118810c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655746988332000.93923b22-75ac-4269-9ea7-7f19ea0a77f0",
+        "id" : "1706816226776213000.ddefc226-a578-43eb-9e88-6fe9e118810c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655747005275000.a2dd7301-12fc-42b0-aa79-48887fa21973",
+      "fullUrl" : "Patient/1706816226792505000.b606fa70-b21f-4548-9755-2bd43d262c70",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655747005275000.a2dd7301-12fc-42b0-aa79-48887fa21973",
+        "id" : "1706816226792505000.b606fa70-b21f-4548-9755-2bd43d262c70",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -161,16 +166,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655747006003000.99f6e58a-b4a5-4b3f-8769-c1c98e0c723b",
+      "fullUrl" : "Provenance/1706816226793272000.935c935d-2900-4537-8d4f-7e1eda2f840d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655747006003000.99f6e58a-b4a5-4b3f-8769-c1c98e0c723b",
+        "id" : "1706816226793272000.935c935d-2900-4537-8d4f-7e1eda2f840d",
         "target" : [
           {
-            "reference" : "Patient/1706655747005275000.a2dd7301-12fc-42b0-aa79-48887fa21973"
+            "reference" : "Patient/1706816226792505000.b606fa70-b21f-4548-9755-2bd43d262c70"
           }
         ],
-        "recorded" : "2024-01-30T18:02:27Z",
+        "recorded" : "2024-02-01T14:37:06Z",
         "activity" : {
           "coding" : [
             {
@@ -182,10 +187,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706655747010683000.7e4e35c5-fae1-49a0-85b6-e3d15a93cbf9",
+      "fullUrl" : "ServiceRequest/1706816226798046000.d7454b35-c24b-4def-9fd6-754ecf71a6b7",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706655747010683000.7e4e35c5-fae1-49a0-85b6-e3d15a93cbf9",
+        "id" : "1706816226798046000.d7454b35-c24b-4def-9fd6-754ecf71a6b7",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -201,18 +206,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655747005275000.a2dd7301-12fc-42b0-aa79-48887fa21973"
+          "reference" : "Patient/1706816226792505000.b606fa70-b21f-4548-9755-2bd43d262c70"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706655747169424000.f085fd98-0da9-435c-be87-d992d2cf18fa",
+      "fullUrl" : "DiagnosticReport/1706816226980488000.003821c3-eb01-442f-8417-1ac197637950",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706655747169424000.f085fd98-0da9-435c-be87-d992d2cf18fa",
+        "id" : "1706816226980488000.003821c3-eb01-442f-8417-1ac197637950",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706655747010683000.7e4e35c5-fae1-49a0-85b6-e3d15a93cbf9"
+            "reference" : "ServiceRequest/1706816226798046000.d7454b35-c24b-4def-9fd6-754ecf71a6b7"
           }
         ],
         "status" : "final",
@@ -230,7 +235,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655747005275000.a2dd7301-12fc-42b0-aa79-48887fa21973"
+          "reference" : "Patient/1706816226792505000.b606fa70-b21f-4548-9755-2bd43d262c70"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-29-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-29-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655756174831000.700d8687-1b44-44e9-b0f4-ec7e8df3b93e",
+  "id" : "1706816236338723000.f777e45b-8e46-4928-bbaf-4998e1f1f86f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T18:02:36.182-05:00"
+    "lastUpdated" : "2024-02-01T14:37:16.345-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655756248513000.805e6dfc-a616-433c-86dc-9d8d5f07b8ad"
+          "reference" : "Organization/1706816236389962000.a4422e9b-1253-415f-8be3-ec5aae607533"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655756248513000.805e6dfc-a616-433c-86dc-9d8d5f07b8ad",
+      "fullUrl" : "Organization/1706816236389962000.a4422e9b-1253-415f-8be3-ec5aae607533",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655756248513000.805e6dfc-a616-433c-86dc-9d8d5f07b8ad",
+        "id" : "1706816236389962000.a4422e9b-1253-415f-8be3-ec5aae607533",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655756564004000.ed5e059e-64f7-43a4-986e-74f3de687e42",
+      "fullUrl" : "Provenance/1706816236739700000.702a768f-1253-44c3-8d73-a182c3d1beb5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655756564004000.ed5e059e-64f7-43a4-986e-74f3de687e42",
+        "id" : "1706816236739700000.702a768f-1253-44c3-8d73-a182c3d1beb5",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706655756783903000.604e0403-076b-42d8-9e55-53d42cdf67ba"
+            "reference" : "DiagnosticReport/1706816236932476000.7f0065d6-d784-45aa-9361-b5382ce26d53"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655756572523000.92278ebd-a854-47a3-adbc-5e1f60edaae4",
+      "fullUrl" : "Provenance/1706816236747568000.b4ca2946-d9b7-4f81-8aaf-07f7e2ff198f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655756572523000.92278ebd-a854-47a3-adbc-5e1f60edaae4",
-        "recorded" : "2024-01-30T18:02:36Z",
+        "id" : "1706816236747568000.b4ca2946-d9b7-4f81-8aaf-07f7e2ff198f",
+        "recorded" : "2024-02-01T14:37:16Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655756571117000.0fed956c-4e9b-4816-9c43-bfea802ceae3"
+              "reference" : "Organization/1706816236746769000.1a0ccac0-5901-4733-9d6f-4df6d5b1966a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655756571117000.0fed956c-4e9b-4816-9c43-bfea802ceae3",
+      "fullUrl" : "Organization/1706816236746769000.1a0ccac0-5901-4733-9d6f-4df6d5b1966a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655756571117000.0fed956c-4e9b-4816-9c43-bfea802ceae3",
+        "id" : "1706816236746769000.1a0ccac0-5901-4733-9d6f-4df6d5b1966a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,10 +147,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655756591856000.e4cbdc73-67dd-418c-95ca-d3f7125caeb3",
+      "fullUrl" : "Patient/1706816236772541000.96c100ee-0ffe-4a8c-bc9e-b01ad6c4baf2",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655756591856000.e4cbdc73-67dd-418c-95ca-d3f7125caeb3",
+        "id" : "1706816236772541000.96c100ee-0ffe-4a8c-bc9e-b01ad6c4baf2",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -169,16 +174,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655756592884000.38347f63-0181-42a5-82cf-ec3ff81fd52e",
+      "fullUrl" : "Provenance/1706816236773358000.37ac442a-148a-4ab2-8abc-59c1ab7123fd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655756592884000.38347f63-0181-42a5-82cf-ec3ff81fd52e",
+        "id" : "1706816236773358000.37ac442a-148a-4ab2-8abc-59c1ab7123fd",
         "target" : [
           {
-            "reference" : "Patient/1706655756591856000.e4cbdc73-67dd-418c-95ca-d3f7125caeb3"
+            "reference" : "Patient/1706816236772541000.96c100ee-0ffe-4a8c-bc9e-b01ad6c4baf2"
           }
         ],
-        "recorded" : "2024-01-30T18:02:36Z",
+        "recorded" : "2024-02-01T14:37:16Z",
         "activity" : {
           "coding" : [
             {
@@ -190,10 +195,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706655756597778000.2fccaadd-aa8f-4b78-a13a-dd70993d56a2",
+      "fullUrl" : "ServiceRequest/1706816236780908000.7a2b90ae-efb8-4554-b76a-6e499c24c3e7",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706655756597778000.2fccaadd-aa8f-4b78-a13a-dd70993d56a2",
+        "id" : "1706816236780908000.7a2b90ae-efb8-4554-b76a-6e499c24c3e7",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -209,18 +214,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655756591856000.e4cbdc73-67dd-418c-95ca-d3f7125caeb3"
+          "reference" : "Patient/1706816236772541000.96c100ee-0ffe-4a8c-bc9e-b01ad6c4baf2"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706655756783903000.604e0403-076b-42d8-9e55-53d42cdf67ba",
+      "fullUrl" : "DiagnosticReport/1706816236932476000.7f0065d6-d784-45aa-9361-b5382ce26d53",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706655756783903000.604e0403-076b-42d8-9e55-53d42cdf67ba",
+        "id" : "1706816236932476000.7f0065d6-d784-45aa-9361-b5382ce26d53",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706655756597778000.2fccaadd-aa8f-4b78-a13a-dd70993d56a2"
+            "reference" : "ServiceRequest/1706816236780908000.7a2b90ae-efb8-4554-b76a-6e499c24c3e7"
           }
         ],
         "status" : "final",
@@ -238,7 +243,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655756591856000.e4cbdc73-67dd-418c-95ca-d3f7125caeb3"
+          "reference" : "Patient/1706816236772541000.96c100ee-0ffe-4a8c-bc9e-b01ad6c4baf2"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-fully-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pid/pid-to-patient-pid-fully-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655765888737000.1bca8a24-9753-4e4a-ac81-93fed963a7ac",
+  "id" : "1706816246773574000.856d99c2-7e12-428b-90b6-226acce5e23a",
   "meta" : {
-    "lastUpdated" : "2024-01-30T18:02:45.896-05:00"
+    "lastUpdated" : "2024-02-01T14:37:26.780-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655765975682000.02c18162-840f-4ba5-97d7-68dc8ca5b022"
+          "reference" : "Organization/1706816246824889000.7ee27e4c-3e29-48e4-904a-c6ff5b64b160"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655765975682000.02c18162-840f-4ba5-97d7-68dc8ca5b022",
+      "fullUrl" : "Organization/1706816246824889000.7ee27e4c-3e29-48e4-904a-c6ff5b64b160",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655765975682000.02c18162-840f-4ba5-97d7-68dc8ca5b022",
+        "id" : "1706816246824889000.7ee27e4c-3e29-48e4-904a-c6ff5b64b160",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655766314339000.31a616de-acd8-4df9-879a-83294c9b3b80",
+      "fullUrl" : "Provenance/1706816247172491000.85451375-9d97-4ede-a6ed-dd9b95ee3370",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655766314339000.31a616de-acd8-4df9-879a-83294c9b3b80",
+        "id" : "1706816247172491000.85451375-9d97-4ede-a6ed-dd9b95ee3370",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706655766547746000.764dd84e-1d8d-45a2-b2a9-16562d643d1c"
+            "reference" : "DiagnosticReport/1706816247406073000.d113ed8d-b337-48b4-b2e1-f40f97e4b5d3"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655766322554000.e95c80bf-38c3-4e1e-95c0-2516c518cc63",
+      "fullUrl" : "Provenance/1706816247180892000.2b9a5a8e-8a0d-4173-89dd-5e88d535faf1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655766322554000.e95c80bf-38c3-4e1e-95c0-2516c518cc63",
-        "recorded" : "2024-01-30T18:02:46Z",
+        "id" : "1706816247180892000.2b9a5a8e-8a0d-4173-89dd-5e88d535faf1",
+        "recorded" : "2024-02-01T14:37:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655766322035000.b09e7504-11c6-43f2-90c9-28e42878d16d"
+              "reference" : "Organization/1706816247180369000.ffe3f650-6914-43c0-8b4e-c5eb1025ee86"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655766322035000.b09e7504-11c6-43f2-90c9-28e42878d16d",
+      "fullUrl" : "Organization/1706816247180369000.ffe3f650-6914-43c0-8b4e-c5eb1025ee86",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766322035000.b09e7504-11c6-43f2-90c9-28e42878d16d",
+        "id" : "1706816247180369000.ffe3f650-6914-43c0-8b4e-c5eb1025ee86",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,16 +147,16 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655766373827000.d58229b6-fa3f-446e-8860-0977176f1c4a",
+      "fullUrl" : "Patient/1706816247227136000.ebc004f7-4d80-4719-a17a-c25f1b5b2a52",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655766373827000.d58229b6-fa3f-446e-8860-0977176f1c4a",
+        "id" : "1706816247227136000.ebc004f7-4d80-4719-a17a-c25f1b5b2a52",
         "meta" : {
           "extension" : [
             {
               "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/last-updated-facility-namespace-id",
               "valueReference" : {
-                "reference" : "Organization/1706655766368430000.af7da894-5dfa-43e9-abad-7f9c65027721"
+                "reference" : "Organization/1706816247222456000.7bc5032a-3536-44ae-8891-f3dde1aa9944"
               }
             }
           ],
@@ -192,7 +197,7 @@
                     {
                       "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                       "valueReference" : {
-                        "reference" : "Organization/1706655766339962000.afdbaf70-8bf6-48be-829a-501eb667020b"
+                        "reference" : "Organization/1706816247196799000.aaa2a52c-c34e-4221-86ec-28b6c10a4d2c"
                       }
                     },
                     {
@@ -238,7 +243,7 @@
                     {
                       "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                       "valueReference" : {
-                        "reference" : "Organization/1706655766341104000.1f7a1aa8-af7c-4955-a918-5b874f1f1794"
+                        "reference" : "Organization/1706816247198021000.e77fc9b0-eb80-4c2c-8992-e43092bd4ac6"
                       }
                     },
                     {
@@ -1068,7 +1073,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655766329314000.fb5cafd7-1119-41f4-bc5f-5d4b6ad49045"
+                  "reference" : "Organization/1706816247187570000.6e6f1552-ac8b-43ee-8032-a502189b73fc"
                 }
               },
               {
@@ -1111,7 +1116,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655766331461000.7dc01d2b-17b6-434f-ada4-026da4bd37c2"
+                  "reference" : "Organization/1706816247189639000.9b24b871-8130-4d4e-9ed6-617ed5dd38f4"
                 }
               },
               {
@@ -1655,13 +1660,13 @@
         "link" : [
           {
             "other" : {
-              "reference" : "RelatedPerson/1706655766361880000.f824ad5a-8994-42e2-bc1e-153694512358"
+              "reference" : "RelatedPerson/1706816247216481000.05baaacb-77a3-4dc4-a2c3-b42ab1685195"
             },
             "type" : "seealso"
           },
           {
             "other" : {
-              "reference" : "RelatedPerson/1706655766362782000.4bb1b50d-cc0d-4757-a791-eb9205c90f93"
+              "reference" : "RelatedPerson/1706816247217446000.ffd7d309-d6c6-4dd6-8258-e53f24007e23"
             },
             "type" : "seealso"
           }
@@ -1669,10 +1674,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766329314000.fb5cafd7-1119-41f4-bc5f-5d4b6ad49045",
+      "fullUrl" : "Organization/1706816247187570000.6e6f1552-ac8b-43ee-8032-a502189b73fc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766329314000.fb5cafd7-1119-41f4-bc5f-5d4b6ad49045",
+        "id" : "1706816247187570000.6e6f1552-ac8b-43ee-8032-a502189b73fc",
         "identifier" : [
           {
             "extension" : [
@@ -1705,10 +1710,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766331461000.7dc01d2b-17b6-434f-ada4-026da4bd37c2",
+      "fullUrl" : "Organization/1706816247189639000.9b24b871-8130-4d4e-9ed6-617ed5dd38f4",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766331461000.7dc01d2b-17b6-434f-ada4-026da4bd37c2",
+        "id" : "1706816247189639000.9b24b871-8130-4d4e-9ed6-617ed5dd38f4",
         "identifier" : [
           {
             "extension" : [
@@ -1741,10 +1746,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766339962000.afdbaf70-8bf6-48be-829a-501eb667020b",
+      "fullUrl" : "Organization/1706816247196799000.aaa2a52c-c34e-4221-86ec-28b6c10a4d2c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766339962000.afdbaf70-8bf6-48be-829a-501eb667020b",
+        "id" : "1706816247196799000.aaa2a52c-c34e-4221-86ec-28b6c10a4d2c",
         "identifier" : [
           {
             "extension" : [
@@ -1777,10 +1782,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766341104000.1f7a1aa8-af7c-4955-a918-5b874f1f1794",
+      "fullUrl" : "Organization/1706816247198021000.e77fc9b0-eb80-4c2c-8992-e43092bd4ac6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766341104000.1f7a1aa8-af7c-4955-a918-5b874f1f1794",
+        "id" : "1706816247198021000.e77fc9b0-eb80-4c2c-8992-e43092bd4ac6",
         "identifier" : [
           {
             "extension" : [
@@ -1813,10 +1818,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766361161000.fdab6aab-01d8-4d9d-a303-b2c685fb2692",
+      "fullUrl" : "Organization/1706816247215589000.cc7750d5-dba8-483d-8b99-95c437a2caba",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766361161000.fdab6aab-01d8-4d9d-a303-b2c685fb2692",
+        "id" : "1706816247215589000.cc7750d5-dba8-483d-8b99-95c437a2caba",
         "identifier" : [
           {
             "extension" : [
@@ -1849,17 +1854,17 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655766361880000.f824ad5a-8994-42e2-bc1e-153694512358",
+      "fullUrl" : "RelatedPerson/1706816247216481000.05baaacb-77a3-4dc4-a2c3-b42ab1685195",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655766361880000.f824ad5a-8994-42e2-bc1e-153694512358",
+        "id" : "1706816247216481000.05baaacb-77a3-4dc4-a2c3-b42ab1685195",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655766361161000.fdab6aab-01d8-4d9d-a303-b2c685fb2692"
+                  "reference" : "Organization/1706816247215589000.cc7750d5-dba8-483d-8b99-95c437a2caba"
                 }
               },
               {
@@ -1897,10 +1902,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766362267000.e6f02704-cf91-4970-832f-54ca96d7358d",
+      "fullUrl" : "Organization/1706816247216992000.25814bb8-5acc-417c-ba40-8cd6936834e5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766362267000.e6f02704-cf91-4970-832f-54ca96d7358d",
+        "id" : "1706816247216992000.25814bb8-5acc-417c-ba40-8cd6936834e5",
         "identifier" : [
           {
             "extension" : [
@@ -1933,17 +1938,17 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655766362782000.4bb1b50d-cc0d-4757-a791-eb9205c90f93",
+      "fullUrl" : "RelatedPerson/1706816247217446000.ffd7d309-d6c6-4dd6-8258-e53f24007e23",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655766362782000.4bb1b50d-cc0d-4757-a791-eb9205c90f93",
+        "id" : "1706816247217446000.ffd7d309-d6c6-4dd6-8258-e53f24007e23",
         "identifier" : [
           {
             "extension" : [
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655766362267000.e6f02704-cf91-4970-832f-54ca96d7358d"
+                  "reference" : "Organization/1706816247216992000.25814bb8-5acc-417c-ba40-8cd6936834e5"
                 }
               },
               {
@@ -1981,10 +1986,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655766368430000.af7da894-5dfa-43e9-abad-7f9c65027721",
+      "fullUrl" : "Organization/1706816247222456000.7bc5032a-3536-44ae-8891-f3dde1aa9944",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766368430000.af7da894-5dfa-43e9-abad-7f9c65027721",
+        "id" : "1706816247222456000.7bc5032a-3536-44ae-8891-f3dde1aa9944",
         "identifier" : [
           {
             "extension" : [
@@ -2017,17 +2022,17 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655766386749000.0ff93429-49d2-4a3c-961c-fcfbb30dff6a",
+      "fullUrl" : "Provenance/1706816247242679000.9a25222a-9fb3-420b-86cf-8b300d60fe2b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655766386749000.0ff93429-49d2-4a3c-961c-fcfbb30dff6a",
+        "id" : "1706816247242679000.9a25222a-9fb3-420b-86cf-8b300d60fe2b",
         "target" : [
           {
-            "reference" : "Patient/1706655766373827000.d58229b6-fa3f-446e-8860-0977176f1c4a"
+            "reference" : "Patient/1706816247227136000.ebc004f7-4d80-4719-a17a-c25f1b5b2a52"
           }
         ],
         "occurredDateTime" : "2012-06-17T00:00:00-05:00",
-        "recorded" : "2024-01-30T18:02:46Z",
+        "recorded" : "2024-02-01T14:37:27Z",
         "activity" : {
           "coding" : [
             {
@@ -2047,17 +2052,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655766386357000.3389a37b-e95a-4f65-8ae1-de03d6c8e153"
+              "reference" : "Organization/1706816247242277000.135c1cde-8916-4700-b696-8a7c94650323"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655766386357000.3389a37b-e95a-4f65-8ae1-de03d6c8e153",
+      "fullUrl" : "Organization/1706816247242277000.135c1cde-8916-4700-b696-8a7c94650323",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655766386357000.3389a37b-e95a-4f65-8ae1-de03d6c8e153",
+        "id" : "1706816247242277000.135c1cde-8916-4700-b696-8a7c94650323",
         "identifier" : [
           {
             "extension" : [
@@ -2090,10 +2095,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706655766390846000.fede0200-12ec-436e-82e0-b51ba67e5b47",
+      "fullUrl" : "ServiceRequest/1706816247247465000.39820e65-3594-45a8-9ca4-3fdfb80350d0",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706655766390846000.fede0200-12ec-436e-82e0-b51ba67e5b47",
+        "id" : "1706816247247465000.39820e65-3594-45a8-9ca4-3fdfb80350d0",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -2109,18 +2114,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655766373827000.d58229b6-fa3f-446e-8860-0977176f1c4a"
+          "reference" : "Patient/1706816247227136000.ebc004f7-4d80-4719-a17a-c25f1b5b2a52"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706655766547746000.764dd84e-1d8d-45a2-b2a9-16562d643d1c",
+      "fullUrl" : "DiagnosticReport/1706816247406073000.d113ed8d-b337-48b4-b2e1-f40f97e4b5d3",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706655766547746000.764dd84e-1d8d-45a2-b2a9-16562d643d1c",
+        "id" : "1706816247406073000.d113ed8d-b337-48b4-b2e1-f40f97e4b5d3",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706655766390846000.fede0200-12ec-436e-82e0-b51ba67e5b47"
+            "reference" : "ServiceRequest/1706816247247465000.39820e65-3594-45a8-9ca4-3fdfb80350d0"
           }
         ],
         "status" : "final",
@@ -2138,7 +2143,7 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706655766373827000.d58229b6-fa3f-446e-8860-0977176f1c4a"
+          "reference" : "Patient/1706816247227136000.ebc004f7-4d80-4719-a17a-c25f1b5b2a52"
         }
       }
     }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-all-leaves.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-all-leaves.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311779133326000.7b7433c7-1d97-4ac5-ac69-a42893a59d82",
+  "id" : "1706816402783475000.0a428ced-6566-4eb2-aa75-27455d582926",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:29:39.147-06:00"
+    "lastUpdated" : "2024-02-01T14:40:02.790-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311779216162000.2711adef-a98e-48e1-a30f-02abdb473ba5"
+          "reference" : "Organization/1706816402834182000.ebdcc182-b919-4130-991c-bc282a6a4c0e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311779216162000.2711adef-a98e-48e1-a30f-02abdb473ba5",
+      "fullUrl" : "Organization/1706816402834182000.ebdcc182-b919-4130-991c-bc282a6a4c0e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311779216162000.2711adef-a98e-48e1-a30f-02abdb473ba5",
+        "id" : "1706816402834182000.ebdcc182-b919-4130-991c-bc282a6a4c0e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311779510387000.d4a32bff-4ba6-448e-992e-df63162aaed2",
+      "fullUrl" : "Provenance/1706816403189728000.1c7e609c-73df-40d7-8686-7cf40a2dccdd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311779510387000.d4a32bff-4ba6-448e-992e-df63162aaed2",
+        "id" : "1706816403189728000.1c7e609c-73df-40d7-8686-7cf40a2dccdd",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311779517434000.9dfa3e40-2e44-4723-a162-f7036f2ecfd7",
+      "fullUrl" : "Provenance/1706816403196906000.e6493345-be9c-4ba3-a826-a453f2c32c56",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311779517434000.9dfa3e40-2e44-4723-a162-f7036f2ecfd7",
-        "recorded" : "2024-01-26T17:29:39Z",
+        "id" : "1706816403196906000.e6493345-be9c-4ba3-a826-a453f2c32c56",
+        "recorded" : "2024-02-01T14:40:03Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311779516374000.c814f382-baec-4d1e-b4c3-20879c6388b9"
+              "reference" : "Organization/1706816403196437000.d9da1f87-2888-4e7c-9276-7ac690f4541b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311779516374000.c814f382-baec-4d1e-b4c3-20879c6388b9",
+      "fullUrl" : "Organization/1706816403196437000.d9da1f87-2888-4e7c-9276-7ac690f4541b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311779516374000.c814f382-baec-4d1e-b4c3-20879c6388b9",
+        "id" : "1706816403196437000.d9da1f87-2888-4e7c-9276-7ac690f4541b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311779531373000.04e07556-298a-48e9-a2ae-d687b2c3c1a1",
+      "fullUrl" : "Patient/1706816403210974000.ecf856d8-2d50-4e47-8e55-e248c12c121d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311779531373000.04e07556-298a-48e9-a2ae-d687b2c3c1a1"
+        "id" : "1706816403210974000.ecf856d8-2d50-4e47-8e55-e248c12c121d"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311779531967000.88870696-6e57-48de-bf82-89fce7d7f4d7",
+      "fullUrl" : "Provenance/1706816403211562000.95abeff4-615b-4027-ab6d-a0639d3449b5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311779531967000.88870696-6e57-48de-bf82-89fce7d7f4d7",
+        "id" : "1706816403211562000.95abeff4-615b-4027-ab6d-a0639d3449b5",
         "target" : [
           {
-            "reference" : "Patient/1706311779531373000.04e07556-298a-48e9-a2ae-d687b2c3c1a1"
+            "reference" : "Patient/1706816403210974000.ecf856d8-2d50-4e47-8e55-e248c12c121d"
           }
         ],
-        "recorded" : "2024-01-26T17:29:39Z",
+        "recorded" : "2024-02-01T14:40:03Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311779540443000.991a184c-1bae-4fa3-828c-5ee6f1f026f7",
+      "fullUrl" : "Encounter/1706816403220966000.9610bff7-4f2f-4811-bfcb-7d83520b162a",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311779540443000.991a184c-1bae-4fa3-828c-5ee6f1f026f7",
+        "id" : "1706816403220966000.9610bff7-4f2f-4811-bfcb-7d83520b162a",
         "subject" : {
-          "reference" : "Patient/1706311779531373000.04e07556-298a-48e9-a2ae-d687b2c3c1a1"
+          "reference" : "Patient/1706816403210974000.ecf856d8-2d50-4e47-8e55-e248c12c121d"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311779540633000.e8b33e81-71ee-437c-9008-6fdff3371af1"
+            "reference" : "EpisodeOfCare/1706816403221232000.866a22b6-d942-4ff1-b435-0022f829357c"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311779539545000.a418bc8e-5a50-40d0-8f41-8f15c53876e7"
+              "reference" : "Location/1706816403220478000.1c0d3f9e-f8a6-4f21-a01c-08e21b80dfc6"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311779535328000.b8035861-7227-4882-bf8c-c1e461b91fbb",
+      "fullUrl" : "Organization/1706816403215380000.d03feea4-a069-4942-8d9c-e1d02bb311bf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311779535328000.b8035861-7227-4882-bf8c-c1e461b91fbb",
+        "id" : "1706816403215380000.d03feea4-a069-4942-8d9c-e1d02bb311bf",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311779538485000.5e7a0d85-426b-4fc2-a8d3-f595077a7606",
+      "fullUrl" : "Location/1706816403219008000.2cf2d8f6-1d82-4867-992f-f4c2ee135fa6",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311779538485000.5e7a0d85-426b-4fc2-a8d3-f595077a7606",
+        "id" : "1706816403219008000.2cf2d8f6-1d82-4867-992f-f4c2ee135fa6",
         "identifier" : [
           {
             "extension" : [
@@ -280,10 +285,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311779538677000.7e4c1c84-2065-4ba8-9953-f5eeed07820a",
+      "fullUrl" : "Location/1706816403219187000.7c2502e9-46f5-44f6-9795-ed5494dce988",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311779538677000.7e4c1c84-2065-4ba8-9953-f5eeed07820a",
+        "id" : "1706816403219187000.7c2502e9-46f5-44f6-9795-ed5494dce988",
         "identifier" : [
           {
             "extension" : [
@@ -326,15 +331,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311779538485000.5e7a0d85-426b-4fc2-a8d3-f595077a7606"
+          "reference" : "Location/1706816403219008000.2cf2d8f6-1d82-4867-992f-f4c2ee135fa6"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311779538812000.3ddc2c6f-e393-4549-b6b6-e265ca45d725",
+      "fullUrl" : "Location/1706816403219357000.86847bdd-f3fc-44a8-9197-86cf6a62e12e",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311779538812000.3ddc2c6f-e393-4549-b6b6-e265ca45d725",
+        "id" : "1706816403219357000.86847bdd-f3fc-44a8-9197-86cf6a62e12e",
         "identifier" : [
           {
             "extension" : [
@@ -377,15 +382,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311779538677000.7e4c1c84-2065-4ba8-9953-f5eeed07820a"
+          "reference" : "Location/1706816403219187000.7c2502e9-46f5-44f6-9795-ed5494dce988"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311779538989000.cb27b6d6-286a-497b-8c26-8930fb961da7",
+      "fullUrl" : "Location/1706816403219532000.28e4b693-1957-4a76-9031-a3a66ea4f111",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311779538989000.cb27b6d6-286a-497b-8c26-8930fb961da7",
+        "id" : "1706816403219532000.28e4b693-1957-4a76-9031-a3a66ea4f111",
         "identifier" : [
           {
             "extension" : [
@@ -435,15 +440,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311779538812000.3ddc2c6f-e393-4549-b6b6-e265ca45d725"
+          "reference" : "Location/1706816403219357000.86847bdd-f3fc-44a8-9197-86cf6a62e12e"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311779539169000.86dea9c9-aab7-48da-9ed6-5955eed77bf7",
+      "fullUrl" : "Location/1706816403219687000.276f4946-f5d5-4194-856f-0ec65e1fc699",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311779539169000.86dea9c9-aab7-48da-9ed6-5955eed77bf7",
+        "id" : "1706816403219687000.276f4946-f5d5-4194-856f-0ec65e1fc699",
         "identifier" : [
           {
             "extension" : [
@@ -486,15 +491,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311779538989000.cb27b6d6-286a-497b-8c26-8930fb961da7"
+          "reference" : "Location/1706816403219532000.28e4b693-1957-4a76-9031-a3a66ea4f111"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311779539545000.a418bc8e-5a50-40d0-8f41-8f15c53876e7",
+      "fullUrl" : "Location/1706816403220478000.1c0d3f9e-f8a6-4f21-a01c-08e21b80dfc6",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311779539545000.a418bc8e-5a50-40d0-8f41-8f15c53876e7",
+        "id" : "1706816403220478000.1c0d3f9e-f8a6-4f21-a01c-08e21b80dfc6",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -554,7 +559,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311779535328000.b8035861-7227-4882-bf8c-c1e461b91fbb"
+              "reference" : "Organization/1706816403215380000.d03feea4-a069-4942-8d9c-e1d02bb311bf"
             }
           }
         ],
@@ -570,15 +575,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311779539169000.86dea9c9-aab7-48da-9ed6-5955eed77bf7"
+          "reference" : "Location/1706816403219687000.276f4946-f5d5-4194-856f-0ec65e1fc699"
         }
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311779540633000.e8b33e81-71ee-437c-9008-6fdff3371af1",
+      "fullUrl" : "EpisodeOfCare/1706816403221232000.866a22b6-d942-4ff1-b435-0022f829357c",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311779540633000.e8b33e81-71ee-437c-9008-6fdff3371af1",
+        "id" : "1706816403221232000.866a22b6-d942-4ff1-b435-0022f829357c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-missing-pl1-pl3.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-missing-pl1-pl3.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311787980015000.26d2b92d-d348-4f30-9b99-8bf188802e34",
+  "id" : "1706816413497326000.23c17c64-a04a-4aa8-aa25-c8379f3655ab",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:29:47.994-06:00"
+    "lastUpdated" : "2024-02-01T14:40:13.503-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311788064451000.88f92faf-48ea-47c5-96ac-90403ed414c1"
+          "reference" : "Organization/1706816413547109000.e12741d1-26b3-4405-a755-3a7af62eb14c"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311788064451000.88f92faf-48ea-47c5-96ac-90403ed414c1",
+      "fullUrl" : "Organization/1706816413547109000.e12741d1-26b3-4405-a755-3a7af62eb14c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311788064451000.88f92faf-48ea-47c5-96ac-90403ed414c1",
+        "id" : "1706816413547109000.e12741d1-26b3-4405-a755-3a7af62eb14c",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311788352717000.d2482ea3-e375-4c3b-869a-6bf77c97e86b",
+      "fullUrl" : "Provenance/1706816413888692000.56511ec3-bfbd-4e0d-9e20-d7fe40759465",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311788352717000.d2482ea3-e375-4c3b-869a-6bf77c97e86b",
+        "id" : "1706816413888692000.56511ec3-bfbd-4e0d-9e20-d7fe40759465",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311788360269000.a8f6b984-2eb1-4090-b899-8ec62aa0f276",
+      "fullUrl" : "Provenance/1706816413896144000.2516962c-417a-43cc-adac-43415826d8d6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311788360269000.a8f6b984-2eb1-4090-b899-8ec62aa0f276",
-        "recorded" : "2024-01-26T17:29:48Z",
+        "id" : "1706816413896144000.2516962c-417a-43cc-adac-43415826d8d6",
+        "recorded" : "2024-02-01T14:40:13Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311788359148000.5b38a283-59cd-475a-b655-2b333d6808ad"
+              "reference" : "Organization/1706816413895674000.d0ba8bb5-47ee-40c4-96b2-7dacfc8d2591"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311788359148000.5b38a283-59cd-475a-b655-2b333d6808ad",
+      "fullUrl" : "Organization/1706816413895674000.d0ba8bb5-47ee-40c4-96b2-7dacfc8d2591",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311788359148000.5b38a283-59cd-475a-b655-2b333d6808ad",
+        "id" : "1706816413895674000.d0ba8bb5-47ee-40c4-96b2-7dacfc8d2591",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311788372704000.913bfba5-6f66-4f84-aed0-26635761471a",
+      "fullUrl" : "Patient/1706816413910571000.d0747f23-ace2-482d-8a8b-84a0b30a9590",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311788372704000.913bfba5-6f66-4f84-aed0-26635761471a"
+        "id" : "1706816413910571000.d0747f23-ace2-482d-8a8b-84a0b30a9590"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311788373250000.43f2ba4d-d5a8-486b-bdd0-224ddd79c022",
+      "fullUrl" : "Provenance/1706816413911213000.3d6312ae-7998-4542-9100-975ed04b0fbc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311788373250000.43f2ba4d-d5a8-486b-bdd0-224ddd79c022",
+        "id" : "1706816413911213000.3d6312ae-7998-4542-9100-975ed04b0fbc",
         "target" : [
           {
-            "reference" : "Patient/1706311788372704000.913bfba5-6f66-4f84-aed0-26635761471a"
+            "reference" : "Patient/1706816413910571000.d0747f23-ace2-482d-8a8b-84a0b30a9590"
           }
         ],
-        "recorded" : "2024-01-26T17:29:48Z",
+        "recorded" : "2024-02-01T14:40:13Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311788380845000.ec457b5a-0ed7-4744-9e33-79e049e192ca",
+      "fullUrl" : "Encounter/1706816413919702000.66d08179-fe28-40d3-a082-e584f2acd86b",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311788380845000.ec457b5a-0ed7-4744-9e33-79e049e192ca",
+        "id" : "1706816413919702000.66d08179-fe28-40d3-a082-e584f2acd86b",
         "subject" : {
-          "reference" : "Patient/1706311788372704000.913bfba5-6f66-4f84-aed0-26635761471a"
+          "reference" : "Patient/1706816413910571000.d0747f23-ace2-482d-8a8b-84a0b30a9590"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311788381067000.b252fa0c-d7e9-42ef-b561-93fbc8b7347c"
+            "reference" : "EpisodeOfCare/1706816413919956000.686c324e-1579-47bc-8f8f-d43c9d30f98f"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311788380417000.6c5e47a1-fb0b-44af-b24f-863fd094cbf9"
+              "reference" : "Location/1706816413919404000.15d59995-8d0b-41b2-9d87-74925cb8a50b"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311788377010000.537fe6a7-3c8f-44f5-8355-4c05d1bdc632",
+      "fullUrl" : "Organization/1706816413914872000.c1c98ead-5a5f-487a-b8fd-4eff7502c074",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311788377010000.537fe6a7-3c8f-44f5-8355-4c05d1bdc632",
+        "id" : "1706816413914872000.c1c98ead-5a5f-487a-b8fd-4eff7502c074",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311788379636000.204d2e0f-e2bc-4f9d-9862-72bd4d16e82f",
+      "fullUrl" : "Location/1706816413917820000.291a302c-5908-456e-837d-431477d9a874",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311788379636000.204d2e0f-e2bc-4f9d-9862-72bd4d16e82f",
+        "id" : "1706816413917820000.291a302c-5908-456e-837d-431477d9a874",
         "identifier" : [
           {
             "extension" : [
@@ -280,10 +285,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311788379806000.a2a227ac-1fcc-482c-95ca-505685f2a6ba",
+      "fullUrl" : "Location/1706816413918579000.ba251fb3-b5e0-46f9-8910-f4771bd8509c",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311788379806000.a2a227ac-1fcc-482c-95ca-505685f2a6ba",
+        "id" : "1706816413918579000.ba251fb3-b5e0-46f9-8910-f4771bd8509c",
         "identifier" : [
           {
             "extension" : [
@@ -326,15 +331,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311788379636000.204d2e0f-e2bc-4f9d-9862-72bd4d16e82f"
+          "reference" : "Location/1706816413917820000.291a302c-5908-456e-837d-431477d9a874"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311788379931000.47fb314e-f4a6-4b9c-a1e2-798671d96b25",
+      "fullUrl" : "Location/1706816413918766000.65dae662-b33c-4dca-bec7-02b170f7d4e7",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311788379931000.47fb314e-f4a6-4b9c-a1e2-798671d96b25",
+        "id" : "1706816413918766000.65dae662-b33c-4dca-bec7-02b170f7d4e7",
         "identifier" : [
           {
             "extension" : [
@@ -377,15 +382,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311788379806000.a2a227ac-1fcc-482c-95ca-505685f2a6ba"
+          "reference" : "Location/1706816413918579000.ba251fb3-b5e0-46f9-8910-f4771bd8509c"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311788380088000.e762c39b-d40b-432c-a30a-7bd1ef7bcea8",
+      "fullUrl" : "Location/1706816413918981000.df8a695a-7077-4b77-95cb-652190fba0ca",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311788380088000.e762c39b-d40b-432c-a30a-7bd1ef7bcea8",
+        "id" : "1706816413918981000.df8a695a-7077-4b77-95cb-652190fba0ca",
         "identifier" : [
           {
             "extension" : [
@@ -428,15 +433,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311788379931000.47fb314e-f4a6-4b9c-a1e2-798671d96b25"
+          "reference" : "Location/1706816413918766000.65dae662-b33c-4dca-bec7-02b170f7d4e7"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311788380417000.6c5e47a1-fb0b-44af-b24f-863fd094cbf9",
+      "fullUrl" : "Location/1706816413919404000.15d59995-8d0b-41b2-9d87-74925cb8a50b",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311788380417000.6c5e47a1-fb0b-44af-b24f-863fd094cbf9",
+        "id" : "1706816413919404000.15d59995-8d0b-41b2-9d87-74925cb8a50b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -496,7 +501,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311788377010000.537fe6a7-3c8f-44f5-8355-4c05d1bdc632"
+              "reference" : "Organization/1706816413914872000.c1c98ead-5a5f-487a-b8fd-4eff7502c074"
             }
           }
         ],
@@ -512,15 +517,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311788380088000.e762c39b-d40b-432c-a30a-7bd1ef7bcea8"
+          "reference" : "Location/1706816413918981000.df8a695a-7077-4b77-95cb-652190fba0ca"
         }
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311788381067000.b252fa0c-d7e9-42ef-b561-93fbc8b7347c",
+      "fullUrl" : "EpisodeOfCare/1706816413919956000.686c324e-1579-47bc-8f8f-d43c9d30f98f",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311788381067000.b252fa0c-d7e9-42ef-b561-93fbc8b7347c",
+        "id" : "1706816413919956000.686c324e-1579-47bc-8f8f-d43c9d30f98f",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-missing-pl1.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-missing-pl1.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311796516346000.58f4708f-30c4-4051-a34b-8b5835d9b603",
+  "id" : "1706816423461660000.f048130f-e4eb-46f1-bd98-3cb528f9300a",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:29:56.530-06:00"
+    "lastUpdated" : "2024-02-01T14:40:23.468-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311796605361000.53cece04-148a-4380-8951-41a379351abb"
+          "reference" : "Organization/1706816423514918000.725fac4d-7cd0-4aee-9091-176f484c47c5"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311796605361000.53cece04-148a-4380-8951-41a379351abb",
+      "fullUrl" : "Organization/1706816423514918000.725fac4d-7cd0-4aee-9091-176f484c47c5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311796605361000.53cece04-148a-4380-8951-41a379351abb",
+        "id" : "1706816423514918000.725fac4d-7cd0-4aee-9091-176f484c47c5",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311796890094000.3dad5c31-09dd-4c88-aa4b-85053bdaf0d9",
+      "fullUrl" : "Provenance/1706816423916230000.c08da603-d2f6-4cd3-9a88-f2929213739b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311796890094000.3dad5c31-09dd-4c88-aa4b-85053bdaf0d9",
+        "id" : "1706816423916230000.c08da603-d2f6-4cd3-9a88-f2929213739b",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311796897316000.5d5471dc-26c5-4b4f-8cc1-39a63f2cb002",
+      "fullUrl" : "Provenance/1706816423924720000.c5b50b95-8766-43cd-8ad1-969b5887ecec",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311796897316000.5d5471dc-26c5-4b4f-8cc1-39a63f2cb002",
-        "recorded" : "2024-01-26T17:29:56Z",
+        "id" : "1706816423924720000.c5b50b95-8766-43cd-8ad1-969b5887ecec",
+        "recorded" : "2024-02-01T14:40:23Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311796896790000.cdc902da-b78b-4b69-99dc-cc74a0e0ec21"
+              "reference" : "Organization/1706816423924178000.4cd23ac9-40a5-4974-9453-e1b5893ce2d8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311796896790000.cdc902da-b78b-4b69-99dc-cc74a0e0ec21",
+      "fullUrl" : "Organization/1706816423924178000.4cd23ac9-40a5-4974-9453-e1b5893ce2d8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311796896790000.cdc902da-b78b-4b69-99dc-cc74a0e0ec21",
+        "id" : "1706816423924178000.4cd23ac9-40a5-4974-9453-e1b5893ce2d8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311796910001000.1ffa61cc-e120-465c-aad8-401ac1dd5541",
+      "fullUrl" : "Patient/1706816423940578000.0c8a7b0b-1366-4a1d-9c6a-d5592444f650",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311796910001000.1ffa61cc-e120-465c-aad8-401ac1dd5541"
+        "id" : "1706816423940578000.0c8a7b0b-1366-4a1d-9c6a-d5592444f650"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311796910583000.deb0440d-7ae2-4686-a934-3368d7eb1ec9",
+      "fullUrl" : "Provenance/1706816423941451000.0885a54b-79c8-458d-8fff-aa525565a39b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311796910583000.deb0440d-7ae2-4686-a934-3368d7eb1ec9",
+        "id" : "1706816423941451000.0885a54b-79c8-458d-8fff-aa525565a39b",
         "target" : [
           {
-            "reference" : "Patient/1706311796910001000.1ffa61cc-e120-465c-aad8-401ac1dd5541"
+            "reference" : "Patient/1706816423940578000.0c8a7b0b-1366-4a1d-9c6a-d5592444f650"
           }
         ],
-        "recorded" : "2024-01-26T17:29:56Z",
+        "recorded" : "2024-02-01T14:40:23Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311796919736000.7ed26a79-d255-46de-83f0-c5bfdbc9ff2a",
+      "fullUrl" : "Encounter/1706816423949301000.40c3498d-1003-4c89-a85a-30f90821d20e",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311796919736000.7ed26a79-d255-46de-83f0-c5bfdbc9ff2a",
+        "id" : "1706816423949301000.40c3498d-1003-4c89-a85a-30f90821d20e",
         "subject" : {
-          "reference" : "Patient/1706311796910001000.1ffa61cc-e120-465c-aad8-401ac1dd5541"
+          "reference" : "Patient/1706816423940578000.0c8a7b0b-1366-4a1d-9c6a-d5592444f650"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311796920021000.34d86374-1f34-48c9-a611-0340f06a4f6c"
+            "reference" : "EpisodeOfCare/1706816423949521000.8b51bf83-673a-4a4e-8406-e79f2a7960e2"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311796919477000.750c7fb5-2a23-4280-8ce4-3c7e6e937feb"
+              "reference" : "Location/1706816423948976000.0839279b-97ac-49e9-97b5-b638c800d048"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311796914859000.31b96c62-d9e7-4e72-bcee-71d639f69e47",
+      "fullUrl" : "Organization/1706816423945176000.a0802b79-d329-4518-87b5-edea3ba97cdc",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311796914859000.31b96c62-d9e7-4e72-bcee-71d639f69e47",
+        "id" : "1706816423945176000.a0802b79-d329-4518-87b5-edea3ba97cdc",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311796918512000.19631d30-4a26-446d-a84f-25be4ef87714",
+      "fullUrl" : "Location/1706816423947962000.0e146bbd-c9e4-416e-b842-06349a366710",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311796918512000.19631d30-4a26-446d-a84f-25be4ef87714",
+        "id" : "1706816423947962000.0e146bbd-c9e4-416e-b842-06349a366710",
         "identifier" : [
           {
             "extension" : [
@@ -280,10 +285,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311796918680000.a71acd14-2290-42fa-8677-d27be3fd8afd",
+      "fullUrl" : "Location/1706816423948138000.8b7541ad-22e7-41fa-8d48-87649aef4e33",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311796918680000.a71acd14-2290-42fa-8677-d27be3fd8afd",
+        "id" : "1706816423948138000.8b7541ad-22e7-41fa-8d48-87649aef4e33",
         "identifier" : [
           {
             "extension" : [
@@ -326,15 +331,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311796918512000.19631d30-4a26-446d-a84f-25be4ef87714"
+          "reference" : "Location/1706816423947962000.0e146bbd-c9e4-416e-b842-06349a366710"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311796918815000.7c9cb161-7532-4f92-86d7-dde9f26a243a",
+      "fullUrl" : "Location/1706816423948331000.ec486c1e-a63e-4376-a00d-5ee76148bdcd",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311796918815000.7c9cb161-7532-4f92-86d7-dde9f26a243a",
+        "id" : "1706816423948331000.ec486c1e-a63e-4376-a00d-5ee76148bdcd",
         "identifier" : [
           {
             "extension" : [
@@ -377,15 +382,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311796918680000.a71acd14-2290-42fa-8677-d27be3fd8afd"
+          "reference" : "Location/1706816423948138000.8b7541ad-22e7-41fa-8d48-87649aef4e33"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311796919092000.f4a1dcd9-a0cf-46f5-a3e8-9d838504c36a",
+      "fullUrl" : "Location/1706816423948581000.6a14c88f-3039-4169-ba92-0bd61c70a7ec",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311796919092000.f4a1dcd9-a0cf-46f5-a3e8-9d838504c36a",
+        "id" : "1706816423948581000.6a14c88f-3039-4169-ba92-0bd61c70a7ec",
         "identifier" : [
           {
             "extension" : [
@@ -428,15 +433,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311796918815000.7c9cb161-7532-4f92-86d7-dde9f26a243a"
+          "reference" : "Location/1706816423948331000.ec486c1e-a63e-4376-a00d-5ee76148bdcd"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311796919477000.750c7fb5-2a23-4280-8ce4-3c7e6e937feb",
+      "fullUrl" : "Location/1706816423948976000.0839279b-97ac-49e9-97b5-b638c800d048",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311796919477000.750c7fb5-2a23-4280-8ce4-3c7e6e937feb",
+        "id" : "1706816423948976000.0839279b-97ac-49e9-97b5-b638c800d048",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -496,7 +501,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311796914859000.31b96c62-d9e7-4e72-bcee-71d639f69e47"
+              "reference" : "Organization/1706816423945176000.a0802b79-d329-4518-87b5-edea3ba97cdc"
             }
           }
         ],
@@ -512,15 +517,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311796919092000.f4a1dcd9-a0cf-46f5-a3e8-9d838504c36a"
+          "reference" : "Location/1706816423948581000.6a14c88f-3039-4169-ba92-0bd61c70a7ec"
         }
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311796920021000.34d86374-1f34-48c9-a611-0340f06a4f6c",
+      "fullUrl" : "EpisodeOfCare/1706816423949521000.8b51bf83-673a-4a4e-8406-e79f2a7960e2",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311796920021000.34d86374-1f34-48c9-a611-0340f06a4f6c",
+        "id" : "1706816423949521000.8b51bf83-673a-4a4e-8406-e79f2a7960e2",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-missing-pl7.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-missing-pl7.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311805185511000.badbb274-ed8c-4b2c-a9ba-2ee5c249ce38",
+  "id" : "1706816433609103000.84ae3cd7-d80a-4bee-9259-79a836de8fd5",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:30:05.199-06:00"
+    "lastUpdated" : "2024-02-01T14:40:33.616-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311805280182000.49e4db82-3190-4097-8443-fbaf7da678b0"
+          "reference" : "Organization/1706816433661375000.91cbcf22-0061-4863-a30b-5d8a8320a9a5"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311805280182000.49e4db82-3190-4097-8443-fbaf7da678b0",
+      "fullUrl" : "Organization/1706816433661375000.91cbcf22-0061-4863-a30b-5d8a8320a9a5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311805280182000.49e4db82-3190-4097-8443-fbaf7da678b0",
+        "id" : "1706816433661375000.91cbcf22-0061-4863-a30b-5d8a8320a9a5",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311805572779000.b9fb2fb6-7b71-4c88-a4f8-828f1efa17f9",
+      "fullUrl" : "Provenance/1706816434021344000.8dbcaa72-2d98-485f-aa8b-eaafb8468a5f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311805572779000.b9fb2fb6-7b71-4c88-a4f8-828f1efa17f9",
+        "id" : "1706816434021344000.8dbcaa72-2d98-485f-aa8b-eaafb8468a5f",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311805580026000.61528b62-9456-4d8d-8a8c-3c263d1dfb45",
+      "fullUrl" : "Provenance/1706816434029425000.6d8942c4-2098-4bc4-bc05-1840b60cd7bc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311805580026000.61528b62-9456-4d8d-8a8c-3c263d1dfb45",
-        "recorded" : "2024-01-26T17:30:05Z",
+        "id" : "1706816434029425000.6d8942c4-2098-4bc4-bc05-1840b60cd7bc",
+        "recorded" : "2024-02-01T14:40:34Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311805578714000.524777d0-681b-4575-b6f9-5a28c6023a7e"
+              "reference" : "Organization/1706816434028904000.e12640ea-23e5-4c6a-8be2-5ce2726f1166"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311805578714000.524777d0-681b-4575-b6f9-5a28c6023a7e",
+      "fullUrl" : "Organization/1706816434028904000.e12640ea-23e5-4c6a-8be2-5ce2726f1166",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311805578714000.524777d0-681b-4575-b6f9-5a28c6023a7e",
+        "id" : "1706816434028904000.e12640ea-23e5-4c6a-8be2-5ce2726f1166",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311805592690000.424b5091-1a54-4f7c-8bae-70e75f8ff125",
+      "fullUrl" : "Patient/1706816434044136000.b6caa0e5-aaff-450b-be9d-207af7fbb7eb",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311805592690000.424b5091-1a54-4f7c-8bae-70e75f8ff125"
+        "id" : "1706816434044136000.b6caa0e5-aaff-450b-be9d-207af7fbb7eb"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311805593259000.f3b7706b-9e6b-4582-9010-fc0007a9b629",
+      "fullUrl" : "Provenance/1706816434045009000.48fda5ef-cfc4-4aec-94af-4612d292cb9f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311805593259000.f3b7706b-9e6b-4582-9010-fc0007a9b629",
+        "id" : "1706816434045009000.48fda5ef-cfc4-4aec-94af-4612d292cb9f",
         "target" : [
           {
-            "reference" : "Patient/1706311805592690000.424b5091-1a54-4f7c-8bae-70e75f8ff125"
+            "reference" : "Patient/1706816434044136000.b6caa0e5-aaff-450b-be9d-207af7fbb7eb"
           }
         ],
-        "recorded" : "2024-01-26T17:30:05Z",
+        "recorded" : "2024-02-01T14:40:34Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311805600851000.fad6b01c-d644-46cf-8b43-29b0d1fb067b",
+      "fullUrl" : "Encounter/1706816434054100000.805d14d4-75b6-460e-ba67-5105d9d8622e",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311805600851000.fad6b01c-d644-46cf-8b43-29b0d1fb067b",
+        "id" : "1706816434054100000.805d14d4-75b6-460e-ba67-5105d9d8622e",
         "subject" : {
-          "reference" : "Patient/1706311805592690000.424b5091-1a54-4f7c-8bae-70e75f8ff125"
+          "reference" : "Patient/1706816434044136000.b6caa0e5-aaff-450b-be9d-207af7fbb7eb"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311805601057000.46ed35fd-a22b-4388-a1d4-f5a73b5704db"
+            "reference" : "EpisodeOfCare/1706816434054341000.3b9ca81f-e034-41f0-8d6e-da9ed12e5145"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311805600598000.d7fcb63e-6127-4ceb-baa1-b95833481301"
+              "reference" : "Location/1706816434053820000.78c76d73-be9d-4def-8d9c-736244d5e28b"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311805596748000.04c934f5-5e35-499c-904f-a0abb4c59f86",
+      "fullUrl" : "Organization/1706816434048874000.66d50cdb-313b-4c53-a613-638428718d32",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311805596748000.04c934f5-5e35-499c-904f-a0abb4c59f86",
+        "id" : "1706816434048874000.66d50cdb-313b-4c53-a613-638428718d32",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311805599768000.8e8ad708-8afd-43c3-8bb0-007fb72fcc83",
+      "fullUrl" : "Location/1706816434052715000.893fd071-18c4-4564-a90f-95fb7159f428",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311805599768000.8e8ad708-8afd-43c3-8bb0-007fb72fcc83",
+        "id" : "1706816434052715000.893fd071-18c4-4564-a90f-95fb7159f428",
         "identifier" : [
           {
             "extension" : [
@@ -280,10 +285,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311805599931000.aa7d38cb-4e3d-472f-bc27-12d30006923a",
+      "fullUrl" : "Location/1706816434052895000.e367cdb4-51f6-4c6c-b519-f05cc6943cf3",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311805599931000.aa7d38cb-4e3d-472f-bc27-12d30006923a",
+        "id" : "1706816434052895000.e367cdb4-51f6-4c6c-b519-f05cc6943cf3",
         "identifier" : [
           {
             "extension" : [
@@ -326,15 +331,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311805599768000.8e8ad708-8afd-43c3-8bb0-007fb72fcc83"
+          "reference" : "Location/1706816434052715000.893fd071-18c4-4564-a90f-95fb7159f428"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311805600069000.a623a0e6-df64-4c95-b129-47d70c4c4043",
+      "fullUrl" : "Location/1706816434053129000.f568a890-809e-4c29-a514-f94fce16c658",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311805600069000.a623a0e6-df64-4c95-b129-47d70c4c4043",
+        "id" : "1706816434053129000.f568a890-809e-4c29-a514-f94fce16c658",
         "identifier" : [
           {
             "extension" : [
@@ -384,15 +389,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311805599931000.aa7d38cb-4e3d-472f-bc27-12d30006923a"
+          "reference" : "Location/1706816434052895000.e367cdb4-51f6-4c6c-b519-f05cc6943cf3"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311805600232000.95170dad-7efc-45be-a810-19606f88423e",
+      "fullUrl" : "Location/1706816434053369000.c10c4439-8285-4e77-8d54-84d9137d8bf0",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311805600232000.95170dad-7efc-45be-a810-19606f88423e",
+        "id" : "1706816434053369000.c10c4439-8285-4e77-8d54-84d9137d8bf0",
         "identifier" : [
           {
             "extension" : [
@@ -435,15 +440,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311805600069000.a623a0e6-df64-4c95-b129-47d70c4c4043"
+          "reference" : "Location/1706816434053129000.f568a890-809e-4c29-a514-f94fce16c658"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311805600598000.d7fcb63e-6127-4ceb-baa1-b95833481301",
+      "fullUrl" : "Location/1706816434053820000.78c76d73-be9d-4def-8d9c-736244d5e28b",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311805600598000.d7fcb63e-6127-4ceb-baa1-b95833481301",
+        "id" : "1706816434053820000.78c76d73-be9d-4def-8d9c-736244d5e28b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -503,7 +508,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311805596748000.04c934f5-5e35-499c-904f-a0abb4c59f86"
+              "reference" : "Organization/1706816434048874000.66d50cdb-313b-4c53-a613-638428718d32"
             }
           }
         ],
@@ -519,15 +524,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311805600232000.95170dad-7efc-45be-a810-19606f88423e"
+          "reference" : "Location/1706816434053369000.c10c4439-8285-4e77-8d54-84d9137d8bf0"
         }
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311805601057000.46ed35fd-a22b-4388-a1d4-f5a73b5704db",
+      "fullUrl" : "EpisodeOfCare/1706816434054341000.3b9ca81f-e034-41f0-8d6e-da9ed12e5145",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311805601057000.46ed35fd-a22b-4388-a1d4-f5a73b5704db",
+        "id" : "1706816434054341000.3b9ca81f-e034-41f0-8d6e-da9ed12e5145",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-only-pl3-pl1-pl4.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-only-pl3-pl1-pl4.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311814788087000.9b8b8e6f-598b-4fe2-ae70-46f3fcc9e9af",
+  "id" : "1706816443483364000.b1767dc0-5762-43a5-8c23-a2b2a70c8d2c",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:30:14.803-06:00"
+    "lastUpdated" : "2024-02-01T14:40:43.493-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311814877351000.88e3a52b-5b9b-4240-a8cc-1cec18c45449"
+          "reference" : "Organization/1706816443539980000.016b3d93-d5eb-476f-b412-2386ae84050c"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311814877351000.88e3a52b-5b9b-4240-a8cc-1cec18c45449",
+      "fullUrl" : "Organization/1706816443539980000.016b3d93-d5eb-476f-b412-2386ae84050c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311814877351000.88e3a52b-5b9b-4240-a8cc-1cec18c45449",
+        "id" : "1706816443539980000.016b3d93-d5eb-476f-b412-2386ae84050c",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311815172579000.61a4a9c4-71fa-4413-9084-8ddd86c2dc04",
+      "fullUrl" : "Provenance/1706816443901399000.c77a887e-5963-48a3-a2cc-5549a72ffd66",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311815172579000.61a4a9c4-71fa-4413-9084-8ddd86c2dc04",
+        "id" : "1706816443901399000.c77a887e-5963-48a3-a2cc-5549a72ffd66",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311815179757000.c03e19ef-19bc-4d42-9e2f-3f650bb5152b",
+      "fullUrl" : "Provenance/1706816443909706000.968dd1f3-1910-4a81-83ae-26b0fddd9cef",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311815179757000.c03e19ef-19bc-4d42-9e2f-3f650bb5152b",
-        "recorded" : "2024-01-26T17:30:15Z",
+        "id" : "1706816443909706000.968dd1f3-1910-4a81-83ae-26b0fddd9cef",
+        "recorded" : "2024-02-01T14:40:43Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311815179239000.f8cb3108-4327-4424-94ee-5f07e9e84afc"
+              "reference" : "Organization/1706816443909257000.fb0d42f6-c761-4287-bf91-647b29fe46e8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311815179239000.f8cb3108-4327-4424-94ee-5f07e9e84afc",
+      "fullUrl" : "Organization/1706816443909257000.fb0d42f6-c761-4287-bf91-647b29fe46e8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311815179239000.f8cb3108-4327-4424-94ee-5f07e9e84afc",
+        "id" : "1706816443909257000.fb0d42f6-c761-4287-bf91-647b29fe46e8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311815192524000.02559076-7668-49ee-9a34-ed76b87fb765",
+      "fullUrl" : "Patient/1706816443926450000.bbb1f246-6542-42c7-88b9-3d62da861581",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311815192524000.02559076-7668-49ee-9a34-ed76b87fb765"
+        "id" : "1706816443926450000.bbb1f246-6542-42c7-88b9-3d62da861581"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311815193100000.d44ec2f6-4a7d-4b1f-b5ca-f87be41d0bbf",
+      "fullUrl" : "Provenance/1706816443927409000.b8bb625a-57fa-4107-b9ff-583bed3f824a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311815193100000.d44ec2f6-4a7d-4b1f-b5ca-f87be41d0bbf",
+        "id" : "1706816443927409000.b8bb625a-57fa-4107-b9ff-583bed3f824a",
         "target" : [
           {
-            "reference" : "Patient/1706311815192524000.02559076-7668-49ee-9a34-ed76b87fb765"
+            "reference" : "Patient/1706816443926450000.bbb1f246-6542-42c7-88b9-3d62da861581"
           }
         ],
-        "recorded" : "2024-01-26T17:30:15Z",
+        "recorded" : "2024-02-01T14:40:43Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311815200044000.88aa9f6f-82a7-4e83-8fbd-910a5ad56b6d",
+      "fullUrl" : "Encounter/1706816443936122000.5469e085-bf75-4884-acec-93f6128908a6",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311815200044000.88aa9f6f-82a7-4e83-8fbd-910a5ad56b6d",
+        "id" : "1706816443936122000.5469e085-bf75-4884-acec-93f6128908a6",
         "subject" : {
-          "reference" : "Patient/1706311815192524000.02559076-7668-49ee-9a34-ed76b87fb765"
+          "reference" : "Patient/1706816443926450000.bbb1f246-6542-42c7-88b9-3d62da861581"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311815200246000.8f9e0a29-e4d4-4586-b2fe-14a331adf6a9"
+            "reference" : "EpisodeOfCare/1706816443936360000.c55a2e51-0518-408e-9cee-9fad27c83613"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311815199802000.ecdc00e9-a6ca-4c74-9efb-1904089bde28"
+              "reference" : "Location/1706816443935788000.c4156d0e-e42d-4ff5-af42-21a991da38f3"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311815197372000.38e4178b-581f-4c0f-b85b-7a678e5e341d",
+      "fullUrl" : "Organization/1706816443932764000.f09a257a-72a3-405c-9d4d-c49121d88263",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311815197372000.38e4178b-581f-4c0f-b85b-7a678e5e341d",
+        "id" : "1706816443932764000.f09a257a-72a3-405c-9d4d-c49121d88263",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311815199082000.65f44403-2d2d-4d51-811f-a6d029ff7183",
+      "fullUrl" : "Location/1706816443934941000.c88607cf-9f41-4e3f-9896-08e550076abd",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311815199082000.65f44403-2d2d-4d51-811f-a6d029ff7183",
+        "id" : "1706816443934941000.c88607cf-9f41-4e3f-9896-08e550076abd",
         "identifier" : [
           {
             "extension" : [
@@ -280,10 +285,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311815199475000.0faf4942-0e9a-4cf3-8c1a-b4f189ebb9ae",
+      "fullUrl" : "Location/1706816443935125000.7fc29c15-38a9-4f92-bf47-98a96d167ba3",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311815199475000.0faf4942-0e9a-4cf3-8c1a-b4f189ebb9ae",
+        "id" : "1706816443935125000.7fc29c15-38a9-4f92-bf47-98a96d167ba3",
         "identifier" : [
           {
             "extension" : [
@@ -333,15 +338,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311815199082000.65f44403-2d2d-4d51-811f-a6d029ff7183"
+          "reference" : "Location/1706816443934941000.c88607cf-9f41-4e3f-9896-08e550076abd"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706311815199802000.ecdc00e9-a6ca-4c74-9efb-1904089bde28",
+      "fullUrl" : "Location/1706816443935788000.c4156d0e-e42d-4ff5-af42-21a991da38f3",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311815199802000.ecdc00e9-a6ca-4c74-9efb-1904089bde28",
+        "id" : "1706816443935788000.c4156d0e-e42d-4ff5-af42-21a991da38f3",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -401,7 +406,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311815197372000.38e4178b-581f-4c0f-b85b-7a678e5e341d"
+              "reference" : "Organization/1706816443932764000.f09a257a-72a3-405c-9d4d-c49121d88263"
             }
           }
         ],
@@ -417,15 +422,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311815199475000.0faf4942-0e9a-4cf3-8c1a-b4f189ebb9ae"
+          "reference" : "Location/1706816443935125000.7fc29c15-38a9-4f92-bf47-98a96d167ba3"
         }
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311815200246000.8f9e0a29-e4d4-4586-b2fe-14a331adf6a9",
+      "fullUrl" : "EpisodeOfCare/1706816443936360000.c55a2e51-0518-408e-9cee-9fad27c83613",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311815200246000.8f9e0a29-e4d4-4586-b2fe-14a331adf6a9",
+        "id" : "1706816443936360000.c55a2e51-0518-408e-9cee-9fad27c83613",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-only-pl3-pl4.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-only-pl3-pl4.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311823309141000.655f6f79-ab87-4dc9-b57a-e68282276261",
+  "id" : "1706816453242706000.dec551d0-356b-4bb8-b7e8-0f836d53a023",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:30:23.322-06:00"
+    "lastUpdated" : "2024-02-01T14:40:53.250-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311823393368000.26f123e5-41f7-4740-ae8a-d2354cecacfe"
+          "reference" : "Organization/1706816453294158000.ec8f52d8-2b77-4118-8165-2dbf42c8274e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311823393368000.26f123e5-41f7-4740-ae8a-d2354cecacfe",
+      "fullUrl" : "Organization/1706816453294158000.ec8f52d8-2b77-4118-8165-2dbf42c8274e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311823393368000.26f123e5-41f7-4740-ae8a-d2354cecacfe",
+        "id" : "1706816453294158000.ec8f52d8-2b77-4118-8165-2dbf42c8274e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311823695286000.2877b9f1-c8cf-4687-88dd-38f17994b6ed",
+      "fullUrl" : "Provenance/1706816453655665000.bc1de0dc-40b5-4ad1-8fbc-705544d96f37",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311823695286000.2877b9f1-c8cf-4687-88dd-38f17994b6ed",
+        "id" : "1706816453655665000.bc1de0dc-40b5-4ad1-8fbc-705544d96f37",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311823701916000.321aff1a-29ee-4046-97e4-a76737482e51",
+      "fullUrl" : "Provenance/1706816453664119000.6f262d5b-0e1f-4c60-8542-bb3477a015b6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311823701916000.321aff1a-29ee-4046-97e4-a76737482e51",
-        "recorded" : "2024-01-26T17:30:23Z",
+        "id" : "1706816453664119000.6f262d5b-0e1f-4c60-8542-bb3477a015b6",
+        "recorded" : "2024-02-01T14:40:53Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311823700731000.0e3348cf-bfd8-4390-8d90-8aaecfb07a50"
+              "reference" : "Organization/1706816453663618000.50ffa1b9-bb6a-4bbe-8be7-8f59dc9d1de2"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311823700731000.0e3348cf-bfd8-4390-8d90-8aaecfb07a50",
+      "fullUrl" : "Organization/1706816453663618000.50ffa1b9-bb6a-4bbe-8be7-8f59dc9d1de2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311823700731000.0e3348cf-bfd8-4390-8d90-8aaecfb07a50",
+        "id" : "1706816453663618000.50ffa1b9-bb6a-4bbe-8be7-8f59dc9d1de2",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311823715403000.cc645c9a-431b-4d1e-836d-2e2500c9bc62",
+      "fullUrl" : "Patient/1706816453681415000.5d1990fa-eda1-4f5a-a8cc-ab056dc8f3e5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311823715403000.cc645c9a-431b-4d1e-836d-2e2500c9bc62"
+        "id" : "1706816453681415000.5d1990fa-eda1-4f5a-a8cc-ab056dc8f3e5"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311823716014000.169ab8b4-9987-4eb2-82f2-604304d3e9c9",
+      "fullUrl" : "Provenance/1706816453681991000.d0728411-4336-45cd-a257-152823119e28",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311823716014000.169ab8b4-9987-4eb2-82f2-604304d3e9c9",
+        "id" : "1706816453681991000.d0728411-4336-45cd-a257-152823119e28",
         "target" : [
           {
-            "reference" : "Patient/1706311823715403000.cc645c9a-431b-4d1e-836d-2e2500c9bc62"
+            "reference" : "Patient/1706816453681415000.5d1990fa-eda1-4f5a-a8cc-ab056dc8f3e5"
           }
         ],
-        "recorded" : "2024-01-26T17:30:23Z",
+        "recorded" : "2024-02-01T14:40:53Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311823721721000.fb03be14-8ddd-42eb-9788-82ecd728e30d",
+      "fullUrl" : "Encounter/1706816453688872000.629905c7-825e-4118-8002-797cc79113f8",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311823721721000.fb03be14-8ddd-42eb-9788-82ecd728e30d",
+        "id" : "1706816453688872000.629905c7-825e-4118-8002-797cc79113f8",
         "subject" : {
-          "reference" : "Patient/1706311823715403000.cc645c9a-431b-4d1e-836d-2e2500c9bc62"
+          "reference" : "Patient/1706816453681415000.5d1990fa-eda1-4f5a-a8cc-ab056dc8f3e5"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311823722031000.9b049df2-861d-462d-8f86-c73dcfba1c6f"
+            "reference" : "EpisodeOfCare/1706816453689103000.34f7c070-3450-4098-be87-99fc51e3d79a"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311823721439000.113eb71a-5590-4ca3-841d-feeff7044975"
+              "reference" : "Location/1706816453688568000.122039b0-ee7c-48f5-b5f3-d23adb6df016"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311823719502000.7a6cf5a7-543e-4507-a272-5b2738de35f2",
+      "fullUrl" : "Organization/1706816453686261000.dffa09ac-bdf5-49eb-9f08-f72205dbe5fd",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311823719502000.7a6cf5a7-543e-4507-a272-5b2738de35f2",
+        "id" : "1706816453686261000.dffa09ac-bdf5-49eb-9f08-f72205dbe5fd",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311823720937000.8c089ebd-c817-4c6d-ac68-be4739eeb831",
+      "fullUrl" : "Location/1706816453688023000.2d2759bd-5033-403b-a4b5-40e0fad52957",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311823720937000.8c089ebd-c817-4c6d-ac68-be4739eeb831",
+        "id" : "1706816453688023000.2d2759bd-5033-403b-a4b5-40e0fad52957",
         "identifier" : [
           {
             "extension" : [
@@ -280,10 +285,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311823721439000.113eb71a-5590-4ca3-841d-feeff7044975",
+      "fullUrl" : "Location/1706816453688568000.122039b0-ee7c-48f5-b5f3-d23adb6df016",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311823721439000.113eb71a-5590-4ca3-841d-feeff7044975",
+        "id" : "1706816453688568000.122039b0-ee7c-48f5-b5f3-d23adb6df016",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -343,7 +348,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311823719502000.7a6cf5a7-543e-4507-a272-5b2738de35f2"
+              "reference" : "Organization/1706816453686261000.dffa09ac-bdf5-49eb-9f08-f72205dbe5fd"
             }
           }
         ],
@@ -359,15 +364,15 @@
           ]
         },
         "partOf" : {
-          "reference" : "Location/1706311823720937000.8c089ebd-c817-4c6d-ac68-be4739eeb831"
+          "reference" : "Location/1706816453688023000.2d2759bd-5033-403b-a4b5-40e0fad52957"
         }
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311823722031000.9b049df2-861d-462d-8f86-c73dcfba1c6f",
+      "fullUrl" : "EpisodeOfCare/1706816453689103000.34f7c070-3450-4098-be87-99fc51e3d79a",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311823722031000.9b049df2-861d-462d-8f86-c73dcfba1c6f",
+        "id" : "1706816453689103000.34f7c070-3450-4098-be87-99fc51e3d79a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-only-pl4.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pl/PL-to-Location-only-pl4.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311831967982000.4df59b87-9aa6-44a1-9d9a-6bd8998a6bdd",
+  "id" : "1706816462904794000.836841bd-7bd1-4e2f-a729-0b4a965cd0a0",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:30:31.981-06:00"
+    "lastUpdated" : "2024-02-01T14:41:02.911-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311832046230000.4f99f8c2-f08d-4634-b582-2275ca1f6f25"
+          "reference" : "Organization/1706816462955066000.b317a725-fa5e-429f-8648-bd304a65302e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311832046230000.4f99f8c2-f08d-4634-b582-2275ca1f6f25",
+      "fullUrl" : "Organization/1706816462955066000.b317a725-fa5e-429f-8648-bd304a65302e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311832046230000.4f99f8c2-f08d-4634-b582-2275ca1f6f25",
+        "id" : "1706816462955066000.b317a725-fa5e-429f-8648-bd304a65302e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311832350520000.e6e6c757-c82f-47eb-8e00-6c5cc8a12595",
+      "fullUrl" : "Provenance/1706816463306800000.c62da465-9f68-440f-9e7b-6fbc2e2a99b1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311832350520000.e6e6c757-c82f-47eb-8e00-6c5cc8a12595",
+        "id" : "1706816463306800000.c62da465-9f68-440f-9e7b-6fbc2e2a99b1",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311832358212000.25bb5eea-6ca9-4cee-98ed-8753c6001615",
+      "fullUrl" : "Provenance/1706816463314721000.c1d4e7ee-cd16-4964-86af-299226cb82d9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311832358212000.25bb5eea-6ca9-4cee-98ed-8753c6001615",
-        "recorded" : "2024-01-26T17:30:32Z",
+        "id" : "1706816463314721000.c1d4e7ee-cd16-4964-86af-299226cb82d9",
+        "recorded" : "2024-02-01T14:41:03Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311832357816000.d0028609-db34-43b1-b2c3-2f2835a2548d"
+              "reference" : "Organization/1706816463314259000.b05af313-ee6e-48d7-a660-f77a59abc8ca"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311832357816000.d0028609-db34-43b1-b2c3-2f2835a2548d",
+      "fullUrl" : "Organization/1706816463314259000.b05af313-ee6e-48d7-a660-f77a59abc8ca",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311832357816000.d0028609-db34-43b1-b2c3-2f2835a2548d",
+        "id" : "1706816463314259000.b05af313-ee6e-48d7-a660-f77a59abc8ca",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,23 +144,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311832371787000.b3bc99cb-7b21-48e8-ac06-f9d9f7b50109",
+      "fullUrl" : "Patient/1706816463335047000.2be6d266-008d-41b8-8dd3-f8f55a497de6",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311832371787000.b3bc99cb-7b21-48e8-ac06-f9d9f7b50109"
+        "id" : "1706816463335047000.2be6d266-008d-41b8-8dd3-f8f55a497de6"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311832372598000.78068a78-0619-4fbd-acc0-6920f19ac925",
+      "fullUrl" : "Provenance/1706816463335641000.dd3146d9-e285-4a40-ac38-9da3016b38ee",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311832372598000.78068a78-0619-4fbd-acc0-6920f19ac925",
+        "id" : "1706816463335641000.dd3146d9-e285-4a40-ac38-9da3016b38ee",
         "target" : [
           {
-            "reference" : "Patient/1706311832371787000.b3bc99cb-7b21-48e8-ac06-f9d9f7b50109"
+            "reference" : "Patient/1706816463335047000.2be6d266-008d-41b8-8dd3-f8f55a497de6"
           }
         ],
-        "recorded" : "2024-01-26T17:30:32Z",
+        "recorded" : "2024-02-01T14:41:03Z",
         "activity" : {
           "coding" : [
             {
@@ -167,16 +172,16 @@
       }
     },
     {
-      "fullUrl" : "Encounter/1706311832378170000.f93b7aea-568a-4e91-8d16-dd4de239c707",
+      "fullUrl" : "Encounter/1706816463341322000.20e99df2-cd08-4b0b-b6df-3be8cbd4aebc",
       "resource" : {
         "resourceType" : "Encounter",
-        "id" : "1706311832378170000.f93b7aea-568a-4e91-8d16-dd4de239c707",
+        "id" : "1706816463341322000.20e99df2-cd08-4b0b-b6df-3be8cbd4aebc",
         "subject" : {
-          "reference" : "Patient/1706311832371787000.b3bc99cb-7b21-48e8-ac06-f9d9f7b50109"
+          "reference" : "Patient/1706816463335047000.2be6d266-008d-41b8-8dd3-f8f55a497de6"
         },
         "episodeOfCare" : [
           {
-            "reference" : "EpisodeOfCare/1706311832378363000.55894af8-c9c2-4f7b-a6af-754bb5a8f209"
+            "reference" : "EpisodeOfCare/1706816463341551000.b346765c-f738-4c50-a50e-669b7095d2e9"
           }
         ],
         "location" : [
@@ -188,7 +193,7 @@
               }
             ],
             "location" : {
-              "reference" : "Location/1706311832377870000.15ef59b4-ea4c-493b-bf13-312e88f89e10"
+              "reference" : "Location/1706816463341026000.f131bcd7-e578-47db-941e-39e1effc10bc"
             },
             "status" : "completed"
           }
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311832376609000.57f93769-566c-454e-8854-7481bba98950",
+      "fullUrl" : "Organization/1706816463339873000.a3be2bdd-18f2-459d-bcf6-abd980862077",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311832376609000.57f93769-566c-454e-8854-7481bba98950",
+        "id" : "1706816463339873000.a3be2bdd-18f2-459d-bcf6-abd980862077",
         "identifier" : [
           {
             "extension" : [
@@ -232,10 +237,10 @@
       }
     },
     {
-      "fullUrl" : "Location/1706311832377870000.15ef59b4-ea4c-493b-bf13-312e88f89e10",
+      "fullUrl" : "Location/1706816463341026000.f131bcd7-e578-47db-941e-39e1effc10bc",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706311832377870000.15ef59b4-ea4c-493b-bf13-312e88f89e10",
+        "id" : "1706816463341026000.f131bcd7-e578-47db-941e-39e1effc10bc",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
@@ -295,7 +300,7 @@
             ],
             "value" : "Entity ID",
             "assigner" : {
-              "reference" : "Organization/1706311832376609000.57f93769-566c-454e-8854-7481bba98950"
+              "reference" : "Organization/1706816463339873000.a3be2bdd-18f2-459d-bcf6-abd980862077"
             }
           }
         ],
@@ -313,10 +318,10 @@
       }
     },
     {
-      "fullUrl" : "EpisodeOfCare/1706311832378363000.55894af8-c9c2-4f7b-a6af-754bb5a8f209",
+      "fullUrl" : "EpisodeOfCare/1706816463341551000.b346765c-f738-4c50-a50e-669b7095d2e9",
       "resource" : {
         "resourceType" : "EpisodeOfCare",
-        "id" : "1706311832378363000.55894af8-c9c2-4f7b-a6af-754bb5a8f209",
+        "id" : "1706816463341551000.b346765c-f738-4c50-a50e-669b7095d2e9",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pt/PT-to-Meta.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pt/PT-to-Meta.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311846370960000.9f688b3c-e152-4ed9-af64-49deaceee311",
+  "id" : "1706816755236587000.3a25550f-151c-41cd-b7ed-5cd6ee826463",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:30:46.383-06:00"
+    "lastUpdated" : "2024-02-01T14:45:55.243-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "3003786103_4988249_33033"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
@@ -34,12 +34,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -48,7 +53,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311846460467000.b530c55f-8bd9-485a-af78-f335521c7293"
+          "reference" : "Organization/1706816755291477000.2e2f36e7-f01e-42af-a2e3-08795243afe9"
         },
         "source" : {
           "_endpoint" : {
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311846460467000.b530c55f-8bd9-485a-af78-f335521c7293",
+      "fullUrl" : "Organization/1706816755291477000.2e2f36e7-f01e-42af-a2e3-08795243afe9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311846460467000.b530c55f-8bd9-485a-af78-f335521c7293",
+        "id" : "1706816755291477000.2e2f36e7-f01e-42af-a2e3-08795243afe9",
         "address" : [
           {
             "country" : "USA"
@@ -75,10 +80,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311846769595000.f7dfeda2-9194-487e-be76-972d9a634168",
+      "fullUrl" : "Provenance/1706816755663260000.cfddea47-0d10-4d54-8b04-8cd715748e8f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311846769595000.f7dfeda2-9194-487e-be76-972d9a634168",
+        "id" : "1706816755663260000.cfddea47-0d10-4d54-8b04-8cd715748e8f",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -95,11 +100,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311846777129000.c5342424-4483-4503-a84f-42c010e2d6c8",
+      "fullUrl" : "Provenance/1706816755670974000.1666b160-f382-41d6-b90b-bdad3b8c371d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311846777129000.c5342424-4483-4503-a84f-42c010e2d6c8",
-        "recorded" : "2024-01-26T17:30:46Z",
+        "id" : "1706816755670974000.1666b160-f382-41d6-b90b-bdad3b8c371d",
+        "recorded" : "2024-02-01T14:45:55Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -121,17 +126,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311846775889000.e1a369c1-1138-49b6-8582-42ec34f7fba9"
+              "reference" : "Organization/1706816755669580000.d825b06d-bf1e-48d7-a6bf-748151e3e2e2"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311846775889000.e1a369c1-1138-49b6-8582-42ec34f7fba9",
+      "fullUrl" : "Organization/1706816755669580000.d825b06d-bf1e-48d7-a6bf-748151e3e2e2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311846775889000.e1a369c1-1138-49b6-8582-42ec34f7fba9",
+        "id" : "1706816755669580000.d825b06d-bf1e-48d7-a6bf-748151e3e2e2",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-n.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-n.fhir
@@ -10,3444 +10,4846 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714143394776000.d59ecb9c-7e64-41fb-836d-18b1ca7df314",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714143394776000.d59ecb9c-7e64-41fb-836d-18b1ca7df314",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714143403668000.0239f626-8aa0-402d-bded-12b8465b37f9",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714143403668000.0239f626-8aa0-402d-bded-12b8465b37f9",
-      "recorded" : "2024-01-31T10:15:43Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714143420925000.9bfda45b-f2b6-4a20-a141-5474d75e4ecf",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714143420925000.9bfda45b-f2b6-4a20-a141-5474d75e4ecf",
-      "target" : [ {
-        "reference" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
-      } ],
-      "recorded" : "2024-01-31T10:15:43Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Encounter/1706714143488399000.5a26138c-c1ba-4712-9c32-49b125d489d3",
-    "resource" : {
-      "resourceType" : "Encounter",
-      "id" : "1706714143488399000.5a26138c-c1ba-4712-9c32-49b125d489d3",
-      "meta" : {
-        "security" : [ {
-          "code" : "false"
-        } ]
-      },
-      "text" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
-          "valueString" : "Description"
-        } ],
-        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "413",
-            "display" : "V"
-          } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706714143394776000.d59ecb9c-7e64-41fb-836d-18b1ca7df314",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714143394776000.d59ecb9c-7e64-41fb-836d-18b1ca7df314",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "423",
-            "display" : "X"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714143403668000.0239f626-8aa0-402d-bded-12b8465b37f9",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714143403668000.0239f626-8aa0-402d-bded-12b8465b37f9",
+        "recorded" : "2024-01-31T10:15:43Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714143420925000.9bfda45b-f2b6-4a20-a141-5474d75e4ecf",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714143420925000.9bfda45b-f2b6-4a20-a141-5474d75e4ecf",
+        "target" : [
+          {
+            "reference" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
+          }
+        ],
+        "recorded" : "2024-01-31T10:15:43Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
-        "valueDateTime" : "2023-06-01T10:25:31-04:00",
-        "_valueDateTime" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230601102531-0400"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
-        "valueDateTime" : "2023-07-01T10:25:31-04:00",
-        "_valueDateTime" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230701102531-0400"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
-        "valueQuantity" : {
-          "value" : 5,
+      }
+    },
+    {
+      "fullUrl" : "Encounter/1706714143488399000.5a26138c-c1ba-4712-9c32-49b125d489d3",
+      "resource" : {
+        "resourceType" : "Encounter",
+        "id" : "1706714143488399000.5a26138c-c1ba-4712-9c32-49b125d489d3",
+        "meta" : {
+          "security" : [
+            {
+              "code" : "false"
+            }
+          ]
+        },
+        "text" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
+              "valueString" : "Description"
+            }
+          ],
+          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
+        },
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "413",
+                  "display" : "V"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "423",
+                  "display" : "X"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
+            "valueDateTime" : "2023-06-01T10:25:31-04:00",
+            "_valueDateTime" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                  "valueString" : "20230601102531-0400"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
+            "valueDateTime" : "2023-07-01T10:25:31-04:00",
+            "_valueDateTime" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                  "valueString" : "20230701102531-0400"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
+            "valueQuantity" : {
+              "value" : 5,
+              "unit" : "days",
+              "system" : "http://unitsofmeasure.org/",
+              "code" : "d"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "100",
+                  "display" : "PublicCode"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          }
+                        ],
+                        "code" : "444",
+                        "display" : "MODE"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "code" : "444",
+              "display" : "MODE"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "123",
+                  "display" : "CARELEVEL1"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+            "extension" : [
+              {
+                "url" : "pv1-12-preadmit-test-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "PRE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-18-patient-type",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "34",
+                      "display" : "PT"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-46-current-patient-balance",
+                "valueDecimal" : 55
+              },
+              {
+                "url" : "pv1-47-total-charges",
+                "valueDecimal" : 1000
+              },
+              {
+                "url" : "pv1-48-total-adjustments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-49-total-payments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-51-visit-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "316",
+                      "display" : "IND"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-30-transfer-to-bad-debt-date",
+                "valueString" : "T"
+              },
+              {
+                "url" : "pv1-31-bad-debt-agency-code",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "AGE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-32-bad-debt-transfer-amount",
+                "valueDecimal" : 3.4
+              },
+              {
+                "url" : "pv1-33-bad-debt-recovery-amount",
+                "valueDecimal" : 1.4
+              },
+              {
+                "url" : "pv1-34-delete-account-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "66",
+                      "display" : "DEL"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-35-delete-account-date",
+                "valueString" : "20240501102531-0400"
+              },
+              {
+                "url" : "pv1-39-servicing-facility",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "5678",
+                      "display" : "SERV"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-41-account-status",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "431",
+                      "display" : "ST"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
+            "extension" : [
+              {
+                "url" : "pv2-15-employment-illness-related-indicator",
+                "valueString" : "EMP_ILL"
+              },
+              {
+                "url" : "pv2-23-clinic-organization-name",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036"
+                }
+              },
+              {
+                "url" : "pv2-23-clinic-organization-name",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe"
+                }
+              },
+              {
+                "url" : "pv2-26-previous-treatment-date",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "pv2-29-first-similar-date",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "visit-number"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "VN"
+                }
+              ],
+              "text" : "visit number"
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "VisitNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber1",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143431660000.f911a672-6707-405a-a764-68f775e90334"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber2",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "status" : "in-progress",
+        "class" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      }
+                    ],
+                    "code" : "O"
+                  }
+                ]
+              }
+            }
+          ],
+          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code" : "AMB",
+          "display" : "ambulatory"
+        },
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          }
+        ],
+        "serviceType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "MED"
+            }
+          ]
+        },
+        "priority" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "VIP"
+            }
+          ]
+        },
+        "subject" : {
+          "reference" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
+        },
+        "episodeOfCare" : [
+          {
+            "reference" : "EpisodeOfCare/1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d"
+          }
+        ],
+        "participant" : [
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4"
+            }
+          }
+        ],
+        "period" : {
+          "start" : "2024-08-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240801102531-0400"
+              }
+            ]
+          }
+        },
+        "length" : {
+          "value" : 12,
           "unit" : "days",
           "system" : "http://unitsofmeasure.org/",
           "code" : "d"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "100",
-            "display" : "PublicCode"
-          } ]
-        }
-      }, {
-        "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                } ],
-                "code" : "444",
-                "display" : "MODE"
-              } ]
-            }
-          } ],
-          "code" : "444",
-          "display" : "MODE"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "123",
-            "display" : "CARELEVEL1"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
-        "extension" : [ {
-          "url" : "pv1-12-preadmit-test-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "PRE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-18-patient-type",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "34",
-              "display" : "PT"
-            } ]
-          }
-        }, {
-          "url" : "pv1-46-current-patient-balance",
-          "valueDecimal" : 55
-        }, {
-          "url" : "pv1-47-total-charges",
-          "valueDecimal" : 1000
-        }, {
-          "url" : "pv1-48-total-adjustments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-49-total-payments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-51-visit-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "316",
-              "display" : "IND"
-            } ]
-          }
-        }, {
-          "url" : "pv1-30-transfer-to-bad-debt-date",
-          "valueString" : "T"
-        }, {
-          "url" : "pv1-31-bad-debt-agency-code",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "AGE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-32-bad-debt-transfer-amount",
-          "valueDecimal" : 3.4
-        }, {
-          "url" : "pv1-33-bad-debt-recovery-amount",
-          "valueDecimal" : 1.4
-        }, {
-          "url" : "pv1-34-delete-account-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "66",
-              "display" : "DEL"
-            } ]
-          }
-        }, {
-          "url" : "pv1-35-delete-account-date",
-          "valueString" : "20240501102531-0400"
-        }, {
-          "url" : "pv1-39-servicing-facility",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "5678",
-              "display" : "SERV"
-            } ]
-          }
-        }, {
-          "url" : "pv1-41-account-status",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "431",
-              "display" : "ST"
-            } ]
-          }
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
-        "extension" : [ {
-          "url" : "pv2-15-employment-illness-related-indicator",
-          "valueString" : "EMP_ILL"
-        }, {
-          "url" : "pv2-23-clinic-organization-name",
-          "valueReference" : {
-            "reference" : "Organization/1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036"
-          }
-        }, {
-          "url" : "pv2-23-clinic-organization-name",
-          "valueReference" : {
-            "reference" : "Organization/1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe"
-          }
-        }, {
-          "url" : "pv2-26-previous-treatment-date",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "pv2-29-first-similar-date",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "visit-number"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "VN"
-          } ],
-          "text" : "visit number"
         },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "VisitNumber",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+        "reasonCode" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "pv2-admit-reason"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "AD"
+              }
+            ]
           }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber1",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714143431660000.f911a672-6707-405a-a764-68f775e90334"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber2",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      } ],
-      "status" : "in-progress",
-      "class" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "O"
-            } ]
-          }
-        } ],
-        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code" : "AMB",
-        "display" : "ambulatory"
-      },
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "R"
-        } ]
-      } ],
-      "serviceType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "MED"
-        } ]
-      },
-      "priority" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "VIP"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
-      },
-      "episodeOfCare" : [ {
-        "reference" : "EpisodeOfCare/1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d"
-      } ],
-      "participant" : [ {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4"
-        }
-      } ],
-      "period" : {
-        "start" : "2024-08-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240801102531-0400"
-          } ]
-        }
-      },
-      "length" : {
-        "value" : 12,
-        "unit" : "days",
-        "system" : "http://unitsofmeasure.org/",
-        "code" : "d"
-      },
-      "reasonCode" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "pv2-admit-reason"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "1",
-          "display" : "AD"
-        } ]
-      } ],
-      "hospitalization" : {
-        "preAdmissionIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-            "valueReference" : {
-              "reference" : "Organization/1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32"
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AASys"
-                } ],
-                "code" : "AACode",
-                "display" : "Assigning Agency"
-              } ]
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AJSys"
-                } ],
-                "code" : "AJCode",
-                "display" : "Assigning Jurisdiction"
-              } ]
-            }
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-            "valueString" : "checkdigitscheme"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-            "valueString" : "checkdigit"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-            "valueString" : "ACSN"
-          } ],
-          "type" : {
-            "coding" : [ {
-              "code" : "ACSN"
-            } ]
-          },
-          "system" : "urn:oid:testcx42",
-          "_system" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "testcx42"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            } ]
-          },
-          "value" : "IDNumber",
-          "period" : {
-            "start" : "1988-07-04",
-            "_start" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "19880704"
-              } ]
+        ],
+        "hospitalization" : {
+          "preAdmissionIdentifier" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
             },
-            "end" : "2088-07-04",
-            "_end" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20880704"
-              } ]
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "IDNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
             }
-          }
-        },
-        "admitSource" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "Source"
-          } ]
-        },
-        "reAdmission" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "R"
-          } ]
-        },
-        "dietPreference" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "VEG"
-          } ]
-        } ],
-        "specialCourtesy" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A0"
-          } ]
-        }, {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A1"
-          } ]
-        } ],
-        "destination" : {
-          "reference" : "Location/1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f"
-        },
-        "dischargeDisposition" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "T"
-          } ]
-        }
-      },
-      "location" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "assigned-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "pending-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4"
-        },
-        "status" : "planned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-pending-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : false
-        } ],
-        "location" : {
-          "reference" : "Location/1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202"
-        },
-        "status" : "planned"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143431660000.f911a672-6707-405a-a764-68f775e90334",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143431660000.f911a672-6707-405a-a764-68f775e90334",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org1"
-    }
-  }, {
-    "fullUrl" : "Location/1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org2"
-    }
-  }, {
-    "fullUrl" : "Location/1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "PrimaryCode",
-          "display" : "Primary Code Display"
-        } ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv2-13-referral-source-code"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referral Source Code1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv2-13-referral-source-code"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referral Source Code2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Assigned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prio"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Pending Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prior Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital PriorPending"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "EpisodeOfCare/1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d",
-    "resource" : {
-      "resourceType" : "EpisodeOfCare",
-      "id" : "1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "service-episode"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-        "valueString" : "ServiceDescriptor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "ServiceIdentifier",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
           },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+          "admitSource" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "Source"
+              }
+            ]
+          },
+          "reAdmission" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          },
+          "dietPreference" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "1",
+                  "display" : "VEG"
+                }
+              ]
+            }
+          ],
+          "specialCourtesy" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A0"
+                }
+              ]
+            },
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A1"
+                }
+              ]
+            }
+          ],
+          "destination" : {
+            "reference" : "Location/1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f"
+          },
+          "dischargeDisposition" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "T"
+              }
+            ]
           }
+        },
+        "location" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "assigned-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "pending-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4"
+            },
+            "status" : "planned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-pending-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : false
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202"
+            },
+            "status" : "planned"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143431660000.f911a672-6707-405a-a764-68f775e90334",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143431660000.f911a672-6707-405a-a764-68f775e90334",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org1"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org2"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+            "valueString" : "20230501102531-0400"
+          }
+        ],
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "LN"
+                  }
+                ],
+                "system" : "http://loinc.org",
+                "code" : "PrimaryCode",
+                "display" : "Primary Code Display"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv2-13-referral-source-code"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referral Source Code1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv2-13-referral-source-code"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referral Source Code2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Assigned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prio"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Pending Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prior Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital PriorPending"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "EpisodeOfCare/1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d",
+      "resource" : {
+        "resourceType" : "EpisodeOfCare",
+        "id" : "1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "service-episode"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+            "valueString" : "ServiceDescriptor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "ServiceIdentifier",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-n.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-n.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654953107753000.4668233d-55bb-4f90-9046-77d00e80c3f1",
+  "id" : "1706714143008307000.db48a5de-0b32-4e65-8769-9b954dd85564",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:49:13.114-05:00"
+    "lastUpdated" : "2024-01-31T10:15:43.016-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,4841 +10,3444 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
+        }
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714143394776000.d59ecb9c-7e64-41fb-836d-18b1ca7df314",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714143394776000.d59ecb9c-7e64-41fb-836d-18b1ca7df314",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
           "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714143403668000.0239f626-8aa0-402d-bded-12b8465b37f9",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714143403668000.0239f626-8aa0-402d-bded-12b8465b37f9",
+      "recorded" : "2024-01-31T10:15:43Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
         },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+        "who" : {
+          "reference" : "Organization/1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b"
         }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143403153000.c39f1491-d10c-484c-bc44-cdfa5278fa0b",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714143420925000.9bfda45b-f2b6-4a20-a141-5474d75e4ecf",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714143420925000.9bfda45b-f2b6-4a20-a141-5474d75e4ecf",
+      "target" : [ {
+        "reference" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
+      } ],
+      "recorded" : "2024-01-31T10:15:43Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
       }
-    },
-    {
-      "fullUrl" : "Provenance/1706654953482646000.7d6f4bd8-dab5-49c1-83ff-97f8666e7b48",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654953482646000.7d6f4bd8-dab5-49c1-83ff-97f8666e7b48",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+    }
+  }, {
+    "fullUrl" : "Encounter/1706714143488399000.5a26138c-c1ba-4712-9c32-49b125d489d3",
+    "resource" : {
+      "resourceType" : "Encounter",
+      "id" : "1706714143488399000.5a26138c-c1ba-4712-9c32-49b125d489d3",
+      "meta" : {
+        "security" : [ {
+          "code" : "false"
+        } ]
+      },
+      "text" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
+          "valueString" : "Description"
+        } ],
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
+      },
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "413",
+            "display" : "V"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654953491272000.421f3928-768f-45a1-adb7-48820b5ed962",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654953491272000.421f3928-768f-45a1-adb7-48820b5ed962",
-        "recorded" : "2024-01-30T17:49:13Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654953490768000.f4b652b7-4d15-45c4-9112-22978b5cbde3"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953490768000.f4b652b7-4d15-45c4-9112-22978b5cbde3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953490768000.f4b652b7-4d15-45c4-9112-22978b5cbde3",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654953505983000.bdabdd6c-25c7-4550-95b3-b434ee094d76",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654953505983000.bdabdd6c-25c7-4550-95b3-b434ee094d76"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654953506668000.6cfa981f-7f68-48e7-8c80-baad14d3cbf0",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654953506668000.6cfa981f-7f68-48e7-8c80-baad14d3cbf0",
-        "target" : [
-          {
-            "reference" : "Patient/1706654953505983000.bdabdd6c-25c7-4550-95b3-b434ee094d76"
-          }
-        ],
-        "recorded" : "2024-01-30T17:49:13Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "423",
+            "display" : "X"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Encounter/1706654953567876000.496c3d62-b945-49dd-836c-6ffaa82b85b4",
-      "resource" : {
-        "resourceType" : "Encounter",
-        "id" : "1706654953567876000.496c3d62-b945-49dd-836c-6ffaa82b85b4",
-        "meta" : {
-          "security" : [
-            {
-              "code" : "false"
-            }
-          ]
-        },
-        "text" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
-              "valueString" : "Description"
-            }
-          ],
-          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
-        },
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "413",
-                  "display" : "V"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "423",
-                  "display" : "X"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
-            "valueDateTime" : "2023-06-01T10:25:31-04:00",
-            "_valueDateTime" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                  "valueString" : "20230601102531-0400"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
-            "valueDateTime" : "2023-07-01T10:25:31-04:00",
-            "_valueDateTime" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                  "valueString" : "20230701102531-0400"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
-            "valueQuantity" : {
-              "value" : 5,
-              "unit" : "days",
-              "system" : "http://unitsofmeasure.org/",
-              "code" : "d"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "100",
-                  "display" : "PublicCode"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          }
-                        ],
-                        "code" : "444",
-                        "display" : "MODE"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "code" : "444",
-              "display" : "MODE"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "123",
-                  "display" : "CARELEVEL1"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter",
-            "extension" : [
-              {
-                "url" : "pv1-12-preadmit-test-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "PRE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-18-patient-type",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "34",
-                      "display" : "PT"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-46-current-patient-balance",
-                "valueDecimal" : 55
-              },
-              {
-                "url" : "pv1-47-total-charges",
-                "valueDecimal" : 1000
-              },
-              {
-                "url" : "pv1-48-total-adjustments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-49-total-payments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-51-visit-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "316",
-                      "display" : "IND"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-30-transfer-to-bad-debt-date",
-                "valueString" : "T"
-              },
-              {
-                "url" : "pv1-31-bad-debt-agency-code",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "AGE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-32-bad-debt-transfer-amount",
-                "valueDecimal" : 3.4
-              },
-              {
-                "url" : "pv1-33-bad-debt-recovery-amount",
-                "valueDecimal" : 1.4
-              },
-              {
-                "url" : "pv1-34-delete-account-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "66",
-                      "display" : "DEL"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-35-delete-account-date",
-                "valueString" : "20240501102531-0400"
-              },
-              {
-                "url" : "pv1-39-servicing-facility",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "5678",
-                      "display" : "SERV"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-41-account-status",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "431",
-                      "display" : "ST"
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-encounter",
-            "extension" : [
-              {
-                "url" : "pv2-15-employment-illness-related-indicator",
-                "valueString" : "EMP_ILL"
-              },
-              {
-                "url" : "pv2-23-clinic-organization-name",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953527237000.77efaaf5-37d1-4c97-aa4a-8a4935987425"
-                }
-              },
-              {
-                "url" : "pv2-23-clinic-organization-name",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953528921000.44f453ae-46ed-4aed-9958-aebcbf88b87a"
-                }
-              },
-              {
-                "url" : "pv2-26-previous-treatment-date",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "pv2-29-first-similar-date",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953510610000.ae17222e-5c57-4b94-846f-58f5618a0a92"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "visit-number"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "VN"
-                }
-              ],
-              "text" : "visit number"
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "VisitNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953513579000.5019a346-ffee-4b9e-9a55-d6e7adcedbb3"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber1",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953516772000.ed27828f-16c2-485a-82c6-a9b468578a64"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber2",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ],
-        "status" : "in-progress",
-        "class" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      }
-                    ],
-                    "code" : "O"
-                  }
-                ]
-              }
-            }
-          ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code" : "AMB",
-          "display" : "ambulatory"
-        },
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          }
-        ],
-        "serviceType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "MED"
-            }
-          ]
-        },
-        "priority" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "VIP"
-            }
-          ]
-        },
-        "subject" : {
-          "reference" : "Patient/1706654953505983000.bdabdd6c-25c7-4550-95b3-b434ee094d76"
-        },
-        "episodeOfCare" : [
-          {
-            "reference" : "EpisodeOfCare/1706654953569320000.33a306b5-ac76-4d0e-b1c6-8caf401d891a"
-          }
-        ],
-        "participant" : [
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953540066000.23ad491f-e796-4795-98d0-a9fa0d73cc74"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953543166000.b876ea04-fb1a-4d4f-bd64-88ad53108b52"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953545637000.aa11a11d-e9cd-4805-b42b-c45fb185e707"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953547948000.1cab79fd-45d1-4cf3-999e-5591b4d5fd96"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953550567000.cd8ff2c0-ea68-48e9-ae92-219727c2ba09"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953552757000.35907294-10af-48bf-a68a-067e7b0a2b46"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953555247000.5581c81c-711f-4b79-89e9-cb05bdbf90c8"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953557617000.fabfc423-63ee-4000-81c7-54b221fa94ce"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953559946000.4fa6050e-a609-4e64-82a2-a7dd7f1155e5"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654953562087000.e9b8c2a8-eeef-428b-9f77-599259521e44"
-            }
-          }
-        ],
-        "period" : {
-          "start" : "2024-08-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240801102531-0400"
-              }
-            ]
-          }
-        },
-        "length" : {
-          "value" : 12,
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
+        "valueDateTime" : "2023-06-01T10:25:31-04:00",
+        "_valueDateTime" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230601102531-0400"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
+        "valueDateTime" : "2023-07-01T10:25:31-04:00",
+        "_valueDateTime" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230701102531-0400"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
+        "valueQuantity" : {
+          "value" : 5,
           "unit" : "days",
           "system" : "http://unitsofmeasure.org/",
           "code" : "d"
-        },
-        "reasonCode" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "pv2-admit-reason"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "AD"
-              }
-            ]
-          }
-        ],
-        "hospitalization" : {
-          "preAdmissionIdentifier" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953530936000.983c8db4-d750-4bda-a376-26837d8a6e39"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "IDNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          "admitSource" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "Source"
-              }
-            ]
-          },
-          "reAdmission" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          },
-          "dietPreference" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "1",
-                  "display" : "VEG"
-                }
-              ]
-            }
-          ],
-          "specialCourtesy" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A0"
-                }
-              ]
-            },
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A1"
-                }
-              ]
-            }
-          ],
-          "destination" : {
-            "reference" : "Location/1706654953529630000.68cd1a78-cdca-49e2-b186-ebd78e0a8699"
-          },
-          "dischargeDisposition" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "T"
-              }
-            ]
-          }
-        },
-        "location" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "assigned-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654953563114000.7e79e104-90c2-4bc9-9a44-a4a538244463"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654953564426000.7f7ea9bc-fc3f-4c84-934c-590ca74492e1"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654953565295000.987d21e0-4e52-4edf-96cd-855e522cd465"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "pending-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654953566060000.94c9dd67-1ff8-4e18-8479-bc926aca5365"
-            },
-            "status" : "planned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654953566926000.e614998b-ec79-47c5-a805-1bd67e62f986"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-pending-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : false
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654953567783000.062ee7cc-02f1-4d98-bf90-fc52922065dd"
-            },
-            "status" : "planned"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953510610000.ae17222e-5c57-4b94-846f-58f5618a0a92",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953510610000.ae17222e-5c57-4b94-846f-58f5618a0a92",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953513579000.5019a346-ffee-4b9e-9a55-d6e7adcedbb3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953513579000.5019a346-ffee-4b9e-9a55-d6e7adcedbb3",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953516772000.ed27828f-16c2-485a-82c6-a9b468578a64",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953516772000.ed27828f-16c2-485a-82c6-a9b468578a64",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953526090000.a8226352-51c3-4a8d-9c61-431254d424b6",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953526090000.a8226352-51c3-4a8d-9c61-431254d424b6",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953527237000.77efaaf5-37d1-4c97-aa4a-8a4935987425",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953527237000.77efaaf5-37d1-4c97-aa4a-8a4935987425",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "100",
+            "display" : "PublicCode"
+          } ]
+        }
+      }, {
+        "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
+                  "valueString" : "coding"
+                } ],
+                "code" : "444",
+                "display" : "MODE"
+              } ]
             }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
+          } ],
+          "code" : "444",
+          "display" : "MODE"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "123",
+            "display" : "CARELEVEL1"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+        "extension" : [ {
+          "url" : "pv1-12-preadmit-test-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "PRE"
+            } ]
           }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654953526090000.a8226352-51c3-4a8d-9c61-431254d424b6"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
+        }, {
+          "url" : "pv1-18-patient-type",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "34",
+              "display" : "PT"
+            } ]
           }
-        ],
-        "name" : "Org1"
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953528081000.6e7aecae-02d8-486d-9e55-d00b8ac02a88",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953528081000.6e7aecae-02d8-486d-9e55-d00b8ac02a88",
-        "extension" : [
-          {
+        }, {
+          "url" : "pv1-46-current-patient-balance",
+          "valueDecimal" : 55
+        }, {
+          "url" : "pv1-47-total-charges",
+          "valueDecimal" : 1000
+        }, {
+          "url" : "pv1-48-total-adjustments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-49-total-payments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-51-visit-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "316",
+              "display" : "IND"
+            } ]
+          }
+        }, {
+          "url" : "pv1-30-transfer-to-bad-debt-date",
+          "valueString" : "T"
+        }, {
+          "url" : "pv1-31-bad-debt-agency-code",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "AGE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-32-bad-debt-transfer-amount",
+          "valueDecimal" : 3.4
+        }, {
+          "url" : "pv1-33-bad-debt-recovery-amount",
+          "valueDecimal" : 1.4
+        }, {
+          "url" : "pv1-34-delete-account-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "66",
+              "display" : "DEL"
+            } ]
+          }
+        }, {
+          "url" : "pv1-35-delete-account-date",
+          "valueString" : "20240501102531-0400"
+        }, {
+          "url" : "pv1-39-servicing-facility",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "5678",
+              "display" : "SERV"
+            } ]
+          }
+        }, {
+          "url" : "pv1-41-account-status",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "431",
+              "display" : "ST"
+            } ]
+          }
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
+        "extension" : [ {
+          "url" : "pv2-15-employment-illness-related-indicator",
+          "valueString" : "EMP_ILL"
+        }, {
+          "url" : "pv2-23-clinic-organization-name",
+          "valueReference" : {
+            "reference" : "Organization/1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036"
+          }
+        }, {
+          "url" : "pv2-23-clinic-organization-name",
+          "valueReference" : {
+            "reference" : "Organization/1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe"
+          }
+        }, {
+          "url" : "pv2-26-previous-treatment-date",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "pv2-29-first-similar-date",
+          "valueString" : "20220501102531-0400"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "visit-number"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "VN"
+          } ],
+          "text" : "visit number"
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "VisitNumber",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
           }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953528921000.44f453ae-46ed-4aed-9958-aebcbf88b87a",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953528921000.44f453ae-46ed-4aed-9958-aebcbf88b87a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber1",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714143431660000.f911a672-6707-405a-a764-68f775e90334"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber2",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ],
+      "status" : "in-progress",
+      "class" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "O"
+            } ]
+          }
+        } ],
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code" : "AMB",
+        "display" : "ambulatory"
+      },
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "R"
+        } ]
+      } ],
+      "serviceType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "MED"
+        } ]
+      },
+      "priority" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "VIP"
+        } ]
+      },
+      "subject" : {
+        "reference" : "Patient/1706714143420279000.95257e5e-a9dc-4c12-9d68-ec1a431fbdb9"
+      },
+      "episodeOfCare" : [ {
+        "reference" : "EpisodeOfCare/1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d"
+      } ],
+      "participant" : [ {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4"
+        }
+      } ],
+      "period" : {
+        "start" : "2024-08-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240801102531-0400"
+          } ]
+        }
+      },
+      "length" : {
+        "value" : 12,
+        "unit" : "days",
+        "system" : "http://unitsofmeasure.org/",
+        "code" : "d"
+      },
+      "reasonCode" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "pv2-admit-reason"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "1",
+          "display" : "AD"
+        } ]
+      } ],
+      "hospitalization" : {
+        "preAdmissionIdentifier" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+            "valueReference" : {
+              "reference" : "Organization/1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32"
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AASys"
+                } ],
+                "code" : "AACode",
+                "display" : "Assigning Agency"
+              } ]
             }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AJSys"
+                } ],
+                "code" : "AJCode",
+                "display" : "Assigning Jurisdiction"
+              } ]
+            }
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            "valueString" : "checkdigitscheme"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            "valueString" : "checkdigit"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+            "valueString" : "ACSN"
+          } ],
+          "type" : {
+            "coding" : [ {
+              "code" : "ACSN"
+            } ]
           },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654953528081000.6e7aecae-02d8-486d-9e55-d00b8ac02a88"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Org2"
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953529630000.68cd1a78-cdca-49e2-b186-ebd78e0a8699",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953529630000.68cd1a78-cdca-49e2-b186-ebd78e0a8699",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "LN"
-                  }
-                ],
-                "system" : "http://loinc.org",
-                "code" : "PrimaryCode",
-                "display" : "Primary Code Display"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953530936000.983c8db4-d750-4bda-a376-26837d8a6e39",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953530936000.983c8db4-d750-4bda-a376-26837d8a6e39",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
+          "system" : "urn:oid:testcx42",
+          "_system" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "testcx42"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            } ]
           },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
+          "value" : "IDNumber",
+          "period" : {
+            "start" : "1988-07-04",
+            "_start" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "19880704"
+              } ]
             },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953540066000.23ad491f-e796-4795-98d0-a9fa0d73cc74",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953540066000.23ad491f-e796-4795-98d0-a9fa0d73cc74",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
+            "end" : "2088-07-04",
+            "_end" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20880704"
+              } ]
             }
           }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953543166000.b876ea04-fb1a-4d4f-bd64-88ad53108b52",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953543166000.b876ea04-fb1a-4d4f-bd64-88ad53108b52",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953545637000.aa11a11d-e9cd-4805-b42b-c45fb185e707",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953545637000.aa11a11d-e9cd-4805-b42b-c45fb185e707",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953547948000.1cab79fd-45d1-4cf3-999e-5591b4d5fd96",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953547948000.1cab79fd-45d1-4cf3-999e-5591b4d5fd96",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953550567000.cd8ff2c0-ea68-48e9-ae92-219727c2ba09",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953550567000.cd8ff2c0-ea68-48e9-ae92-219727c2ba09",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953552757000.35907294-10af-48bf-a68a-067e7b0a2b46",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953552757000.35907294-10af-48bf-a68a-067e7b0a2b46",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953555247000.5581c81c-711f-4b79-89e9-cb05bdbf90c8",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953555247000.5581c81c-711f-4b79-89e9-cb05bdbf90c8",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953557617000.fabfc423-63ee-4000-81c7-54b221fa94ce",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953557617000.fabfc423-63ee-4000-81c7-54b221fa94ce",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953559946000.4fa6050e-a609-4e64-82a2-a7dd7f1155e5",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953559946000.4fa6050e-a609-4e64-82a2-a7dd7f1155e5",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv2-13-referral-source-code"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "urn:oid:AssigningSystem",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referral Source Code1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654953562087000.e9b8c2a8-eeef-428b-9f77-599259521e44",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654953562087000.e9b8c2a8-eeef-428b-9f77-599259521e44",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv2-13-referral-source-code"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "urn:oid:AssigningSystem",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referral Source Code2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953562605000.c2ab0d43-30ea-402b-8f7a-8067d53010cd",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953562605000.c2ab0d43-30ea-402b-8f7a-8067d53010cd",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953563114000.7e79e104-90c2-4bc9-9a44-a4a538244463",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953563114000.7e79e104-90c2-4bc9-9a44-a4a538244463",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Assigned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654953562605000.c2ab0d43-30ea-402b-8f7a-8067d53010cd"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+        },
+        "admitSource" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "Source"
+          } ]
+        },
+        "reAdmission" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "R"
+          } ]
+        },
+        "dietPreference" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "VEG"
+          } ]
+        } ],
+        "specialCourtesy" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A0"
+          } ]
+        }, {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A1"
+          } ]
+        } ],
+        "destination" : {
+          "reference" : "Location/1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f"
+        },
+        "dischargeDisposition" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "T"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953563836000.56d0d794-112c-4f74-9a31-bc8920364b81",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953563836000.56d0d794-112c-4f74-9a31-bc8920364b81",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953564426000.7f7ea9bc-fc3f-4c84-934c-590ca74492e1",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953564426000.7f7ea9bc-fc3f-4c84-934c-590ca74492e1",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prio"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654953563836000.56d0d794-112c-4f74-9a31-bc8920364b81"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953564885000.ee30e093-64c4-41d3-b58e-cb0ae263e78b",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953564885000.ee30e093-64c4-41d3-b58e-cb0ae263e78b",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953565295000.987d21e0-4e52-4edf-96cd-855e522cd465",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953565295000.987d21e0-4e52-4edf-96cd-855e522cd465",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654953564885000.ee30e093-64c4-41d3-b58e-cb0ae263e78b"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953565675000.4cbdd750-b8b6-4c62-ba9d-cfe76d223844",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953565675000.4cbdd750-b8b6-4c62-ba9d-cfe76d223844",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953566060000.94c9dd67-1ff8-4e18-8479-bc926aca5365",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953566060000.94c9dd67-1ff8-4e18-8479-bc926aca5365",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Pending Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654953565675000.4cbdd750-b8b6-4c62-ba9d-cfe76d223844"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953566473000.bb68aa2f-9588-476f-8e31-887797f220c3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953566473000.bb68aa2f-9588-476f-8e31-887797f220c3",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953566926000.e614998b-ec79-47c5-a805-1bd67e62f986",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953566926000.e614998b-ec79-47c5-a805-1bd67e62f986",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prior Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654953566473000.bb68aa2f-9588-476f-8e31-887797f220c3"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953567370000.5cd2bcab-1f38-4394-b29c-39e75018432a",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953567370000.5cd2bcab-1f38-4394-b29c-39e75018432a",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654953567783000.062ee7cc-02f1-4d98-bf90-fc52922065dd",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654953567783000.062ee7cc-02f1-4d98-bf90-fc52922065dd",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital PriorPending"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654953567370000.5cd2bcab-1f38-4394-b29c-39e75018432a"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654953568478000.9b1e2a8a-4d4f-4530-80dd-12337a84776a",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654953568478000.9b1e2a8a-4d4f-4530-80dd-12337a84776a",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "EpisodeOfCare/1706654953569320000.33a306b5-ac76-4d0e-b1c6-8caf401d891a",
-      "resource" : {
-        "resourceType" : "EpisodeOfCare",
-        "id" : "1706654953569320000.33a306b5-ac76-4d0e-b1c6-8caf401d891a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "service-episode"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-            "valueString" : "ServiceDescriptor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654953568478000.9b1e2a8a-4d4f-4530-80dd-12337a84776a"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "ServiceIdentifier",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ]
+      },
+      "location" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "assigned-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "pending-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4"
+        },
+        "status" : "planned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-pending-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : false
+        } ],
+        "location" : {
+          "reference" : "Location/1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202"
+        },
+        "status" : "planned"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143424649000.9e0e6706-7e6d-40ea-922e-39843467963e",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143428170000.820874d7-6e6a-4a12-95e5-b412aafd11f7",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143431660000.f911a672-6707-405a-a764-68f775e90334",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143431660000.f911a672-6707-405a-a764-68f775e90334",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143443818000.52d48c57-cf83-4b05-946f-10a724214036",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714143442725000.4b1e875d-18a8-46ba-aaa8-0a4b433fc3e8"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org1"
+    }
+  }, {
+    "fullUrl" : "Location/1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143445514000.a966fe5c-d097-448c-bb95-f7e3b4a3efbe",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714143444722000.ee7654e3-3532-4a48-8e79-df2ef2b613dd"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org2"
+    }
+  }, {
+    "fullUrl" : "Location/1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143446638000.f3d1bf39-dde5-4756-8571-e8636ef4492f",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+        "valueString" : "20230501102531-0400"
+      } ],
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "LN"
+          } ],
+          "system" : "http://loinc.org",
+          "code" : "PrimaryCode",
+          "display" : "Primary Code Display"
+        } ]
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143448837000.17f3b9ce-da16-4d61-83c3-a1fef75ddd32",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143466327000.31a9ccf6-09ec-4d80-afb4-72762187918a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143469284000.6d3bb98a-d87c-4b5c-abfc-64d76370f093",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143471808000.4aa95b7c-4642-43b2-b3fa-9d5d6b5ca130",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143473774000.c58271b6-8c35-4ee7-8f53-49e37795da31",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143475559000.75e3537b-3a65-4a33-ba07-889947ec4953",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143477293000.f2393d3b-c86b-4de9-861a-b3886f845a95",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143479117000.33fe5c60-34b5-403e-a360-1945004c049d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143480746000.4f11391d-b55f-4dae-83fe-74ab7ebc7b50",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143482484000.c3c8f570-e426-4a80-8663-4f0b3332159e",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv2-13-referral-source-code"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "urn:oid:AssigningSystem",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referral Source Code1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714143484134000.d12915cf-50ef-4522-9bbc-1c80304774b4",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv2-13-referral-source-code"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "urn:oid:AssigningSystem",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referral Source Code2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143484923000.136c5c17-2201-4ead-b685-d8fd57bfcb3d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Assigned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714143484569000.84663d04-8eec-46b7-b101-4df1a55a8d08"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143485619000.b0ce2cb7-e845-4c87-8076-1927052684b0",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prio"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714143485262000.45f67f3b-af41-494d-a8af-99f0949fd247"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143486308000.05656f01-a5b4-448b-a77d-4529acde5886",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714143485964000.0720d6ca-60f1-4571-96a6-ad38260195d5"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143486959000.738e3f99-0949-46e4-b4ec-6231007390c4",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Pending Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714143486631000.f022606d-e9b7-4e95-90b2-84fba4589861"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143487661000.789413c9-f8a8-49a3-9403-935176fd9a8b",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prior Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714143487300000.9fad4343-1394-415b-98c8-d2e24e8c84f6"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714143488325000.ca24a116-bb65-4dc0-8623-e657465b5202",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital PriorPending"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714143487989000.187a2ab6-9a7a-4fde-a61c-3358b2ab425c"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "EpisodeOfCare/1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d",
+    "resource" : {
+      "resourceType" : "EpisodeOfCare",
+      "id" : "1706714143489934000.6a80d5f7-a83f-42ff-ba38-aa064d51793d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "service-episode"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+        "valueString" : "ServiceDescriptor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714143488960000.1170dc4b-821c-4657-b443-38aaa1dc20f5"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "ServiceIdentifier",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-y.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-y.fhir
@@ -10,3444 +10,4846 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714154076020000.c1adf546-98f1-4994-982c-beac1babb24e",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714154076020000.c1adf546-98f1-4994-982c-beac1babb24e",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714154083144000.e1221354-1ea1-43f8-8703-7bb935c84252",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714154083144000.e1221354-1ea1-43f8-8703-7bb935c84252",
-      "recorded" : "2024-01-31T10:15:54Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714154097450000.6a7235a4-83ea-4902-ad34-be382171ac41",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714154097450000.6a7235a4-83ea-4902-ad34-be382171ac41",
-      "target" : [ {
-        "reference" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
-      } ],
-      "recorded" : "2024-01-31T10:15:54Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Encounter/1706714154168226000.ec6d8dc4-0337-4ba1-a47d-80ce021968fd",
-    "resource" : {
-      "resourceType" : "Encounter",
-      "id" : "1706714154168226000.ec6d8dc4-0337-4ba1-a47d-80ce021968fd",
-      "meta" : {
-        "security" : [ {
-          "code" : "true"
-        } ]
-      },
-      "text" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
-          "valueString" : "Description"
-        } ],
-        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "413",
-            "display" : "V"
-          } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706714154076020000.c1adf546-98f1-4994-982c-beac1babb24e",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714154076020000.c1adf546-98f1-4994-982c-beac1babb24e",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "423",
-            "display" : "X"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714154083144000.e1221354-1ea1-43f8-8703-7bb935c84252",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714154083144000.e1221354-1ea1-43f8-8703-7bb935c84252",
+        "recorded" : "2024-01-31T10:15:54Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714154097450000.6a7235a4-83ea-4902-ad34-be382171ac41",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714154097450000.6a7235a4-83ea-4902-ad34-be382171ac41",
+        "target" : [
+          {
+            "reference" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
+          }
+        ],
+        "recorded" : "2024-01-31T10:15:54Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
-        "valueDateTime" : "2023-06-01T10:25:31-04:00",
-        "_valueDateTime" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230601102531-0400"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
-        "valueDateTime" : "2023-07-01T10:25:31-04:00",
-        "_valueDateTime" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230701102531-0400"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
-        "valueQuantity" : {
-          "value" : 5,
+      }
+    },
+    {
+      "fullUrl" : "Encounter/1706714154168226000.ec6d8dc4-0337-4ba1-a47d-80ce021968fd",
+      "resource" : {
+        "resourceType" : "Encounter",
+        "id" : "1706714154168226000.ec6d8dc4-0337-4ba1-a47d-80ce021968fd",
+        "meta" : {
+          "security" : [
+            {
+              "code" : "true"
+            }
+          ]
+        },
+        "text" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
+              "valueString" : "Description"
+            }
+          ],
+          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
+        },
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "413",
+                  "display" : "V"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "423",
+                  "display" : "X"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
+            "valueDateTime" : "2023-06-01T10:25:31-04:00",
+            "_valueDateTime" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                  "valueString" : "20230601102531-0400"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
+            "valueDateTime" : "2023-07-01T10:25:31-04:00",
+            "_valueDateTime" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                  "valueString" : "20230701102531-0400"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
+            "valueQuantity" : {
+              "value" : 5,
+              "unit" : "days",
+              "system" : "http://unitsofmeasure.org/",
+              "code" : "d"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "100",
+                  "display" : "PublicCode"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          }
+                        ],
+                        "code" : "444",
+                        "display" : "MODE"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "code" : "444",
+              "display" : "MODE"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "123",
+                  "display" : "CARELEVEL1"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+            "extension" : [
+              {
+                "url" : "pv1-12-preadmit-test-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "PRE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-18-patient-type",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "34",
+                      "display" : "PT"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-46-current-patient-balance",
+                "valueDecimal" : 55
+              },
+              {
+                "url" : "pv1-47-total-charges",
+                "valueDecimal" : 1000
+              },
+              {
+                "url" : "pv1-48-total-adjustments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-49-total-payments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-51-visit-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "316",
+                      "display" : "IND"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-30-transfer-to-bad-debt-date",
+                "valueString" : "T"
+              },
+              {
+                "url" : "pv1-31-bad-debt-agency-code",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "AGE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-32-bad-debt-transfer-amount",
+                "valueDecimal" : 3.4
+              },
+              {
+                "url" : "pv1-33-bad-debt-recovery-amount",
+                "valueDecimal" : 1.4
+              },
+              {
+                "url" : "pv1-34-delete-account-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "66",
+                      "display" : "DEL"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-35-delete-account-date",
+                "valueString" : "20240501102531-0400"
+              },
+              {
+                "url" : "pv1-39-servicing-facility",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "5678",
+                      "display" : "SERV"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-41-account-status",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "431",
+                      "display" : "ST"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
+            "extension" : [
+              {
+                "url" : "pv2-15-employment-illness-related-indicator",
+                "valueString" : "EMP_ILL"
+              },
+              {
+                "url" : "pv2-23-clinic-organization-name",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e"
+                }
+              },
+              {
+                "url" : "pv2-23-clinic-organization-name",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128"
+                }
+              },
+              {
+                "url" : "pv2-26-previous-treatment-date",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "pv2-29-first-similar-date",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "visit-number"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "VN"
+                }
+              ],
+              "text" : "visit number"
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "VisitNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber1",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber2",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "status" : "in-progress",
+        "class" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      }
+                    ],
+                    "code" : "O"
+                  }
+                ]
+              }
+            }
+          ],
+          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code" : "AMB",
+          "display" : "ambulatory"
+        },
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          }
+        ],
+        "serviceType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "MED"
+            }
+          ]
+        },
+        "priority" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "VIP"
+            }
+          ]
+        },
+        "subject" : {
+          "reference" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
+        },
+        "episodeOfCare" : [
+          {
+            "reference" : "EpisodeOfCare/1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c"
+          }
+        ],
+        "participant" : [
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee"
+            }
+          }
+        ],
+        "period" : {
+          "start" : "2024-08-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240801102531-0400"
+              }
+            ]
+          }
+        },
+        "length" : {
+          "value" : 12,
           "unit" : "days",
           "system" : "http://unitsofmeasure.org/",
           "code" : "d"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "100",
-            "display" : "PublicCode"
-          } ]
-        }
-      }, {
-        "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                } ],
-                "code" : "444",
-                "display" : "MODE"
-              } ]
-            }
-          } ],
-          "code" : "444",
-          "display" : "MODE"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "123",
-            "display" : "CARELEVEL1"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
-        "extension" : [ {
-          "url" : "pv1-12-preadmit-test-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "PRE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-18-patient-type",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "34",
-              "display" : "PT"
-            } ]
-          }
-        }, {
-          "url" : "pv1-46-current-patient-balance",
-          "valueDecimal" : 55
-        }, {
-          "url" : "pv1-47-total-charges",
-          "valueDecimal" : 1000
-        }, {
-          "url" : "pv1-48-total-adjustments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-49-total-payments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-51-visit-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "316",
-              "display" : "IND"
-            } ]
-          }
-        }, {
-          "url" : "pv1-30-transfer-to-bad-debt-date",
-          "valueString" : "T"
-        }, {
-          "url" : "pv1-31-bad-debt-agency-code",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "AGE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-32-bad-debt-transfer-amount",
-          "valueDecimal" : 3.4
-        }, {
-          "url" : "pv1-33-bad-debt-recovery-amount",
-          "valueDecimal" : 1.4
-        }, {
-          "url" : "pv1-34-delete-account-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "66",
-              "display" : "DEL"
-            } ]
-          }
-        }, {
-          "url" : "pv1-35-delete-account-date",
-          "valueString" : "20240501102531-0400"
-        }, {
-          "url" : "pv1-39-servicing-facility",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "5678",
-              "display" : "SERV"
-            } ]
-          }
-        }, {
-          "url" : "pv1-41-account-status",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "431",
-              "display" : "ST"
-            } ]
-          }
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
-        "extension" : [ {
-          "url" : "pv2-15-employment-illness-related-indicator",
-          "valueString" : "EMP_ILL"
-        }, {
-          "url" : "pv2-23-clinic-organization-name",
-          "valueReference" : {
-            "reference" : "Organization/1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e"
-          }
-        }, {
-          "url" : "pv2-23-clinic-organization-name",
-          "valueReference" : {
-            "reference" : "Organization/1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128"
-          }
-        }, {
-          "url" : "pv2-26-previous-treatment-date",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "pv2-29-first-similar-date",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "visit-number"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "VN"
-          } ],
-          "text" : "visit number"
         },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "VisitNumber",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+        "reasonCode" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "pv2-admit-reason"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "AD"
+              }
+            ]
           }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber1",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber2",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      } ],
-      "status" : "in-progress",
-      "class" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "O"
-            } ]
-          }
-        } ],
-        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code" : "AMB",
-        "display" : "ambulatory"
-      },
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "R"
-        } ]
-      } ],
-      "serviceType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "MED"
-        } ]
-      },
-      "priority" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "VIP"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
-      },
-      "episodeOfCare" : [ {
-        "reference" : "EpisodeOfCare/1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c"
-      } ],
-      "participant" : [ {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee"
-        }
-      } ],
-      "period" : {
-        "start" : "2024-08-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240801102531-0400"
-          } ]
-        }
-      },
-      "length" : {
-        "value" : 12,
-        "unit" : "days",
-        "system" : "http://unitsofmeasure.org/",
-        "code" : "d"
-      },
-      "reasonCode" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "pv2-admit-reason"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "1",
-          "display" : "AD"
-        } ]
-      } ],
-      "hospitalization" : {
-        "preAdmissionIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-            "valueReference" : {
-              "reference" : "Organization/1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a"
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AASys"
-                } ],
-                "code" : "AACode",
-                "display" : "Assigning Agency"
-              } ]
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AJSys"
-                } ],
-                "code" : "AJCode",
-                "display" : "Assigning Jurisdiction"
-              } ]
-            }
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-            "valueString" : "checkdigitscheme"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-            "valueString" : "checkdigit"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-            "valueString" : "ACSN"
-          } ],
-          "type" : {
-            "coding" : [ {
-              "code" : "ACSN"
-            } ]
-          },
-          "system" : "urn:oid:testcx42",
-          "_system" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "testcx42"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            } ]
-          },
-          "value" : "IDNumber",
-          "period" : {
-            "start" : "1988-07-04",
-            "_start" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "19880704"
-              } ]
+        ],
+        "hospitalization" : {
+          "preAdmissionIdentifier" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
             },
-            "end" : "2088-07-04",
-            "_end" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20880704"
-              } ]
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "IDNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
             }
-          }
-        },
-        "admitSource" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "Source"
-          } ]
-        },
-        "reAdmission" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "R"
-          } ]
-        },
-        "dietPreference" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "VEG"
-          } ]
-        } ],
-        "specialCourtesy" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A0"
-          } ]
-        }, {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A1"
-          } ]
-        } ],
-        "destination" : {
-          "reference" : "Location/1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3"
-        },
-        "dischargeDisposition" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "T"
-          } ]
-        }
-      },
-      "location" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "assigned-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "pending-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73"
-        },
-        "status" : "planned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-pending-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : false
-        } ],
-        "location" : {
-          "reference" : "Location/1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72"
-        },
-        "status" : "planned"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org1"
-    }
-  }, {
-    "fullUrl" : "Location/1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org2"
-    }
-  }, {
-    "fullUrl" : "Location/1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "PrimaryCode",
-          "display" : "Primary Code Display"
-        } ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv2-13-referral-source-code"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referral Source Code1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv2-13-referral-source-code"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referral Source Code2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Assigned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prio"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Pending Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prior Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital PriorPending"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "EpisodeOfCare/1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c",
-    "resource" : {
-      "resourceType" : "EpisodeOfCare",
-      "id" : "1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "service-episode"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-        "valueString" : "ServiceDescriptor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "ServiceIdentifier",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
           },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+          "admitSource" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "Source"
+              }
+            ]
+          },
+          "reAdmission" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          },
+          "dietPreference" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "1",
+                  "display" : "VEG"
+                }
+              ]
+            }
+          ],
+          "specialCourtesy" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A0"
+                }
+              ]
+            },
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A1"
+                }
+              ]
+            }
+          ],
+          "destination" : {
+            "reference" : "Location/1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3"
+          },
+          "dischargeDisposition" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "T"
+              }
+            ]
           }
+        },
+        "location" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "assigned-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "pending-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73"
+            },
+            "status" : "planned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-pending-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : false
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72"
+            },
+            "status" : "planned"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org1"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org2"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+            "valueString" : "20230501102531-0400"
+          }
+        ],
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "LN"
+                  }
+                ],
+                "system" : "http://loinc.org",
+                "code" : "PrimaryCode",
+                "display" : "Primary Code Display"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv2-13-referral-source-code"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referral Source Code1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv2-13-referral-source-code"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referral Source Code2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Assigned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prio"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Pending Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prior Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital PriorPending"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "EpisodeOfCare/1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c",
+      "resource" : {
+        "resourceType" : "EpisodeOfCare",
+        "id" : "1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "service-episode"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+            "valueString" : "ServiceDescriptor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "ServiceIdentifier",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-y.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter-pv22-y.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654964353003000.ef21ba4c-15ce-45f8-ab3a-13d935460b4c",
+  "id" : "1706714153695337000.58fe2f60-1eab-4561-a6a1-097c7c29557a",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:49:24.360-05:00"
+    "lastUpdated" : "2024-01-31T10:15:53.703-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,4841 +10,3444 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
+        }
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714154076020000.c1adf546-98f1-4994-982c-beac1babb24e",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714154076020000.c1adf546-98f1-4994-982c-beac1babb24e",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
           "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714154083144000.e1221354-1ea1-43f8-8703-7bb935c84252",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714154083144000.e1221354-1ea1-43f8-8703-7bb935c84252",
+      "recorded" : "2024-01-31T10:15:54Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
         },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+        "who" : {
+          "reference" : "Organization/1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21"
         }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154082380000.fee7eb74-e0b4-45e2-9e24-8beb37172d21",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714154097450000.6a7235a4-83ea-4902-ad34-be382171ac41",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714154097450000.6a7235a4-83ea-4902-ad34-be382171ac41",
+      "target" : [ {
+        "reference" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
+      } ],
+      "recorded" : "2024-01-31T10:15:54Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
       }
-    },
-    {
-      "fullUrl" : "Provenance/1706654964782270000.3fa4e129-478e-43cf-969d-6028995ec46c",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654964782270000.3fa4e129-478e-43cf-969d-6028995ec46c",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+    }
+  }, {
+    "fullUrl" : "Encounter/1706714154168226000.ec6d8dc4-0337-4ba1-a47d-80ce021968fd",
+    "resource" : {
+      "resourceType" : "Encounter",
+      "id" : "1706714154168226000.ec6d8dc4-0337-4ba1-a47d-80ce021968fd",
+      "meta" : {
+        "security" : [ {
+          "code" : "true"
+        } ]
+      },
+      "text" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
+          "valueString" : "Description"
+        } ],
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
+      },
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "413",
+            "display" : "V"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654964795535000.c54c0281-a5c7-421f-95ff-01979a0b313f",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654964795535000.c54c0281-a5c7-421f-95ff-01979a0b313f",
-        "recorded" : "2024-01-30T17:49:24Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654964790911000.77e4fda8-d381-40f0-8597-29c6234a8a9c"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964790911000.77e4fda8-d381-40f0-8597-29c6234a8a9c",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964790911000.77e4fda8-d381-40f0-8597-29c6234a8a9c",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654964811949000.4e88701d-2663-404e-9084-da42744f6de5",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654964811949000.4e88701d-2663-404e-9084-da42744f6de5"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654964812565000.c9a8c591-06db-4bc2-92d5-35683c7c13fa",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654964812565000.c9a8c591-06db-4bc2-92d5-35683c7c13fa",
-        "target" : [
-          {
-            "reference" : "Patient/1706654964811949000.4e88701d-2663-404e-9084-da42744f6de5"
-          }
-        ],
-        "recorded" : "2024-01-30T17:49:24Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "423",
+            "display" : "X"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Encounter/1706654964872867000.0f26e26c-010b-4fb7-95d2-f9a77e8e245a",
-      "resource" : {
-        "resourceType" : "Encounter",
-        "id" : "1706654964872867000.0f26e26c-010b-4fb7-95d2-f9a77e8e245a",
-        "meta" : {
-          "security" : [
-            {
-              "code" : "true"
-            }
-          ]
-        },
-        "text" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
-              "valueString" : "Description"
-            }
-          ],
-          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
-        },
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "413",
-                  "display" : "V"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "423",
-                  "display" : "X"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
-            "valueDateTime" : "2023-06-01T10:25:31-04:00",
-            "_valueDateTime" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                  "valueString" : "20230601102531-0400"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
-            "valueDateTime" : "2023-07-01T10:25:31-04:00",
-            "_valueDateTime" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                  "valueString" : "20230701102531-0400"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
-            "valueQuantity" : {
-              "value" : 5,
-              "unit" : "days",
-              "system" : "http://unitsofmeasure.org/",
-              "code" : "d"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "100",
-                  "display" : "PublicCode"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          }
-                        ],
-                        "code" : "444",
-                        "display" : "MODE"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "code" : "444",
-              "display" : "MODE"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "123",
-                  "display" : "CARELEVEL1"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter",
-            "extension" : [
-              {
-                "url" : "pv1-12-preadmit-test-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "PRE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-18-patient-type",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "34",
-                      "display" : "PT"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-46-current-patient-balance",
-                "valueDecimal" : 55
-              },
-              {
-                "url" : "pv1-47-total-charges",
-                "valueDecimal" : 1000
-              },
-              {
-                "url" : "pv1-48-total-adjustments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-49-total-payments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-51-visit-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "316",
-                      "display" : "IND"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-30-transfer-to-bad-debt-date",
-                "valueString" : "T"
-              },
-              {
-                "url" : "pv1-31-bad-debt-agency-code",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "AGE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-32-bad-debt-transfer-amount",
-                "valueDecimal" : 3.4
-              },
-              {
-                "url" : "pv1-33-bad-debt-recovery-amount",
-                "valueDecimal" : 1.4
-              },
-              {
-                "url" : "pv1-34-delete-account-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "66",
-                      "display" : "DEL"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-35-delete-account-date",
-                "valueString" : "20240501102531-0400"
-              },
-              {
-                "url" : "pv1-39-servicing-facility",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "5678",
-                      "display" : "SERV"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-41-account-status",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "431",
-                      "display" : "ST"
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-encounter",
-            "extension" : [
-              {
-                "url" : "pv2-15-employment-illness-related-indicator",
-                "valueString" : "EMP_ILL"
-              },
-              {
-                "url" : "pv2-23-clinic-organization-name",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964836579000.19fe3cf1-02f7-4f14-b67d-2970034b0e67"
-                }
-              },
-              {
-                "url" : "pv2-23-clinic-organization-name",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964838663000.19c5d4da-9d5d-47c3-95bc-c535eef67db6"
-                }
-              },
-              {
-                "url" : "pv2-26-previous-treatment-date",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "pv2-29-first-similar-date",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964815584000.82d8a8d0-dc10-4f91-a61e-552a95f01b58"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "visit-number"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "VN"
-                }
-              ],
-              "text" : "visit number"
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "VisitNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964818527000.c8a61d57-9468-4851-b7cf-c9f599f53a8a"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber1",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964823890000.7ed2b690-3ae3-4e70-a8b6-a5bb3fa9b322"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber2",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ],
-        "status" : "in-progress",
-        "class" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      }
-                    ],
-                    "code" : "O"
-                  }
-                ]
-              }
-            }
-          ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code" : "AMB",
-          "display" : "ambulatory"
-        },
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          }
-        ],
-        "serviceType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "MED"
-            }
-          ]
-        },
-        "priority" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "VIP"
-            }
-          ]
-        },
-        "subject" : {
-          "reference" : "Patient/1706654964811949000.4e88701d-2663-404e-9084-da42744f6de5"
-        },
-        "episodeOfCare" : [
-          {
-            "reference" : "EpisodeOfCare/1706654964874194000.11c0bd3f-a189-4317-b986-af0ad96acddf"
-          }
-        ],
-        "participant" : [
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964849420000.aa98a5ee-effe-4ef2-a732-3f5554aede17"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964851973000.9690d7fb-c8d6-460a-91d0-1c21b8ff7b7a"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964855076000.ddd90ca9-fcf6-4d22-bdd3-b0c79a0469ab"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964857290000.afa252d6-f600-4fa1-ad7c-a1df1f11ad47"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964859221000.b3b040db-916e-486f-981f-8089bc828db0"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964861138000.fc77d996-8c81-4872-bc57-6249e76bc540"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964862862000.775f08b2-74a4-4706-a6e6-5810e02c5b55"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964864385000.c71b90db-61c6-422d-9aab-3a0b913626b0"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964866134000.50a4a874-340b-4587-a820-4489367c4283"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654964868200000.bb294877-6e27-48d3-b6b2-18d7a696df1b"
-            }
-          }
-        ],
-        "period" : {
-          "start" : "2024-08-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240801102531-0400"
-              }
-            ]
-          }
-        },
-        "length" : {
-          "value" : 12,
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
+        "valueDateTime" : "2023-06-01T10:25:31-04:00",
+        "_valueDateTime" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230601102531-0400"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
+        "valueDateTime" : "2023-07-01T10:25:31-04:00",
+        "_valueDateTime" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230701102531-0400"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
+        "valueQuantity" : {
+          "value" : 5,
           "unit" : "days",
           "system" : "http://unitsofmeasure.org/",
           "code" : "d"
-        },
-        "reasonCode" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "pv2-admit-reason"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "AD"
-              }
-            ]
-          }
-        ],
-        "hospitalization" : {
-          "preAdmissionIdentifier" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964840530000.4007610f-1c79-4d9f-97d8-0d48de64d01d"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "IDNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          "admitSource" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "Source"
-              }
-            ]
-          },
-          "reAdmission" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          },
-          "dietPreference" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "1",
-                  "display" : "VEG"
-                }
-              ]
-            }
-          ],
-          "specialCourtesy" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A0"
-                }
-              ]
-            },
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A1"
-                }
-              ]
-            }
-          ],
-          "destination" : {
-            "reference" : "Location/1706654964839457000.e7f6fc72-d66e-46c1-9614-66b18d945b46"
-          },
-          "dischargeDisposition" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "T"
-              }
-            ]
-          }
-        },
-        "location" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "assigned-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654964869231000.b7fdb7d3-c978-4760-8b18-52f6e7259010"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654964869968000.c28491eb-e8ba-4cf5-be62-14bd1b6c385d"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654964870687000.f6e3b2d6-418d-49ba-a4de-d502b281fc58"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "pending-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654964871371000.6314efbb-6fde-4890-9131-c1c5cf16de34"
-            },
-            "status" : "planned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654964872087000.74e41882-4203-4fda-8bfc-bcd86ac75e86"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-pending-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : false
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654964872786000.fccd4a64-0919-4974-8ce4-5dcb8555fbe0"
-            },
-            "status" : "planned"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964815584000.82d8a8d0-dc10-4f91-a61e-552a95f01b58",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964815584000.82d8a8d0-dc10-4f91-a61e-552a95f01b58",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964818527000.c8a61d57-9468-4851-b7cf-c9f599f53a8a",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964818527000.c8a61d57-9468-4851-b7cf-c9f599f53a8a",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964823890000.7ed2b690-3ae3-4e70-a8b6-a5bb3fa9b322",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964823890000.7ed2b690-3ae3-4e70-a8b6-a5bb3fa9b322",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964835117000.31e5e5d9-dd78-4ef8-a7d5-0e16ee701cfb",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964835117000.31e5e5d9-dd78-4ef8-a7d5-0e16ee701cfb",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964836579000.19fe3cf1-02f7-4f14-b67d-2970034b0e67",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964836579000.19fe3cf1-02f7-4f14-b67d-2970034b0e67",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "100",
+            "display" : "PublicCode"
+          } ]
+        }
+      }, {
+        "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
+                  "valueString" : "coding"
+                } ],
+                "code" : "444",
+                "display" : "MODE"
+              } ]
             }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
+          } ],
+          "code" : "444",
+          "display" : "MODE"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "123",
+            "display" : "CARELEVEL1"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+        "extension" : [ {
+          "url" : "pv1-12-preadmit-test-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "PRE"
+            } ]
           }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654964835117000.31e5e5d9-dd78-4ef8-a7d5-0e16ee701cfb"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
+        }, {
+          "url" : "pv1-18-patient-type",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "34",
+              "display" : "PT"
+            } ]
           }
-        ],
-        "name" : "Org1"
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964837662000.98260dd2-ca3f-4f21-8a77-716268644589",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964837662000.98260dd2-ca3f-4f21-8a77-716268644589",
-        "extension" : [
-          {
+        }, {
+          "url" : "pv1-46-current-patient-balance",
+          "valueDecimal" : 55
+        }, {
+          "url" : "pv1-47-total-charges",
+          "valueDecimal" : 1000
+        }, {
+          "url" : "pv1-48-total-adjustments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-49-total-payments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-51-visit-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "316",
+              "display" : "IND"
+            } ]
+          }
+        }, {
+          "url" : "pv1-30-transfer-to-bad-debt-date",
+          "valueString" : "T"
+        }, {
+          "url" : "pv1-31-bad-debt-agency-code",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "AGE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-32-bad-debt-transfer-amount",
+          "valueDecimal" : 3.4
+        }, {
+          "url" : "pv1-33-bad-debt-recovery-amount",
+          "valueDecimal" : 1.4
+        }, {
+          "url" : "pv1-34-delete-account-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "66",
+              "display" : "DEL"
+            } ]
+          }
+        }, {
+          "url" : "pv1-35-delete-account-date",
+          "valueString" : "20240501102531-0400"
+        }, {
+          "url" : "pv1-39-servicing-facility",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "5678",
+              "display" : "SERV"
+            } ]
+          }
+        }, {
+          "url" : "pv1-41-account-status",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "431",
+              "display" : "ST"
+            } ]
+          }
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
+        "extension" : [ {
+          "url" : "pv2-15-employment-illness-related-indicator",
+          "valueString" : "EMP_ILL"
+        }, {
+          "url" : "pv2-23-clinic-organization-name",
+          "valueReference" : {
+            "reference" : "Organization/1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e"
+          }
+        }, {
+          "url" : "pv2-23-clinic-organization-name",
+          "valueReference" : {
+            "reference" : "Organization/1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128"
+          }
+        }, {
+          "url" : "pv2-26-previous-treatment-date",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "pv2-29-first-similar-date",
+          "valueString" : "20220501102531-0400"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "visit-number"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "VN"
+          } ],
+          "text" : "visit number"
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "VisitNumber",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
           }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964838663000.19c5d4da-9d5d-47c3-95bc-c535eef67db6",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964838663000.19c5d4da-9d5d-47c3-95bc-c535eef67db6",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber1",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber2",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ],
+      "status" : "in-progress",
+      "class" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "O"
+            } ]
+          }
+        } ],
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code" : "AMB",
+        "display" : "ambulatory"
+      },
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "R"
+        } ]
+      } ],
+      "serviceType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "MED"
+        } ]
+      },
+      "priority" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "VIP"
+        } ]
+      },
+      "subject" : {
+        "reference" : "Patient/1706714154096851000.165fee3c-6cc0-4543-8f14-dceb18b97f01"
+      },
+      "episodeOfCare" : [ {
+        "reference" : "EpisodeOfCare/1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c"
+      } ],
+      "participant" : [ {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee"
+        }
+      } ],
+      "period" : {
+        "start" : "2024-08-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240801102531-0400"
+          } ]
+        }
+      },
+      "length" : {
+        "value" : 12,
+        "unit" : "days",
+        "system" : "http://unitsofmeasure.org/",
+        "code" : "d"
+      },
+      "reasonCode" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "pv2-admit-reason"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "1",
+          "display" : "AD"
+        } ]
+      } ],
+      "hospitalization" : {
+        "preAdmissionIdentifier" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+            "valueReference" : {
+              "reference" : "Organization/1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a"
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AASys"
+                } ],
+                "code" : "AACode",
+                "display" : "Assigning Agency"
+              } ]
             }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AJSys"
+                } ],
+                "code" : "AJCode",
+                "display" : "Assigning Jurisdiction"
+              } ]
+            }
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            "valueString" : "checkdigitscheme"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            "valueString" : "checkdigit"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+            "valueString" : "ACSN"
+          } ],
+          "type" : {
+            "coding" : [ {
+              "code" : "ACSN"
+            } ]
           },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654964837662000.98260dd2-ca3f-4f21-8a77-716268644589"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Org2"
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964839457000.e7f6fc72-d66e-46c1-9614-66b18d945b46",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964839457000.e7f6fc72-d66e-46c1-9614-66b18d945b46",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "LN"
-                  }
-                ],
-                "system" : "http://loinc.org",
-                "code" : "PrimaryCode",
-                "display" : "Primary Code Display"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964840530000.4007610f-1c79-4d9f-97d8-0d48de64d01d",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964840530000.4007610f-1c79-4d9f-97d8-0d48de64d01d",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
+          "system" : "urn:oid:testcx42",
+          "_system" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "testcx42"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            } ]
           },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
+          "value" : "IDNumber",
+          "period" : {
+            "start" : "1988-07-04",
+            "_start" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "19880704"
+              } ]
             },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964849420000.aa98a5ee-effe-4ef2-a732-3f5554aede17",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964849420000.aa98a5ee-effe-4ef2-a732-3f5554aede17",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
+            "end" : "2088-07-04",
+            "_end" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20880704"
+              } ]
             }
           }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964851973000.9690d7fb-c8d6-460a-91d0-1c21b8ff7b7a",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964851973000.9690d7fb-c8d6-460a-91d0-1c21b8ff7b7a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964855076000.ddd90ca9-fcf6-4d22-bdd3-b0c79a0469ab",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964855076000.ddd90ca9-fcf6-4d22-bdd3-b0c79a0469ab",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964857290000.afa252d6-f600-4fa1-ad7c-a1df1f11ad47",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964857290000.afa252d6-f600-4fa1-ad7c-a1df1f11ad47",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964859221000.b3b040db-916e-486f-981f-8089bc828db0",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964859221000.b3b040db-916e-486f-981f-8089bc828db0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964861138000.fc77d996-8c81-4872-bc57-6249e76bc540",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964861138000.fc77d996-8c81-4872-bc57-6249e76bc540",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964862862000.775f08b2-74a4-4706-a6e6-5810e02c5b55",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964862862000.775f08b2-74a4-4706-a6e6-5810e02c5b55",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964864385000.c71b90db-61c6-422d-9aab-3a0b913626b0",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964864385000.c71b90db-61c6-422d-9aab-3a0b913626b0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964866134000.50a4a874-340b-4587-a820-4489367c4283",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964866134000.50a4a874-340b-4587-a820-4489367c4283",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv2-13-referral-source-code"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "urn:oid:AssigningSystem",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referral Source Code1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654964868200000.bb294877-6e27-48d3-b6b2-18d7a696df1b",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654964868200000.bb294877-6e27-48d3-b6b2-18d7a696df1b",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv2-13-referral-source-code"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "urn:oid:AssigningSystem",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referral Source Code2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964868733000.f421e7d6-4510-4f8b-8676-652c95068d70",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964868733000.f421e7d6-4510-4f8b-8676-652c95068d70",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964869231000.b7fdb7d3-c978-4760-8b18-52f6e7259010",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964869231000.b7fdb7d3-c978-4760-8b18-52f6e7259010",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Assigned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654964868733000.f421e7d6-4510-4f8b-8676-652c95068d70"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+        },
+        "admitSource" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "Source"
+          } ]
+        },
+        "reAdmission" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "R"
+          } ]
+        },
+        "dietPreference" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "VEG"
+          } ]
+        } ],
+        "specialCourtesy" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A0"
+          } ]
+        }, {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A1"
+          } ]
+        } ],
+        "destination" : {
+          "reference" : "Location/1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3"
+        },
+        "dischargeDisposition" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "T"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964869597000.cb207d3c-a4b2-41b1-aff6-6dce560d92e9",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964869597000.cb207d3c-a4b2-41b1-aff6-6dce560d92e9",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964869968000.c28491eb-e8ba-4cf5-be62-14bd1b6c385d",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964869968000.c28491eb-e8ba-4cf5-be62-14bd1b6c385d",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prio"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654964869597000.cb207d3c-a4b2-41b1-aff6-6dce560d92e9"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964870327000.8b8f6521-0e42-4e57-b951-0bf9f74609fa",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964870327000.8b8f6521-0e42-4e57-b951-0bf9f74609fa",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964870687000.f6e3b2d6-418d-49ba-a4de-d502b281fc58",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964870687000.f6e3b2d6-418d-49ba-a4de-d502b281fc58",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654964870327000.8b8f6521-0e42-4e57-b951-0bf9f74609fa"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964871034000.60f8e4f0-ee86-4182-8485-dd41d5078920",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964871034000.60f8e4f0-ee86-4182-8485-dd41d5078920",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964871371000.6314efbb-6fde-4890-9131-c1c5cf16de34",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964871371000.6314efbb-6fde-4890-9131-c1c5cf16de34",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Pending Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654964871034000.60f8e4f0-ee86-4182-8485-dd41d5078920"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964871723000.3cc681b6-2926-4da7-bb09-010067fa2985",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964871723000.3cc681b6-2926-4da7-bb09-010067fa2985",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964872087000.74e41882-4203-4fda-8bfc-bcd86ac75e86",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964872087000.74e41882-4203-4fda-8bfc-bcd86ac75e86",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prior Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654964871723000.3cc681b6-2926-4da7-bb09-010067fa2985"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964872449000.4c23a9c6-c63a-40b7-aa86-3ce01f6cfd88",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964872449000.4c23a9c6-c63a-40b7-aa86-3ce01f6cfd88",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654964872786000.fccd4a64-0919-4974-8ce4-5dcb8555fbe0",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654964872786000.fccd4a64-0919-4974-8ce4-5dcb8555fbe0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital PriorPending"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654964872449000.4c23a9c6-c63a-40b7-aa86-3ce01f6cfd88"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654964873520000.a5cadf08-5104-491d-94c3-a0f5b5ea43e1",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654964873520000.a5cadf08-5104-491d-94c3-a0f5b5ea43e1",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "EpisodeOfCare/1706654964874194000.11c0bd3f-a189-4317-b986-af0ad96acddf",
-      "resource" : {
-        "resourceType" : "EpisodeOfCare",
-        "id" : "1706654964874194000.11c0bd3f-a189-4317-b986-af0ad96acddf",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "service-episode"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-            "valueString" : "ServiceDescriptor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654964873520000.a5cadf08-5104-491d-94c3-a0f5b5ea43e1"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "ServiceIdentifier",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ]
+      },
+      "location" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "assigned-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "pending-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73"
+        },
+        "status" : "planned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-pending-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : false
+        } ],
+        "location" : {
+          "reference" : "Location/1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72"
+        },
+        "status" : "planned"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154100359000.156d262b-38f9-495e-8cc8-eda415da1c96",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154103008000.fc98a369-5bd6-4f13-8bfe-8e0e2b72d615",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154105825000.58a7fb5f-f203-4d9a-a5cc-4f0966dccf2b",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154115160000.54dd85f5-6311-4ed4-832c-cfd021cc0e6e",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714154113999000.1bc2ca2c-4129-449d-9148-9655a6ac8a9a"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org1"
+    }
+  }, {
+    "fullUrl" : "Location/1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154122611000.214ce61c-6556-4add-bfdc-270aea048128",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714154121583000.9a0e9915-c522-4d9e-8983-b83a32abf467"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org2"
+    }
+  }, {
+    "fullUrl" : "Location/1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154123518000.00c2b8cf-d779-4c74-8fd9-f7b882ba0dd3",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+        "valueString" : "20230501102531-0400"
+      } ],
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "LN"
+          } ],
+          "system" : "http://loinc.org",
+          "code" : "PrimaryCode",
+          "display" : "Primary Code Display"
+        } ]
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154124638000.0d44ffe7-2267-42c7-9b3a-fae74df0833a",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154134332000.3882f480-d5c5-4089-a04b-57dd90f6e872",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154137432000.eff871a1-1d0b-4950-8b9a-bb64d4bf3b0c",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154141830000.45c39d1f-4532-4557-87a6-93c87eda86da",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154145587000.548f403d-309c-4b78-b1e1-1527baf575f9",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154148447000.f666de4f-d595-4b75-9274-cb4d640f612a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154151035000.93687c46-644b-4d28-aa4c-23c6a5a15b84",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154153716000.7f1ad6c0-032d-458a-8972-0b82dede7c06",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154156574000.13c1bc74-73e7-4571-a604-f026e755a9bb",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154159269000.ab1958c3-fa54-42f8-a856-81925df294fc",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv2-13-referral-source-code"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "urn:oid:AssigningSystem",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referral Source Code1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714154161820000.78f603e6-2edb-47cb-a4b2-53d75e776bee",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv2-13-referral-source-code"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "urn:oid:AssigningSystem",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referral Source Code2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154162954000.aafce93d-9010-4ce4-a380-c82a9484ca78",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Assigned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714154162407000.040d75fb-b6cc-46a6-b6ff-0fb1da4d6e94"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154163965000.5b933f36-1ada-4d89-8d85-179b5b9a401b",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prio"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714154163455000.a2eca500-6144-4d9d-8bb4-d06796604736"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154165047000.007d4265-ee23-4dda-965e-04f7f61484f8",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714154164427000.63f4f030-25bb-45a7-a3bd-62cb24c96200"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154165935000.2b628680-60dd-4924-a823-bbfc1355ec73",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Pending Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714154165488000.84437b5a-bef7-4098-8049-c66fb6052b59"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154167003000.7ca92cf3-80b0-477e-ab71-abcf92d66a6b",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prior Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714154166422000.4802528b-9796-46e7-b49d-df5a70ad207a"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714154168126000.3d56e083-3b81-4e01-b819-433e5375cd72",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital PriorPending"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714154167490000.fcc6708d-3d07-4f52-9dff-1ae902045b3b"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "EpisodeOfCare/1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c",
+    "resource" : {
+      "resourceType" : "EpisodeOfCare",
+      "id" : "1706714154169901000.6d56f426-8e8b-41c7-81ed-86ed1b58b32c",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "service-episode"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+        "valueString" : "ServiceDescriptor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714154168888000.922e6f2f-4ce0-4268-b89d-17a4e0fe36ce"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "ServiceIdentifier",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter.fhir
@@ -10,3444 +10,4846 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714165362583000.d07d67c5-449a-4359-b32b-bdd4108472f3",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714165362583000.d07d67c5-449a-4359-b32b-bdd4108472f3",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714165369929000.add4f998-103e-48c1-bd76-a07a517a49cd",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714165369929000.add4f998-103e-48c1-bd76-a07a517a49cd",
-      "recorded" : "2024-01-31T10:16:05Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714165385932000.63422aee-d739-4d2f-8f7c-a31602252d77",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714165385932000.63422aee-d739-4d2f-8f7c-a31602252d77",
-      "target" : [ {
-        "reference" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
-      } ],
-      "recorded" : "2024-01-31T10:16:05Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Encounter/1706714165452559000.be2b3b0c-0fc7-428f-af28-900db358763a",
-    "resource" : {
-      "resourceType" : "Encounter",
-      "id" : "1706714165452559000.be2b3b0c-0fc7-428f-af28-900db358763a",
-      "meta" : {
-        "security" : [ {
-          "code" : "SEC"
-        } ]
-      },
-      "text" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
-          "valueString" : "Description"
-        } ],
-        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "413",
-            "display" : "V"
-          } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706714165362583000.d07d67c5-449a-4359-b32b-bdd4108472f3",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714165362583000.d07d67c5-449a-4359-b32b-bdd4108472f3",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "423",
-            "display" : "X"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714165369929000.add4f998-103e-48c1-bd76-a07a517a49cd",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714165369929000.add4f998-103e-48c1-bd76-a07a517a49cd",
+        "recorded" : "2024-01-31T10:16:05Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714165385932000.63422aee-d739-4d2f-8f7c-a31602252d77",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714165385932000.63422aee-d739-4d2f-8f7c-a31602252d77",
+        "target" : [
+          {
+            "reference" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
+          }
+        ],
+        "recorded" : "2024-01-31T10:16:05Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
         }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
-        "valueDateTime" : "2023-06-01T10:25:31-04:00",
-        "_valueDateTime" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230601102531-0400"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
-        "valueDateTime" : "2023-07-01T10:25:31-04:00",
-        "_valueDateTime" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20230701102531-0400"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
-        "valueQuantity" : {
-          "value" : 5,
+      }
+    },
+    {
+      "fullUrl" : "Encounter/1706714165452559000.be2b3b0c-0fc7-428f-af28-900db358763a",
+      "resource" : {
+        "resourceType" : "Encounter",
+        "id" : "1706714165452559000.be2b3b0c-0fc7-428f-af28-900db358763a",
+        "meta" : {
+          "security" : [
+            {
+              "code" : "SEC"
+            }
+          ]
+        },
+        "text" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
+              "valueString" : "Description"
+            }
+          ],
+          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
+        },
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "413",
+                  "display" : "V"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "423",
+                  "display" : "X"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
+            "valueDateTime" : "2023-06-01T10:25:31-04:00",
+            "_valueDateTime" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                  "valueString" : "20230601102531-0400"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
+            "valueDateTime" : "2023-07-01T10:25:31-04:00",
+            "_valueDateTime" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                  "valueString" : "20230701102531-0400"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
+            "valueQuantity" : {
+              "value" : 5,
+              "unit" : "days",
+              "system" : "http://unitsofmeasure.org/",
+              "code" : "d"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "100",
+                  "display" : "PublicCode"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          }
+                        ],
+                        "code" : "444",
+                        "display" : "MODE"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "code" : "444",
+              "display" : "MODE"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "123",
+                  "display" : "CARELEVEL1"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+            "extension" : [
+              {
+                "url" : "pv1-12-preadmit-test-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "PRE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-18-patient-type",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "34",
+                      "display" : "PT"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-46-current-patient-balance",
+                "valueDecimal" : 55
+              },
+              {
+                "url" : "pv1-47-total-charges",
+                "valueDecimal" : 1000
+              },
+              {
+                "url" : "pv1-48-total-adjustments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-49-total-payments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-51-visit-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "316",
+                      "display" : "IND"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-30-transfer-to-bad-debt-date",
+                "valueString" : "T"
+              },
+              {
+                "url" : "pv1-31-bad-debt-agency-code",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "AGE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-32-bad-debt-transfer-amount",
+                "valueDecimal" : 3.4
+              },
+              {
+                "url" : "pv1-33-bad-debt-recovery-amount",
+                "valueDecimal" : 1.4
+              },
+              {
+                "url" : "pv1-34-delete-account-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "66",
+                      "display" : "DEL"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-35-delete-account-date",
+                "valueString" : "20240501102531-0400"
+              },
+              {
+                "url" : "pv1-39-servicing-facility",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "5678",
+                      "display" : "SERV"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-41-account-status",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "431",
+                      "display" : "ST"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
+            "extension" : [
+              {
+                "url" : "pv2-15-employment-illness-related-indicator",
+                "valueString" : "EMP_ILL"
+              },
+              {
+                "url" : "pv2-23-clinic-organization-name",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f"
+                }
+              },
+              {
+                "url" : "pv2-23-clinic-organization-name",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a"
+                }
+              },
+              {
+                "url" : "pv2-26-previous-treatment-date",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "pv2-29-first-similar-date",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "visit-number"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "VN"
+                }
+              ],
+              "text" : "visit number"
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "VisitNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber1",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber2",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "status" : "in-progress",
+        "class" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      }
+                    ],
+                    "code" : "O"
+                  }
+                ]
+              }
+            }
+          ],
+          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code" : "AMB",
+          "display" : "ambulatory"
+        },
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          }
+        ],
+        "serviceType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "MED"
+            }
+          ]
+        },
+        "priority" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "VIP"
+            }
+          ]
+        },
+        "subject" : {
+          "reference" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
+        },
+        "episodeOfCare" : [
+          {
+            "reference" : "EpisodeOfCare/1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a"
+          }
+        ],
+        "participant" : [
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74"
+            }
+          }
+        ],
+        "period" : {
+          "start" : "2024-08-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240801102531-0400"
+              }
+            ]
+          }
+        },
+        "length" : {
+          "value" : 12,
           "unit" : "days",
           "system" : "http://unitsofmeasure.org/",
           "code" : "d"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "100",
-            "display" : "PublicCode"
-          } ]
-        }
-      }, {
-        "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                } ],
-                "code" : "444",
-                "display" : "MODE"
-              } ]
-            }
-          } ],
-          "code" : "444",
-          "display" : "MODE"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "123",
-            "display" : "CARELEVEL1"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
-        "extension" : [ {
-          "url" : "pv1-12-preadmit-test-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "PRE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-18-patient-type",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "34",
-              "display" : "PT"
-            } ]
-          }
-        }, {
-          "url" : "pv1-46-current-patient-balance",
-          "valueDecimal" : 55
-        }, {
-          "url" : "pv1-47-total-charges",
-          "valueDecimal" : 1000
-        }, {
-          "url" : "pv1-48-total-adjustments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-49-total-payments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-51-visit-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "316",
-              "display" : "IND"
-            } ]
-          }
-        }, {
-          "url" : "pv1-30-transfer-to-bad-debt-date",
-          "valueString" : "T"
-        }, {
-          "url" : "pv1-31-bad-debt-agency-code",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "AGE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-32-bad-debt-transfer-amount",
-          "valueDecimal" : 3.4
-        }, {
-          "url" : "pv1-33-bad-debt-recovery-amount",
-          "valueDecimal" : 1.4
-        }, {
-          "url" : "pv1-34-delete-account-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "66",
-              "display" : "DEL"
-            } ]
-          }
-        }, {
-          "url" : "pv1-35-delete-account-date",
-          "valueString" : "20240501102531-0400"
-        }, {
-          "url" : "pv1-39-servicing-facility",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "5678",
-              "display" : "SERV"
-            } ]
-          }
-        }, {
-          "url" : "pv1-41-account-status",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "431",
-              "display" : "ST"
-            } ]
-          }
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
-        "extension" : [ {
-          "url" : "pv2-15-employment-illness-related-indicator",
-          "valueString" : "EMP_ILL"
-        }, {
-          "url" : "pv2-23-clinic-organization-name",
-          "valueReference" : {
-            "reference" : "Organization/1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f"
-          }
-        }, {
-          "url" : "pv2-23-clinic-organization-name",
-          "valueReference" : {
-            "reference" : "Organization/1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a"
-          }
-        }, {
-          "url" : "pv2-26-previous-treatment-date",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "pv2-29-first-similar-date",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "visit-number"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "VN"
-          } ],
-          "text" : "visit number"
         },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "VisitNumber",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+        "reasonCode" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "pv2-admit-reason"
+              }
+            ],
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "AD"
+              }
+            ]
           }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber1",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber2",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      } ],
-      "status" : "in-progress",
-      "class" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "O"
-            } ]
-          }
-        } ],
-        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code" : "AMB",
-        "display" : "ambulatory"
-      },
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "R"
-        } ]
-      } ],
-      "serviceType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "MED"
-        } ]
-      },
-      "priority" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "VIP"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
-      },
-      "episodeOfCare" : [ {
-        "reference" : "EpisodeOfCare/1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a"
-      } ],
-      "participant" : [ {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74"
-        }
-      } ],
-      "period" : {
-        "start" : "2024-08-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240801102531-0400"
-          } ]
-        }
-      },
-      "length" : {
-        "value" : 12,
-        "unit" : "days",
-        "system" : "http://unitsofmeasure.org/",
-        "code" : "d"
-      },
-      "reasonCode" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "pv2-admit-reason"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "1",
-          "display" : "AD"
-        } ]
-      } ],
-      "hospitalization" : {
-        "preAdmissionIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-            "valueReference" : {
-              "reference" : "Organization/1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58"
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AASys"
-                } ],
-                "code" : "AACode",
-                "display" : "Assigning Agency"
-              } ]
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AJSys"
-                } ],
-                "code" : "AJCode",
-                "display" : "Assigning Jurisdiction"
-              } ]
-            }
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-            "valueString" : "checkdigitscheme"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-            "valueString" : "checkdigit"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-            "valueString" : "ACSN"
-          } ],
-          "type" : {
-            "coding" : [ {
-              "code" : "ACSN"
-            } ]
-          },
-          "system" : "urn:oid:testcx42",
-          "_system" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "testcx42"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            } ]
-          },
-          "value" : "IDNumber",
-          "period" : {
-            "start" : "1988-07-04",
-            "_start" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "19880704"
-              } ]
+        ],
+        "hospitalization" : {
+          "preAdmissionIdentifier" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
             },
-            "end" : "2088-07-04",
-            "_end" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20880704"
-              } ]
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "IDNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
             }
-          }
-        },
-        "admitSource" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "Source"
-          } ]
-        },
-        "reAdmission" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "R"
-          } ]
-        },
-        "dietPreference" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "VEG"
-          } ]
-        } ],
-        "specialCourtesy" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A0"
-          } ]
-        }, {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A1"
-          } ]
-        } ],
-        "destination" : {
-          "reference" : "Location/1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c"
-        },
-        "dischargeDisposition" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "T"
-          } ]
-        }
-      },
-      "location" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "assigned-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714165448263000.c3135427-1e81-4306-834e-df63346cc817"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "pending-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6"
-        },
-        "status" : "planned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-pending-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : false
-        } ],
-        "location" : {
-          "reference" : "Location/1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f"
-        },
-        "status" : "planned"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org1"
-    }
-  }, {
-    "fullUrl" : "Location/1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-        "valueCode" : "ISO"
-      } ],
-      "identifier" : [ {
-        "value" : "2.16.840.1.113883.9.11"
-      } ],
-      "name" : "Hospital A",
-      "physicalType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueCodeableConcept" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "organization-name-type-code"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "1",
-                "code" : "1234-5",
-                "display" : "TestText"
-              }, {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "alt-coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "LN"
-                } ],
-                "system" : "http://loinc.org",
-                "version" : "2",
-                "code" : "1234-5",
-                "display" : "TestAltText"
-              } ],
-              "text" : "OriginalText"
-            }
-          } ],
-          "system" : "LN",
-          "version" : "1",
-          "code" : "1234-5",
-          "display" : "TestText"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-        "extension" : [ {
-          "url" : "XON.3",
-          "valueString" : "123"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "Check Digit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "Assigning Authority"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "2.1.4.1"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "C1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-          "valueReference" : {
-            "reference" : "Location/1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MD"
-          } ]
-        },
-        "value" : "123"
-      } ],
-      "name" : "Org2"
-    }
-  }, {
-    "fullUrl" : "Location/1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "PrimaryCode",
-          "display" : "Primary Code Display"
-        } ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv2-13-referral-source-code"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referral Source Code1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv2-13-referral-source-code"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referral Source Code2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Assigned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165448263000.c3135427-1e81-4306-834e-df63346cc817",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165448263000.c3135427-1e81-4306-834e-df63346cc817",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prio"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Pending Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prior Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital PriorPending"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "EpisodeOfCare/1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a",
-    "resource" : {
-      "resourceType" : "EpisodeOfCare",
-      "id" : "1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "service-episode"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-        "valueString" : "ServiceDescriptor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "ServiceIdentifier",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
           },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+          "admitSource" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "Source"
+              }
+            ]
+          },
+          "reAdmission" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          },
+          "dietPreference" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "1",
+                  "display" : "VEG"
+                }
+              ]
+            }
+          ],
+          "specialCourtesy" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A0"
+                }
+              ]
+            },
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A1"
+                }
+              ]
+            }
+          ],
+          "destination" : {
+            "reference" : "Location/1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c"
+          },
+          "dischargeDisposition" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "T"
+              }
+            ]
           }
+        },
+        "location" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "assigned-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714165448263000.c3135427-1e81-4306-834e-df63346cc817"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "pending-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6"
+            },
+            "status" : "planned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-pending-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : false
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f"
+            },
+            "status" : "planned"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org1"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          }
+        ],
+        "identifier" : [
+          {
+            "value" : "2.16.840.1.113883.9.11"
+          }
+        ],
+        "name" : "Hospital A",
+        "physicalType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                  "valueString" : "identifier"
+                }
+              ],
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+            "valueCoding" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueCodeableConcept" : {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                        "valueString" : "organization-name-type-code"
+                      }
+                    ],
+                    "coding" : [
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "1",
+                        "code" : "1234-5",
+                        "display" : "TestText"
+                      },
+                      {
+                        "extension" : [
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                            "valueString" : "alt-coding"
+                          },
+                          {
+                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                            "valueString" : "LN"
+                          }
+                        ],
+                        "system" : "http://loinc.org",
+                        "version" : "2",
+                        "code" : "1234-5",
+                        "display" : "TestAltText"
+                      }
+                    ],
+                    "text" : "OriginalText"
+                  }
+                }
+              ],
+              "system" : "LN",
+              "version" : "1",
+              "code" : "1234-5",
+              "display" : "TestText"
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+            "extension" : [
+              {
+                "url" : "XON.3",
+                "valueString" : "123"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "Check Digit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                    "valueString" : "Assigning Authority"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                    "valueString" : "2.1.4.1"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                    "valueCode" : "ISO"
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "C1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+                "valueReference" : {
+                  "reference" : "Location/1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af"
+                }
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                      "valueString" : "identifier"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MD"
+                }
+              ]
+            },
+            "value" : "123"
+          }
+        ],
+        "name" : "Org2"
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+            "valueString" : "20230501102531-0400"
+          }
+        ],
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "LN"
+                  }
+                ],
+                "system" : "http://loinc.org",
+                "code" : "PrimaryCode",
+                "display" : "Primary Code Display"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv2-13-referral-source-code"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referral Source Code1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv2-13-referral-source-code"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referral Source Code2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Assigned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165448263000.c3135427-1e81-4306-834e-df63346cc817",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165448263000.c3135427-1e81-4306-834e-df63346cc817",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prio"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Pending Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prior Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital PriorPending"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "EpisodeOfCare/1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a",
+      "resource" : {
+        "resourceType" : "EpisodeOfCare",
+        "id" : "1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "service-episode"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+            "valueString" : "ServiceDescriptor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "ServiceIdentifier",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-PV2-to-Encounter.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654974421269000.8940a79f-b208-4f13-af58-954f00bc159c",
+  "id" : "1706714164996120000.d094331f-ae22-4862-a226-f206b18fcb3f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:49:34.429-05:00"
+    "lastUpdated" : "2024-01-31T10:16:05.003-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,4841 +10,3444 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
+        }
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714165362583000.d07d67c5-449a-4359-b32b-bdd4108472f3",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714165362583000.d07d67c5-449a-4359-b32b-bdd4108472f3",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
           "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714165369929000.add4f998-103e-48c1-bd76-a07a517a49cd",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714165369929000.add4f998-103e-48c1-bd76-a07a517a49cd",
+      "recorded" : "2024-01-31T10:16:05Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
         },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+        "who" : {
+          "reference" : "Organization/1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2"
         }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165369240000.348fbda4-5645-47cb-a547-4c3ecf18cba2",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714165385932000.63422aee-d739-4d2f-8f7c-a31602252d77",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714165385932000.63422aee-d739-4d2f-8f7c-a31602252d77",
+      "target" : [ {
+        "reference" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
+      } ],
+      "recorded" : "2024-01-31T10:16:05Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
       }
-    },
-    {
-      "fullUrl" : "Provenance/1706654974835440000.99607d86-4f78-4d9d-93c7-6a21ab89fc6b",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654974835440000.99607d86-4f78-4d9d-93c7-6a21ab89fc6b",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
+    }
+  }, {
+    "fullUrl" : "Encounter/1706714165452559000.be2b3b0c-0fc7-428f-af28-900db358763a",
+    "resource" : {
+      "resourceType" : "Encounter",
+      "id" : "1706714165452559000.be2b3b0c-0fc7-428f-af28-900db358763a",
+      "meta" : {
+        "security" : [ {
+          "code" : "SEC"
+        } ]
+      },
+      "text" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
+          "valueString" : "Description"
+        } ],
+        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
+      },
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "413",
+            "display" : "V"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654974843005000.bdd0f09c-15c7-4140-80c4-9e4cd63863ce",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654974843005000.bdd0f09c-15c7-4140-80c4-9e4cd63863ce",
-        "recorded" : "2024-01-30T17:49:34Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654974842554000.6ad1010f-ceec-486c-a231-d02aaf8b312d"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974842554000.6ad1010f-ceec-486c-a231-d02aaf8b312d",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974842554000.6ad1010f-ceec-486c-a231-d02aaf8b312d",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654974858802000.5b3e6b4b-d2bc-4df5-be45-5b29d41c3ad8",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654974858802000.5b3e6b4b-d2bc-4df5-be45-5b29d41c3ad8"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654974859530000.97e60e3b-b06c-4ff9-81c1-c17c1458bff1",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654974859530000.97e60e3b-b06c-4ff9-81c1-c17c1458bff1",
-        "target" : [
-          {
-            "reference" : "Patient/1706654974858802000.5b3e6b4b-d2bc-4df5-be45-5b29d41c3ad8"
-          }
-        ],
-        "recorded" : "2024-01-30T17:49:34Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "423",
+            "display" : "X"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Encounter/1706654974925424000.6d3f6c00-7b3f-4a9b-8616-0e63531526f6",
-      "resource" : {
-        "resourceType" : "Encounter",
-        "id" : "1706654974925424000.6d3f6c00-7b3f-4a9b-8616-0e63531526f6",
-        "meta" : {
-          "security" : [
-            {
-              "code" : "SEC"
-            }
-          ]
-        },
-        "text" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-visit-description",
-              "valueString" : "Description"
-            }
-          ],
-          "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\">Description</div>"
-        },
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "413",
-                  "display" : "V"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/visit-user-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "423",
-                  "display" : "X"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
-            "valueDateTime" : "2023-06-01T10:25:31-04:00",
-            "_valueDateTime" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                  "valueString" : "20230601102531-0400"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
-            "valueDateTime" : "2023-07-01T10:25:31-04:00",
-            "_valueDateTime" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                  "valueString" : "20230701102531-0400"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
-            "valueQuantity" : {
-              "value" : 5,
-              "unit" : "days",
-              "system" : "http://unitsofmeasure.org/",
-              "code" : "d"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "100",
-                  "display" : "PublicCode"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
-            "valueCoding" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          }
-                        ],
-                        "code" : "444",
-                        "display" : "MODE"
-                      }
-                    ]
-                  }
-                }
-              ],
-              "code" : "444",
-              "display" : "MODE"
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
-            "valueCodeableConcept" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "123",
-                  "display" : "CARELEVEL1"
-                }
-              ]
-            }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter",
-            "extension" : [
-              {
-                "url" : "pv1-12-preadmit-test-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "PRE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-18-patient-type",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "34",
-                      "display" : "PT"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-46-current-patient-balance",
-                "valueDecimal" : 55
-              },
-              {
-                "url" : "pv1-47-total-charges",
-                "valueDecimal" : 1000
-              },
-              {
-                "url" : "pv1-48-total-adjustments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-49-total-payments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-51-visit-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "316",
-                      "display" : "IND"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-30-transfer-to-bad-debt-date",
-                "valueString" : "T"
-              },
-              {
-                "url" : "pv1-31-bad-debt-agency-code",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "AGE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-32-bad-debt-transfer-amount",
-                "valueDecimal" : 3.4
-              },
-              {
-                "url" : "pv1-33-bad-debt-recovery-amount",
-                "valueDecimal" : 1.4
-              },
-              {
-                "url" : "pv1-34-delete-account-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "66",
-                      "display" : "DEL"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-35-delete-account-date",
-                "valueString" : "20240501102531-0400"
-              },
-              {
-                "url" : "pv1-39-servicing-facility",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "5678",
-                      "display" : "SERV"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-41-account-status",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "431",
-                      "display" : "ST"
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-encounter",
-            "extension" : [
-              {
-                "url" : "pv2-15-employment-illness-related-indicator",
-                "valueString" : "EMP_ILL"
-              },
-              {
-                "url" : "pv2-23-clinic-organization-name",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974884469000.85af9ce3-d482-4c0e-9d1b-f6d4d1386611"
-                }
-              },
-              {
-                "url" : "pv2-23-clinic-organization-name",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974886162000.2639de84-830f-4576-8082-50b3ebc98ea3"
-                }
-              },
-              {
-                "url" : "pv2-26-previous-treatment-date",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "pv2-29-first-similar-date",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974862959000.644b1a16-bb93-4cbb-8d89-774a4acb4570"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "visit-number"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "VN"
-                }
-              ],
-              "text" : "visit number"
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "VisitNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974865884000.7f6ed2f4-a533-4cd4-9396-7265e04116d7"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber1",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974868125000.4151455c-efb5-454b-869f-12afccf353b3"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber2",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ],
-        "status" : "in-progress",
-        "class" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      }
-                    ],
-                    "code" : "O"
-                  }
-                ]
-              }
-            }
-          ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code" : "AMB",
-          "display" : "ambulatory"
-        },
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          }
-        ],
-        "serviceType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "MED"
-            }
-          ]
-        },
-        "priority" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "VIP"
-            }
-          ]
-        },
-        "subject" : {
-          "reference" : "Patient/1706654974858802000.5b3e6b4b-d2bc-4df5-be45-5b29d41c3ad8"
-        },
-        "episodeOfCare" : [
-          {
-            "reference" : "EpisodeOfCare/1706654974926846000.152b52e7-bec3-468e-935e-f00e2df4f510"
-          }
-        ],
-        "participant" : [
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974898615000.51354708-9eb6-4994-9efe-477ec40c381d"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974901607000.763d8209-7f0b-422c-8597-cb45533b6c56"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974904336000.dbc21911-bdea-4938-b62d-ee2a1b89aaf6"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974907062000.b6bc37d0-5ddc-4c68-b026-363fc4c99d03"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974909510000.de5936cf-916e-4dd7-87ec-9448eb95a19a"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974911698000.3fcc5b07-581c-43f4-807c-5ae8f4f74c25"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974914126000.b0d2aecd-6c5b-48be-be49-412bce27b9a5"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974916791000.76445c3a-f2ab-4e34-973c-d847cac8c165"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974919196000.0b71a23a-eb24-4776-91bb-d70d8e10ce51"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654974921004000.fdd48bdd-2816-4e6b-b5bb-5db949dc672f"
-            }
-          }
-        ],
-        "period" : {
-          "start" : "2024-08-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240801102531-0400"
-              }
-            ]
-          }
-        },
-        "length" : {
-          "value" : 12,
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-start-date",
+        "valueDateTime" : "2023-06-01T10:25:31-04:00",
+        "_valueDateTime" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230601102531-0400"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/planned-discharge-date",
+        "valueDateTime" : "2023-07-01T10:25:31-04:00",
+        "_valueDateTime" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20230701102531-0400"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/estimated-length",
+        "valueQuantity" : {
+          "value" : 5,
           "unit" : "days",
           "system" : "http://unitsofmeasure.org/",
           "code" : "d"
-        },
-        "reasonCode" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                "valueString" : "pv2-admit-reason"
-              }
-            ],
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "AD"
-              }
-            ]
-          }
-        ],
-        "hospitalization" : {
-          "preAdmissionIdentifier" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974888606000.2ea7f778-8e76-4fac-a379-61714ecdd205"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "IDNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          "admitSource" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "Source"
-              }
-            ]
-          },
-          "reAdmission" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          },
-          "dietPreference" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "1",
-                  "display" : "VEG"
-                }
-              ]
-            }
-          ],
-          "specialCourtesy" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A0"
-                }
-              ]
-            },
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A1"
-                }
-              ]
-            }
-          ],
-          "destination" : {
-            "reference" : "Location/1706654974887375000.2808c691-f26c-424e-aead-88b0898b8b08"
-          },
-          "dischargeDisposition" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "T"
-              }
-            ]
-          }
-        },
-        "location" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "assigned-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654974921913000.7b056417-8a53-48c0-8462-431ea37248ad"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654974922657000.789db49e-37d1-44fc-84ad-dfb33ac26f65"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654974923355000.707618df-9491-4a6f-9e7d-4e627458f999"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "pending-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654974923985000.a3a91232-054b-46a7-ad86-2801dcfa9a00"
-            },
-            "status" : "planned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654974924667000.5beacdb8-d10f-4b3f-a045-052dbcc758ea"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-pending-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : false
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654974925348000.ed01e476-a7ca-4619-b3a5-e8597ccb5da5"
-            },
-            "status" : "planned"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974862959000.644b1a16-bb93-4cbb-8d89-774a4acb4570",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974862959000.644b1a16-bb93-4cbb-8d89-774a4acb4570",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974865884000.7f6ed2f4-a533-4cd4-9396-7265e04116d7",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974865884000.7f6ed2f4-a533-4cd4-9396-7265e04116d7",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974868125000.4151455c-efb5-454b-869f-12afccf353b3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974868125000.4151455c-efb5-454b-869f-12afccf353b3",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974883289000.a312380c-5404-42f6-9d9e-3a1a5d321872",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974883289000.a312380c-5404-42f6-9d9e-3a1a5d321872",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
-          }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974884469000.85af9ce3-d482-4c0e-9d1b-f6d4d1386611",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974884469000.85af9ce3-d482-4c0e-9d1b-f6d4d1386611",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/publicity-code",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "100",
+            "display" : "PublicCode"
+          } ]
+        }
+      }, {
+        "url" : "http://hl7.org/fhir/StructureDefinition/encounter-modeOfArrival",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
+                  "valueString" : "coding"
+                } ],
+                "code" : "444",
+                "display" : "MODE"
+              } ]
             }
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
+          } ],
+          "code" : "444",
+          "display" : "MODE"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/admission-level-of-care",
+        "valueCodeableConcept" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "123",
+            "display" : "CARELEVEL1"
+          } ]
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+        "extension" : [ {
+          "url" : "pv1-12-preadmit-test-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "PRE"
+            } ]
           }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654974883289000.a312380c-5404-42f6-9d9e-3a1a5d321872"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
+        }, {
+          "url" : "pv1-18-patient-type",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "34",
+              "display" : "PT"
+            } ]
           }
-        ],
-        "name" : "Org1"
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974885340000.fb002e69-7475-4e87-8ce1-b10cde692fdf",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974885340000.fb002e69-7475-4e87-8ce1-b10cde692fdf",
-        "extension" : [
-          {
+        }, {
+          "url" : "pv1-46-current-patient-balance",
+          "valueDecimal" : 55
+        }, {
+          "url" : "pv1-47-total-charges",
+          "valueDecimal" : 1000
+        }, {
+          "url" : "pv1-48-total-adjustments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-49-total-payments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-51-visit-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "316",
+              "display" : "IND"
+            } ]
+          }
+        }, {
+          "url" : "pv1-30-transfer-to-bad-debt-date",
+          "valueString" : "T"
+        }, {
+          "url" : "pv1-31-bad-debt-agency-code",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "AGE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-32-bad-debt-transfer-amount",
+          "valueDecimal" : 3.4
+        }, {
+          "url" : "pv1-33-bad-debt-recovery-amount",
+          "valueDecimal" : 1.4
+        }, {
+          "url" : "pv1-34-delete-account-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "66",
+              "display" : "DEL"
+            } ]
+          }
+        }, {
+          "url" : "pv1-35-delete-account-date",
+          "valueString" : "20240501102531-0400"
+        }, {
+          "url" : "pv1-39-servicing-facility",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "5678",
+              "display" : "SERV"
+            } ]
+          }
+        }, {
+          "url" : "pv1-41-account-status",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "431",
+              "display" : "ST"
+            } ]
+          }
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv2-patient-visit-additional-information",
+        "extension" : [ {
+          "url" : "pv2-15-employment-illness-related-indicator",
+          "valueString" : "EMP_ILL"
+        }, {
+          "url" : "pv2-23-clinic-organization-name",
+          "valueReference" : {
+            "reference" : "Organization/1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f"
+          }
+        }, {
+          "url" : "pv2-23-clinic-organization-name",
+          "valueReference" : {
+            "reference" : "Organization/1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a"
+          }
+        }, {
+          "url" : "pv2-26-previous-treatment-date",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "pv2-29-first-similar-date",
+          "valueString" : "20220501102531-0400"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "visit-number"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "VN"
+          } ],
+          "text" : "visit number"
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueCode" : "ISO"
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "VisitNumber",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
           }
-        ],
-        "identifier" : [
-          {
-            "value" : "2.16.840.1.113883.9.11"
-          }
-        ],
-        "name" : "Hospital A",
-        "physicalType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                  "valueString" : "identifier"
-                }
-              ],
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974886162000.2639de84-830f-4576-8082-50b3ebc98ea3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974886162000.2639de84-830f-4576-8082-50b3ebc98ea3",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-            "valueCoding" : {
-              "extension" : [
-                {
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber1",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber2",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ],
+      "status" : "in-progress",
+      "class" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "O"
+            } ]
+          }
+        } ],
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code" : "AMB",
+        "display" : "ambulatory"
+      },
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "R"
+        } ]
+      } ],
+      "serviceType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "MED"
+        } ]
+      },
+      "priority" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "VIP"
+        } ]
+      },
+      "subject" : {
+        "reference" : "Patient/1706714165385294000.c69b3cf2-b2b3-44a2-9908-6ad85d16319e"
+      },
+      "episodeOfCare" : [ {
+        "reference" : "EpisodeOfCare/1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a"
+      } ],
+      "participant" : [ {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74"
+        }
+      } ],
+      "period" : {
+        "start" : "2024-08-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240801102531-0400"
+          } ]
+        }
+      },
+      "length" : {
+        "value" : 12,
+        "unit" : "days",
+        "system" : "http://unitsofmeasure.org/",
+        "code" : "d"
+      },
+      "reasonCode" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+          "valueString" : "pv2-admit-reason"
+        } ],
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "1",
+          "display" : "AD"
+        } ]
+      } ],
+      "hospitalization" : {
+        "preAdmissionIdentifier" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+            "valueReference" : {
+              "reference" : "Organization/1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58"
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
                   "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueCodeableConcept" : {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-                        "valueString" : "organization-name-type-code"
-                      }
-                    ],
-                    "coding" : [
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "1",
-                        "code" : "1234-5",
-                        "display" : "TestText"
-                      },
-                      {
-                        "extension" : [
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                            "valueString" : "alt-coding"
-                          },
-                          {
-                            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                            "valueString" : "LN"
-                          }
-                        ],
-                        "system" : "http://loinc.org",
-                        "version" : "2",
-                        "code" : "1234-5",
-                        "display" : "TestAltText"
-                      }
-                    ],
-                    "text" : "OriginalText"
-                  }
-                }
-              ],
-              "system" : "LN",
-              "version" : "1",
-              "code" : "1234-5",
-              "display" : "TestText"
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AASys"
+                } ],
+                "code" : "AACode",
+                "display" : "Assigning Agency"
+              } ]
             }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AJSys"
+                } ],
+                "code" : "AJCode",
+                "display" : "Assigning Jurisdiction"
+              } ]
+            }
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            "valueString" : "checkdigitscheme"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            "valueString" : "checkdigit"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+            "valueString" : "ACSN"
+          } ],
+          "type" : {
+            "coding" : [ {
+              "code" : "ACSN"
+            } ]
           },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
-            "extension" : [
-              {
-                "url" : "XON.3",
-                "valueString" : "123"
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "Check Digit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                    "valueString" : "Assigning Authority"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                    "valueString" : "2.1.4.1"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                    "valueCode" : "ISO"
-                  }
-                ]
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "C1"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
-                "valueReference" : {
-                  "reference" : "Location/1706654974885340000.fb002e69-7475-4e87-8ce1-b10cde692fdf"
-                }
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                      "valueString" : "identifier"
-                    }
-                  ],
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "MD"
-                }
-              ]
-            },
-            "value" : "123"
-          }
-        ],
-        "name" : "Org2"
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974887375000.2808c691-f26c-424e-aead-88b0898b8b08",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974887375000.2808c691-f26c-424e-aead-88b0898b8b08",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "LN"
-                  }
-                ],
-                "system" : "http://loinc.org",
-                "code" : "PrimaryCode",
-                "display" : "Primary Code Display"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974888606000.2ea7f778-8e76-4fac-a379-61714ecdd205",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974888606000.2ea7f778-8e76-4fac-a379-61714ecdd205",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
+          "system" : "urn:oid:testcx42",
+          "_system" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "testcx42"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            } ]
           },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
+          "value" : "IDNumber",
+          "period" : {
+            "start" : "1988-07-04",
+            "_start" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "19880704"
+              } ]
             },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974898615000.51354708-9eb6-4994-9efe-477ec40c381d",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974898615000.51354708-9eb6-4994-9efe-477ec40c381d",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
+            "end" : "2088-07-04",
+            "_end" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20880704"
+              } ]
             }
           }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974901607000.763d8209-7f0b-422c-8597-cb45533b6c56",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974901607000.763d8209-7f0b-422c-8597-cb45533b6c56",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974904336000.dbc21911-bdea-4938-b62d-ee2a1b89aaf6",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974904336000.dbc21911-bdea-4938-b62d-ee2a1b89aaf6",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974907062000.b6bc37d0-5ddc-4c68-b026-363fc4c99d03",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974907062000.b6bc37d0-5ddc-4c68-b026-363fc4c99d03",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974909510000.de5936cf-916e-4dd7-87ec-9448eb95a19a",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974909510000.de5936cf-916e-4dd7-87ec-9448eb95a19a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974911698000.3fcc5b07-581c-43f4-807c-5ae8f4f74c25",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974911698000.3fcc5b07-581c-43f4-807c-5ae8f4f74c25",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974914126000.b0d2aecd-6c5b-48be-be49-412bce27b9a5",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974914126000.b0d2aecd-6c5b-48be-be49-412bce27b9a5",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974916791000.76445c3a-f2ab-4e34-973c-d847cac8c165",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974916791000.76445c3a-f2ab-4e34-973c-d847cac8c165",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974919196000.0b71a23a-eb24-4776-91bb-d70d8e10ce51",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974919196000.0b71a23a-eb24-4776-91bb-d70d8e10ce51",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv2-13-referral-source-code"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "urn:oid:AssigningSystem",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referral Source Code1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654974921004000.fdd48bdd-2816-4e6b-b5bb-5db949dc672f",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654974921004000.fdd48bdd-2816-4e6b-b5bb-5db949dc672f",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "ISO"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv2-13-referral-source-code"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "urn:oid:AssigningSystem",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referral Source Code2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974921522000.75c2698d-4cef-4b88-abbe-4b2cf05d9de5",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974921522000.75c2698d-4cef-4b88-abbe-4b2cf05d9de5",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974921913000.7b056417-8a53-48c0-8462-431ea37248ad",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974921913000.7b056417-8a53-48c0-8462-431ea37248ad",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Assigned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654974921522000.75c2698d-4cef-4b88-abbe-4b2cf05d9de5"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
+        },
+        "admitSource" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "Source"
+          } ]
+        },
+        "reAdmission" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "R"
+          } ]
+        },
+        "dietPreference" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "VEG"
+          } ]
+        } ],
+        "specialCourtesy" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A0"
+          } ]
+        }, {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A1"
+          } ]
+        } ],
+        "destination" : {
+          "reference" : "Location/1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c"
+        },
+        "dischargeDisposition" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "T"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974922287000.3d971ca9-e5e6-48f3-b372-8be8ee7bd3ca",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974922287000.3d971ca9-e5e6-48f3-b372-8be8ee7bd3ca",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974922657000.789db49e-37d1-44fc-84ad-dfb33ac26f65",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974922657000.789db49e-37d1-44fc-84ad-dfb33ac26f65",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prio"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654974922287000.3d971ca9-e5e6-48f3-b372-8be8ee7bd3ca"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974923019000.0deb0754-8440-4757-90db-7493d37e62b0",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974923019000.0deb0754-8440-4757-90db-7493d37e62b0",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974923355000.707618df-9491-4a6f-9e7d-4e627458f999",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974923355000.707618df-9491-4a6f-9e7d-4e627458f999",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654974923019000.0deb0754-8440-4757-90db-7493d37e62b0"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974923674000.78fb9f30-c719-4d9b-8772-0b07147320e8",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974923674000.78fb9f30-c719-4d9b-8772-0b07147320e8",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974923985000.a3a91232-054b-46a7-ad86-2801dcfa9a00",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974923985000.a3a91232-054b-46a7-ad86-2801dcfa9a00",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Pending Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654974923674000.78fb9f30-c719-4d9b-8772-0b07147320e8"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974924320000.160a306f-3d09-4846-9e37-1774bcba16b4",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974924320000.160a306f-3d09-4846-9e37-1774bcba16b4",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974924667000.5beacdb8-d10f-4b3f-a045-052dbcc758ea",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974924667000.5beacdb8-d10f-4b3f-a045-052dbcc758ea",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prior Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654974924320000.160a306f-3d09-4846-9e37-1774bcba16b4"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974925014000.7514fc24-36d8-43d4-b759-8e3a7d56cf31",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974925014000.7514fc24-36d8-43d4-b759-8e3a7d56cf31",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654974925348000.ed01e476-a7ca-4619-b3a5-e8597ccb5da5",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654974925348000.ed01e476-a7ca-4619-b3a5-e8597ccb5da5",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital PriorPending"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654974925014000.7514fc24-36d8-43d4-b759-8e3a7d56cf31"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654974925915000.19f2fab2-fe47-433a-979b-9c8d863a33ad",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654974925915000.19f2fab2-fe47-433a-979b-9c8d863a33ad",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "EpisodeOfCare/1706654974926846000.152b52e7-bec3-468e-935e-f00e2df4f510",
-      "resource" : {
-        "resourceType" : "EpisodeOfCare",
-        "id" : "1706654974926846000.152b52e7-bec3-468e-935e-f00e2df4f510",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "service-episode"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-            "valueString" : "ServiceDescriptor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654974925915000.19f2fab2-fe47-433a-979b-9c8d863a33ad"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "ServiceIdentifier",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ]
+      },
+      "location" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "assigned-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714165448263000.c3135427-1e81-4306-834e-df63346cc817"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "pending-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6"
+        },
+        "status" : "planned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-pending-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : false
+        } ],
+        "location" : {
+          "reference" : "Location/1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f"
+        },
+        "status" : "planned"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165389002000.122fbd7e-85a1-4bc1-93f0-464910026bba",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165391645000.2578c222-36c1-44ee-9cc0-734096cf6ff1",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165394041000.94734b05-3fba-4fb3-bd23-29e5e1ba8c64",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Organization/1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165403616000.7a4795b6-e311-4292-9ca1-2207ae0f5f2f",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714165402336000.aec0e889-969f-448f-b671-d6d3716c567c"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org1"
+    }
+  }, {
+    "fullUrl" : "Location/1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+        "valueCode" : "ISO"
+      } ],
+      "identifier" : [ {
+        "value" : "2.16.840.1.113883.9.11"
+      } ],
+      "name" : "Hospital A",
+      "physicalType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+            "valueString" : "identifier"
+          } ],
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165405313000.cffca105-7c2f-4295-8344-9a40bdac923a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+        "valueCoding" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueCodeableConcept" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "organization-name-type-code"
+              } ],
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "1",
+                "code" : "1234-5",
+                "display" : "TestText"
+              }, {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "alt-coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                } ],
+                "system" : "http://loinc.org",
+                "version" : "2",
+                "code" : "1234-5",
+                "display" : "TestAltText"
+              } ],
+              "text" : "OriginalText"
+            }
+          } ],
+          "system" : "LN",
+          "version" : "1",
+          "code" : "1234-5",
+          "display" : "TestText"
+        }
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+        "extension" : [ {
+          "url" : "XON.3",
+          "valueString" : "123"
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "Check Digit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+            "valueString" : "Assigning Authority"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "2.1.4.1"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueCode" : "ISO"
+          } ]
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "C1"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
+          "valueReference" : {
+            "reference" : "Location/1706714165404470000.fc577765-69b3-46ce-b985-49580ae8d3af"
+          }
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+              "valueString" : "identifier"
+            } ],
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "MD"
+          } ]
+        },
+        "value" : "123"
+      } ],
+      "name" : "Org2"
+    }
+  }, {
+    "fullUrl" : "Location/1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165406152000.713cccaa-267e-4931-a477-dd1e89e7e21c",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+        "valueString" : "20230501102531-0400"
+      } ],
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "LN"
+          } ],
+          "system" : "http://loinc.org",
+          "code" : "PrimaryCode",
+          "display" : "Primary Code Display"
+        } ]
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165407271000.21ff44ab-6580-404c-b24e-fbeb37637f58",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165416249000.182675ec-9417-4dbb-8761-33e7c12880a9",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165419578000.eeb9bf41-3c57-4f29-9061-24b9b5b79f78",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165423777000.70b25974-c87b-48fb-91d4-88462131cde3",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165428554000.dfa6aad4-893d-42f9-ac3c-fa073425e7b6",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165431824000.cfe5d7e8-7da7-4088-b77b-59a55469ed07",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165434496000.609c4e9f-9de4-40a8-9a5e-207c077824ab",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165437566000.67a49d04-d4f5-4b08-b2d2-afc037cf7660",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165440199000.f8b546ab-2714-4f93-92c9-6e20a073ad39",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165442890000.6c6690ad-7ece-4050-aa04-77bc43ca9de2",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv2-13-referral-source-code"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "urn:oid:AssigningSystem",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referral Source Code1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714165445462000.c786e531-5e55-49d8-aeda-ffa6b7c93b74",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "ISO"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv2-13-referral-source-code"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "urn:oid:AssigningSystem",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referral Source Code2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165446680000.76cd3d0f-7a3c-4987-acd5-df0c00a7b871",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Assigned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714165446105000.217295f7-05f9-4d4e-ac1d-7a1a15b052d8"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165448263000.c3135427-1e81-4306-834e-df63346cc817",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165448263000.c3135427-1e81-4306-834e-df63346cc817",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prio"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714165447153000.1f61e9d8-2f80-40d4-a302-6fd31f0bc6b1"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165449362000.5fb06660-ddf8-4af4-aecf-695cbcbc3ced",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714165448814000.d1d2dfeb-352f-4380-a712-efda01df12bf"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165450340000.3efadbc1-e107-48ef-ab97-70c78de520f6",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Pending Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714165449827000.e56bc7c8-458d-4a78-83f7-a509d6396c4f"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165451413000.8263783a-64cc-435a-8c7a-7f4dab96a4a8",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prior Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714165450856000.5acfc4f9-5e60-4dbf-ac88-057291307878"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714165452459000.080ec82b-41d7-40bc-aa1b-b34ad3f5b20f",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital PriorPending"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714165451934000.8a09774c-2691-4569-b211-4d05bb17bc13"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "EpisodeOfCare/1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a",
+    "resource" : {
+      "resourceType" : "EpisodeOfCare",
+      "id" : "1706714165454202000.7c57c818-d9fc-4d4a-bbfa-94252fd1907a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "service-episode"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+        "valueString" : "ServiceDescriptor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714165453192000.d718fd1d-3ad8-46b3-890c-72957ebec3bf"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "ServiceIdentifier",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv12-p.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv12-p.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654983983999000.e0f4a1b9-3e7d-4184-8325-3885bc40068a",
+  "id" : "1706714175015830000.9a9a0393-2157-4181-90be-7c03141f4d59",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:49:43.991-05:00"
+    "lastUpdated" : "2024-01-31T10:16:15.023-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,3719 +10,2643 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654984370739000.03b0493b-2cc4-407b-a01b-66478311a616",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654984370739000.03b0493b-2cc4-407b-a01b-66478311a616",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654984378612000.f0245cfb-30ed-47f3-a1c1-30cafdcfd4a4",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654984378612000.f0245cfb-30ed-47f3-a1c1-30cafdcfd4a4",
-        "recorded" : "2024-01-30T17:49:44Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654984377979000.c2279986-8c78-4f2f-af00-a9c04916430b"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984377979000.c2279986-8c78-4f2f-af00-a9c04916430b",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984377979000.c2279986-8c78-4f2f-af00-a9c04916430b",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654984392001000.59ba9d89-bd06-488e-8508-dd93b63199f9",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654984392001000.59ba9d89-bd06-488e-8508-dd93b63199f9"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654984392610000.1dbf6a1e-23cc-4e6e-b90c-987315e93457",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654984392610000.1dbf6a1e-23cc-4e6e-b90c-987315e93457",
-        "target" : [
-          {
-            "reference" : "Patient/1706654984392001000.59ba9d89-bd06-488e-8508-dd93b63199f9"
-          }
-        ],
-        "recorded" : "2024-01-30T17:49:44Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Encounter/1706654984444789000.e78a1dd4-5026-4b32-95f7-807067a0c1e4",
-      "resource" : {
-        "resourceType" : "Encounter",
-        "id" : "1706654984444789000.e78a1dd4-5026-4b32-95f7-807067a0c1e4",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter",
-            "extension" : [
-              {
-                "url" : "pv1-12-preadmit-test-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "PRE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-18-patient-type",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "34",
-                      "display" : "PT"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-46-current-patient-balance",
-                "valueDecimal" : 55
-              },
-              {
-                "url" : "pv1-47-total-charges",
-                "valueDecimal" : 1000
-              },
-              {
-                "url" : "pv1-48-total-adjustments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-49-total-payments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-51-visit-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "316",
-                      "display" : "IND"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-30-transfer-to-bad-debt-date",
-                "valueString" : "T"
-              },
-              {
-                "url" : "pv1-31-bad-debt-agency-code",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "AGE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-32-bad-debt-transfer-amount",
-                "valueDecimal" : 3.4
-              },
-              {
-                "url" : "pv1-33-bad-debt-recovery-amount",
-                "valueDecimal" : 1.4
-              },
-              {
-                "url" : "pv1-34-delete-account-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "66",
-                      "display" : "DEL"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-35-delete-account-date",
-                "valueString" : "20240501102531-0400"
-              },
-              {
-                "url" : "pv1-39-servicing-facility",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "5678",
-                      "display" : "SERV"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-41-account-status",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "431",
-                      "display" : "ST"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654984395473000.26ab154f-64e6-4342-ae5b-e5b89d56180c"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "visit-number"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "VN"
-                }
-              ],
-              "text" : "visit number"
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "VisitNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654984398394000.9ce3de13-3182-4588-806c-4326bd6215c8"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber1",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654984400532000.f34c46f9-609e-4e93-8c62-93e9d8392d03"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber2",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ],
-        "status" : "planned",
-        "class" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      }
-                    ],
-                    "code" : "P"
-                  }
-                ]
-              }
-            }
-          ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code" : "PRENC",
-          "display" : "pre-admission"
-        },
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          }
-        ],
-        "serviceType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "MED"
-            }
-          ]
-        },
-        "subject" : {
-          "reference" : "Patient/1706654984392001000.59ba9d89-bd06-488e-8508-dd93b63199f9"
-        },
-        "episodeOfCare" : [
-          {
-            "reference" : "EpisodeOfCare/1706654984446426000.b72f925c-6da8-4d08-a228-b24efac82854"
-          }
-        ],
-        "participant" : [
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984418548000.f0b7914b-ff59-4bcd-a672-e2d11a0cb997"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984423195000.c7791d42-90f0-45c0-8d42-d141a08e3384"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984426075000.a4936a32-cb1e-4cbc-8465-e7a72911829f"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984428444000.790cfefa-c63b-467c-b6d9-dd629e513497"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984430897000.28162cb1-f865-4e6f-a1d8-94036ffc724d"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984433736000.1f3be474-0046-4bea-bd85-0dec6607495c"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984436919000.63e1da23-99e3-42aa-a093-80ec82fc430d"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654984439535000.cc1fb804-97b2-4714-aa19-d33cb8b05c6b"
-            }
-          }
-        ],
-        "period" : {
-          "start" : "2024-08-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240801102531-0400"
-              }
-            ]
-          }
-        },
-        "hospitalization" : {
-          "preAdmissionIdentifier" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654984408094000.837721ca-4602-4b1e-92c4-df69ad72ceba"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "IDNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          "admitSource" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "Source"
-              }
-            ]
-          },
-          "reAdmission" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          },
-          "dietPreference" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "1",
-                  "display" : "VEG"
-                }
-              ]
-            }
-          ],
-          "specialCourtesy" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A0"
-                }
-              ]
-            },
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A1"
-                }
-              ]
-            }
-          ],
-          "destination" : {
-            "reference" : "Location/1706654984406946000.84a62472-fb0a-4413-849c-5f64490ef2d4"
-          },
-          "dischargeDisposition" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "T"
-              }
-            ]
-          }
-        },
-        "location" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "assigned-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654984440605000.b6916ff9-a07b-4678-ac77-c42be962125c"
-            },
-            "status" : "planned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654984441557000.603b66f6-92d4-427c-9c3e-39c6d1deade0"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654984442588000.6be9b460-ac97-4228-a22e-3093785aacd0"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "pending-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654984443570000.9da8860e-1aaa-49b6-b215-4958c2e40eda"
-            },
-            "status" : "planned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654984444629000.805debc1-7789-4a83-9ccc-97051a57ceee"
-            },
-            "status" : "completed"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984395473000.26ab154f-64e6-4342-ae5b-e5b89d56180c",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984395473000.26ab154f-64e6-4342-ae5b-e5b89d56180c",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984398394000.9ce3de13-3182-4588-806c-4326bd6215c8",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984398394000.9ce3de13-3182-4588-806c-4326bd6215c8",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984400532000.f34c46f9-609e-4e93-8c62-93e9d8392d03",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984400532000.f34c46f9-609e-4e93-8c62-93e9d8392d03",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654984406946000.84a62472-fb0a-4413-849c-5f64490ef2d4",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654984406946000.84a62472-fb0a-4413-849c-5f64490ef2d4",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "LN"
-                  }
-                ],
-                "system" : "http://loinc.org",
-                "code" : "PrimaryCode",
-                "display" : "Primary Code Display"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984408094000.837721ca-4602-4b1e-92c4-df69ad72ceba",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984408094000.837721ca-4602-4b1e-92c4-df69ad72ceba",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984418548000.f0b7914b-ff59-4bcd-a672-e2d11a0cb997",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984418548000.f0b7914b-ff59-4bcd-a672-e2d11a0cb997",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984423195000.c7791d42-90f0-45c0-8d42-d141a08e3384",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984423195000.c7791d42-90f0-45c0-8d42-d141a08e3384",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984426075000.a4936a32-cb1e-4cbc-8465-e7a72911829f",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984426075000.a4936a32-cb1e-4cbc-8465-e7a72911829f",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984428444000.790cfefa-c63b-467c-b6d9-dd629e513497",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984428444000.790cfefa-c63b-467c-b6d9-dd629e513497",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984430897000.28162cb1-f865-4e6f-a1d8-94036ffc724d",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984430897000.28162cb1-f865-4e6f-a1d8-94036ffc724d",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984433736000.1f3be474-0046-4bea-bd85-0dec6607495c",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984433736000.1f3be474-0046-4bea-bd85-0dec6607495c",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984436919000.63e1da23-99e3-42aa-a093-80ec82fc430d",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984436919000.63e1da23-99e3-42aa-a093-80ec82fc430d",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting1"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654984439535000.cc1fb804-97b2-4714-aa19-d33cb8b05c6b",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654984439535000.cc1fb804-97b2-4714-aa19-d33cb8b05c6b",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting2"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984440163000.cf1fb10d-5dd6-4c8c-b754-5cd48e8d544b",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984440163000.cf1fb10d-5dd6-4c8c-b754-5cd48e8d544b",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654984440605000.b6916ff9-a07b-4678-ac77-c42be962125c",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654984440605000.b6916ff9-a07b-4678-ac77-c42be962125c",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Assigned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654984440163000.cf1fb10d-5dd6-4c8c-b754-5cd48e8d544b"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984441150000.b84b5b6c-7274-4fd7-83a7-a097190b8bf8",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984441150000.b84b5b6c-7274-4fd7-83a7-a097190b8bf8",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654984441557000.603b66f6-92d4-427c-9c3e-39c6d1deade0",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654984441557000.603b66f6-92d4-427c-9c3e-39c6d1deade0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prio"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654984441150000.b84b5b6c-7274-4fd7-83a7-a097190b8bf8"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984442078000.3b26070a-8298-4054-91ae-c71b6028feba",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984442078000.3b26070a-8298-4054-91ae-c71b6028feba",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654984442588000.6be9b460-ac97-4228-a22e-3093785aacd0",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654984442588000.6be9b460-ac97-4228-a22e-3093785aacd0",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654984442078000.3b26070a-8298-4054-91ae-c71b6028feba"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984443066000.d84a465f-bf3d-4e66-ae77-94c45b61e245",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984443066000.d84a465f-bf3d-4e66-ae77-94c45b61e245",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654984443570000.9da8860e-1aaa-49b6-b215-4958c2e40eda",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654984443570000.9da8860e-1aaa-49b6-b215-4958c2e40eda",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Pending Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654984443066000.d84a465f-bf3d-4e66-ae77-94c45b61e245"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984444121000.2e89b814-7b3a-4353-8460-3c18587c66a4",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984444121000.2e89b814-7b3a-4353-8460-3c18587c66a4",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654984444629000.805debc1-7789-4a83-9ccc-97051a57ceee",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654984444629000.805debc1-7789-4a83-9ccc-97051a57ceee",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prior Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654984444121000.2e89b814-7b3a-4353-8460-3c18587c66a4"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654984445451000.c7aae89b-98d5-42db-970a-f79316457860",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654984445451000.c7aae89b-98d5-42db-970a-f79316457860",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "EpisodeOfCare/1706654984446426000.b72f925c-6da8-4d08-a228-b24efac82854",
-      "resource" : {
-        "resourceType" : "EpisodeOfCare",
-        "id" : "1706654984446426000.b72f925c-6da8-4d08-a228-b24efac82854",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "service-episode"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-            "valueString" : "ServiceDescriptor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654984445451000.c7aae89b-98d5-42db-970a-f79316457860"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "ServiceIdentifier",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714175408690000.f263195a-cdbc-4931-917a-ebe7fcbcbd7a",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714175408690000.f263195a-cdbc-4931-917a-ebe7fcbcbd7a",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714175417354000.0d8c96d5-5591-43e9-a57f-df87205e8170",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714175417354000.0d8c96d5-5591-43e9-a57f-df87205e8170",
+      "recorded" : "2024-01-31T10:16:15Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714175436733000.f198d544-7266-4a3b-845a-eb578d829fc0",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714175436733000.f198d544-7266-4a3b-845a-eb578d829fc0",
+      "target" : [ {
+        "reference" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
+      } ],
+      "recorded" : "2024-01-31T10:16:15Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Encounter/1706714175494436000.172d882c-a1b7-4171-9f88-25cc0da45ceb",
+    "resource" : {
+      "resourceType" : "Encounter",
+      "id" : "1706714175494436000.172d882c-a1b7-4171-9f88-25cc0da45ceb",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+        "extension" : [ {
+          "url" : "pv1-12-preadmit-test-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "PRE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-18-patient-type",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "34",
+              "display" : "PT"
+            } ]
+          }
+        }, {
+          "url" : "pv1-46-current-patient-balance",
+          "valueDecimal" : 55
+        }, {
+          "url" : "pv1-47-total-charges",
+          "valueDecimal" : 1000
+        }, {
+          "url" : "pv1-48-total-adjustments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-49-total-payments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-51-visit-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "316",
+              "display" : "IND"
+            } ]
+          }
+        }, {
+          "url" : "pv1-30-transfer-to-bad-debt-date",
+          "valueString" : "T"
+        }, {
+          "url" : "pv1-31-bad-debt-agency-code",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "AGE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-32-bad-debt-transfer-amount",
+          "valueDecimal" : 3.4
+        }, {
+          "url" : "pv1-33-bad-debt-recovery-amount",
+          "valueDecimal" : 1.4
+        }, {
+          "url" : "pv1-34-delete-account-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "66",
+              "display" : "DEL"
+            } ]
+          }
+        }, {
+          "url" : "pv1-35-delete-account-date",
+          "valueString" : "20240501102531-0400"
+        }, {
+          "url" : "pv1-39-servicing-facility",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "5678",
+              "display" : "SERV"
+            } ]
+          }
+        }, {
+          "url" : "pv1-41-account-status",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "431",
+              "display" : "ST"
+            } ]
+          }
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "visit-number"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "VN"
+          } ],
+          "text" : "visit number"
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "VisitNumber",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber1",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber2",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ],
+      "status" : "planned",
+      "class" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "P"
+            } ]
+          }
+        } ],
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code" : "PRENC",
+        "display" : "pre-admission"
+      },
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "R"
+        } ]
+      } ],
+      "serviceType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "MED"
+        } ]
+      },
+      "subject" : {
+        "reference" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
+      },
+      "episodeOfCare" : [ {
+        "reference" : "EpisodeOfCare/1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d"
+      } ],
+      "participant" : [ {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3"
+        }
+      } ],
+      "period" : {
+        "start" : "2024-08-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240801102531-0400"
+          } ]
+        }
+      },
+      "hospitalization" : {
+        "preAdmissionIdentifier" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+            "valueReference" : {
+              "reference" : "Organization/1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9"
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AASys"
+                } ],
+                "code" : "AACode",
+                "display" : "Assigning Agency"
+              } ]
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AJSys"
+                } ],
+                "code" : "AJCode",
+                "display" : "Assigning Jurisdiction"
+              } ]
+            }
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            "valueString" : "checkdigitscheme"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            "valueString" : "checkdigit"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+            "valueString" : "ACSN"
+          } ],
+          "type" : {
+            "coding" : [ {
+              "code" : "ACSN"
+            } ]
+          },
+          "system" : "urn:oid:testcx42",
+          "_system" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "testcx42"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            } ]
+          },
+          "value" : "IDNumber",
+          "period" : {
+            "start" : "1988-07-04",
+            "_start" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "19880704"
+              } ]
+            },
+            "end" : "2088-07-04",
+            "_end" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20880704"
+              } ]
+            }
+          }
+        },
+        "admitSource" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "Source"
+          } ]
+        },
+        "reAdmission" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "R"
+          } ]
+        },
+        "dietPreference" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "VEG"
+          } ]
+        } ],
+        "specialCourtesy" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A0"
+          } ]
+        }, {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A1"
+          } ]
+        } ],
+        "destination" : {
+          "reference" : "Location/1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574"
+        },
+        "dischargeDisposition" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "T"
+          } ]
+        }
+      },
+      "location" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "assigned-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb"
+        },
+        "status" : "planned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "pending-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29"
+        },
+        "status" : "planned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9"
+        },
+        "status" : "completed"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+        "valueString" : "20230501102531-0400"
+      } ],
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "LN"
+          } ],
+          "system" : "http://loinc.org",
+          "code" : "PrimaryCode",
+          "display" : "Primary Code Display"
+        } ]
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting1"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting2"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Assigned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prio"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Pending Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prior Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "EpisodeOfCare/1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d",
+    "resource" : {
+      "resourceType" : "EpisodeOfCare",
+      "id" : "1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "service-episode"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+        "valueString" : "ServiceDescriptor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "ServiceIdentifier",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv12-p.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv12-p.fhir
@@ -10,2643 +10,3724 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714175408690000.f263195a-cdbc-4931-917a-ebe7fcbcbd7a",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714175408690000.f263195a-cdbc-4931-917a-ebe7fcbcbd7a",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
       }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714175417354000.0d8c96d5-5591-43e9-a57f-df87205e8170",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714175417354000.0d8c96d5-5591-43e9-a57f-df87205e8170",
-      "recorded" : "2024-01-31T10:16:15Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629"
+    },
+    {
+      "fullUrl" : "Provenance/1706714175408690000.f263195a-cdbc-4931-917a-ebe7fcbcbd7a",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714175408690000.f263195a-cdbc-4931-917a-ebe7fcbcbd7a",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714175436733000.f198d544-7266-4a3b-845a-eb578d829fc0",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714175436733000.f198d544-7266-4a3b-845a-eb578d829fc0",
-      "target" : [ {
-        "reference" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
-      } ],
-      "recorded" : "2024-01-31T10:16:15Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Encounter/1706714175494436000.172d882c-a1b7-4171-9f88-25cc0da45ceb",
-    "resource" : {
-      "resourceType" : "Encounter",
-      "id" : "1706714175494436000.172d882c-a1b7-4171-9f88-25cc0da45ceb",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
-        "extension" : [ {
-          "url" : "pv1-12-preadmit-test-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "PRE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-18-patient-type",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "34",
-              "display" : "PT"
-            } ]
-          }
-        }, {
-          "url" : "pv1-46-current-patient-balance",
-          "valueDecimal" : 55
-        }, {
-          "url" : "pv1-47-total-charges",
-          "valueDecimal" : 1000
-        }, {
-          "url" : "pv1-48-total-adjustments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-49-total-payments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-51-visit-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "316",
-              "display" : "IND"
-            } ]
-          }
-        }, {
-          "url" : "pv1-30-transfer-to-bad-debt-date",
-          "valueString" : "T"
-        }, {
-          "url" : "pv1-31-bad-debt-agency-code",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "AGE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-32-bad-debt-transfer-amount",
-          "valueDecimal" : 3.4
-        }, {
-          "url" : "pv1-33-bad-debt-recovery-amount",
-          "valueDecimal" : 1.4
-        }, {
-          "url" : "pv1-34-delete-account-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "66",
-              "display" : "DEL"
-            } ]
-          }
-        }, {
-          "url" : "pv1-35-delete-account-date",
-          "valueString" : "20240501102531-0400"
-        }, {
-          "url" : "pv1-39-servicing-facility",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "5678",
-              "display" : "SERV"
-            } ]
-          }
-        }, {
-          "url" : "pv1-41-account-status",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "431",
-              "display" : "ST"
-            } ]
-          }
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "visit-number"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "VN"
-          } ],
-          "text" : "visit number"
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "VisitNumber",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber1",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber2",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      } ],
-      "status" : "planned",
-      "class" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "P"
-            } ]
-          }
-        } ],
-        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code" : "PRENC",
-        "display" : "pre-admission"
-      },
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "R"
-        } ]
-      } ],
-      "serviceType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "MED"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
-      },
-      "episodeOfCare" : [ {
-        "reference" : "EpisodeOfCare/1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d"
-      } ],
-      "participant" : [ {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3"
-        }
-      } ],
-      "period" : {
-        "start" : "2024-08-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240801102531-0400"
-          } ]
-        }
-      },
-      "hospitalization" : {
-        "preAdmissionIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-            "valueReference" : {
-              "reference" : "Organization/1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9"
+    },
+    {
+      "fullUrl" : "Provenance/1706714175417354000.0d8c96d5-5591-43e9-a57f-df87205e8170",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714175417354000.0d8c96d5-5591-43e9-a57f-df87205e8170",
+        "recorded" : "2024-01-31T10:16:15Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
             }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AASys"
-                } ],
-                "code" : "AACode",
-                "display" : "Assigning Agency"
-              } ]
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AJSys"
-                } ],
-                "code" : "AJCode",
-                "display" : "Assigning Jurisdiction"
-              } ]
-            }
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-            "valueString" : "checkdigitscheme"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-            "valueString" : "checkdigit"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-            "valueString" : "ACSN"
-          } ],
-          "type" : {
-            "coding" : [ {
-              "code" : "ACSN"
-            } ]
-          },
-          "system" : "urn:oid:testcx42",
-          "_system" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "testcx42"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            } ]
-          },
-          "value" : "IDNumber",
-          "period" : {
-            "start" : "1988-07-04",
-            "_start" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "19880704"
-              } ]
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
             },
-            "end" : "2088-07-04",
-            "_end" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20880704"
-              } ]
+            "who" : {
+              "reference" : "Organization/1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629"
             }
           }
-        },
-        "admitSource" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "Source"
-          } ]
-        },
-        "reAdmission" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "R"
-          } ]
-        },
-        "dietPreference" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "VEG"
-          } ]
-        } ],
-        "specialCourtesy" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A0"
-          } ]
-        }, {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A1"
-          } ]
-        } ],
-        "destination" : {
-          "reference" : "Location/1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574"
-        },
-        "dischargeDisposition" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "T"
-          } ]
-        }
-      },
-      "location" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "assigned-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb"
-        },
-        "status" : "planned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "pending-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29"
-        },
-        "status" : "planned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9"
-        },
-        "status" : "completed"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "PrimaryCode",
-          "display" : "Primary Code Display"
-        } ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting1"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting2"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Assigned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
+        ]
       }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prio"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Pending Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prior Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "EpisodeOfCare/1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d",
-    "resource" : {
-      "resourceType" : "EpisodeOfCare",
-      "id" : "1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "service-episode"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-        "valueString" : "ServiceDescriptor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "ServiceIdentifier",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
+    },
+    {
+      "fullUrl" : "Organization/1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175416880000.11c4a0c4-b96b-4f80-961f-bf75cfa70629",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
           },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
           }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714175436733000.f198d544-7266-4a3b-845a-eb578d829fc0",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714175436733000.f198d544-7266-4a3b-845a-eb578d829fc0",
+        "target" : [
+          {
+            "reference" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
+          }
+        ],
+        "recorded" : "2024-01-31T10:16:15Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
         }
-      } ]
+      }
+    },
+    {
+      "fullUrl" : "Encounter/1706714175494436000.172d882c-a1b7-4171-9f88-25cc0da45ceb",
+      "resource" : {
+        "resourceType" : "Encounter",
+        "id" : "1706714175494436000.172d882c-a1b7-4171-9f88-25cc0da45ceb",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+            "extension" : [
+              {
+                "url" : "pv1-12-preadmit-test-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "PRE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-18-patient-type",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "34",
+                      "display" : "PT"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-46-current-patient-balance",
+                "valueDecimal" : 55
+              },
+              {
+                "url" : "pv1-47-total-charges",
+                "valueDecimal" : 1000
+              },
+              {
+                "url" : "pv1-48-total-adjustments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-49-total-payments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-51-visit-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "316",
+                      "display" : "IND"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-30-transfer-to-bad-debt-date",
+                "valueString" : "T"
+              },
+              {
+                "url" : "pv1-31-bad-debt-agency-code",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "AGE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-32-bad-debt-transfer-amount",
+                "valueDecimal" : 3.4
+              },
+              {
+                "url" : "pv1-33-bad-debt-recovery-amount",
+                "valueDecimal" : 1.4
+              },
+              {
+                "url" : "pv1-34-delete-account-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "66",
+                      "display" : "DEL"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-35-delete-account-date",
+                "valueString" : "20240501102531-0400"
+              },
+              {
+                "url" : "pv1-39-servicing-facility",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "5678",
+                      "display" : "SERV"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-41-account-status",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "431",
+                      "display" : "ST"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "visit-number"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "VN"
+                }
+              ],
+              "text" : "visit number"
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "VisitNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber1",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber2",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "status" : "planned",
+        "class" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      }
+                    ],
+                    "code" : "P"
+                  }
+                ]
+              }
+            }
+          ],
+          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code" : "PRENC",
+          "display" : "pre-admission"
+        },
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          }
+        ],
+        "serviceType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "MED"
+            }
+          ]
+        },
+        "subject" : {
+          "reference" : "Patient/1706714175435876000.8719546d-e7ca-40b1-b2c4-d03a91eda6e1"
+        },
+        "episodeOfCare" : [
+          {
+            "reference" : "EpisodeOfCare/1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d"
+          }
+        ],
+        "participant" : [
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3"
+            }
+          }
+        ],
+        "period" : {
+          "start" : "2024-08-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240801102531-0400"
+              }
+            ]
+          }
+        },
+        "hospitalization" : {
+          "preAdmissionIdentifier" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "IDNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          "admitSource" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "Source"
+              }
+            ]
+          },
+          "reAdmission" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          },
+          "dietPreference" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "1",
+                  "display" : "VEG"
+                }
+              ]
+            }
+          ],
+          "specialCourtesy" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A0"
+                }
+              ]
+            },
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A1"
+                }
+              ]
+            }
+          ],
+          "destination" : {
+            "reference" : "Location/1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574"
+          },
+          "dischargeDisposition" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "T"
+              }
+            ]
+          }
+        },
+        "location" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "assigned-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb"
+            },
+            "status" : "planned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "pending-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29"
+            },
+            "status" : "planned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9"
+            },
+            "status" : "completed"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175439958000.a052802a-292e-4d10-ac39-a955292d56c4",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175442912000.6ca08eb3-9a41-4d73-9592-22dbb29221b7",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175448390000.b7f3da6e-86e3-4d3e-83c1-ae32875ba795",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714175455935000.44ac9dcc-3bf1-4e03-988e-816dc10f6574",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+            "valueString" : "20230501102531-0400"
+          }
+        ],
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "LN"
+                  }
+                ],
+                "system" : "http://loinc.org",
+                "code" : "PrimaryCode",
+                "display" : "Primary Code Display"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175457887000.4e48f89d-798f-4874-964e-cbed8cdc4df9",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175468200000.767ddb41-293e-4968-8e32-1d9d8d6591fb",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175472053000.175e16c0-27e3-4923-9a8e-b62c05aaca1a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175475607000.c1c480cb-7196-45da-9bc0-1228d360062e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175478861000.90fbe035-f612-403f-8351-29f44d27fb50",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175482752000.9530150d-193b-4fad-923d-7daf09889c78",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175485859000.87a0dc12-e1c7-4cb2-9e5a-231ee542a9c3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175488039000.15d42fa9-a0d7-4ca7-99b5-83f283ecdccc",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting1"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714175490271000.b2df5195-3768-4f6e-9694-1f0f0c478db3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting2"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714175491417000.fedc0b03-61d6-4cac-a2e6-b780ed064bdb",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Assigned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714175490802000.f8aa534f-7d14-4334-9e9d-dd1b5d7652f2"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714175492137000.a4e08f7e-fc05-47ea-9c1c-cbb3717a942d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prio"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714175491803000.02c20df0-053a-4165-ae6e-bee403e24be9"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714175492864000.150aa892-8fc7-45e2-9152-fef7b77fcf7e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714175492504000.7973b2c4-f5db-4d97-871b-6d4fabd4d3e5"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714175493568000.806748e5-0b17-4a7b-b83b-c0dd0bff7f29",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Pending Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714175493209000.e06ed772-25e4-4458-9809-90cba5c13f03"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714175494241000.50c9d6fe-5b4e-4b6f-b4ac-a4d700beddd9",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prior Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714175493891000.05e69a1b-89f8-4991-b135-1ec707aa1856"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "EpisodeOfCare/1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d",
+      "resource" : {
+        "resourceType" : "EpisodeOfCare",
+        "id" : "1706714175495689000.19c90ba0-c0e1-49ee-9397-d56781ed956d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "service-episode"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+            "valueString" : "ServiceDescriptor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714175494992000.ab7034ac-e07a-4ac2-9e65-17ec1bd4e970"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "ServiceIdentifier",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv145-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv145-valued.fhir
@@ -10,1244 +10,1747 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714185335019000.7089ff16-c439-4abd-8905-71f416665f46",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714185335019000.7089ff16-c439-4abd-8905-71f416665f46",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
       }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714185342654000.17c76530-3c42-469d-8d73-d451ba128913",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714185342654000.17c76530-3c42-469d-8d73-d451ba128913",
-      "recorded" : "2024-01-31T10:16:25Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3"
+    },
+    {
+      "fullUrl" : "Provenance/1706714185335019000.7089ff16-c439-4abd-8905-71f416665f46",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714185335019000.7089ff16-c439-4abd-8905-71f416665f46",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714185364260000.74557f64-6279-4a9b-8fef-8589eb8096b3",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714185364260000.74557f64-6279-4a9b-8fef-8589eb8096b3",
-      "target" : [ {
-        "reference" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
-      } ],
-      "recorded" : "2024-01-31T10:16:25Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Encounter/1706714185401029000.fcbb5e29-44c0-4b9c-a83c-a9b2b0472116",
-    "resource" : {
-      "resourceType" : "Encounter",
-      "id" : "1706714185401029000.fcbb5e29-44c0-4b9c-a83c-a9b2b0472116",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
-        "extension" : [ {
-          "url" : "pv1-12-preadmit-test-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "PRE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-18-patient-type",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "34",
-              "display" : "PT"
-            } ]
-          }
-        }, {
-          "url" : "pv1-46-current-patient-balance",
-          "valueDecimal" : 55
-        }, {
-          "url" : "pv1-47-total-charges",
-          "valueDecimal" : 1000
-        }, {
-          "url" : "pv1-48-total-adjustments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-49-total-payments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-51-visit-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "316",
-              "display" : "IND"
-            } ]
-          }
-        }, {
-          "url" : "pv1-30-transfer-to-bad-debt-date",
-          "valueString" : "T"
-        }, {
-          "url" : "pv1-31-bad-debt-agency-code",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "AGE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-32-bad-debt-transfer-amount",
-          "valueDecimal" : 3.4
-        }, {
-          "url" : "pv1-33-bad-debt-recovery-amount",
-          "valueDecimal" : 1.4
-        }, {
-          "url" : "pv1-34-delete-account-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "66",
-              "display" : "DEL"
-            } ]
-          }
-        }, {
-          "url" : "pv1-35-delete-account-date",
-          "valueString" : "20240501102531-0400"
-        }, {
-          "url" : "pv1-39-servicing-facility",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "5678",
-              "display" : "SERV"
-            } ]
-          }
-        }, {
-          "url" : "pv1-41-account-status",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "431",
-              "display" : "ST"
-            } ]
-          }
-        } ]
-      } ],
-      "status" : "finished",
-      "class" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "O"
-            } ]
-          }
-        } ],
-        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code" : "AMB",
-        "display" : "ambulatory"
-      },
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "R"
-        } ]
-      } ],
-      "serviceType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "MED"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
-      },
-      "episodeOfCare" : [ {
-        "reference" : "EpisodeOfCare/1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951"
-      } ],
-      "participant" : [ {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722"
-        }
-      } ],
-      "period" : {
-        "start" : "2024-08-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240801102531-0400"
-          } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706714185342654000.17c76530-3c42-469d-8d73-d451ba128913",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714185342654000.17c76530-3c42-469d-8d73-d451ba128913",
+        "recorded" : "2024-01-31T10:16:25Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "end" : "2024-09-01T10:25:31-04:00",
-        "_end" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240901102531-0400"
-          } ]
-        }
-      },
-      "hospitalization" : {
-        "preAdmissionIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-            "valueReference" : {
-              "reference" : "Organization/1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4"
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AASys"
-                } ],
-                "code" : "AACode",
-                "display" : "Assigning Agency"
-              } ]
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AJSys"
-                } ],
-                "code" : "AJCode",
-                "display" : "Assigning Jurisdiction"
-              } ]
-            }
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-            "valueString" : "checkdigitscheme"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-            "valueString" : "checkdigit"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-            "valueString" : "ACSN"
-          } ],
-          "type" : {
-            "coding" : [ {
-              "code" : "ACSN"
-            } ]
-          },
-          "system" : "urn:oid:testcx42",
-          "_system" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "testcx42"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            } ]
-          },
-          "value" : "IDNumber",
-          "period" : {
-            "start" : "1988-07-04",
-            "_start" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "19880704"
-              } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
             },
-            "end" : "2088-07-04",
-            "_end" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20880704"
-              } ]
+            "who" : {
+              "reference" : "Organization/1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3"
             }
           }
-        },
-        "admitSource" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "Source"
-          } ]
-        },
-        "reAdmission" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "R"
-          } ]
-        },
-        "dietPreference" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "VEG"
-          } ]
-        } ],
-        "specialCourtesy" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A0"
-          } ]
-        }, {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A1"
-          } ]
-        } ],
-        "destination" : {
-          "reference" : "Location/1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9"
-        },
-        "dischargeDisposition" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "T"
-          } ]
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714185364260000.74557f64-6279-4a9b-8fef-8589eb8096b3",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714185364260000.74557f64-6279-4a9b-8fef-8589eb8096b3",
+        "target" : [
+          {
+            "reference" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
+          }
+        ],
+        "recorded" : "2024-01-31T10:16:25Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
         }
-      },
-      "location" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "assigned-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14"
-        },
-        "status" : "active"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "PrimaryCode",
-          "display" : "Primary Code Display"
-        } ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+      }
+    },
+    {
+      "fullUrl" : "Encounter/1706714185401029000.fcbb5e29-44c0-4b9c-a83c-a9b2b0472116",
+      "resource" : {
+        "resourceType" : "Encounter",
+        "id" : "1706714185401029000.fcbb5e29-44c0-4b9c-a83c-a9b2b0472116",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+            "extension" : [
+              {
+                "url" : "pv1-12-preadmit-test-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "PRE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-18-patient-type",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "34",
+                      "display" : "PT"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-46-current-patient-balance",
+                "valueDecimal" : 55
+              },
+              {
+                "url" : "pv1-47-total-charges",
+                "valueDecimal" : 1000
+              },
+              {
+                "url" : "pv1-48-total-adjustments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-49-total-payments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-51-visit-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "316",
+                      "display" : "IND"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-30-transfer-to-bad-debt-date",
+                "valueString" : "T"
+              },
+              {
+                "url" : "pv1-31-bad-debt-agency-code",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "AGE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-32-bad-debt-transfer-amount",
+                "valueDecimal" : 3.4
+              },
+              {
+                "url" : "pv1-33-bad-debt-recovery-amount",
+                "valueDecimal" : 1.4
+              },
+              {
+                "url" : "pv1-34-delete-account-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "66",
+                      "display" : "DEL"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-35-delete-account-date",
+                "valueString" : "20240501102531-0400"
+              },
+              {
+                "url" : "pv1-39-servicing-facility",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "5678",
+                      "display" : "SERV"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-41-account-status",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "431",
+                      "display" : "ST"
+                    }
+                  ]
+                }
+              }
+            ]
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
+        ],
+        "status" : "finished",
+        "class" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      }
+                    ],
+                    "code" : "O"
+                  }
+                ]
+              }
+            }
+          ],
+          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code" : "AMB",
+          "display" : "ambulatory"
         },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          }
+        ],
+        "serviceType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "MED"
+            }
+          ]
         },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
+        "subject" : {
+          "reference" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
+        },
+        "episodeOfCare" : [
+          {
+            "reference" : "EpisodeOfCare/1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951"
+          }
+        ],
+        "participant" : [
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722"
+            }
+          }
+        ],
         "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+          "start" : "2024-08-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240801102531-0400"
+              }
+            ]
+          },
+          "end" : "2024-09-01T10:25:31-04:00",
+          "_end" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240901102531-0400"
+              }
+            ]
+          }
+        },
+        "hospitalization" : {
+          "preAdmissionIdentifier" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "IDNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          "admitSource" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "Source"
+              }
+            ]
+          },
+          "reAdmission" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          },
+          "dietPreference" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "1",
+                  "display" : "VEG"
+                }
+              ]
+            }
+          ],
+          "specialCourtesy" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A0"
+                }
+              ]
+            },
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A1"
+                }
+              ]
+            }
+          ],
+          "destination" : {
+            "reference" : "Location/1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9"
+          },
+          "dischargeDisposition" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "T"
+              }
+            ]
+          }
+        },
+        "location" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "assigned-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14"
+            },
+            "status" : "active"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+            "valueString" : "20230501102531-0400"
+          }
+        ],
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "LN"
+                  }
+                ],
+                "system" : "http://loinc.org",
+                "code" : "PrimaryCode",
+                "display" : "Primary Code Display"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Assigned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
           }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prio"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25"
+            }
           }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
           }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2"
+            }
           }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Assigned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "EpisodeOfCare/1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951",
+      "resource" : {
+        "resourceType" : "EpisodeOfCare",
+        "id" : "1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "service-episode"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "Organization/1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prio"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "EpisodeOfCare/1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951",
-    "resource" : {
-      "resourceType" : "EpisodeOfCare",
-      "id" : "1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "service-episode"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv145-valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter-pv145-valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706654993595911000.35aa5a04-8078-4711-b224-5285dc37e346",
+  "id" : "1706714184957886000.01cf7cc2-b7ef-405d-b4e8-59d4cf0b6ec0",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:49:53.601-05:00"
+    "lastUpdated" : "2024-01-31T10:16:24.965-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,1742 +10,1244 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654993985538000.b16be359-20ea-4dc6-847b-b230e7d9be7e",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654993985538000.b16be359-20ea-4dc6-847b-b230e7d9be7e",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654993993897000.f2dd2d39-0c6f-4cc6-ac97-517c5fbacc4e",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654993993897000.f2dd2d39-0c6f-4cc6-ac97-517c5fbacc4e",
-        "recorded" : "2024-01-30T17:49:53Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706654993993430000.fe9a4ace-cc7c-44de-a0aa-6389b8a8a1cb"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654993993430000.fe9a4ace-cc7c-44de-a0aa-6389b8a8a1cb",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654993993430000.fe9a4ace-cc7c-44de-a0aa-6389b8a8a1cb",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706654994009836000.93dbc2d6-2776-4f75-bed2-287301c10159",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706654994009836000.93dbc2d6-2776-4f75-bed2-287301c10159"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706654994010521000.c6025a17-21d7-47a7-a689-cc6203e21153",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706654994010521000.c6025a17-21d7-47a7-a689-cc6203e21153",
-        "target" : [
-          {
-            "reference" : "Patient/1706654994009836000.93dbc2d6-2776-4f75-bed2-287301c10159"
-          }
-        ],
-        "recorded" : "2024-01-30T17:49:54Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Encounter/1706654994051643000.1b697375-be6c-4321-adf9-5ac68adaa778",
-      "resource" : {
-        "resourceType" : "Encounter",
-        "id" : "1706654994051643000.1b697375-be6c-4321-adf9-5ac68adaa778",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter",
-            "extension" : [
-              {
-                "url" : "pv1-12-preadmit-test-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "PRE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-18-patient-type",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "34",
-                      "display" : "PT"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-46-current-patient-balance",
-                "valueDecimal" : 55
-              },
-              {
-                "url" : "pv1-47-total-charges",
-                "valueDecimal" : 1000
-              },
-              {
-                "url" : "pv1-48-total-adjustments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-49-total-payments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-51-visit-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "316",
-                      "display" : "IND"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-30-transfer-to-bad-debt-date",
-                "valueString" : "T"
-              },
-              {
-                "url" : "pv1-31-bad-debt-agency-code",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "AGE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-32-bad-debt-transfer-amount",
-                "valueDecimal" : 3.4
-              },
-              {
-                "url" : "pv1-33-bad-debt-recovery-amount",
-                "valueDecimal" : 1.4
-              },
-              {
-                "url" : "pv1-34-delete-account-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "66",
-                      "display" : "DEL"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-35-delete-account-date",
-                "valueString" : "20240501102531-0400"
-              },
-              {
-                "url" : "pv1-39-servicing-facility",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "5678",
-                      "display" : "SERV"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-41-account-status",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "431",
-                      "display" : "ST"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "status" : "finished",
-        "class" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      }
-                    ],
-                    "code" : "O"
-                  }
-                ]
-              }
-            }
-          ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code" : "AMB",
-          "display" : "ambulatory"
-        },
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          }
-        ],
-        "serviceType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "MED"
-            }
-          ]
-        },
-        "subject" : {
-          "reference" : "Patient/1706654994009836000.93dbc2d6-2776-4f75-bed2-287301c10159"
-        },
-        "episodeOfCare" : [
-          {
-            "reference" : "EpisodeOfCare/1706654994051970000.6f0842e3-7a74-47f9-b49c-c08d7f9fe116"
-          }
-        ],
-        "participant" : [
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654994039669000.b1af730c-c4d4-42b0-ba48-98fc40d51a15"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654994044052000.0e7daaf6-bddf-4b8b-97ec-a08881601a39"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706654994047656000.979796f0-537b-492d-a753-64429b62f801"
-            }
-          }
-        ],
-        "period" : {
-          "start" : "2024-08-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240801102531-0400"
-              }
-            ]
-          },
-          "end" : "2024-09-01T10:25:31-04:00",
-          "_end" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240901102531-0400"
-              }
-            ]
-          }
-        },
-        "hospitalization" : {
-          "preAdmissionIdentifier" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706654994022257000.27ca49ef-da2a-46c7-a5f9-f1433e7b64b9"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "IDNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          "admitSource" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "Source"
-              }
-            ]
-          },
-          "reAdmission" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          },
-          "dietPreference" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "1",
-                  "display" : "VEG"
-                }
-              ]
-            }
-          ],
-          "specialCourtesy" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A0"
-                }
-              ]
-            },
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A1"
-                }
-              ]
-            }
-          ],
-          "destination" : {
-            "reference" : "Location/1706654994018919000.51676f1e-7d7e-4260-a21f-9afae63c567b"
-          },
-          "dischargeDisposition" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "T"
-              }
-            ]
-          }
-        },
-        "location" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "assigned-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654994049097000.b873874c-ecbd-4c81-be43-0277576a5047"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654994050334000.5cdf5d8e-23f8-40ed-981d-4adbbccb5833"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706654994051475000.dcce949a-78b2-4e7a-bc18-a2de2a66f665"
-            },
-            "status" : "active"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654994018919000.51676f1e-7d7e-4260-a21f-9afae63c567b",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654994018919000.51676f1e-7d7e-4260-a21f-9afae63c567b",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "LN"
-                  }
-                ],
-                "system" : "http://loinc.org",
-                "code" : "PrimaryCode",
-                "display" : "Primary Code Display"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654994022257000.27ca49ef-da2a-46c7-a5f9-f1433e7b64b9",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654994022257000.27ca49ef-da2a-46c7-a5f9-f1433e7b64b9",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654994039669000.b1af730c-c4d4-42b0-ba48-98fc40d51a15",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654994039669000.b1af730c-c4d4-42b0-ba48-98fc40d51a15",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654994044052000.0e7daaf6-bddf-4b8b-97ec-a08881601a39",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654994044052000.0e7daaf6-bddf-4b8b-97ec-a08881601a39",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706654994047656000.979796f0-537b-492d-a753-64429b62f801",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706654994047656000.979796f0-537b-492d-a753-64429b62f801",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654994048517000.5418b104-7684-4959-b0b8-feef0a4eedaf",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654994048517000.5418b104-7684-4959-b0b8-feef0a4eedaf",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654994049097000.b873874c-ecbd-4c81-be43-0277576a5047",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654994049097000.b873874c-ecbd-4c81-be43-0277576a5047",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Assigned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654994048517000.5418b104-7684-4959-b0b8-feef0a4eedaf"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654994049738000.f6f93070-8f7f-4f2e-827c-840433d0a692",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654994049738000.f6f93070-8f7f-4f2e-827c-840433d0a692",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654994050334000.5cdf5d8e-23f8-40ed-981d-4adbbccb5833",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654994050334000.5cdf5d8e-23f8-40ed-981d-4adbbccb5833",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prio"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654994049738000.f6f93070-8f7f-4f2e-827c-840433d0a692"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706654994050868000.94349d33-30bc-4f84-b11b-a75ff93377d3",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706654994050868000.94349d33-30bc-4f84-b11b-a75ff93377d3",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706654994051475000.dcce949a-78b2-4e7a-bc18-a2de2a66f665",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706654994051475000.dcce949a-78b2-4e7a-bc18-a2de2a66f665",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706654994050868000.94349d33-30bc-4f84-b11b-a75ff93377d3"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "EpisodeOfCare/1706654994051970000.6f0842e3-7a74-47f9-b49c-c08d7f9fe116",
-      "resource" : {
-        "resourceType" : "EpisodeOfCare",
-        "id" : "1706654994051970000.6f0842e3-7a74-47f9-b49c-c08d7f9fe116",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "service-episode"
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714185335019000.7089ff16-c439-4abd-8905-71f416665f46",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714185335019000.7089ff16-c439-4abd-8905-71f416665f46",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714185342654000.17c76530-3c42-469d-8d73-d451ba128913",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714185342654000.17c76530-3c42-469d-8d73-d451ba128913",
+      "recorded" : "2024-01-31T10:16:25Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714185342186000.2c6a1b9a-743b-41e9-9641-35c19f5e85d3",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714185364260000.74557f64-6279-4a9b-8fef-8589eb8096b3",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714185364260000.74557f64-6279-4a9b-8fef-8589eb8096b3",
+      "target" : [ {
+        "reference" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
+      } ],
+      "recorded" : "2024-01-31T10:16:25Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Encounter/1706714185401029000.fcbb5e29-44c0-4b9c-a83c-a9b2b0472116",
+    "resource" : {
+      "resourceType" : "Encounter",
+      "id" : "1706714185401029000.fcbb5e29-44c0-4b9c-a83c-a9b2b0472116",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+        "extension" : [ {
+          "url" : "pv1-12-preadmit-test-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "PRE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-18-patient-type",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "34",
+              "display" : "PT"
+            } ]
+          }
+        }, {
+          "url" : "pv1-46-current-patient-balance",
+          "valueDecimal" : 55
+        }, {
+          "url" : "pv1-47-total-charges",
+          "valueDecimal" : 1000
+        }, {
+          "url" : "pv1-48-total-adjustments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-49-total-payments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-51-visit-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "316",
+              "display" : "IND"
+            } ]
+          }
+        }, {
+          "url" : "pv1-30-transfer-to-bad-debt-date",
+          "valueString" : "T"
+        }, {
+          "url" : "pv1-31-bad-debt-agency-code",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "AGE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-32-bad-debt-transfer-amount",
+          "valueDecimal" : 3.4
+        }, {
+          "url" : "pv1-33-bad-debt-recovery-amount",
+          "valueDecimal" : 1.4
+        }, {
+          "url" : "pv1-34-delete-account-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "66",
+              "display" : "DEL"
+            } ]
+          }
+        }, {
+          "url" : "pv1-35-delete-account-date",
+          "valueString" : "20240501102531-0400"
+        }, {
+          "url" : "pv1-39-servicing-facility",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "5678",
+              "display" : "SERV"
+            } ]
+          }
+        }, {
+          "url" : "pv1-41-account-status",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "431",
+              "display" : "ST"
+            } ]
+          }
+        } ]
+      } ],
+      "status" : "finished",
+      "class" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "O"
+            } ]
+          }
+        } ],
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code" : "AMB",
+        "display" : "ambulatory"
+      },
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "R"
+        } ]
+      } ],
+      "serviceType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "MED"
+        } ]
+      },
+      "subject" : {
+        "reference" : "Patient/1706714185363334000.67cc7fcb-3192-4d65-b525-58c3849bc5c4"
+      },
+      "episodeOfCare" : [ {
+        "reference" : "EpisodeOfCare/1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951"
+      } ],
+      "participant" : [ {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722"
+        }
+      } ],
+      "period" : {
+        "start" : "2024-08-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240801102531-0400"
+          } ]
+        },
+        "end" : "2024-09-01T10:25:31-04:00",
+        "_end" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240901102531-0400"
+          } ]
+        }
+      },
+      "hospitalization" : {
+        "preAdmissionIdentifier" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+            "valueReference" : {
+              "reference" : "Organization/1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4"
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AASys"
+                } ],
+                "code" : "AACode",
+                "display" : "Assigning Agency"
+              } ]
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AJSys"
+                } ],
+                "code" : "AJCode",
+                "display" : "Assigning Jurisdiction"
+              } ]
+            }
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            "valueString" : "checkdigitscheme"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            "valueString" : "checkdigit"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+            "valueString" : "ACSN"
+          } ],
+          "type" : {
+            "coding" : [ {
+              "code" : "ACSN"
+            } ]
+          },
+          "system" : "urn:oid:testcx42",
+          "_system" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "testcx42"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            } ]
+          },
+          "value" : "IDNumber",
+          "period" : {
+            "start" : "1988-07-04",
+            "_start" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "19880704"
+              } ]
+            },
+            "end" : "2088-07-04",
+            "_end" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20880704"
+              } ]
+            }
+          }
+        },
+        "admitSource" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "Source"
+          } ]
+        },
+        "reAdmission" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "R"
+          } ]
+        },
+        "dietPreference" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "VEG"
+          } ]
+        } ],
+        "specialCourtesy" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A0"
+          } ]
+        }, {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A1"
+          } ]
+        } ],
+        "destination" : {
+          "reference" : "Location/1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9"
+        },
+        "dischargeDisposition" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "T"
+          } ]
+        }
+      },
+      "location" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "assigned-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14"
+        },
+        "status" : "active"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714185372620000.27126eec-10c5-4888-a508-47e9f7eb2af9",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+        "valueString" : "20230501102531-0400"
+      } ],
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "LN"
+          } ],
+          "system" : "http://loinc.org",
+          "code" : "PrimaryCode",
+          "display" : "Primary Code Display"
+        } ]
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714185374977000.95b3d500-d87b-4235-bf94-20ada054b7e4",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714185387567000.03c559d0-3ac9-4e7f-90c6-27312cf06dcd",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714185391054000.5441cd5c-d234-4879-9a01-cc684b985a49",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714185395386000.995ac498-5278-4f25-8a52-4063536c8722",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714185396961000.ae630da3-d927-48fb-b3fa-33d520ae4876",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Assigned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714185396324000.e8c808b0-fd0e-4d1e-ba57-72ae45ca7b7c"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714185398571000.de1527d0-afb9-4229-a839-479bbd2b14a1",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prio"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714185397936000.a082a591-50ec-4510-94df-ecf6c48a2a25"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714185400820000.31e23290-39f1-4218-9a58-f973cd1d9a14",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714185399997000.11ddd2b9-fafc-47e9-bccc-d998340db8a2"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "EpisodeOfCare/1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951",
+    "resource" : {
+      "resourceType" : "EpisodeOfCare",
+      "id" : "1706714185401444000.46dc8cca-8f20-4a91-92d8-2e3d42fc7951",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "service-episode"
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter.fhir
@@ -10,1908 +10,2667 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
-        "extension" : [ {
-          "url" : "MSH.7",
-          "valueString" : "20230501102531-0400"
-        } ]
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714195017466000.e79ffa4b-aaf8-4562-b0e2-7725c7d59dbf",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714195017466000.e79ffa4b-aaf8-4562-b0e2-7725c7d59dbf",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
       }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714195026792000.d9adf105-5a42-4994-8de4-b36f549283e0",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714195026792000.d9adf105-5a42-4994-8de4-b36f549283e0",
-      "recorded" : "2024-01-31T10:16:35Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a"
+    },
+    {
+      "fullUrl" : "Provenance/1706714195017466000.e79ffa4b-aaf8-4562-b0e2-7725c7d59dbf",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714195017466000.e79ffa4b-aaf8-4562-b0e2-7725c7d59dbf",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
-    }
-  }, {
-    "fullUrl" : "Provenance/1706714195043734000.6769257f-2556-49bc-9ee2-6a790cb5745f",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706714195043734000.6769257f-2556-49bc-9ee2-6a790cb5745f",
-      "target" : [ {
-        "reference" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
-      } ],
-      "recorded" : "2024-01-31T10:16:35Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Encounter/1706714195086552000.f28d8ca0-9912-4a7e-b49f-861eebd9feaf",
-    "resource" : {
-      "resourceType" : "Encounter",
-      "id" : "1706714195086552000.f28d8ca0-9912-4a7e-b49f-861eebd9feaf",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
-        "extension" : [ {
-          "url" : "pv1-12-preadmit-test-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "PRE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-18-patient-type",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "34",
-              "display" : "PT"
-            } ]
-          }
-        }, {
-          "url" : "pv1-46-current-patient-balance",
-          "valueDecimal" : 55
-        }, {
-          "url" : "pv1-47-total-charges",
-          "valueDecimal" : 1000
-        }, {
-          "url" : "pv1-48-total-adjustments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-49-total-payments",
-          "valueDecimal" : 0
-        }, {
-          "url" : "pv1-51-visit-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "316",
-              "display" : "IND"
-            } ]
-          }
-        }, {
-          "url" : "pv1-30-transfer-to-bad-debt-date",
-          "valueString" : "T"
-        }, {
-          "url" : "pv1-31-bad-debt-agency-code",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "1",
-              "display" : "AGE"
-            } ]
-          }
-        }, {
-          "url" : "pv1-32-bad-debt-transfer-amount",
-          "valueDecimal" : 3.4
-        }, {
-          "url" : "pv1-33-bad-debt-recovery-amount",
-          "valueDecimal" : 1.4
-        }, {
-          "url" : "pv1-34-delete-account-indicator",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "66",
-              "display" : "DEL"
-            } ]
-          }
-        }, {
-          "url" : "pv1-35-delete-account-date",
-          "valueString" : "20240501102531-0400"
-        }, {
-          "url" : "pv1-39-servicing-facility",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "5678",
-              "display" : "SERV"
-            } ]
-          }
-        }, {
-          "url" : "pv1-41-account-status",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "431",
-              "display" : "ST"
-            } ]
-          }
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "visit-number"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "VN"
-          } ],
-          "text" : "visit number"
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "VisitNumber",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "alternate-visit-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "AltVisitNumber",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
-          },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
-          }
-        }
-      } ],
-      "status" : "in-progress",
-      "class" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "O"
-            } ]
-          }
-        } ],
-        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "code" : "AMB",
-        "display" : "ambulatory"
-      },
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "R"
-        } ]
-      } ],
-      "serviceType" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          } ],
-          "code" : "MED"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
-      },
-      "episodeOfCare" : [ {
-        "reference" : "EpisodeOfCare/1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54"
-      } ],
-      "participant" : [ {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ATND",
-            "display" : "attender"
-          } ]
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "REF"
-          } ],
-          "text" : "referrer"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "CON"
-          } ],
-          "text" : "consultant"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402"
-        }
-      }, {
-        "type" : [ {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-            "code" : "ADM"
-          } ],
-          "text" : "admitter"
-        } ],
-        "individual" : {
-          "reference" : "Practitioner/1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a"
-        }
-      } ],
-      "period" : {
-        "start" : "2024-08-01T10:25:31-04:00",
-        "_start" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-            "valueString" : "20240801102531-0400"
-          } ]
-        }
-      },
-      "hospitalization" : {
-        "preAdmissionIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-            "valueReference" : {
-              "reference" : "Organization/1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c"
+    },
+    {
+      "fullUrl" : "Provenance/1706714195026792000.d9adf105-5a42-4994-8de4-b36f549283e0",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714195026792000.d9adf105-5a42-4994-8de4-b36f549283e0",
+        "recorded" : "2024-01-31T10:16:35Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
             }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AASys"
-                } ],
-                "code" : "AACode",
-                "display" : "Assigning Agency"
-              } ]
-            }
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-            "valueCodeableConcept" : {
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }, {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                  "valueString" : "AJSys"
-                } ],
-                "code" : "AJCode",
-                "display" : "Assigning Jurisdiction"
-              } ]
-            }
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-            "valueString" : "checkdigitscheme"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-            "valueString" : "checkdigit"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-            "valueString" : "ACSN"
-          } ],
-          "type" : {
-            "coding" : [ {
-              "code" : "ACSN"
-            } ]
-          },
-          "system" : "urn:oid:testcx42",
-          "_system" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-              "valueString" : "testcx42"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-              "valueString" : "ISO"
-            } ]
-          },
-          "value" : "IDNumber",
-          "period" : {
-            "start" : "1988-07-04",
-            "_start" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "19880704"
-              } ]
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
             },
-            "end" : "2088-07-04",
-            "_end" : {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20880704"
-              } ]
+            "who" : {
+              "reference" : "Organization/1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a"
             }
           }
-        },
-        "admitSource" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "Source"
-          } ]
-        },
-        "reAdmission" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "R"
-          } ]
-        },
-        "dietPreference" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "1",
-            "display" : "VEG"
-          } ]
-        } ],
-        "specialCourtesy" : [ {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A0"
-          } ]
-        }, {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "A1"
-          } ]
-        } ],
-        "destination" : {
-          "reference" : "Location/1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7"
-        },
-        "dischargeDisposition" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            } ],
-            "code" : "T"
-          } ]
-        }
-      },
-      "location" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "assigned-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-patient-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263"
-        },
-        "status" : "completed"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714195084837000.78997828-a7d2-4274-9684-920544640d88"
-        },
-        "status" : "active"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "pending-location"
-        } ],
-        "location" : {
-          "reference" : "Location/1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1"
-        },
-        "status" : "planned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "prior-temporary-location"
-        }, {
-          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-          "valueBoolean" : true
-        } ],
-        "location" : {
-          "reference" : "Location/1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e"
-        },
-        "status" : "completed"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "type" : [ {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "PrimaryCode",
-          "display" : "Primary Code Display"
-        } ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-7-attending-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Attending"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-8-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Referring"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-9-referring-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Consulting"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "pv1-17-admitting-doctor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "Admitting"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Assigned"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
+        ]
       }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prio"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714195084837000.78997828-a7d2-4274-9684-920544640d88",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714195084837000.78997828-a7d2-4274-9684-920544640d88",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Pending Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "ASSIGNEE"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "UUID"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "222.1111.22222"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-        "valueString" : "location type"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Hospital Prior Temporary Location"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "ISO"
-          } ]
-        },
-        "value" : "2.4.4.4"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "NAME"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "UNI"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-          "valueString" : "organization"
-        } ],
-        "value" : "Entity ID",
-        "assigner" : {
-          "reference" : "Organization/1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3"
-        }
-      } ],
-      "status" : "active",
-      "description" : "Description",
-      "mode" : "instance",
-      "physicalType" : {
-        "coding" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-          "code" : "si"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "blah2"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIP"
-          } ]
-        },
-        "value" : "blah2"
-      } ]
-    }
-  }, {
-    "fullUrl" : "EpisodeOfCare/1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54",
-    "resource" : {
-      "resourceType" : "EpisodeOfCare",
-      "id" : "1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "service-episode"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-        "valueString" : "ServiceDescriptor"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AASys"
-              } ],
-              "code" : "AACode",
-              "display" : "Assigning Agency"
-            } ]
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              }, {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                "valueString" : "AJSys"
-              } ],
-              "code" : "AJCode",
-              "display" : "Assigning Jurisdiction"
-            } ]
-          }
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueString" : "checkdigitscheme"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "checkdigit"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "ACSN"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "ACSN"
-          } ]
-        },
-        "system" : "urn:oid:testcx42",
-        "_system" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueString" : "testcx42"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-            "valueString" : "ISO"
-          } ]
-        },
-        "value" : "ServiceIdentifier",
-        "period" : {
-          "start" : "1988-07-04",
-          "_start" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "19880704"
-            } ]
+    },
+    {
+      "fullUrl" : "Organization/1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
           },
-          "end" : "2088-07-04",
-          "_end" : {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-              "valueString" : "20880704"
-            } ]
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
           }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706714195043734000.6769257f-2556-49bc-9ee2-6a790cb5745f",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706714195043734000.6769257f-2556-49bc-9ee2-6a790cb5745f",
+        "target" : [
+          {
+            "reference" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
+          }
+        ],
+        "recorded" : "2024-01-31T10:16:35Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
         }
-      } ]
+      }
+    },
+    {
+      "fullUrl" : "Encounter/1706714195086552000.f28d8ca0-9912-4a7e-b49f-861eebd9feaf",
+      "resource" : {
+        "resourceType" : "Encounter",
+        "id" : "1706714195086552000.f28d8ca0-9912-4a7e-b49f-861eebd9feaf",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+            "extension" : [
+              {
+                "url" : "pv1-12-preadmit-test-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "PRE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-18-patient-type",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "34",
+                      "display" : "PT"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-46-current-patient-balance",
+                "valueDecimal" : 55
+              },
+              {
+                "url" : "pv1-47-total-charges",
+                "valueDecimal" : 1000
+              },
+              {
+                "url" : "pv1-48-total-adjustments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-49-total-payments",
+                "valueDecimal" : 0
+              },
+              {
+                "url" : "pv1-51-visit-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "316",
+                      "display" : "IND"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-30-transfer-to-bad-debt-date",
+                "valueString" : "T"
+              },
+              {
+                "url" : "pv1-31-bad-debt-agency-code",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "1",
+                      "display" : "AGE"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-32-bad-debt-transfer-amount",
+                "valueDecimal" : 3.4
+              },
+              {
+                "url" : "pv1-33-bad-debt-recovery-amount",
+                "valueDecimal" : 1.4
+              },
+              {
+                "url" : "pv1-34-delete-account-indicator",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "66",
+                      "display" : "DEL"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-35-delete-account-date",
+                "valueString" : "20240501102531-0400"
+              },
+              {
+                "url" : "pv1-39-servicing-facility",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "5678",
+                      "display" : "SERV"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pv1-41-account-status",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "431",
+                      "display" : "ST"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "visit-number"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "VN"
+                }
+              ],
+              "text" : "visit number"
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "VisitNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "alternate-visit-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "AltVisitNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "status" : "in-progress",
+        "class" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+              "valueCodeableConcept" : {
+                "coding" : [
+                  {
+                    "extension" : [
+                      {
+                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                        "valueString" : "coding"
+                      }
+                    ],
+                    "code" : "O"
+                  }
+                ]
+              }
+            }
+          ],
+          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code" : "AMB",
+          "display" : "ambulatory"
+        },
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          }
+        ],
+        "serviceType" : {
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }
+              ],
+              "code" : "MED"
+            }
+          ]
+        },
+        "subject" : {
+          "reference" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
+        },
+        "episodeOfCare" : [
+          {
+            "reference" : "EpisodeOfCare/1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54"
+          }
+        ],
+        "participant" : [
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ATND",
+                    "display" : "attender"
+                  }
+                ]
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "REF"
+                  }
+                ],
+                "text" : "referrer"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "CON"
+                  }
+                ],
+                "text" : "consultant"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402"
+            }
+          },
+          {
+            "type" : [
+              {
+                "coding" : [
+                  {
+                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code" : "ADM"
+                  }
+                ],
+                "text" : "admitter"
+              }
+            ],
+            "individual" : {
+              "reference" : "Practitioner/1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a"
+            }
+          }
+        ],
+        "period" : {
+          "start" : "2024-08-01T10:25:31-04:00",
+          "_start" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20240801102531-0400"
+              }
+            ]
+          }
+        },
+        "hospitalization" : {
+          "preAdmissionIdentifier" : {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "IDNumber",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          },
+          "admitSource" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "1",
+                "display" : "Source"
+              }
+            ]
+          },
+          "reAdmission" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "R"
+              }
+            ]
+          },
+          "dietPreference" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "1",
+                  "display" : "VEG"
+                }
+              ]
+            }
+          ],
+          "specialCourtesy" : [
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A0"
+                }
+              ]
+            },
+            {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    }
+                  ],
+                  "code" : "A1"
+                }
+              ]
+            }
+          ],
+          "destination" : {
+            "reference" : "Location/1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7"
+          },
+          "dischargeDisposition" : {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  }
+                ],
+                "code" : "T"
+              }
+            ]
+          }
+        },
+        "location" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "assigned-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-patient-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263"
+            },
+            "status" : "completed"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714195084837000.78997828-a7d2-4274-9684-920544640d88"
+            },
+            "status" : "active"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "pending-location"
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1"
+            },
+            "status" : "planned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "prior-temporary-location"
+              },
+              {
+                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+                "valueBoolean" : true
+              }
+            ],
+            "location" : {
+              "reference" : "Location/1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e"
+            },
+            "status" : "completed"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+            "valueString" : "20230501102531-0400"
+          }
+        ],
+        "type" : [
+          {
+            "coding" : [
+              {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                    "valueString" : "coding"
+                  },
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                    "valueString" : "LN"
+                  }
+                ],
+                "system" : "http://loinc.org",
+                "code" : "PrimaryCode",
+                "display" : "Primary Code Display"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-7-attending-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Attending"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-8-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Referring"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-9-referring-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Consulting"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "pv1-17-admitting-doctor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "Admitting"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Assigned"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prio"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714195084837000.78997828-a7d2-4274-9684-920544640d88",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714195084837000.78997828-a7d2-4274-9684-920544640d88",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Pending Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "ASSIGNEE"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "UUID"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "222.1111.22222"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Location/1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e",
+      "resource" : {
+        "resourceType" : "Location",
+        "id" : "1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+            "valueString" : "location type"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Hospital Prior Temporary Location"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "value" : "2.4.4.4"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "NAME"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "UNI"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+                "valueString" : "organization"
+              }
+            ],
+            "value" : "Entity ID",
+            "assigner" : {
+              "reference" : "Organization/1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3"
+            }
+          }
+        ],
+        "status" : "active",
+        "description" : "Description",
+        "mode" : "instance",
+        "physicalType" : {
+          "coding" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+              "code" : "si"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "blah2"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIP"
+                }
+              ]
+            },
+            "value" : "blah2"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "EpisodeOfCare/1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54",
+      "resource" : {
+        "resourceType" : "EpisodeOfCare",
+        "id" : "1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "service-episode"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+            "valueString" : "ServiceDescriptor"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AASys"
+                        }
+                      ],
+                      "code" : "AACode",
+                      "display" : "Assigning Agency"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                          "valueString" : "AJSys"
+                        }
+                      ],
+                      "code" : "AJCode",
+                      "display" : "Assigning Jurisdiction"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueString" : "checkdigitscheme"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "checkdigit"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "ACSN"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "ACSN"
+                }
+              ]
+            },
+            "system" : "urn:oid:testcx42",
+            "_system" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                  "valueString" : "testcx42"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                  "valueString" : "ISO"
+                }
+              ]
+            },
+            "value" : "ServiceIdentifier",
+            "period" : {
+              "start" : "1988-07-04",
+              "_start" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "19880704"
+                  }
+                ]
+              },
+              "end" : "2088-07-04",
+              "_end" : {
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                    "valueString" : "20880704"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/pv1pv2/PV1-to-Encounter.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655003148357000.5d759bcf-6fea-4111-bf7f-5d39130e351e",
+  "id" : "1706714194648266000.51038d3f-ab6a-433a-8c62-0b7837c24c50",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:50:03.153-05:00"
+    "lastUpdated" : "2024-01-31T10:16:34.655-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,2662 +10,1908 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [
-    {
-      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "resource" : {
-        "resourceType" : "MessageHeader",
-        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-            "valueString" : "^~\\&#"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "eventCoding" : {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-          "code" : "R01",
-          "display" : "ORU^R01^ORU_R01"
-        },
-        "source" : {
-          "_endpoint" : {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-                "valueCode" : "unknown"
-              }
-            ]
-          }
+  "entry" : [ {
+    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+    "resource" : {
+      "resourceType" : "MessageHeader",
+      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+        "valueString" : "^~\\&#"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+        "extension" : [ {
+          "url" : "MSH.7",
+          "valueString" : "20230501102531-0400"
+        } ]
+      } ],
+      "eventCoding" : {
+        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+        "code" : "R01",
+        "display" : "ORU^R01^ORU_R01"
+      },
+      "source" : {
+        "_endpoint" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode" : "unknown"
+          } ]
         }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706655003529328000.3d091129-b35a-4bc7-979f-b89fdf284426",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706655003529328000.3d091129-b35a-4bc7-979f-b89fdf284426",
-        "target" : [
-          {
-            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-          }
-        ],
-        "recorded" : "2023-05-01T10:25:31-04:00",
-        "activity" : {
-          "coding" : [
-            {
-              "display" : "ORU^R01^ORU_R01"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706655003538093000.26871f57-412c-4be2-ad19-d99c6ed0987c",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706655003538093000.26871f57-412c-4be2-ad19-d99c6ed0987c",
-        "recorded" : "2024-01-30T17:50:03Z",
-        "policy" : [
-          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
-        ],
-        "activity" : {
-          "coding" : [
-            {
-              "code" : "v2-FHIR transformation"
-            }
-          ]
-        },
-        "agent" : [
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-                  "code" : "assembler"
-                }
-              ]
-            },
-            "who" : {
-              "reference" : "Organization/1706655003537487000.2fa1a2fe-43a4-4907-b7c4-18d66b1db0c4"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003537487000.2fa1a2fe-43a4-4907-b7c4-18d66b1db0c4",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003537487000.2fa1a2fe-43a4-4907-b7c4-18d66b1db0c4",
-        "identifier" : [
-          {
-            "value" : "CDC PRIME - Atlanta"
-          },
-          {
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "2.16.840.1.114222.4.1.237821"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Patient/1706655003555179000.7d6ec683-4132-477b-95ab-b1f7aff53f42",
-      "resource" : {
-        "resourceType" : "Patient",
-        "id" : "1706655003555179000.7d6ec683-4132-477b-95ab-b1f7aff53f42"
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706655003555860000.63be6e59-ad51-47f8-8d95-3b43b8189f4a",
-      "resource" : {
-        "resourceType" : "Provenance",
-        "id" : "1706655003555860000.63be6e59-ad51-47f8-8d95-3b43b8189f4a",
-        "target" : [
-          {
-            "reference" : "Patient/1706655003555179000.7d6ec683-4132-477b-95ab-b1f7aff53f42"
-          }
-        ],
-        "recorded" : "2024-01-30T17:50:03Z",
-        "activity" : {
-          "coding" : [
-            {
-              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-              "code" : "UPDATE"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Encounter/1706655003599850000.d9125aaa-267e-4992-95a9-a3840447fb18",
-      "resource" : {
-        "resourceType" : "Encounter",
-        "id" : "1706655003599850000.d9125aaa-267e-4992-95a9-a3840447fb18",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-encounter",
-            "extension" : [
-              {
-                "url" : "pv1-12-preadmit-test-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "PRE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-18-patient-type",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "34",
-                      "display" : "PT"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-46-current-patient-balance",
-                "valueDecimal" : 55
-              },
-              {
-                "url" : "pv1-47-total-charges",
-                "valueDecimal" : 1000
-              },
-              {
-                "url" : "pv1-48-total-adjustments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-49-total-payments",
-                "valueDecimal" : 0
-              },
-              {
-                "url" : "pv1-51-visit-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "316",
-                      "display" : "IND"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-30-transfer-to-bad-debt-date",
-                "valueString" : "T"
-              },
-              {
-                "url" : "pv1-31-bad-debt-agency-code",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "1",
-                      "display" : "AGE"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-32-bad-debt-transfer-amount",
-                "valueDecimal" : 3.4
-              },
-              {
-                "url" : "pv1-33-bad-debt-recovery-amount",
-                "valueDecimal" : 1.4
-              },
-              {
-                "url" : "pv1-34-delete-account-indicator",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "66",
-                      "display" : "DEL"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-35-delete-account-date",
-                "valueString" : "20240501102531-0400"
-              },
-              {
-                "url" : "pv1-39-servicing-facility",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "5678",
-                      "display" : "SERV"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "pv1-41-account-status",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "431",
-                      "display" : "ST"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706655003559512000.91f9481f-514b-498b-8f06-1cbfd10fd537"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "visit-number"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "VN"
-                }
-              ],
-              "text" : "visit number"
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "VisitNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706655003562102000.c91f4ce4-0ac4-4660-83b8-541df7b026a7"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "alternate-visit-id"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "AltVisitNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ],
-        "status" : "in-progress",
-        "class" : {
-          "extension" : [
-            {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
-              "valueCodeableConcept" : {
-                "coding" : [
-                  {
-                    "extension" : [
-                      {
-                        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                        "valueString" : "coding"
-                      }
-                    ],
-                    "code" : "O"
-                  }
-                ]
-              }
-            }
-          ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-          "code" : "AMB",
-          "display" : "ambulatory"
-        },
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          }
-        ],
-        "serviceType" : {
-          "coding" : [
-            {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                }
-              ],
-              "code" : "MED"
-            }
-          ]
-        },
-        "subject" : {
-          "reference" : "Patient/1706655003555179000.7d6ec683-4132-477b-95ab-b1f7aff53f42"
-        },
-        "episodeOfCare" : [
-          {
-            "reference" : "EpisodeOfCare/1706655003601581000.3abc9e4b-982b-4989-a309-b38c75174c04"
-          }
-        ],
-        "participant" : [
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ATND",
-                    "display" : "attender"
-                  }
-                ]
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706655003583880000.109f6128-e9a8-49a3-9840-70849a6bf463"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "REF"
-                  }
-                ],
-                "text" : "referrer"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706655003588045000.1aec59d4-3f9c-409e-9b2d-0b616a3d5229"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "CON"
-                  }
-                ],
-                "text" : "consultant"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706655003591196000.511cff85-4d2f-43e6-8219-81bf15930102"
-            }
-          },
-          {
-            "type" : [
-              {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                    "code" : "ADM"
-                  }
-                ],
-                "text" : "admitter"
-              }
-            ],
-            "individual" : {
-              "reference" : "Practitioner/1706655003594114000.0652cc24-cdc0-4355-89c6-949dbead9ef8"
-            }
-          }
-        ],
-        "period" : {
-          "start" : "2024-08-01T10:25:31-04:00",
-          "_start" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                "valueString" : "20240801102531-0400"
-              }
-            ]
-          }
-        },
-        "hospitalization" : {
-          "preAdmissionIdentifier" : {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706655003573006000.774ed905-c0f5-40c2-a5d6-31fd2ccc27f0"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "IDNumber",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          },
-          "admitSource" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "1",
-                "display" : "Source"
-              }
-            ]
-          },
-          "reAdmission" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "R"
-              }
-            ]
-          },
-          "dietPreference" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "1",
-                  "display" : "VEG"
-                }
-              ]
-            }
-          ],
-          "specialCourtesy" : [
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A0"
-                }
-              ]
-            },
-            {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                      "valueString" : "coding"
-                    }
-                  ],
-                  "code" : "A1"
-                }
-              ]
-            }
-          ],
-          "destination" : {
-            "reference" : "Location/1706655003570753000.71302841-8e7e-479d-8d3f-9447fdb35020"
-          },
-          "dischargeDisposition" : {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  }
-                ],
-                "code" : "T"
-              }
-            ]
-          }
-        },
-        "location" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "assigned-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706655003595235000.61139427-f950-4a2e-bf60-e3dcb4771289"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-patient-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706655003596612000.ae90ba46-05d1-49f0-bb03-1ff5e92ff3a2"
-            },
-            "status" : "completed"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706655003597680000.f967208a-1d49-43d5-8b77-c8c7d4f86758"
-            },
-            "status" : "active"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "pending-location"
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706655003598563000.2eb36ed8-4bb1-4147-b617-4f676a9fef0d"
-            },
-            "status" : "planned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                "valueString" : "prior-temporary-location"
-              },
-              {
-                "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
-                "valueBoolean" : true
-              }
-            ],
-            "location" : {
-              "reference" : "Location/1706655003599658000.8c54c93c-3684-45a8-b173-23486e27cf0a"
-            },
-            "status" : "completed"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003559512000.91f9481f-514b-498b-8f06-1cbfd10fd537",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003559512000.91f9481f-514b-498b-8f06-1cbfd10fd537",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003562102000.c91f4ce4-0ac4-4660-83b8-541df7b026a7",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003562102000.c91f4ce4-0ac4-4660-83b8-541df7b026a7",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706655003570753000.71302841-8e7e-479d-8d3f-9447fdb35020",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706655003570753000.71302841-8e7e-479d-8d3f-9447fdb35020",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
-            "valueString" : "20230501102531-0400"
-          }
-        ],
-        "type" : [
-          {
-            "coding" : [
-              {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  },
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                    "valueString" : "LN"
-                  }
-                ],
-                "system" : "http://loinc.org",
-                "code" : "PrimaryCode",
-                "display" : "Primary Code Display"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003573006000.774ed905-c0f5-40c2-a5d6-31fd2ccc27f0",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003573006000.774ed905-c0f5-40c2-a5d6-31fd2ccc27f0",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706655003583880000.109f6128-e9a8-49a3-9840-70849a6bf463",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706655003583880000.109f6128-e9a8-49a3-9840-70849a6bf463",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-7-attending-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Attending"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706655003588045000.1aec59d4-3f9c-409e-9b2d-0b616a3d5229",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706655003588045000.1aec59d4-3f9c-409e-9b2d-0b616a3d5229",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-8-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Referring"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706655003591196000.511cff85-4d2f-43e6-8219-81bf15930102",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706655003591196000.511cff85-4d2f-43e6-8219-81bf15930102",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-9-referring-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Consulting"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Practitioner/1706655003594114000.0652cc24-cdc0-4355-89c6-949dbead9ef8",
-      "resource" : {
-        "resourceType" : "Practitioner",
-        "id" : "1706655003594114000.0652cc24-cdc0-4355-89c6-949dbead9ef8",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "Namespace"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "AssigningSystem"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueCode" : "UUID"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-            "extension" : [
-              {
-                "url" : "XCN.3",
-                "valueString" : "LUDWIG"
-              },
-              {
-                "url" : "XCN.4",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.20",
-                "valueString" : "20230501102531-0400"
-              },
-              {
-                "url" : "XCN.21",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.22",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignJ"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.23",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "AssignA"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.5",
-                "valueString" : "2ND"
-              },
-              {
-                "url" : "XCN.7",
-                "valueString" : "MD"
-              },
-              {
-                "url" : "XCN.8",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "SRC"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.10",
-                "valueString" : "B"
-              },
-              {
-                "url" : "XCN.15",
-                "valueString" : "A"
-              },
-              {
-                "url" : "XCN.16",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        }
-                      ],
-                      "code" : "NameContext"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "XCN.19",
-                "valueString" : "20220501102531-0400"
-              }
-            ]
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-            "valueString" : "pv1-17-admitting-doctor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "A"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueCode" : "NPI"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "DL"
-                }
-              ]
-            },
-            "system" : "Namespace",
-            "value" : "1"
-          }
-        ],
-        "name" : [
-          {
-            "extension" : [
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-                "valueCode" : "G"
-              }
-            ],
-            "use" : "official",
-            "family" : "BEETHOVEN",
-            "_family" : {
-              "extension" : [
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-                  "valueString" : "VAN"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-                  "valueString" : "Admitting"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-                  "valueString" : "VAL"
-                },
-                {
-                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-                  "valueString" : "ROGER"
-                }
-              ]
-            },
-            "given" : [
-              "LUDWIG",
-              "B"
-            ],
-            "prefix" : [
-              "DR"
-            ],
-            "suffix" : [
-              "2ND",
-              "MD",
-              "MD"
-            ],
-            "period" : {
-              "start" : "2022-05-01T10:25:31-04:00",
-              "end" : "2023-05-01T10:25:31-04:00"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003594817000.4331adb4-78a3-41bf-99bc-f9a7cfe3608c",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003594817000.4331adb4-78a3-41bf-99bc-f9a7cfe3608c",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706655003595235000.61139427-f950-4a2e-bf60-e3dcb4771289",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706655003595235000.61139427-f950-4a2e-bf60-e3dcb4771289",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Assigned"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706655003594817000.4331adb4-78a3-41bf-99bc-f9a7cfe3608c"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003596021000.66ab1a4b-2957-41c0-823c-f6ba3ece9af0",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003596021000.66ab1a4b-2957-41c0-823c-f6ba3ece9af0",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706655003596612000.ae90ba46-05d1-49f0-bb03-1ff5e92ff3a2",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706655003596612000.ae90ba46-05d1-49f0-bb03-1ff5e92ff3a2",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prio"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706655003596021000.66ab1a4b-2957-41c0-823c-f6ba3ece9af0"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003597178000.32dbbe15-7464-411f-a8de-65492ac2cec7",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003597178000.32dbbe15-7464-411f-a8de-65492ac2cec7",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706655003597680000.f967208a-1d49-43d5-8b77-c8c7d4f86758",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706655003597680000.f967208a-1d49-43d5-8b77-c8c7d4f86758",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706655003597178000.32dbbe15-7464-411f-a8de-65492ac2cec7"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003598128000.de02fae9-fb8c-4916-a2ae-d1d59fdb1993",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003598128000.de02fae9-fb8c-4916-a2ae-d1d59fdb1993",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706655003598563000.2eb36ed8-4bb1-4147-b617-4f676a9fef0d",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706655003598563000.2eb36ed8-4bb1-4147-b617-4f676a9fef0d",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Pending Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706655003598128000.de02fae9-fb8c-4916-a2ae-d1d59fdb1993"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003599019000.15548443-ab63-433c-902d-34129e4210e7",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003599019000.15548443-ab63-433c-902d-34129e4210e7",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "ASSIGNEE"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "UUID"
-                }
-              ]
-            },
-            "system" : "urn:ietf:rfc:3986",
-            "value" : "222.1111.22222"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Location/1706655003599658000.8c54c93c-3684-45a8-b173-23486e27cf0a",
-      "resource" : {
-        "resourceType" : "Location",
-        "id" : "1706655003599658000.8c54c93c-3684-45a8-b173-23486e27cf0a",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
-            "valueString" : "location type"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "Hospital Prior Temporary Location"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "extension" : [
-                    {
-                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-                      "valueString" : "id-code"
-                    }
-                  ],
-                  "code" : "ISO"
-                }
-              ]
-            },
-            "value" : "2.4.4.4"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-                "valueString" : "NAME"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                "valueString" : "UNI"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                "valueString" : "ISO"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
-                "valueString" : "organization"
-              }
-            ],
-            "value" : "Entity ID",
-            "assigner" : {
-              "reference" : "Organization/1706655003599019000.15548443-ab63-433c-902d-34129e4210e7"
-            }
-          }
-        ],
-        "status" : "active",
-        "description" : "Description",
-        "mode" : "instance",
-        "physicalType" : {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
-              "code" : "si"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "fullUrl" : "Organization/1706655003600694000.c7c8a871-db21-4994-8675-446670d11845",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655003600694000.c7c8a871-db21-4994-8675-446670d11845",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "blah2"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIP"
-                }
-              ]
-            },
-            "value" : "blah2"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "EpisodeOfCare/1706655003601581000.3abc9e4b-982b-4989-a309-b38c75174c04",
-      "resource" : {
-        "resourceType" : "EpisodeOfCare",
-        "id" : "1706655003601581000.3abc9e4b-982b-4989-a309-b38c75174c04",
-        "extension" : [
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-            "valueString" : "service-episode"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
-            "valueString" : "ServiceDescriptor"
-          }
-        ],
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-                "valueReference" : {
-                  "reference" : "Organization/1706655003600694000.c7c8a871-db21-4994-8675-446670d11845"
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AASys"
-                        }
-                      ],
-                      "code" : "AACode",
-                      "display" : "Assigning Agency"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
-                "valueCodeableConcept" : {
-                  "coding" : [
-                    {
-                      "extension" : [
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                          "valueString" : "coding"
-                        },
-                        {
-                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-                          "valueString" : "AJSys"
-                        }
-                      ],
-                      "code" : "AJCode",
-                      "display" : "Assigning Jurisdiction"
-                    }
-                  ]
-                }
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-                "valueString" : "checkdigitscheme"
-              },
-              {
-                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-                "valueString" : "checkdigit"
-              },
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-                "valueString" : "ACSN"
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "code" : "ACSN"
-                }
-              ]
-            },
-            "system" : "urn:oid:testcx42",
-            "_system" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueString" : "testcx42"
-                },
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-                  "valueString" : "ISO"
-                }
-              ]
-            },
-            "value" : "ServiceIdentifier",
-            "period" : {
-              "start" : "1988-07-04",
-              "_start" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "19880704"
-                  }
-                ]
-              },
-              "end" : "2088-07-04",
-              "_end" : {
-                "extension" : [
-                  {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
-                    "valueString" : "20880704"
-                  }
-                ]
-              }
-            }
-          }
-        ]
       }
     }
-  ]
+  }, {
+    "fullUrl" : "Provenance/1706714195017466000.e79ffa4b-aaf8-4562-b0e2-7725c7d59dbf",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714195017466000.e79ffa4b-aaf8-4562-b0e2-7725c7d59dbf",
+      "target" : [ {
+        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+      } ],
+      "recorded" : "2023-05-01T10:25:31-04:00",
+      "activity" : {
+        "coding" : [ {
+          "display" : "ORU^R01^ORU_R01"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714195026792000.d9adf105-5a42-4994-8de4-b36f549283e0",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714195026792000.d9adf105-5a42-4994-8de4-b36f549283e0",
+      "recorded" : "2024-01-31T10:16:35Z",
+      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
+      "activity" : {
+        "coding" : [ {
+          "code" : "v2-FHIR transformation"
+        } ]
+      },
+      "agent" : [ {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code" : "assembler"
+          } ]
+        },
+        "who" : {
+          "reference" : "Organization/1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195026252000.8c678c90-86df-42e6-8e85-c05ca658106a",
+      "identifier" : [ {
+        "value" : "CDC PRIME - Atlanta"
+      }, {
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "2.16.840.1.114222.4.1.237821"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e",
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
+    }
+  }, {
+    "fullUrl" : "Provenance/1706714195043734000.6769257f-2556-49bc-9ee2-6a790cb5745f",
+    "resource" : {
+      "resourceType" : "Provenance",
+      "id" : "1706714195043734000.6769257f-2556-49bc-9ee2-6a790cb5745f",
+      "target" : [ {
+        "reference" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
+      } ],
+      "recorded" : "2024-01-31T10:16:35Z",
+      "activity" : {
+        "coding" : [ {
+          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+          "code" : "UPDATE"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Encounter/1706714195086552000.f28d8ca0-9912-4a7e-b49f-861eebd9feaf",
+    "resource" : {
+      "resourceType" : "Encounter",
+      "id" : "1706714195086552000.f28d8ca0-9912-4a7e-b49f-861eebd9feaf",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-patient-visit",
+        "extension" : [ {
+          "url" : "pv1-12-preadmit-test-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "PRE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-18-patient-type",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "34",
+              "display" : "PT"
+            } ]
+          }
+        }, {
+          "url" : "pv1-46-current-patient-balance",
+          "valueDecimal" : 55
+        }, {
+          "url" : "pv1-47-total-charges",
+          "valueDecimal" : 1000
+        }, {
+          "url" : "pv1-48-total-adjustments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-49-total-payments",
+          "valueDecimal" : 0
+        }, {
+          "url" : "pv1-51-visit-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "316",
+              "display" : "IND"
+            } ]
+          }
+        }, {
+          "url" : "pv1-30-transfer-to-bad-debt-date",
+          "valueString" : "T"
+        }, {
+          "url" : "pv1-31-bad-debt-agency-code",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "1",
+              "display" : "AGE"
+            } ]
+          }
+        }, {
+          "url" : "pv1-32-bad-debt-transfer-amount",
+          "valueDecimal" : 3.4
+        }, {
+          "url" : "pv1-33-bad-debt-recovery-amount",
+          "valueDecimal" : 1.4
+        }, {
+          "url" : "pv1-34-delete-account-indicator",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "66",
+              "display" : "DEL"
+            } ]
+          }
+        }, {
+          "url" : "pv1-35-delete-account-date",
+          "valueString" : "20240501102531-0400"
+        }, {
+          "url" : "pv1-39-servicing-facility",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "5678",
+              "display" : "SERV"
+            } ]
+          }
+        }, {
+          "url" : "pv1-41-account-status",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "431",
+              "display" : "ST"
+            } ]
+          }
+        } ]
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "visit-number"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "VN"
+          } ],
+          "text" : "visit number"
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "VisitNumber",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "alternate-visit-id"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "AltVisitNumber",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ],
+      "status" : "in-progress",
+      "class" : {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pv1-2-patient-class",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "O"
+            } ]
+          }
+        } ],
+        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code" : "AMB",
+        "display" : "ambulatory"
+      },
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "R"
+        } ]
+      } ],
+      "serviceType" : {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          } ],
+          "code" : "MED"
+        } ]
+      },
+      "subject" : {
+        "reference" : "Patient/1706714195043082000.ec5facaa-c477-4fe8-8597-7cd70fabf02e"
+      },
+      "episodeOfCare" : [ {
+        "reference" : "EpisodeOfCare/1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54"
+      } ],
+      "participant" : [ {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ATND",
+            "display" : "attender"
+          } ]
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "REF"
+          } ],
+          "text" : "referrer"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "CON"
+          } ],
+          "text" : "consultant"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402"
+        }
+      }, {
+        "type" : [ {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+            "code" : "ADM"
+          } ],
+          "text" : "admitter"
+        } ],
+        "individual" : {
+          "reference" : "Practitioner/1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a"
+        }
+      } ],
+      "period" : {
+        "start" : "2024-08-01T10:25:31-04:00",
+        "_start" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+            "valueString" : "20240801102531-0400"
+          } ]
+        }
+      },
+      "hospitalization" : {
+        "preAdmissionIdentifier" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+            "valueReference" : {
+              "reference" : "Organization/1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c"
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AASys"
+                } ],
+                "code" : "AACode",
+                "display" : "Assigning Agency"
+              } ]
+            }
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+            "valueCodeableConcept" : {
+              "coding" : [ {
+                "extension" : [ {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                }, {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "AJSys"
+                } ],
+                "code" : "AJCode",
+                "display" : "Assigning Jurisdiction"
+              } ]
+            }
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            "valueString" : "checkdigitscheme"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            "valueString" : "checkdigit"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+            "valueString" : "ACSN"
+          } ],
+          "type" : {
+            "coding" : [ {
+              "code" : "ACSN"
+            } ]
+          },
+          "system" : "urn:oid:testcx42",
+          "_system" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "testcx42"
+            }, {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            } ]
+          },
+          "value" : "IDNumber",
+          "period" : {
+            "start" : "1988-07-04",
+            "_start" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "19880704"
+              } ]
+            },
+            "end" : "2088-07-04",
+            "_end" : {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                "valueString" : "20880704"
+              } ]
+            }
+          }
+        },
+        "admitSource" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "Source"
+          } ]
+        },
+        "reAdmission" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "R"
+          } ]
+        },
+        "dietPreference" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "1",
+            "display" : "VEG"
+          } ]
+        } ],
+        "specialCourtesy" : [ {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A0"
+          } ]
+        }, {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "A1"
+          } ]
+        } ],
+        "destination" : {
+          "reference" : "Location/1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7"
+        },
+        "dischargeDisposition" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+              "valueString" : "coding"
+            } ],
+            "code" : "T"
+          } ]
+        }
+      },
+      "location" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "assigned-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-patient-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263"
+        },
+        "status" : "completed"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714195084837000.78997828-a7d2-4274-9684-920544640d88"
+        },
+        "status" : "active"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "pending-location"
+        } ],
+        "location" : {
+          "reference" : "Location/1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1"
+        },
+        "status" : "planned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+          "valueString" : "prior-temporary-location"
+        }, {
+          "url" : "https://hl7.org/fhir/StructureDefinition/temporary-location",
+          "valueBoolean" : true
+        } ],
+        "location" : {
+          "reference" : "Location/1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e"
+        },
+        "status" : "completed"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195047238000.baca0571-91fd-44a4-84db-6c1a18f783d7",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195050913000.6dc31924-f484-474b-bbe1-d960a87dbe47",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714195062321000.63e08caa-b438-4d77-a26a-4cca47d385d7",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/dld2-effective-date",
+        "valueString" : "20230501102531-0400"
+      } ],
+      "type" : [ {
+        "coding" : [ {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+            "valueString" : "coding"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+            "valueString" : "LN"
+          } ],
+          "system" : "http://loinc.org",
+          "code" : "PrimaryCode",
+          "display" : "Primary Code Display"
+        } ]
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195063799000.ffa64520-8856-4a51-841e-94179dead38c",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714195073621000.248661cb-e82f-4810-bf9c-69031493d5c3",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-7-attending-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Attending"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714195076765000.ed97ffec-c2d3-40e0-870b-18d7e629228e",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-8-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Referring"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714195079790000.2f6f95c4-bbe4-4f4a-9033-4d9c5f894402",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-9-referring-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Consulting"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Practitioner/1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a",
+    "resource" : {
+      "resourceType" : "Practitioner",
+      "id" : "1706714195081922000.fefe70cb-2129-4dd8-8364-57e69db5700a",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "Namespace"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "AssigningSystem"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueCode" : "UUID"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+        "extension" : [ {
+          "url" : "XCN.3",
+          "valueString" : "LUDWIG"
+        }, {
+          "url" : "XCN.4",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.20",
+          "valueString" : "20230501102531-0400"
+        }, {
+          "url" : "XCN.21",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.22",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignJ"
+            } ]
+          }
+        }, {
+          "url" : "XCN.23",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "AssignA"
+            } ]
+          }
+        }, {
+          "url" : "XCN.5",
+          "valueString" : "2ND"
+        }, {
+          "url" : "XCN.7",
+          "valueString" : "MD"
+        }, {
+          "url" : "XCN.8",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "SRC"
+            } ]
+          }
+        }, {
+          "url" : "XCN.10",
+          "valueString" : "B"
+        }, {
+          "url" : "XCN.15",
+          "valueString" : "A"
+        }, {
+          "url" : "XCN.16",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              } ],
+              "code" : "NameContext"
+            } ]
+          }
+        }, {
+          "url" : "XCN.19",
+          "valueString" : "20220501102531-0400"
+        } ]
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+        "valueString" : "pv1-17-admitting-doctor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "A"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueCode" : "NPI"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "DL"
+          } ]
+        },
+        "system" : "Namespace",
+        "value" : "1"
+      } ],
+      "name" : [ {
+        "extension" : [ {
+          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+          "valueCode" : "G"
+        } ],
+        "use" : "official",
+        "family" : "BEETHOVEN",
+        "_family" : {
+          "extension" : [ {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+            "valueString" : "VAN"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+            "valueString" : "Admitting"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+            "valueString" : "VAL"
+          }, {
+            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+            "valueString" : "ROGER"
+          } ]
+        },
+        "given" : [ "LUDWIG", "B" ],
+        "prefix" : [ "DR" ],
+        "suffix" : [ "2ND", "MD", "MD" ],
+        "period" : {
+          "start" : "2022-05-01T10:25:31-04:00",
+          "end" : "2023-05-01T10:25:31-04:00"
+        }
+      } ]
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714195082931000.53f1ce28-f59b-4dd1-a15d-044229ec8890",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Assigned"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714195082513000.4efb285e-c2c6-4bb1-8c54-5b8bd11879ab"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714195083835000.e7560d3e-6c79-4229-9c07-de6e03cd7263",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prio"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714195083472000.c4d7e14b-a645-42aa-a571-4d320cecbd58"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714195084837000.78997828-a7d2-4274-9684-920544640d88",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714195084837000.78997828-a7d2-4274-9684-920544640d88",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714195084412000.fc695c41-e808-45f1-b211-a4d46a2e2290"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714195085722000.d9425515-7e4a-4dee-bb2e-362a45f03cc1",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Pending Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714195085360000.95b9db72-1ad8-480a-92e0-7c67f402c881"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "ASSIGNEE"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "UUID"
+          } ]
+        },
+        "system" : "urn:ietf:rfc:3986",
+        "value" : "222.1111.22222"
+      } ]
+    }
+  }, {
+    "fullUrl" : "Location/1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e",
+    "resource" : {
+      "resourceType" : "Location",
+      "id" : "1706714195086419000.9955d860-9e14-4e37-bcc7-25079ab82b0e",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pl6-person-location-type",
+        "valueString" : "location type"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "Hospital Prior Temporary Location"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "id-code"
+            } ],
+            "code" : "ISO"
+          } ]
+        },
+        "value" : "2.4.4.4"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+          "valueString" : "NAME"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+          "valueString" : "UNI"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+          "valueString" : "ISO"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ei-assigner-organization-type",
+          "valueString" : "organization"
+        } ],
+        "value" : "Entity ID",
+        "assigner" : {
+          "reference" : "Organization/1706714195086083000.fae5cc45-cf92-4031-a565-ccbb1b4b41a3"
+        }
+      } ],
+      "status" : "active",
+      "description" : "Description",
+      "mode" : "instance",
+      "physicalType" : {
+        "coding" : [ {
+          "system" : "http://terminology.hl7.org/CodeSystem/location-physical-type",
+          "code" : "si"
+        } ]
+      }
+    }
+  }, {
+    "fullUrl" : "Organization/1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d",
+    "resource" : {
+      "resourceType" : "Organization",
+      "id" : "1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d",
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+          "valueBoolean" : true
+        } ],
+        "value" : "blah2"
+      }, {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+          "valueBoolean" : true
+        } ],
+        "type" : {
+          "coding" : [ {
+            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+            "code" : "CLIP"
+          } ]
+        },
+        "value" : "blah2"
+      } ]
+    }
+  }, {
+    "fullUrl" : "EpisodeOfCare/1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54",
+    "resource" : {
+      "resourceType" : "EpisodeOfCare",
+      "id" : "1706714195087821000.dad14087-9037-44e8-a63f-b3d618899c54",
+      "extension" : [ {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+        "valueString" : "service-episode"
+      }, {
+        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/episode-of-care-name",
+        "valueString" : "ServiceDescriptor"
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+          "valueReference" : {
+            "reference" : "Organization/1706714195087111000.9af71fac-8f1f-4ad7-b380-9e81eda6fe5d"
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-agency-or-department",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AASys"
+              } ],
+              "code" : "AACode",
+              "display" : "Assigning Agency"
+            } ]
+          }
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-jurisdiction",
+          "valueCodeableConcept" : {
+            "coding" : [ {
+              "extension" : [ {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                "valueString" : "coding"
+              }, {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                "valueString" : "AJSys"
+              } ],
+              "code" : "AJCode",
+              "display" : "Assigning Jurisdiction"
+            } ]
+          }
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+          "valueString" : "checkdigitscheme"
+        }, {
+          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+          "valueString" : "checkdigit"
+        }, {
+          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+          "valueString" : "ACSN"
+        } ],
+        "type" : {
+          "coding" : [ {
+            "code" : "ACSN"
+          } ]
+        },
+        "system" : "urn:oid:testcx42",
+        "_system" : {
+          "extension" : [ {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+            "valueString" : "testcx42"
+          }, {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+            "valueString" : "ISO"
+          } ]
+        },
+        "value" : "ServiceIdentifier",
+        "period" : {
+          "start" : "1988-07-04",
+          "_start" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "19880704"
+            } ]
+          },
+          "end" : "2088-07-04",
+          "_end" : {
+            "extension" : [ {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+              "valueString" : "20880704"
+            } ]
+          }
+        }
+      } ]
+    }
+  } ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/spm/SPM-with-17-2-not-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/spm/SPM-with-17-2-not-populated.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311906667394000.7538497d-0372-4a79-bdd6-7f76a3488c65",
+  "id" : "1706817309476662000.fe7a2369-07db-458f-ab37-ffa24f9db14a",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:31:46.679-06:00"
+    "lastUpdated" : "2024-02-01T14:55:09.483-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311906752119000.51aac6b1-2c9b-471c-ada0-e47ad519f57e"
+          "reference" : "Organization/1706817309532323000.ccd47b28-a7a4-4882-a5f0-dec09354a34b"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311906752119000.51aac6b1-2c9b-471c-ada0-e47ad519f57e",
+      "fullUrl" : "Organization/1706817309532323000.ccd47b28-a7a4-4882-a5f0-dec09354a34b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311906752119000.51aac6b1-2c9b-471c-ada0-e47ad519f57e",
+        "id" : "1706817309532323000.ccd47b28-a7a4-4882-a5f0-dec09354a34b",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311907055390000.1d483836-a7bd-4e70-b897-5c4a4e1d0fda",
+      "fullUrl" : "Provenance/1706817309921515000.4d92665d-a232-4941-8915-8f50f7b7ecdd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311907055390000.1d483836-a7bd-4e70-b897-5c4a4e1d0fda",
+        "id" : "1706817309921515000.4d92665d-a232-4941-8915-8f50f7b7ecdd",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706311907254405000.3ef3cc91-29c4-4a75-922a-82fc2e3f04bb"
+            "reference" : "DiagnosticReport/1706817310173972000.744fbaa6-89ae-4cb7-bf86-f10eee184851"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311907062562000.89c49673-dedb-4230-ac17-abe86dca574c",
+      "fullUrl" : "Provenance/1706817309931847000.8b1cf372-9eb6-4242-87cd-9636c3818494",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311907062562000.89c49673-dedb-4230-ac17-abe86dca574c",
-        "recorded" : "2024-01-26T17:31:47Z",
+        "id" : "1706817309931847000.8b1cf372-9eb6-4242-87cd-9636c3818494",
+        "recorded" : "2024-02-01T14:55:09Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311907061558000.c5482504-6442-47b4-ab2e-108d0b0c7ea8"
+              "reference" : "Organization/1706817309931366000.751f72a1-2287-4425-98a3-4cce2958c15e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311907061558000.c5482504-6442-47b4-ab2e-108d0b0c7ea8",
+      "fullUrl" : "Organization/1706817309931366000.751f72a1-2287-4425-98a3-4cce2958c15e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311907061558000.c5482504-6442-47b4-ab2e-108d0b0c7ea8",
+        "id" : "1706817309931366000.751f72a1-2287-4425-98a3-4cce2958c15e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311907075186000.feb0803f-cdcd-47eb-9070-004119f40932",
+      "fullUrl" : "Patient/1706817309951581000.106126de-a4b0-4d80-9fa5-5b594430410c",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311907075186000.feb0803f-cdcd-47eb-9070-004119f40932"
+        "id" : "1706817309951581000.106126de-a4b0-4d80-9fa5-5b594430410c"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311907075758000.fee45f76-c986-4047-910e-7291633c790a",
+      "fullUrl" : "Provenance/1706817309952371000.d51298af-d7f8-4ae5-b1fd-a054d00d3c20",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311907075758000.fee45f76-c986-4047-910e-7291633c790a",
+        "id" : "1706817309952371000.d51298af-d7f8-4ae5-b1fd-a054d00d3c20",
         "target" : [
           {
-            "reference" : "Patient/1706311907075186000.feb0803f-cdcd-47eb-9070-004119f40932"
+            "reference" : "Patient/1706817309951581000.106126de-a4b0-4d80-9fa5-5b594430410c"
           }
         ],
-        "recorded" : "2024-01-26T17:31:47Z",
+        "recorded" : "2024-02-01T14:55:09Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706311907093629000.b651c1d5-f935-4652-bbdc-097899a73981",
+      "fullUrl" : "Specimen/1706817309975558000.fb58a2b6-64a2-4f96-aabd-21c9f525605c",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706311907093629000.b651c1d5-f935-4652-bbdc-097899a73981",
+        "id" : "1706817309975558000.fb58a2b6-64a2-4f96-aabd-21c9f525605c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/spm-specimen",
@@ -1256,7 +1261,7 @@
         },
         "parent" : [
           {
-            "reference" : "Specimen/1706311907081938000.ef3c9987-233a-4eb7-a7da-e08110e84ea5"
+            "reference" : "Specimen/1706817309958702000.bab8d9fc-26ec-4785-a168-18aff30baa8c"
           }
         ],
         "collection" : {
@@ -1575,10 +1580,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706311907081938000.ef3c9987-233a-4eb7-a7da-e08110e84ea5",
+      "fullUrl" : "Specimen/1706817309958702000.bab8d9fc-26ec-4785-a168-18aff30baa8c",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706311907081938000.ef3c9987-233a-4eb7-a7da-e08110e84ea5",
+        "id" : "1706817309958702000.bab8d9fc-26ec-4785-a168-18aff30baa8c",
         "identifier" : [
           {
             "extension" : [
@@ -1684,10 +1689,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706311907252598000.294df7c0-4908-4379-94f9-af0e2136bced",
+      "fullUrl" : "ServiceRequest/1706817310170872000.92d069dd-01d9-4bd4-b0c1-28f0ba088236",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706311907252598000.294df7c0-4908-4379-94f9-af0e2136bced",
+        "id" : "1706817310170872000.92d069dd-01d9-4bd4-b0c1-28f0ba088236",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -1703,18 +1708,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311907075186000.feb0803f-cdcd-47eb-9070-004119f40932"
+          "reference" : "Patient/1706817309951581000.106126de-a4b0-4d80-9fa5-5b594430410c"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706311907254405000.3ef3cc91-29c4-4a75-922a-82fc2e3f04bb",
+      "fullUrl" : "DiagnosticReport/1706817310173972000.744fbaa6-89ae-4cb7-bf86-f10eee184851",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706311907254405000.3ef3cc91-29c4-4a75-922a-82fc2e3f04bb",
+        "id" : "1706817310173972000.744fbaa6-89ae-4cb7-bf86-f10eee184851",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706311907252598000.294df7c0-4908-4379-94f9-af0e2136bced"
+            "reference" : "ServiceRequest/1706817310170872000.92d069dd-01d9-4bd4-b0c1-28f0ba088236"
           }
         ],
         "status" : "final",
@@ -1732,11 +1737,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311907075186000.feb0803f-cdcd-47eb-9070-004119f40932"
+          "reference" : "Patient/1706817309951581000.106126de-a4b0-4d80-9fa5-5b594430410c"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706311907093629000.b651c1d5-f935-4652-bbdc-097899a73981"
+            "reference" : "Specimen/1706817309975558000.fb58a2b6-64a2-4f96-aabd-21c9f525605c"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/spm/SPM-with-17-2-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/spm/SPM-with-17-2-populated.fhir
@@ -1,15 +1,15 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706311915135067000.92da5b4a-c23c-4709-91f4-4e75fa0a270e",
+  "id" : "1706817320739759000.0c50574a-6999-45b7-be1b-1ef344a1b95c",
   "meta" : {
-    "lastUpdated" : "2024-01-26T17:31:55.147-06:00"
+    "lastUpdated" : "2024-02-01T14:55:20.746-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
     "value" : "12345"
   },
   "type" : "message",
-  "timestamp" : "2023-05-01T09:25:31.000-05:00",
+  "timestamp" : "2023-05-01T10:25:31.000-04:00",
   "entry" : [
     {
       "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706311915218362000.9bfb3011-38f8-4e31-8eee-983973163f3c"
+          "reference" : "Organization/1706817320804572000.582c404d-904c-433b-aa44-d3153381c8e3"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706311915218362000.9bfb3011-38f8-4e31-8eee-983973163f3c",
+      "fullUrl" : "Organization/1706817320804572000.582c404d-904c-433b-aa44-d3153381c8e3",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311915218362000.9bfb3011-38f8-4e31-8eee-983973163f3c",
+        "id" : "1706817320804572000.582c404d-904c-433b-aa44-d3153381c8e3",
         "address" : [
           {
             "country" : "USA"
@@ -63,16 +68,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311915540900000.5bc8c1bd-038d-4387-9e9b-078c4b83fa3f",
+      "fullUrl" : "Provenance/1706817321193836000.e711f7c1-d47b-40bd-9bce-cf06000957c8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311915540900000.5bc8c1bd-038d-4387-9e9b-078c4b83fa3f",
+        "id" : "1706817321193836000.e711f7c1-d47b-40bd-9bce-cf06000957c8",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
           },
           {
-            "reference" : "DiagnosticReport/1706311915735797000.e1571047-7f85-456a-91a1-383f52ee3cff"
+            "reference" : "DiagnosticReport/1706817321454568000.54afc2d2-b1d1-48e5-9773-06896ad59115"
           }
         ],
         "recorded" : "2023-05-01T10:25:31-04:00",
@@ -86,11 +91,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706311915547884000.0d2240d1-26c5-4099-8798-48d023967774",
+      "fullUrl" : "Provenance/1706817321205209000.5ae5a87a-f63a-4e41-a49e-87e792de9589",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311915547884000.0d2240d1-26c5-4099-8798-48d023967774",
-        "recorded" : "2024-01-26T17:31:55Z",
+        "id" : "1706817321205209000.5ae5a87a-f63a-4e41-a49e-87e792de9589",
+        "recorded" : "2024-02-01T14:55:21Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -112,17 +117,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706311915546739000.ab162142-ffba-4d2f-aa1d-1f87909cb3e8"
+              "reference" : "Organization/1706817321204690000.e842d742-3095-4d46-b0fa-0cca88c0c42c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706311915546739000.ab162142-ffba-4d2f-aa1d-1f87909cb3e8",
+      "fullUrl" : "Organization/1706817321204690000.e842d742-3095-4d46-b0fa-0cca88c0c42c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706311915546739000.ab162142-ffba-4d2f-aa1d-1f87909cb3e8",
+        "id" : "1706817321204690000.e842d742-3095-4d46-b0fa-0cca88c0c42c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -142,23 +147,23 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706311915560186000.4cf73825-1397-4a82-960d-8dfcdbbc13dc",
+      "fullUrl" : "Patient/1706817321226100000.cfdef39d-366c-40de-8af1-aefa6c26f90e",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706311915560186000.4cf73825-1397-4a82-960d-8dfcdbbc13dc"
+        "id" : "1706817321226100000.cfdef39d-366c-40de-8af1-aefa6c26f90e"
       }
     },
     {
-      "fullUrl" : "Provenance/1706311915560654000.14c6ffa6-62e2-4fa0-ae81-dfed520963db",
+      "fullUrl" : "Provenance/1706817321226984000.6cdde9ec-1f80-4349-9308-77f1c521d66f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706311915560654000.14c6ffa6-62e2-4fa0-ae81-dfed520963db",
+        "id" : "1706817321226984000.6cdde9ec-1f80-4349-9308-77f1c521d66f",
         "target" : [
           {
-            "reference" : "Patient/1706311915560186000.4cf73825-1397-4a82-960d-8dfcdbbc13dc"
+            "reference" : "Patient/1706817321226100000.cfdef39d-366c-40de-8af1-aefa6c26f90e"
           }
         ],
-        "recorded" : "2024-01-26T17:31:55Z",
+        "recorded" : "2024-02-01T14:55:21Z",
         "activity" : {
           "coding" : [
             {
@@ -170,10 +175,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706311915578717000.b26772fa-5f51-43c6-8f85-cad00b4fc5c3",
+      "fullUrl" : "Specimen/1706817321255280000.b0816435-e3df-4f97-b712-6be77dd53814",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706311915578717000.b26772fa-5f51-43c6-8f85-cad00b4fc5c3",
+        "id" : "1706817321255280000.b0816435-e3df-4f97-b712-6be77dd53814",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/spm-specimen",
@@ -1256,7 +1261,7 @@
         },
         "parent" : [
           {
-            "reference" : "Specimen/1706311915566156000.84899b93-d192-450e-8cfc-25cc7bc7f0c5"
+            "reference" : "Specimen/1706817321235806000.15af7583-1081-40b3-b43c-8f294b435eb3"
           }
         ],
         "collection" : {
@@ -1585,10 +1590,10 @@
       }
     },
     {
-      "fullUrl" : "Specimen/1706311915566156000.84899b93-d192-450e-8cfc-25cc7bc7f0c5",
+      "fullUrl" : "Specimen/1706817321235806000.15af7583-1081-40b3-b43c-8f294b435eb3",
       "resource" : {
         "resourceType" : "Specimen",
-        "id" : "1706311915566156000.84899b93-d192-450e-8cfc-25cc7bc7f0c5",
+        "id" : "1706817321235806000.15af7583-1081-40b3-b43c-8f294b435eb3",
         "identifier" : [
           {
             "extension" : [
@@ -1694,10 +1699,10 @@
       }
     },
     {
-      "fullUrl" : "ServiceRequest/1706311915733993000.44782e11-1736-407f-889a-9092a3593a53",
+      "fullUrl" : "ServiceRequest/1706817321452276000.47be8332-9c2e-40d7-b00f-2b2071cbd485",
       "resource" : {
         "resourceType" : "ServiceRequest",
-        "id" : "1706311915733993000.44782e11-1736-407f-889a-9092a3593a53",
+        "id" : "1706817321452276000.47be8332-9c2e-40d7-b00f-2b2071cbd485",
         "status" : "unknown",
         "code" : {
           "coding" : [
@@ -1713,18 +1718,18 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311915560186000.4cf73825-1397-4a82-960d-8dfcdbbc13dc"
+          "reference" : "Patient/1706817321226100000.cfdef39d-366c-40de-8af1-aefa6c26f90e"
         }
       }
     },
     {
-      "fullUrl" : "DiagnosticReport/1706311915735797000.e1571047-7f85-456a-91a1-383f52ee3cff",
+      "fullUrl" : "DiagnosticReport/1706817321454568000.54afc2d2-b1d1-48e5-9773-06896ad59115",
       "resource" : {
         "resourceType" : "DiagnosticReport",
-        "id" : "1706311915735797000.e1571047-7f85-456a-91a1-383f52ee3cff",
+        "id" : "1706817321454568000.54afc2d2-b1d1-48e5-9773-06896ad59115",
         "basedOn" : [
           {
-            "reference" : "ServiceRequest/1706311915733993000.44782e11-1736-407f-889a-9092a3593a53"
+            "reference" : "ServiceRequest/1706817321452276000.47be8332-9c2e-40d7-b00f-2b2071cbd485"
           }
         ],
         "status" : "final",
@@ -1742,11 +1747,11 @@
           ]
         },
         "subject" : {
-          "reference" : "Patient/1706311915560186000.4cf73825-1397-4a82-960d-8dfcdbbc13dc"
+          "reference" : "Patient/1706817321226100000.cfdef39d-366c-40de-8af1-aefa6c26f90e"
         },
         "specimen" : [
           {
-            "reference" : "Specimen/1706311915578717000.b26772fa-5f51-43c6-8f85-cad00b4fc5c3"
+            "reference" : "Specimen/1706817321255280000.b0816435-e3df-4f97-b712-6be77dd53814"
           }
         ]
       }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-ignores-xad12-for-xad13.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-ignores-xad12-for-xad13.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655048333021000.77a33092-968c-446b-ac69-d66dfef53095",
+  "id" : "1706817386208802000.7a2f5f68-6dea-433f-8234-5c097d57ad3f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:50:48.340-05:00"
+    "lastUpdated" : "2024-02-01T14:56:26.215-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,300 +10,419 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706655048408035000.d96ab77c-14b4-40ad-8f6e-eec34c219747"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706655048408035000.d96ab77c-14b4-40ad-8f6e-eec34c219747",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655048408035000.d96ab77c-14b4-40ad-8f6e-eec34c219747",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655048733881000.197170a6-4116-4391-bbf7-937fcd3fab6f",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655048733881000.197170a6-4116-4391-bbf7-937fcd3fab6f",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655048741939000.a4b6cbd4-f12c-42e9-aaa4-465e849be1ce",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655048741939000.a4b6cbd4-f12c-42e9-aaa4-465e849be1ce",
-      "recorded" : "2024-01-30T17:50:48Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706655048741520000.558774e2-730a-4bb9-8945-895c8780ec33"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655048741520000.558774e2-730a-4bb9-8945-895c8780ec33",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655048741520000.558774e2-730a-4bb9-8945-895c8780ec33",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706655048766785000.045344bd-2db7-48eb-94a8-425f6c9850a7",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706655048766785000.045344bd-2db7-48eb-94a8-425f6c9850a7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "patient-identifier-list"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "MR"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "MR"
-          } ]
-        },
-        "value" : "11102779"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "BB SARAH"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "SMITH",
-        "given" : [ "BB SARAH" ]
-      } ],
-      "contact" : [ {
-        "name" : { },
-        "organization" : {
-          "reference" : "Organization/1706655048761145000.22f96c8a-b47c-4d67-bc90-77c79ff1c8b5"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655048761145000.22f96c8a-b47c-4d67-bc90-77c79ff1c8b5",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655048761145000.22f96c8a-b47c-4d67-bc90-77c79ff1c8b5",
-      "contact" : [ {
-        "address" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
-            "valueCode" : "6059"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-              "extension" : [ {
-                "url" : "SAD.1",
-                "valueString" : "4861"
-              }, {
-                "url" : "SAD.2",
-                "valueString" : "20TH AVE"
-              }, {
-                "url" : "SAD.3",
-                "valueString" : "1"
-              } ]
-            }, {
-              "url" : "XAD.2",
-              "valueString" : "Other Designation"
-            }, {
-              "url" : "XAD.7",
-              "valueCode" : "H"
-            }, {
-              "url" : "XAD.8",
-              "valueString" : "Other Geographic Designation"
-            }, {
-              "url" : "XAD.11",
-              "valueCode" : "A"
-            }, {
-              "url" : "XAD.12",
-              "extension" : [ {
-                "url" : "XAD.12.1",
-                "valueString" : "20220501102531-0400"
-              }, {
-                "url" : "XAD.12.2",
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
                 "valueString" : "20230501102531-0400"
-              } ]
-            }, {
-              "url" : "XAD.13",
-              "valueString" : "20220501102531-0400"
-            }, {
-              "url" : "XAD.19",
-              "valueCode" : "Adressee"
-            } ]
-          } ],
-          "use" : "home",
-          "line" : [ "4861", "20TH AVE", "1", "Other Designation", "Adressee" ],
-          "city" : "THUNDER MOUNTAIN",
-          "district" : "County",
-          "state" : "IG",
-          "postalCode" : "99999",
-          "country" : "USA",
-          "period" : {
-            "start" : "2022-05-01T10:25:31-04:00"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
+        },
+        "sender" : {
+          "reference" : "Organization/1706817386262972000.7292707f-9191-4b06-8b69-0dc20703efed"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
           }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655048769246000.f988df89-bc60-4793-b1f4-d6295196f5b9",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655048769246000.f988df89-bc60-4793-b1f4-d6295196f5b9",
-      "target" : [ {
-        "reference" : "Patient/1706655048766785000.045344bd-2db7-48eb-94a8-425f6c9850a7"
-      } ],
-      "recorded" : "2024-01-30T17:50:48Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817386262972000.7292707f-9191-4b06-8b69-0dc20703efed",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817386262972000.7292707f-9191-4b06-8b69-0dc20703efed",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817386650747000.c1d87d8c-463c-4e03-8013-c3a01efa39f0",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817386650747000.c1d87d8c-463c-4e03-8013-c3a01efa39f0",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817386659764000.b6fe379f-d4f5-4cd2-bcb2-76575196de83",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817386659764000.b6fe379f-d4f5-4cd2-bcb2-76575196de83",
+        "recorded" : "2024-02-01T14:56:26Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817386659239000.aecca110-69c0-4663-8a32-15c117a097ca"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817386659239000.aecca110-69c0-4663-8a32-15c117a097ca",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817386659239000.aecca110-69c0-4663-8a32-15c117a097ca",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706817386687577000.0a2967bc-babd-4071-81e1-be555fe272ca",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706817386687577000.0a2967bc-babd-4071-81e1-be555fe272ca",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "patient-identifier-list"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "MR"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "MR"
+                }
+              ]
+            },
+            "value" : "11102779"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "BB SARAH"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "SMITH",
+            "given" : [
+              "BB SARAH"
+            ]
+          }
+        ],
+        "contact" : [
+          {
+            "name" : {},
+            "organization" : {
+              "reference" : "Organization/1706817386682396000.cf7454f3-4d8d-41e2-9fd9-4bb32790992b"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817386682396000.cf7454f3-4d8d-41e2-9fd9-4bb32790992b",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817386682396000.cf7454f3-4d8d-41e2-9fd9-4bb32790992b",
+        "contact" : [
+          {
+            "address" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                  "valueCode" : "6059"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                      "extension" : [
+                        {
+                          "url" : "SAD.1",
+                          "valueString" : "4861"
+                        },
+                        {
+                          "url" : "SAD.2",
+                          "valueString" : "20TH AVE"
+                        },
+                        {
+                          "url" : "SAD.3",
+                          "valueString" : "1"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.2",
+                      "valueString" : "Other Designation"
+                    },
+                    {
+                      "url" : "XAD.7",
+                      "valueCode" : "H"
+                    },
+                    {
+                      "url" : "XAD.8",
+                      "valueString" : "Other Geographic Designation"
+                    },
+                    {
+                      "url" : "XAD.11",
+                      "valueCode" : "A"
+                    },
+                    {
+                      "url" : "XAD.12",
+                      "extension" : [
+                        {
+                          "url" : "XAD.12.1",
+                          "valueString" : "20220501102531-0400"
+                        },
+                        {
+                          "url" : "XAD.12.2",
+                          "valueString" : "20230501102531-0400"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.13",
+                      "valueString" : "20220501102531-0400"
+                    },
+                    {
+                      "url" : "XAD.19",
+                      "valueCode" : "Adressee"
+                    }
+                  ]
+                }
+              ],
+              "use" : "home",
+              "line" : [
+                "4861",
+                "20TH AVE",
+                "1",
+                "Other Designation",
+                "Adressee"
+              ],
+              "city" : "THUNDER MOUNTAIN",
+              "district" : "County",
+              "state" : "IG",
+              "postalCode" : "99999",
+              "country" : "USA",
+              "period" : {
+                "start" : "2022-05-01T10:25:31-04:00"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817386689887000.856574e3-91c7-405e-8f42-fad9cad3c904",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817386689887000.856574e3-91c7-405e-8f42-fad9cad3c904",
+        "target" : [
+          {
+            "reference" : "Patient/1706817386687577000.0a2967bc-babd-4071-81e1-be555fe272ca"
+          }
+        ],
+        "recorded" : "2024-02-01T14:56:26Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706817386692942000.72e57846-c017-4465-8c9e-b8045ed00f10",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706817386692942000.72e57846-c017-4465-8c9e-b8045ed00f10",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706817386687577000.0a2967bc-babd-4071-81e1-be555fe272ca"
+        },
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                "valueCode" : "6059"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861"
+                      },
+                      {
+                        "url" : "SAD.2",
+                        "valueString" : "20TH AVE"
+                      },
+                      {
+                        "url" : "SAD.3",
+                        "valueString" : "1"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.2",
+                    "valueString" : "Other Designation"
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  },
+                  {
+                    "url" : "XAD.8",
+                    "valueString" : "Other Geographic Designation"
+                  },
+                  {
+                    "url" : "XAD.11",
+                    "valueCode" : "A"
+                  },
+                  {
+                    "url" : "XAD.12",
+                    "extension" : [
+                      {
+                        "url" : "XAD.12.1",
+                        "valueString" : "20220501102531-0400"
+                      },
+                      {
+                        "url" : "XAD.12.2",
+                        "valueString" : "20230501102531-0400"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.13",
+                    "valueString" : "20220501102531-0400"
+                  },
+                  {
+                    "url" : "XAD.19",
+                    "valueCode" : "Adressee"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861",
+              "20TH AVE",
+              "1",
+              "Other Designation",
+              "Adressee"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "district" : "County",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA",
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00"
+            }
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "RelatedPerson/1706655048772374000.aede436e-9379-48be-a474-8e522d2d0efe",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706655048772374000.aede436e-9379-48be-a474-8e522d2d0efe",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706655048766785000.045344bd-2db7-48eb-94a8-425f6c9850a7"
-      },
-      "address" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
-          "valueCode" : "6059"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861"
-            }, {
-              "url" : "SAD.2",
-              "valueString" : "20TH AVE"
-            }, {
-              "url" : "SAD.3",
-              "valueString" : "1"
-            } ]
-          }, {
-            "url" : "XAD.2",
-            "valueString" : "Other Designation"
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          }, {
-            "url" : "XAD.8",
-            "valueString" : "Other Geographic Designation"
-          }, {
-            "url" : "XAD.11",
-            "valueCode" : "A"
-          }, {
-            "url" : "XAD.12",
-            "extension" : [ {
-              "url" : "XAD.12.1",
-              "valueString" : "20220501102531-0400"
-            }, {
-              "url" : "XAD.12.2",
-              "valueString" : "20230501102531-0400"
-            } ]
-          }, {
-            "url" : "XAD.13",
-            "valueString" : "20220501102531-0400"
-          }, {
-            "url" : "XAD.19",
-            "valueCode" : "Adressee"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861", "20TH AVE", "1", "Other Designation", "Adressee" ],
-        "city" : "THUNDER MOUNTAIN",
-        "district" : "County",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA",
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-ignores-xad12-for-xad14.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-ignores-xad12-for-xad14.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655057757534000.dbd76172-adcd-4406-b871-71e8cada7740",
+  "id" : "1706817397207975000.c4b37697-598f-4f9e-8d61-7f13d73a69b1",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:50:57.764-05:00"
+    "lastUpdated" : "2024-02-01T14:56:37.215-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,300 +10,419 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706655057832021000.7977f5f4-f988-4e1f-8a1a-5aa601f4bee6"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706655057832021000.7977f5f4-f988-4e1f-8a1a-5aa601f4bee6",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655057832021000.7977f5f4-f988-4e1f-8a1a-5aa601f4bee6",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655058166658000.4b0628a0-2748-42e8-a2a7-e422e1dbf367",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655058166658000.4b0628a0-2748-42e8-a2a7-e422e1dbf367",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655058173266000.62134f4a-a8f9-4cc1-9ec3-aade1e0b0b11",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655058173266000.62134f4a-a8f9-4cc1-9ec3-aade1e0b0b11",
-      "recorded" : "2024-01-30T17:50:58Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706655058172853000.42cdb15a-8543-4344-a7bf-27e79d5a7d0b"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655058172853000.42cdb15a-8543-4344-a7bf-27e79d5a7d0b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655058172853000.42cdb15a-8543-4344-a7bf-27e79d5a7d0b",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706655058201539000.67935379-d6d9-4792-9f03-d0d96c932bec",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706655058201539000.67935379-d6d9-4792-9f03-d0d96c932bec",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "patient-identifier-list"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "MR"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "MR"
-          } ]
-        },
-        "value" : "11102779"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "BB SARAH"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "SMITH",
-        "given" : [ "BB SARAH" ]
-      } ],
-      "contact" : [ {
-        "name" : { },
-        "organization" : {
-          "reference" : "Organization/1706655058194933000.862d6e6c-1faa-4400-bcfd-ae021f0fb855"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655058194933000.862d6e6c-1faa-4400-bcfd-ae021f0fb855",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655058194933000.862d6e6c-1faa-4400-bcfd-ae021f0fb855",
-      "contact" : [ {
-        "address" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
-            "valueCode" : "6059"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-              "extension" : [ {
-                "url" : "SAD.1",
-                "valueString" : "4861"
-              }, {
-                "url" : "SAD.2",
-                "valueString" : "20TH AVE"
-              }, {
-                "url" : "SAD.3",
-                "valueString" : "1"
-              } ]
-            }, {
-              "url" : "XAD.2",
-              "valueString" : "Other Designation"
-            }, {
-              "url" : "XAD.7",
-              "valueCode" : "H"
-            }, {
-              "url" : "XAD.8",
-              "valueString" : "Other Geographic Designation"
-            }, {
-              "url" : "XAD.11",
-              "valueCode" : "A"
-            }, {
-              "url" : "XAD.12",
-              "extension" : [ {
-                "url" : "XAD.12.1",
-                "valueString" : "20220501102531-0400"
-              }, {
-                "url" : "XAD.12.2",
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
                 "valueString" : "20230501102531-0400"
-              } ]
-            }, {
-              "url" : "XAD.14",
-              "valueString" : "20230501102531-0400"
-            }, {
-              "url" : "XAD.19",
-              "valueCode" : "Adressee"
-            } ]
-          } ],
-          "use" : "home",
-          "line" : [ "4861", "20TH AVE", "1", "Other Designation", "Adressee" ],
-          "city" : "THUNDER MOUNTAIN",
-          "district" : "County",
-          "state" : "IG",
-          "postalCode" : "99999",
-          "country" : "USA",
-          "period" : {
-            "end" : "2023-05-01T10:25:31-04:00"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
+        },
+        "sender" : {
+          "reference" : "Organization/1706817397267129000.37cbc1fc-f54f-48b6-ad76-b685d9a977ab"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
           }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655058203986000.8ff4e1dd-fe37-410a-9a01-d6e95fa5c7de",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655058203986000.8ff4e1dd-fe37-410a-9a01-d6e95fa5c7de",
-      "target" : [ {
-        "reference" : "Patient/1706655058201539000.67935379-d6d9-4792-9f03-d0d96c932bec"
-      } ],
-      "recorded" : "2024-01-30T17:50:58Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817397267129000.37cbc1fc-f54f-48b6-ad76-b685d9a977ab",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817397267129000.37cbc1fc-f54f-48b6-ad76-b685d9a977ab",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817397638561000.96651379-a9e4-4fdd-b3c4-b5443f04f79a",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817397638561000.96651379-a9e4-4fdd-b3c4-b5443f04f79a",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817397647169000.264df14a-2a71-4c86-b1c4-47265436ddcc",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817397647169000.264df14a-2a71-4c86-b1c4-47265436ddcc",
+        "recorded" : "2024-02-01T14:56:37Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817397646690000.8aa8900c-fe35-42e8-b3f1-1bcf6021fc2a"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817397646690000.8aa8900c-fe35-42e8-b3f1-1bcf6021fc2a",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817397646690000.8aa8900c-fe35-42e8-b3f1-1bcf6021fc2a",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706817397676366000.d8dcd109-9909-40e0-895d-d5ba27360b22",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706817397676366000.d8dcd109-9909-40e0-895d-d5ba27360b22",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "patient-identifier-list"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "MR"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "MR"
+                }
+              ]
+            },
+            "value" : "11102779"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "BB SARAH"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "SMITH",
+            "given" : [
+              "BB SARAH"
+            ]
+          }
+        ],
+        "contact" : [
+          {
+            "name" : {},
+            "organization" : {
+              "reference" : "Organization/1706817397670060000.191324ad-eb55-4e83-9b91-798ec5916a78"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817397670060000.191324ad-eb55-4e83-9b91-798ec5916a78",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817397670060000.191324ad-eb55-4e83-9b91-798ec5916a78",
+        "contact" : [
+          {
+            "address" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                  "valueCode" : "6059"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                      "extension" : [
+                        {
+                          "url" : "SAD.1",
+                          "valueString" : "4861"
+                        },
+                        {
+                          "url" : "SAD.2",
+                          "valueString" : "20TH AVE"
+                        },
+                        {
+                          "url" : "SAD.3",
+                          "valueString" : "1"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.2",
+                      "valueString" : "Other Designation"
+                    },
+                    {
+                      "url" : "XAD.7",
+                      "valueCode" : "H"
+                    },
+                    {
+                      "url" : "XAD.8",
+                      "valueString" : "Other Geographic Designation"
+                    },
+                    {
+                      "url" : "XAD.11",
+                      "valueCode" : "A"
+                    },
+                    {
+                      "url" : "XAD.12",
+                      "extension" : [
+                        {
+                          "url" : "XAD.12.1",
+                          "valueString" : "20220501102531-0400"
+                        },
+                        {
+                          "url" : "XAD.12.2",
+                          "valueString" : "20230501102531-0400"
+                        }
+                      ]
+                    },
+                    {
+                      "url" : "XAD.14",
+                      "valueString" : "20230501102531-0400"
+                    },
+                    {
+                      "url" : "XAD.19",
+                      "valueCode" : "Adressee"
+                    }
+                  ]
+                }
+              ],
+              "use" : "home",
+              "line" : [
+                "4861",
+                "20TH AVE",
+                "1",
+                "Other Designation",
+                "Adressee"
+              ],
+              "city" : "THUNDER MOUNTAIN",
+              "district" : "County",
+              "state" : "IG",
+              "postalCode" : "99999",
+              "country" : "USA",
+              "period" : {
+                "end" : "2023-05-01T10:25:31-04:00"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817397678838000.91209326-ecc1-4aef-8b61-c52829f8624d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817397678838000.91209326-ecc1-4aef-8b61-c52829f8624d",
+        "target" : [
+          {
+            "reference" : "Patient/1706817397676366000.d8dcd109-9909-40e0-895d-d5ba27360b22"
+          }
+        ],
+        "recorded" : "2024-02-01T14:56:37Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706817397682187000.821737c8-d006-49d6-ac07-0b45bc19abfd",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706817397682187000.821737c8-d006-49d6-ac07-0b45bc19abfd",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706817397676366000.d8dcd109-9909-40e0-895d-d5ba27360b22"
+        },
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                "valueCode" : "6059"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "contact-person-address"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "4861"
+                      },
+                      {
+                        "url" : "SAD.2",
+                        "valueString" : "20TH AVE"
+                      },
+                      {
+                        "url" : "SAD.3",
+                        "valueString" : "1"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.2",
+                    "valueString" : "Other Designation"
+                  },
+                  {
+                    "url" : "XAD.7",
+                    "valueCode" : "H"
+                  },
+                  {
+                    "url" : "XAD.8",
+                    "valueString" : "Other Geographic Designation"
+                  },
+                  {
+                    "url" : "XAD.11",
+                    "valueCode" : "A"
+                  },
+                  {
+                    "url" : "XAD.12",
+                    "extension" : [
+                      {
+                        "url" : "XAD.12.1",
+                        "valueString" : "20220501102531-0400"
+                      },
+                      {
+                        "url" : "XAD.12.2",
+                        "valueString" : "20230501102531-0400"
+                      }
+                    ]
+                  },
+                  {
+                    "url" : "XAD.14",
+                    "valueString" : "20230501102531-0400"
+                  },
+                  {
+                    "url" : "XAD.19",
+                    "valueCode" : "Adressee"
+                  }
+                ]
+              }
+            ],
+            "use" : "home",
+            "line" : [
+              "4861",
+              "20TH AVE",
+              "1",
+              "Other Designation",
+              "Adressee"
+            ],
+            "city" : "THUNDER MOUNTAIN",
+            "district" : "County",
+            "state" : "IG",
+            "postalCode" : "99999",
+            "country" : "USA",
+            "period" : {
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "RelatedPerson/1706655058206545000.66764bac-c1af-48aa-a1dc-5dd93ab71bf8",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706655058206545000.66764bac-c1af-48aa-a1dc-5dd93ab71bf8",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706655058201539000.67935379-d6d9-4792-9f03-d0d96c932bec"
-      },
-      "address" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
-          "valueCode" : "6059"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "contact-person-address"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "4861"
-            }, {
-              "url" : "SAD.2",
-              "valueString" : "20TH AVE"
-            }, {
-              "url" : "SAD.3",
-              "valueString" : "1"
-            } ]
-          }, {
-            "url" : "XAD.2",
-            "valueString" : "Other Designation"
-          }, {
-            "url" : "XAD.7",
-            "valueCode" : "H"
-          }, {
-            "url" : "XAD.8",
-            "valueString" : "Other Geographic Designation"
-          }, {
-            "url" : "XAD.11",
-            "valueCode" : "A"
-          }, {
-            "url" : "XAD.12",
-            "extension" : [ {
-              "url" : "XAD.12.1",
-              "valueString" : "20220501102531-0400"
-            }, {
-              "url" : "XAD.12.2",
-              "valueString" : "20230501102531-0400"
-            } ]
-          }, {
-            "url" : "XAD.14",
-            "valueString" : "20230501102531-0400"
-          }, {
-            "url" : "XAD.19",
-            "valueCode" : "Adressee"
-          } ]
-        } ],
-        "use" : "home",
-        "line" : [ "4861", "20TH AVE", "1", "Other Designation", "Adressee" ],
-        "city" : "THUNDER MOUNTAIN",
-        "district" : "County",
-        "state" : "IG",
-        "postalCode" : "99999",
-        "country" : "USA",
-        "period" : {
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-b.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-b.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655067109674000.0fb7305c-e224-4b7f-ad7f-becc1be1937f",
+  "id" : "1706817407492957000.10507008-59ca-4dd4-8395-c6f046d326f1",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:51:07.116-05:00"
+    "lastUpdated" : "2024-02-01T14:56:47.499-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655067182442000.600351db-faeb-4b88-90d7-5106e7e1caeb"
+          "reference" : "Organization/1706817407546886000.2d73579a-80b4-438b-8097-42339aa71b1f"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655067182442000.600351db-faeb-4b88-90d7-5106e7e1caeb",
+      "fullUrl" : "Organization/1706817407546886000.2d73579a-80b4-438b-8097-42339aa71b1f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655067182442000.600351db-faeb-4b88-90d7-5106e7e1caeb",
+        "id" : "1706817407546886000.2d73579a-80b4-438b-8097-42339aa71b1f",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655067511197000.d82e8197-77de-4e5d-b392-514c29932199",
+      "fullUrl" : "Provenance/1706817407940599000.34815629-eb0c-44d9-a751-2390294979d3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655067511197000.d82e8197-77de-4e5d-b392-514c29932199",
+        "id" : "1706817407940599000.34815629-eb0c-44d9-a751-2390294979d3",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655067519008000.a4ce75b6-3b4b-42be-ae94-ac1422b68513",
+      "fullUrl" : "Provenance/1706817407950256000.385cbd8c-d68a-4d95-afa9-37514196a0b5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655067519008000.a4ce75b6-3b4b-42be-ae94-ac1422b68513",
-        "recorded" : "2024-01-30T17:51:07Z",
+        "id" : "1706817407950256000.385cbd8c-d68a-4d95-afa9-37514196a0b5",
+        "recorded" : "2024-02-01T14:56:47Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655067518591000.8573f0cb-e64f-4a98-89ac-a41efa7e9157"
+              "reference" : "Organization/1706817407949720000.05633766-51dd-41a7-a08e-74e925c0817c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655067518591000.8573f0cb-e64f-4a98-89ac-a41efa7e9157",
+      "fullUrl" : "Organization/1706817407949720000.05633766-51dd-41a7-a08e-74e925c0817c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655067518591000.8573f0cb-e64f-4a98-89ac-a41efa7e9157",
+        "id" : "1706817407949720000.05633766-51dd-41a7-a08e-74e925c0817c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655067544482000.0faedd7d-5b86-43b9-8d30-671e02b443bc",
+      "fullUrl" : "Patient/1706817407982063000.fed04d3a-51d2-459e-8a9f-7b005d7c205f",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655067544482000.0faedd7d-5b86-43b9-8d30-671e02b443bc",
+        "id" : "1706817407982063000.fed04d3a-51d2-459e-8a9f-7b005d7c205f",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655067538215000.07469920-3942-466c-a358-b94186df4080"
+              "reference" : "Organization/1706817407974961000.52ab3338-25c6-45fb-9a32-49d88cd1d138"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655067538215000.07469920-3942-466c-a358-b94186df4080",
+      "fullUrl" : "Organization/1706817407974961000.52ab3338-25c6-45fb-9a32-49d88cd1d138",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655067538215000.07469920-3942-466c-a358-b94186df4080",
+        "id" : "1706817407974961000.52ab3338-25c6-45fb-9a32-49d88cd1d138",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655067546662000.a0313e87-afbe-46a2-ad58-efcb238d12d6",
+      "fullUrl" : "Provenance/1706817407984595000.969818bf-f2d8-4e38-b066-0c1e155cd4aa",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655067546662000.a0313e87-afbe-46a2-ad58-efcb238d12d6",
+        "id" : "1706817407984595000.969818bf-f2d8-4e38-b066-0c1e155cd4aa",
         "target" : [
           {
-            "reference" : "Patient/1706655067544482000.0faedd7d-5b86-43b9-8d30-671e02b443bc"
+            "reference" : "Patient/1706817407982063000.fed04d3a-51d2-459e-8a9f-7b005d7c205f"
           }
         ],
-        "recorded" : "2024-01-30T17:51:07Z",
+        "recorded" : "2024-02-01T14:56:47Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655067549913000.f2ed4426-7b7f-4dff-b329-8b914bea5e0b",
+      "fullUrl" : "RelatedPerson/1706817407987085000.ca20de2f-6780-4de6-a81a-abe385c30908",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655067549913000.f2ed4426-7b7f-4dff-b329-8b914bea5e0b",
+        "id" : "1706817407987085000.ca20de2f-6780-4de6-a81a-abe385c30908",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655067544482000.0faedd7d-5b86-43b9-8d30-671e02b443bc"
+          "reference" : "Patient/1706817407982063000.fed04d3a-51d2-459e-8a9f-7b005d7c205f"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-ba.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-ba.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655076471111000.6d842cb4-86af-4fd4-aa14-3451285719dc",
+  "id" : "1706817418345498000.17509060-ddc8-4a27-b777-096ac4f7e807",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:51:16.478-05:00"
+    "lastUpdated" : "2024-02-01T14:56:58.352-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655076545146000.45be650a-27ba-40d7-8815-41003eb070c0"
+          "reference" : "Organization/1706817418399312000.e6df8e8f-1756-4d2f-86d9-0846684a8ea9"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655076545146000.45be650a-27ba-40d7-8815-41003eb070c0",
+      "fullUrl" : "Organization/1706817418399312000.e6df8e8f-1756-4d2f-86d9-0846684a8ea9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655076545146000.45be650a-27ba-40d7-8815-41003eb070c0",
+        "id" : "1706817418399312000.e6df8e8f-1756-4d2f-86d9-0846684a8ea9",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655076878014000.08b8c114-2f69-4b1b-8ce9-0a6b231ebec7",
+      "fullUrl" : "Provenance/1706817418772898000.f71cc294-6ab4-408d-b94a-7770da3b6631",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655076878014000.08b8c114-2f69-4b1b-8ce9-0a6b231ebec7",
+        "id" : "1706817418772898000.f71cc294-6ab4-408d-b94a-7770da3b6631",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655076885882000.a510b70e-0718-4b71-b378-d6621fc27fe3",
+      "fullUrl" : "Provenance/1706817418780609000.517a6357-e566-47ab-a25c-f6eeaad7f3b7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655076885882000.a510b70e-0718-4b71-b378-d6621fc27fe3",
-        "recorded" : "2024-01-30T17:51:16Z",
+        "id" : "1706817418780609000.517a6357-e566-47ab-a25c-f6eeaad7f3b7",
+        "recorded" : "2024-02-01T14:56:58Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655076885459000.36bae0c9-eda9-4300-b176-340e97cf97bd"
+              "reference" : "Organization/1706817418779682000.59e4e2c9-bb23-4dd4-9bae-999aea8cc22a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655076885459000.36bae0c9-eda9-4300-b176-340e97cf97bd",
+      "fullUrl" : "Organization/1706817418779682000.59e4e2c9-bb23-4dd4-9bae-999aea8cc22a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655076885459000.36bae0c9-eda9-4300-b176-340e97cf97bd",
+        "id" : "1706817418779682000.59e4e2c9-bb23-4dd4-9bae-999aea8cc22a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655076910222000.9efce65b-71a3-4e6f-bbff-5ae99c8f165d",
+      "fullUrl" : "Patient/1706817418807674000.81513da6-185d-4021-ae27-4818ea08ce03",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655076910222000.9efce65b-71a3-4e6f-bbff-5ae99c8f165d",
+        "id" : "1706817418807674000.81513da6-185d-4021-ae27-4818ea08ce03",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655076904633000.d08516b7-ece5-4dda-b659-cc656507350d"
+              "reference" : "Organization/1706817418802605000.03474775-8f5d-4a5e-aa11-3a4a9c537583"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655076904633000.d08516b7-ece5-4dda-b659-cc656507350d",
+      "fullUrl" : "Organization/1706817418802605000.03474775-8f5d-4a5e-aa11-3a4a9c537583",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655076904633000.d08516b7-ece5-4dda-b659-cc656507350d",
+        "id" : "1706817418802605000.03474775-8f5d-4a5e-aa11-3a4a9c537583",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655076912874000.2c52c191-3274-4877-b735-b64156b4d9b2",
+      "fullUrl" : "Provenance/1706817418809895000.6945fb94-15a8-474f-a5eb-442ba18931ea",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655076912874000.2c52c191-3274-4877-b735-b64156b4d9b2",
+        "id" : "1706817418809895000.6945fb94-15a8-474f-a5eb-442ba18931ea",
         "target" : [
           {
-            "reference" : "Patient/1706655076910222000.9efce65b-71a3-4e6f-bbff-5ae99c8f165d"
+            "reference" : "Patient/1706817418807674000.81513da6-185d-4021-ae27-4818ea08ce03"
           }
         ],
-        "recorded" : "2024-01-30T17:51:16Z",
+        "recorded" : "2024-02-01T14:56:58Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655076918655000.2d8d7e65-b8dc-4bca-856b-261f44f0dbe3",
+      "fullUrl" : "RelatedPerson/1706817418812798000.c22bf388-d26f-48dd-8c52-19237fe1fe85",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655076918655000.2d8d7e65-b8dc-4bca-856b-261f44f0dbe3",
+        "id" : "1706817418812798000.c22bf388-d26f-48dd-8c52-19237fe1fe85",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655076910222000.9efce65b-71a3-4e6f-bbff-5ae99c8f165d"
+          "reference" : "Patient/1706817418807674000.81513da6-185d-4021-ae27-4818ea08ce03"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-bi.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-bi.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655085703457000.e57db58d-bad8-4dfc-9a2a-4f7970442ce8",
+  "id" : "1706817429104423000.291ddac5-9a7c-48bd-9333-4c05e7cd5740",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:51:25.708-05:00"
+    "lastUpdated" : "2024-02-01T14:57:09.111-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655085779284000.a8892e0c-65e7-4d90-9890-1e5afde27867"
+          "reference" : "Organization/1706817429157624000.1a1e06d4-b016-4c1a-99c9-2f5a4b1be0bb"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655085779284000.a8892e0c-65e7-4d90-9890-1e5afde27867",
+      "fullUrl" : "Organization/1706817429157624000.1a1e06d4-b016-4c1a-99c9-2f5a4b1be0bb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655085779284000.a8892e0c-65e7-4d90-9890-1e5afde27867",
+        "id" : "1706817429157624000.1a1e06d4-b016-4c1a-99c9-2f5a4b1be0bb",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655086102811000.646bd1cd-e0e8-47b9-bd22-b0a5f1ec0d11",
+      "fullUrl" : "Provenance/1706817429545873000.dbcb9e0a-d961-41ca-b320-08a0298908e5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655086102811000.646bd1cd-e0e8-47b9-bd22-b0a5f1ec0d11",
+        "id" : "1706817429545873000.dbcb9e0a-d961-41ca-b320-08a0298908e5",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655086109491000.57bd24c1-122c-467e-b7b9-15cbf3243733",
+      "fullUrl" : "Provenance/1706817429553559000.6b25bd26-09f8-46bf-a464-4c7956ab2f11",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655086109491000.57bd24c1-122c-467e-b7b9-15cbf3243733",
-        "recorded" : "2024-01-30T17:51:26Z",
+        "id" : "1706817429553559000.6b25bd26-09f8-46bf-a464-4c7956ab2f11",
+        "recorded" : "2024-02-01T14:57:09Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655086109069000.7a2a934a-cd9f-4bf9-b66a-75a5e8220082"
+              "reference" : "Organization/1706817429553102000.3a362b46-30ea-44e6-aa44-2e67b132e041"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655086109069000.7a2a934a-cd9f-4bf9-b66a-75a5e8220082",
+      "fullUrl" : "Organization/1706817429553102000.3a362b46-30ea-44e6-aa44-2e67b132e041",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655086109069000.7a2a934a-cd9f-4bf9-b66a-75a5e8220082",
+        "id" : "1706817429553102000.3a362b46-30ea-44e6-aa44-2e67b132e041",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655086134019000.3f311b2b-d962-402a-b0c3-f367b73bc03a",
+      "fullUrl" : "Patient/1706817429580455000.041bc842-0ce7-4188-a125-8025a8fc253d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655086134019000.3f311b2b-d962-402a-b0c3-f367b73bc03a",
+        "id" : "1706817429580455000.041bc842-0ce7-4188-a125-8025a8fc253d",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655086127745000.642f7b49-9803-4a06-b081-1d53e3db9227"
+              "reference" : "Organization/1706817429575262000.d133ecd8-47c0-4d40-b3a1-159d7cdf7248"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655086127745000.642f7b49-9803-4a06-b081-1d53e3db9227",
+      "fullUrl" : "Organization/1706817429575262000.d133ecd8-47c0-4d40-b3a1-159d7cdf7248",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655086127745000.642f7b49-9803-4a06-b081-1d53e3db9227",
+        "id" : "1706817429575262000.d133ecd8-47c0-4d40-b3a1-159d7cdf7248",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655086136910000.5d41a5bf-5462-4cc3-ae0f-01dadc805d37",
+      "fullUrl" : "Provenance/1706817429582775000.2d3bedeb-0be6-4bed-9128-958e9e33960d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655086136910000.5d41a5bf-5462-4cc3-ae0f-01dadc805d37",
+        "id" : "1706817429582775000.2d3bedeb-0be6-4bed-9128-958e9e33960d",
         "target" : [
           {
-            "reference" : "Patient/1706655086134019000.3f311b2b-d962-402a-b0c3-f367b73bc03a"
+            "reference" : "Patient/1706817429580455000.041bc842-0ce7-4188-a125-8025a8fc253d"
           }
         ],
-        "recorded" : "2024-01-30T17:51:26Z",
+        "recorded" : "2024-02-01T14:57:09Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655086140198000.7d246c22-5c09-47ad-a982-15da372ad5cb",
+      "fullUrl" : "RelatedPerson/1706817429584815000.22b57530-4f0b-43d7-a38c-94a11766cbac",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655086140198000.7d246c22-5c09-47ad-a982-15da372ad5cb",
+        "id" : "1706817429584815000.22b57530-4f0b-43d7-a38c-94a11766cbac",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655086134019000.3f311b2b-d962-402a-b0c3-f367b73bc03a"
+          "reference" : "Patient/1706817429580455000.041bc842-0ce7-4188-a125-8025a8fc253d"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-c.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-c.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655095401946000.199d5bd4-b8d0-4e97-b220-7836bd657725",
+  "id" : "1706817441236276000.407f1c1d-22f8-4805-a976-b07245660d0e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:51:35.408-05:00"
+    "lastUpdated" : "2024-02-01T14:57:21.243-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655095481875000.c947e3d0-fc87-4649-b5bc-9b29fc14215c"
+          "reference" : "Organization/1706817441289501000.71cebdb6-3e18-4e9d-88e9-57dde389e322"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655095481875000.c947e3d0-fc87-4649-b5bc-9b29fc14215c",
+      "fullUrl" : "Organization/1706817441289501000.71cebdb6-3e18-4e9d-88e9-57dde389e322",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655095481875000.c947e3d0-fc87-4649-b5bc-9b29fc14215c",
+        "id" : "1706817441289501000.71cebdb6-3e18-4e9d-88e9-57dde389e322",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655095798059000.ce2c765c-4ab1-4e8e-a47c-51f10349b516",
+      "fullUrl" : "Provenance/1706817441638949000.fa1f70bb-6a08-4db1-8941-7e4c56e1c349",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655095798059000.ce2c765c-4ab1-4e8e-a47c-51f10349b516",
+        "id" : "1706817441638949000.fa1f70bb-6a08-4db1-8941-7e4c56e1c349",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655095805430000.4e8edc5e-dbfe-4269-9399-5bf89dcf2376",
+      "fullUrl" : "Provenance/1706817441646199000.2eb699ae-0b3e-46f3-8bb9-dccde393cd57",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655095805430000.4e8edc5e-dbfe-4269-9399-5bf89dcf2376",
-        "recorded" : "2024-01-30T17:51:35Z",
+        "id" : "1706817441646199000.2eb699ae-0b3e-46f3-8bb9-dccde393cd57",
+        "recorded" : "2024-02-01T14:57:21Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655095804854000.cd2e495c-fef2-4b7f-ab6e-654e34514f53"
+              "reference" : "Organization/1706817441645699000.ddf5f732-9998-4b73-b30e-c2dda54e6e1a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655095804854000.cd2e495c-fef2-4b7f-ab6e-654e34514f53",
+      "fullUrl" : "Organization/1706817441645699000.ddf5f732-9998-4b73-b30e-c2dda54e6e1a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655095804854000.cd2e495c-fef2-4b7f-ab6e-654e34514f53",
+        "id" : "1706817441645699000.ddf5f732-9998-4b73-b30e-c2dda54e6e1a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655095831601000.a51ee453-b1ae-4420-a2ef-8b1a80195278",
+      "fullUrl" : "Patient/1706817441671942000.8091d59c-3e2b-458c-b010-5217bd4c4ba4",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655095831601000.a51ee453-b1ae-4420-a2ef-8b1a80195278",
+        "id" : "1706817441671942000.8091d59c-3e2b-458c-b010-5217bd4c4ba4",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655095824393000.dec6ed8d-e61a-4558-b3a6-441c7509f98d"
+              "reference" : "Organization/1706817441667220000.6b1e92ac-51df-4da9-871f-33f94137df69"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655095824393000.dec6ed8d-e61a-4558-b3a6-441c7509f98d",
+      "fullUrl" : "Organization/1706817441667220000.6b1e92ac-51df-4da9-871f-33f94137df69",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655095824393000.dec6ed8d-e61a-4558-b3a6-441c7509f98d",
+        "id" : "1706817441667220000.6b1e92ac-51df-4da9-871f-33f94137df69",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655095837181000.276668ed-ce7c-4657-877c-a6fa6740de74",
+      "fullUrl" : "Provenance/1706817441673958000.d19ddf31-bc24-4771-9e45-a7064e2a9c38",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655095837181000.276668ed-ce7c-4657-877c-a6fa6740de74",
+        "id" : "1706817441673958000.d19ddf31-bc24-4771-9e45-a7064e2a9c38",
         "target" : [
           {
-            "reference" : "Patient/1706655095831601000.a51ee453-b1ae-4420-a2ef-8b1a80195278"
+            "reference" : "Patient/1706817441671942000.8091d59c-3e2b-458c-b010-5217bd4c4ba4"
           }
         ],
-        "recorded" : "2024-01-30T17:51:35Z",
+        "recorded" : "2024-02-01T14:57:21Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655095839768000.fb4722ab-6461-4ad7-9f43-34237f2a0db9",
+      "fullUrl" : "RelatedPerson/1706817441676282000.30a9f634-a0ef-40be-9bed-d39e088146ac",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655095839768000.fb4722ab-6461-4ad7-9f43-34237f2a0db9",
+        "id" : "1706817441676282000.30a9f634-a0ef-40be-9bed-d39e088146ac",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655095831601000.a51ee453-b1ae-4420-a2ef-8b1a80195278"
+          "reference" : "Patient/1706817441671942000.8091d59c-3e2b-458c-b010-5217bd4c4ba4"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-h.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-h.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655104880485000.6b296fe4-2039-4d30-b6b7-117ce88faf49",
+  "id" : "1706817452526262000.263d2647-2b45-4d76-8b20-dba8b8da091e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:51:44.887-05:00"
+    "lastUpdated" : "2024-02-01T14:57:32.534-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655104956310000.f02be685-7455-4d82-a52f-313cc7599948"
+          "reference" : "Organization/1706817452584394000.b8509ab7-260e-4df1-bfb3-7199e81b6db5"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655104956310000.f02be685-7455-4d82-a52f-313cc7599948",
+      "fullUrl" : "Organization/1706817452584394000.b8509ab7-260e-4df1-bfb3-7199e81b6db5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655104956310000.f02be685-7455-4d82-a52f-313cc7599948",
+        "id" : "1706817452584394000.b8509ab7-260e-4df1-bfb3-7199e81b6db5",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655105277354000.15fcbb85-9002-443b-a9d1-dc79bc5aa44c",
+      "fullUrl" : "Provenance/1706817452952689000.5cbf077f-17ff-4aee-ad3a-d950b5e78508",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655105277354000.15fcbb85-9002-443b-a9d1-dc79bc5aa44c",
+        "id" : "1706817452952689000.5cbf077f-17ff-4aee-ad3a-d950b5e78508",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655105284623000.c30c058d-c836-4a08-8091-97719e3a62c7",
+      "fullUrl" : "Provenance/1706817452961264000.610d4567-f1f1-4ad0-95b2-9f24e81ad1d0",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655105284623000.c30c058d-c836-4a08-8091-97719e3a62c7",
-        "recorded" : "2024-01-30T17:51:45Z",
+        "id" : "1706817452961264000.610d4567-f1f1-4ad0-95b2-9f24e81ad1d0",
+        "recorded" : "2024-02-01T14:57:32Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655105284108000.9f52bcf3-beac-4332-9425-c856bfb66c6e"
+              "reference" : "Organization/1706817452960801000.7207eefd-1d04-4bb4-bbd7-a0b90f99a84f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655105284108000.9f52bcf3-beac-4332-9425-c856bfb66c6e",
+      "fullUrl" : "Organization/1706817452960801000.7207eefd-1d04-4bb4-bbd7-a0b90f99a84f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655105284108000.9f52bcf3-beac-4332-9425-c856bfb66c6e",
+        "id" : "1706817452960801000.7207eefd-1d04-4bb4-bbd7-a0b90f99a84f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655105311670000.625f3436-b6a8-434d-8c02-aefed0fea6cc",
+      "fullUrl" : "Patient/1706817452987567000.e2835d0e-2bd0-4177-8371-adfc82b23c54",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655105311670000.625f3436-b6a8-434d-8c02-aefed0fea6cc",
+        "id" : "1706817452987567000.e2835d0e-2bd0-4177-8371-adfc82b23c54",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655105305615000.be6c8622-69e1-4c47-b981-9376c430a30a"
+              "reference" : "Organization/1706817452982566000.cef676dd-93ae-4d20-a298-6eef7c4c5f0e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655105305615000.be6c8622-69e1-4c47-b981-9376c430a30a",
+      "fullUrl" : "Organization/1706817452982566000.cef676dd-93ae-4d20-a298-6eef7c4c5f0e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655105305615000.be6c8622-69e1-4c47-b981-9376c430a30a",
+        "id" : "1706817452982566000.cef676dd-93ae-4d20-a298-6eef7c4c5f0e",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655105314031000.3353c46c-1e0a-4785-a1d5-296e76744eb0",
+      "fullUrl" : "Provenance/1706817452990049000.0f55aea0-0f47-4092-857d-ae16438f6415",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655105314031000.3353c46c-1e0a-4785-a1d5-296e76744eb0",
+        "id" : "1706817452990049000.0f55aea0-0f47-4092-857d-ae16438f6415",
         "target" : [
           {
-            "reference" : "Patient/1706655105311670000.625f3436-b6a8-434d-8c02-aefed0fea6cc"
+            "reference" : "Patient/1706817452987567000.e2835d0e-2bd0-4177-8371-adfc82b23c54"
           }
         ],
-        "recorded" : "2024-01-30T17:51:45Z",
+        "recorded" : "2024-02-01T14:57:32Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655105317447000.68e5a283-e83f-45dd-b813-70757afd4f3c",
+      "fullUrl" : "RelatedPerson/1706817452992420000.7a3c7b0e-e3a8-410d-ae19-8bf5523501a1",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655105317447000.68e5a283-e83f-45dd-b813-70757afd4f3c",
+        "id" : "1706817452992420000.7a3c7b0e-e3a8-410d-ae19-8bf5523501a1",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655105311670000.625f3436-b6a8-434d-8c02-aefed0fea6cc"
+          "reference" : "Patient/1706817452987567000.e2835d0e-2bd0-4177-8371-adfc82b23c54"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-hv.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-hv.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655114319859000.2fe39a3b-0784-4607-b900-ac6a37a61d87",
+  "id" : "1706817463210271000.6e895358-84a3-4b55-87fa-735f51e81bf8",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:51:54.325-05:00"
+    "lastUpdated" : "2024-02-01T14:57:43.218-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655114391022000.75d5e14f-84b1-4b18-8843-3f29f6fe8c06"
+          "reference" : "Organization/1706817463265086000.95c8be65-06fe-4266-bf9c-0c4a73b3fbdb"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655114391022000.75d5e14f-84b1-4b18-8843-3f29f6fe8c06",
+      "fullUrl" : "Organization/1706817463265086000.95c8be65-06fe-4266-bf9c-0c4a73b3fbdb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655114391022000.75d5e14f-84b1-4b18-8843-3f29f6fe8c06",
+        "id" : "1706817463265086000.95c8be65-06fe-4266-bf9c-0c4a73b3fbdb",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655114724931000.1f2092b4-8f63-48e4-876e-baee87d8f799",
+      "fullUrl" : "Provenance/1706817463660702000.379df5a0-f2d9-4f68-a73b-5aee79bdfb7b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655114724931000.1f2092b4-8f63-48e4-876e-baee87d8f799",
+        "id" : "1706817463660702000.379df5a0-f2d9-4f68-a73b-5aee79bdfb7b",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655114732834000.7817c6f2-dcf5-424c-b6a1-2ae1e93469bf",
+      "fullUrl" : "Provenance/1706817463669283000.89fa48f5-71f0-4da5-b7fd-7e1fb48c7aac",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655114732834000.7817c6f2-dcf5-424c-b6a1-2ae1e93469bf",
-        "recorded" : "2024-01-30T17:51:54Z",
+        "id" : "1706817463669283000.89fa48f5-71f0-4da5-b7fd-7e1fb48c7aac",
+        "recorded" : "2024-02-01T14:57:43Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655114732256000.95e59f81-1e95-40c8-8250-134b1dbf762f"
+              "reference" : "Organization/1706817463668804000.c6a647cc-1c61-45da-8247-5a4206833916"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655114732256000.95e59f81-1e95-40c8-8250-134b1dbf762f",
+      "fullUrl" : "Organization/1706817463668804000.c6a647cc-1c61-45da-8247-5a4206833916",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655114732256000.95e59f81-1e95-40c8-8250-134b1dbf762f",
+        "id" : "1706817463668804000.c6a647cc-1c61-45da-8247-5a4206833916",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655114757368000.7aaf7924-504f-4a63-9357-b1554ec70250",
+      "fullUrl" : "Patient/1706817463697987000.13e1d06d-7827-4926-8b71-5b52863f85f2",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655114757368000.7aaf7924-504f-4a63-9357-b1554ec70250",
+        "id" : "1706817463697987000.13e1d06d-7827-4926-8b71-5b52863f85f2",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655114752070000.aca3a062-71b1-4aa9-9136-62f781af9f65"
+              "reference" : "Organization/1706817463692598000.fad504fe-8946-404f-95b3-7470b76861a0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655114752070000.aca3a062-71b1-4aa9-9136-62f781af9f65",
+      "fullUrl" : "Organization/1706817463692598000.fad504fe-8946-404f-95b3-7470b76861a0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655114752070000.aca3a062-71b1-4aa9-9136-62f781af9f65",
+        "id" : "1706817463692598000.fad504fe-8946-404f-95b3-7470b76861a0",
         "contact" : [
           {
             "address" : {
@@ -289,16 +294,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655114759414000.d4f6e73b-6b88-45d8-9a97-4c0115e70594",
+      "fullUrl" : "Provenance/1706817463700301000.c9fd5462-e62f-404d-9b8b-0ad83fe07bb5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655114759414000.d4f6e73b-6b88-45d8-9a97-4c0115e70594",
+        "id" : "1706817463700301000.c9fd5462-e62f-404d-9b8b-0ad83fe07bb5",
         "target" : [
           {
-            "reference" : "Patient/1706655114757368000.7aaf7924-504f-4a63-9357-b1554ec70250"
+            "reference" : "Patient/1706817463697987000.13e1d06d-7827-4926-8b71-5b52863f85f2"
           }
         ],
-        "recorded" : "2024-01-30T17:51:54Z",
+        "recorded" : "2024-02-01T14:57:43Z",
         "activity" : {
           "coding" : [
             {
@@ -310,10 +315,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655114762525000.4ec07646-7d83-40fd-9204-74f576073b0a",
+      "fullUrl" : "RelatedPerson/1706817463703777000.1bb01ea5-bd03-4792-89ba-eb7ad9866e7c",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655114762525000.4ec07646-7d83-40fd-9204-74f576073b0a",
+        "id" : "1706817463703777000.1bb01ea5-bd03-4792-89ba-eb7ad9866e7c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -321,7 +326,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655114757368000.7aaf7924-504f-4a63-9357-b1554ec70250"
+          "reference" : "Patient/1706817463697987000.13e1d06d-7827-4926-8b71-5b52863f85f2"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-m.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-m.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655123754226000.df14d2d5-1458-4083-bcbc-b41d5d90fefb",
+  "id" : "1706817473966212000.edbc9d8c-160e-4011-862c-9a2995ff7a61",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:52:03.760-05:00"
+    "lastUpdated" : "2024-02-01T14:57:53.973-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655123829984000.424e56f8-c6bc-4940-b116-0f21aed58f30"
+          "reference" : "Organization/1706817474020481000.fe349813-cf02-4313-8453-3fe1a219e9ab"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655123829984000.424e56f8-c6bc-4940-b116-0f21aed58f30",
+      "fullUrl" : "Organization/1706817474020481000.fe349813-cf02-4313-8453-3fe1a219e9ab",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655123829984000.424e56f8-c6bc-4940-b116-0f21aed58f30",
+        "id" : "1706817474020481000.fe349813-cf02-4313-8453-3fe1a219e9ab",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655124157956000.be5b0a86-1855-4e6c-b251-28c515c363d1",
+      "fullUrl" : "Provenance/1706817474392058000.e39d0ac1-d5e4-4f89-92ae-3937dc888aae",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655124157956000.be5b0a86-1855-4e6c-b251-28c515c363d1",
+        "id" : "1706817474392058000.e39d0ac1-d5e4-4f89-92ae-3937dc888aae",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655124166774000.b56b9a9f-a2c1-4610-9f09-56ae63a7478c",
+      "fullUrl" : "Provenance/1706817474399739000.28599b7f-4016-4b97-ab62-c32e901773c6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655124166774000.b56b9a9f-a2c1-4610-9f09-56ae63a7478c",
-        "recorded" : "2024-01-30T17:52:04Z",
+        "id" : "1706817474399739000.28599b7f-4016-4b97-ab62-c32e901773c6",
+        "recorded" : "2024-02-01T14:57:54Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655124166364000.781e1aab-1deb-428d-a940-f84e6d84987a"
+              "reference" : "Organization/1706817474399257000.db554be9-29f2-488c-92c1-80a0f978c7f9"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655124166364000.781e1aab-1deb-428d-a940-f84e6d84987a",
+      "fullUrl" : "Organization/1706817474399257000.db554be9-29f2-488c-92c1-80a0f978c7f9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655124166364000.781e1aab-1deb-428d-a940-f84e6d84987a",
+        "id" : "1706817474399257000.db554be9-29f2-488c-92c1-80a0f978c7f9",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655124195886000.d1b064f7-9178-4db4-9bdd-e11e43fe794b",
+      "fullUrl" : "Patient/1706817474431603000.da13a57a-faa8-41da-8afd-f0af33d77874",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655124195886000.d1b064f7-9178-4db4-9bdd-e11e43fe794b",
+        "id" : "1706817474431603000.da13a57a-faa8-41da-8afd-f0af33d77874",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655124189721000.03bee8c0-fef5-4239-8dd6-4d132c05c328"
+              "reference" : "Organization/1706817474422025000.84226046-23b7-4287-9449-d6b213458af6"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655124189721000.03bee8c0-fef5-4239-8dd6-4d132c05c328",
+      "fullUrl" : "Organization/1706817474422025000.84226046-23b7-4287-9449-d6b213458af6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655124189721000.03bee8c0-fef5-4239-8dd6-4d132c05c328",
+        "id" : "1706817474422025000.84226046-23b7-4287-9449-d6b213458af6",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655124198776000.713f3ef5-4b1d-4ab6-8aab-e0e0acc4db61",
+      "fullUrl" : "Provenance/1706817474436836000.1d1445db-4efa-4f5e-99fb-b10e5016060f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655124198776000.713f3ef5-4b1d-4ab6-8aab-e0e0acc4db61",
+        "id" : "1706817474436836000.1d1445db-4efa-4f5e-99fb-b10e5016060f",
         "target" : [
           {
-            "reference" : "Patient/1706655124195886000.d1b064f7-9178-4db4-9bdd-e11e43fe794b"
+            "reference" : "Patient/1706817474431603000.da13a57a-faa8-41da-8afd-f0af33d77874"
           }
         ],
-        "recorded" : "2024-01-30T17:52:04Z",
+        "recorded" : "2024-02-01T14:57:54Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655124202175000.304d0017-3aa4-4a10-a1e8-1e3e00084620",
+      "fullUrl" : "RelatedPerson/1706817474439350000.bf857fbe-0d04-4fa1-a3c9-3aa5a90c3716",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655124202175000.304d0017-3aa4-4a10-a1e8-1e3e00084620",
+        "id" : "1706817474439350000.bf857fbe-0d04-4fa1-a3c9-3aa5a90c3716",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655124195886000.d1b064f7-9178-4db4-9bdd-e11e43fe794b"
+          "reference" : "Patient/1706817474431603000.da13a57a-faa8-41da-8afd-f0af33d77874"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-o.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-o.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655133221760000.946dc54e-d0c8-4f94-8025-aff1ffb08a59",
+  "id" : "1706817485680675000.44cf0f53-df14-4a78-98a1-e4b15cb42ea5",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:52:13.228-05:00"
+    "lastUpdated" : "2024-02-01T14:58:05.689-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655133295284000.1c6754b4-7f83-4ed5-86d2-a5a0ef11f17c"
+          "reference" : "Organization/1706817485736365000.9288150e-b151-4a06-b30a-9d5450cd6653"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655133295284000.1c6754b4-7f83-4ed5-86d2-a5a0ef11f17c",
+      "fullUrl" : "Organization/1706817485736365000.9288150e-b151-4a06-b30a-9d5450cd6653",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655133295284000.1c6754b4-7f83-4ed5-86d2-a5a0ef11f17c",
+        "id" : "1706817485736365000.9288150e-b151-4a06-b30a-9d5450cd6653",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655133612877000.8cbe8a93-2bcc-4995-a4ba-cebc62cdf27c",
+      "fullUrl" : "Provenance/1706817486113064000.a2008996-a567-4add-b245-0fcf4dab4ec9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655133612877000.8cbe8a93-2bcc-4995-a4ba-cebc62cdf27c",
+        "id" : "1706817486113064000.a2008996-a567-4add-b245-0fcf4dab4ec9",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655133620269000.25c68b58-e8c8-4d3d-8229-79b87e91d75c",
+      "fullUrl" : "Provenance/1706817486120973000.cfe3ad86-b0e4-494f-9ddd-7bd888e9706d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655133620269000.25c68b58-e8c8-4d3d-8229-79b87e91d75c",
-        "recorded" : "2024-01-30T17:52:13Z",
+        "id" : "1706817486120973000.cfe3ad86-b0e4-494f-9ddd-7bd888e9706d",
+        "recorded" : "2024-02-01T14:58:06Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655133619771000.18393ce8-1c3a-4461-bf93-88d36ec810ef"
+              "reference" : "Organization/1706817486120491000.b63e215b-028b-44c3-8e38-c16718cbbb74"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655133619771000.18393ce8-1c3a-4461-bf93-88d36ec810ef",
+      "fullUrl" : "Organization/1706817486120491000.b63e215b-028b-44c3-8e38-c16718cbbb74",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655133619771000.18393ce8-1c3a-4461-bf93-88d36ec810ef",
+        "id" : "1706817486120491000.b63e215b-028b-44c3-8e38-c16718cbbb74",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655133654433000.fb553264-de98-4241-a4f8-161ec13c3d40",
+      "fullUrl" : "Patient/1706817486151917000.15c5591c-c072-4ace-9238-7fd23d37a0ae",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655133654433000.fb553264-de98-4241-a4f8-161ec13c3d40",
+        "id" : "1706817486151917000.15c5591c-c072-4ace-9238-7fd23d37a0ae",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655133648241000.f9f0b44c-e98f-4997-a588-fedb93a64f0e"
+              "reference" : "Organization/1706817486143832000.0140515a-2009-49d0-a633-d1c2fbb7137a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655133648241000.f9f0b44c-e98f-4997-a588-fedb93a64f0e",
+      "fullUrl" : "Organization/1706817486143832000.0140515a-2009-49d0-a633-d1c2fbb7137a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655133648241000.f9f0b44c-e98f-4997-a588-fedb93a64f0e",
+        "id" : "1706817486143832000.0140515a-2009-49d0-a633-d1c2fbb7137a",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655133656677000.3d681d03-077a-4e88-b7f3-6603e0ad12bc",
+      "fullUrl" : "Provenance/1706817486154232000.982a6d9a-0b5b-40c5-94a3-d108a65628b7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655133656677000.3d681d03-077a-4e88-b7f3-6603e0ad12bc",
+        "id" : "1706817486154232000.982a6d9a-0b5b-40c5-94a3-d108a65628b7",
         "target" : [
           {
-            "reference" : "Patient/1706655133654433000.fb553264-de98-4241-a4f8-161ec13c3d40"
+            "reference" : "Patient/1706817486151917000.15c5591c-c072-4ace-9238-7fd23d37a0ae"
           }
         ],
-        "recorded" : "2024-01-30T17:52:13Z",
+        "recorded" : "2024-02-01T14:58:06Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655133659673000.58a4c3fb-5e00-498f-a384-d2daa20db504",
+      "fullUrl" : "RelatedPerson/1706817486156827000.16d44409-108b-4a35-b4e5-803a26828b1a",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655133659673000.58a4c3fb-5e00-498f-a384-d2daa20db504",
+        "id" : "1706817486156827000.16d44409-108b-4a35-b4e5-803a26828b1a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655133654433000.fb553264-de98-4241-a4f8-161ec13c3d40"
+          "reference" : "Patient/1706817486151917000.15c5591c-c072-4ace-9238-7fd23d37a0ae"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-sh.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-type-sh.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655142365002000.793db855-cff8-4b41-947e-77cc2e70e9f7",
+  "id" : "1706817498392714000.e5dde55c-57bf-4a8a-b64e-3a974ac19af0",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:52:22.372-05:00"
+    "lastUpdated" : "2024-02-01T14:58:18.402-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655142438198000.e65b5ebf-5c70-4de1-b45d-adc3720b12f0"
+          "reference" : "Organization/1706817498504636000.6dbe23fb-fe07-4391-9117-9a4453de8b7b"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655142438198000.e65b5ebf-5c70-4de1-b45d-adc3720b12f0",
+      "fullUrl" : "Organization/1706817498504636000.6dbe23fb-fe07-4391-9117-9a4453de8b7b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655142438198000.e65b5ebf-5c70-4de1-b45d-adc3720b12f0",
+        "id" : "1706817498504636000.6dbe23fb-fe07-4391-9117-9a4453de8b7b",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655142751806000.b7c42799-3366-4c2e-92d7-6d0e8ef97bd5",
+      "fullUrl" : "Provenance/1706817499077973000.5428930f-f39d-416d-bb2a-af8139e6b33c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655142751806000.b7c42799-3366-4c2e-92d7-6d0e8ef97bd5",
+        "id" : "1706817499077973000.5428930f-f39d-416d-bb2a-af8139e6b33c",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655142759594000.74aad7da-012a-45c3-9b58-96091006f34e",
+      "fullUrl" : "Provenance/1706817499088940000.36278368-24e7-421b-9918-32507ac047bc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655142759594000.74aad7da-012a-45c3-9b58-96091006f34e",
-        "recorded" : "2024-01-30T17:52:22Z",
+        "id" : "1706817499088940000.36278368-24e7-421b-9918-32507ac047bc",
+        "recorded" : "2024-02-01T14:58:19Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655142758269000.dc7e1c15-5993-460c-9421-8b4bd0cfb066"
+              "reference" : "Organization/1706817499087955000.fce44293-1558-4e68-b7f9-cd9df19391d8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655142758269000.dc7e1c15-5993-460c-9421-8b4bd0cfb066",
+      "fullUrl" : "Organization/1706817499087955000.fce44293-1558-4e68-b7f9-cd9df19391d8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655142758269000.dc7e1c15-5993-460c-9421-8b4bd0cfb066",
+        "id" : "1706817499087955000.fce44293-1558-4e68-b7f9-cd9df19391d8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655142787025000.8b0cfc4e-082b-4aa5-b7df-de1017c0847a",
+      "fullUrl" : "Patient/1706817499138149000.36ccba5f-f32e-44d4-80b1-b4e1d5566bc2",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655142787025000.8b0cfc4e-082b-4aa5-b7df-de1017c0847a",
+        "id" : "1706817499138149000.36ccba5f-f32e-44d4-80b1-b4e1d5566bc2",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655142779623000.4b1e54da-e3d1-45cf-8d95-af14963564ef"
+              "reference" : "Organization/1706817499132605000.e3bdbb7b-d7df-4749-8d0b-2c191194deeb"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655142779623000.4b1e54da-e3d1-45cf-8d95-af14963564ef",
+      "fullUrl" : "Organization/1706817499132605000.e3bdbb7b-d7df-4749-8d0b-2c191194deeb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655142779623000.4b1e54da-e3d1-45cf-8d95-af14963564ef",
+        "id" : "1706817499132605000.e3bdbb7b-d7df-4749-8d0b-2c191194deeb",
         "contact" : [
           {
             "address" : {
@@ -286,16 +291,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655142789199000.6e8bf253-2de0-43f7-a383-77a44fee9e40",
+      "fullUrl" : "Provenance/1706817499154560000.dfe6c4a5-a9ad-44b9-8b4c-97f9ac05e936",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655142789199000.6e8bf253-2de0-43f7-a383-77a44fee9e40",
+        "id" : "1706817499154560000.dfe6c4a5-a9ad-44b9-8b4c-97f9ac05e936",
         "target" : [
           {
-            "reference" : "Patient/1706655142787025000.8b0cfc4e-082b-4aa5-b7df-de1017c0847a"
+            "reference" : "Patient/1706817499138149000.36ccba5f-f32e-44d4-80b1-b4e1d5566bc2"
           }
         ],
-        "recorded" : "2024-01-30T17:52:22Z",
+        "recorded" : "2024-02-01T14:58:19Z",
         "activity" : {
           "coding" : [
             {
@@ -307,10 +312,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655142792145000.589f4eb1-2e60-4056-aaa2-fb992299685b",
+      "fullUrl" : "RelatedPerson/1706817499160548000.2544ff05-3bf9-400f-b8a9-1e6cd8615744",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655142792145000.589f4eb1-2e60-4056-aaa2-fb992299685b",
+        "id" : "1706817499160548000.2544ff05-3bf9-400f-b8a9-1e6cd8615744",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -318,7 +323,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655142787025000.8b0cfc4e-082b-4aa5-b7df-de1017c0847a"
+          "reference" : "Patient/1706817499138149000.36ccba5f-f32e-44d4-80b1-b4e1d5566bc2"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-uses-xad12.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xad/xad-to-address-uses-xad12.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655151437433000.400295c2-b9b6-4c15-82fd-a0438dd90ecc",
+  "id" : "1706817511006684000.a0c4ba8d-9c70-4f7e-a2a6-4251f018fbd8",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:52:31.446-05:00"
+    "lastUpdated" : "2024-02-01T14:58:31.014-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655151512964000.9a3d8a82-9c3a-4070-b850-8f5f6a50668d"
+          "reference" : "Organization/1706817511086453000.d0d996d0-7edb-4af9-aeda-536fff64b412"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655151512964000.9a3d8a82-9c3a-4070-b850-8f5f6a50668d",
+      "fullUrl" : "Organization/1706817511086453000.d0d996d0-7edb-4af9-aeda-536fff64b412",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655151512964000.9a3d8a82-9c3a-4070-b850-8f5f6a50668d",
+        "id" : "1706817511086453000.d0d996d0-7edb-4af9-aeda-536fff64b412",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655151834545000.9b8e6667-3426-4a3c-b771-672488b1e323",
+      "fullUrl" : "Provenance/1706817511542521000.7bfa7885-1692-4b92-90f5-11e6573ad003",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655151834545000.9b8e6667-3426-4a3c-b771-672488b1e323",
+        "id" : "1706817511542521000.7bfa7885-1692-4b92-90f5-11e6573ad003",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655151840845000.60ef2849-84b5-430c-b15c-0ef594fa0eae",
+      "fullUrl" : "Provenance/1706817511553054000.86623ce4-b1c2-4139-90d6-72592243814f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655151840845000.60ef2849-84b5-430c-b15c-0ef594fa0eae",
-        "recorded" : "2024-01-30T17:52:31Z",
+        "id" : "1706817511553054000.86623ce4-b1c2-4139-90d6-72592243814f",
+        "recorded" : "2024-02-01T14:58:31Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655151840427000.222a0399-8618-4e90-8b6e-74e9232f26b3"
+              "reference" : "Organization/1706817511551332000.e3526e56-7352-4b4d-b681-de2942445b41"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655151840427000.222a0399-8618-4e90-8b6e-74e9232f26b3",
+      "fullUrl" : "Organization/1706817511551332000.e3526e56-7352-4b4d-b681-de2942445b41",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655151840427000.222a0399-8618-4e90-8b6e-74e9232f26b3",
+        "id" : "1706817511551332000.e3526e56-7352-4b4d-b681-de2942445b41",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655151864147000.0234a20b-b7a7-4164-9018-1cebbe8adc6f",
+      "fullUrl" : "Patient/1706817511604749000.7df5422a-21cb-4bc1-826c-2b83e25e55d5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655151864147000.0234a20b-b7a7-4164-9018-1cebbe8adc6f",
+        "id" : "1706817511604749000.7df5422a-21cb-4bc1-826c-2b83e25e55d5",
         "identifier" : [
           {
             "extension" : [
@@ -193,17 +198,17 @@
           {
             "name" : {},
             "organization" : {
-              "reference" : "Organization/1706655151858825000.951aa545-8eb5-445a-a446-572e788b39ca"
+              "reference" : "Organization/1706817511590320000.060d4ebe-6ac5-44fd-a2cf-8082f32e7928"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655151858825000.951aa545-8eb5-445a-a446-572e788b39ca",
+      "fullUrl" : "Organization/1706817511590320000.060d4ebe-6ac5-44fd-a2cf-8082f32e7928",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655151858825000.951aa545-8eb5-445a-a446-572e788b39ca",
+        "id" : "1706817511590320000.060d4ebe-6ac5-44fd-a2cf-8082f32e7928",
         "contact" : [
           {
             "address" : {
@@ -291,16 +296,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655151866666000.d678cebd-ed43-4e4b-a603-f83dac90d58a",
+      "fullUrl" : "Provenance/1706817511608897000.5320c770-10da-48ba-97ce-990ca3da5351",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655151866666000.d678cebd-ed43-4e4b-a603-f83dac90d58a",
+        "id" : "1706817511608897000.5320c770-10da-48ba-97ce-990ca3da5351",
         "target" : [
           {
-            "reference" : "Patient/1706655151864147000.0234a20b-b7a7-4164-9018-1cebbe8adc6f"
+            "reference" : "Patient/1706817511604749000.7df5422a-21cb-4bc1-826c-2b83e25e55d5"
           }
         ],
-        "recorded" : "2024-01-30T17:52:31Z",
+        "recorded" : "2024-02-01T14:58:31Z",
         "activity" : {
           "coding" : [
             {
@@ -312,10 +317,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655151870403000.a9cbc67a-7512-408e-abf6-7ca6fda2b8be",
+      "fullUrl" : "RelatedPerson/1706817511612393000.82acaabc-6be4-4867-bf22-8fc8eb3dc416",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655151870403000.a9cbc67a-7512-408e-abf6-7ca6fda2b8be",
+        "id" : "1706817511612393000.82acaabc-6be4-4867-bf22-8fc8eb3dc416",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -323,7 +328,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655151864147000.0234a20b-b7a7-4164-9018-1cebbe8adc6f"
+          "reference" : "Patient/1706817511604749000.7df5422a-21cb-4bc1-826c-2b83e25e55d5"
         },
         "address" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-dns-assigning-authority.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-dns-assigning-authority.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706641676874971000.8649c099-5473-4d4a-8b63-3c252b01f751",
+  "id" : "1706817756103897000.7d07260f-a8da-4c3b-bff0-c550edf0eb0d",
   "meta" : {
-    "lastUpdated" : "2024-01-30T14:07:56.881-05:00"
+    "lastUpdated" : "2024-02-01T15:02:36.111-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,321 +10,451 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641677285181000.0fb922e3-e18a-4384-a3b3-d2503604a0c2",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641677285181000.0fb922e3-e18a-4384-a3b3-d2503604a0c2",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      }, {
-        "reference" : "DiagnosticReport/1706641677461309000.4e055294-882d-4b68-8f2c-79fcdef64148"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817756532921000.a1a583c8-78a9-4c6b-b422-cfe1630bdedf",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817756532921000.a1a583c8-78a9-4c6b-b422-cfe1630bdedf",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          },
+          {
+            "reference" : "DiagnosticReport/1706817756739741000.030883a0-4821-4bba-a723-70a248f84001"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817756542152000.543b063f-da44-41b6-8145-d5d1c6996311",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817756542152000.543b063f-da44-41b6-8145-d5d1c6996311",
+        "recorded" : "2024-02-01T15:02:36Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817756541632000.74743dcb-af94-4be6-9ab1-b6561bceb6d5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817756541632000.74743dcb-af94-4be6-9ab1-b6561bceb6d5",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817756541632000.74743dcb-af94-4be6-9ab1-b6561bceb6d5",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706817756569868000.0e2732a8-a265-4d90-95a5-55da8774d509",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706817756569868000.0e2732a8-a265-4d90-95a5-55da8774d509",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+            "extension" : [
+              {
+                "url" : "obr-10-collector-identifier",
+                "valueReference" : {
+                  "reference" : "Practitioner/1706817756568315000.671428d1-c2b5-4e63-a60f-f8cb088bb4fb"
+                }
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817756559263000.d130be78-e501-469d-8385-4816b270ce17",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817756559263000.d130be78-e501-469d-8385-4816b270ce17",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Namespace"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "DNS"
+                }
+              ]
+            },
+            "value" : "AssigningOrganization"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706817756568315000.671428d1-c2b5-4e63-a60f-f8cb088bb4fb",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706817756568315000.671428d1-c2b5-4e63-a60f-f8cb088bb4fb",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
+                "valueCode" : "AssigningOrganization"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "DNS"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "value" : "1",
+            "assigner" : {
+              "reference" : "Organization/1706817756559263000.d130be78-e501-469d-8385-4816b270ce17"
+            }
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706817756739741000.030883a0-4821-4bba-a723-70a248f84001",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706817756739741000.030883a0-4821-4bba-a723-70a248f84001",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706817756569868000.0e2732a8-a265-4d90-95a5-55da8774d509"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706641677293951000.d43b18d8-4230-402d-bec9-6d54ef814860",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641677293951000.d43b18d8-4230-402d-bec9-6d54ef814860",
-      "recorded" : "2024-01-30T14:07:57Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706641677293243000.0b54f099-7cd7-4169-a7e8-7034a5f28e7b"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706641677293243000.0b54f099-7cd7-4169-a7e8-7034a5f28e7b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641677293243000.0b54f099-7cd7-4169-a7e8-7034a5f28e7b",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706641677319489000.87072750-6f96-43b5-87ee-83b63683ba11",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706641677319489000.87072750-6f96-43b5-87ee-83b63683ba11",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
-        "extension" : [ {
-          "url" : "obr-10-collector-identifier",
-          "valueReference" : {
-            "reference" : "Practitioner/1706641677317459000.7f8b7052-b454-4561-9a39-e4d0f0374feb"
-          }
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706641677308849000.9320350e-c1d5-4f4a-bd68-fdb6ef91bef7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641677308849000.9320350e-c1d5-4f4a-bd68-fdb6ef91bef7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Namespace"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "DNS"
-          } ]
-        },
-        "value" : "AssigningOrganization"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706641677317459000.7f8b7052-b454-4561-9a39-e4d0f0374feb",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706641677317459000.7f8b7052-b454-4561-9a39-e4d0f0374feb",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
-          "valueCode" : "AssigningOrganization"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "DNS"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "value" : "1",
-        "assigner" : {
-          "reference" : "Organization/1706641677308849000.9320350e-c1d5-4f4a-bd68-fdb6ef91bef7"
-        }
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706641677461309000.4e055294-882d-4b68-8f2c-79fcdef64148",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706641677461309000.4e055294-882d-4b68-8f2c-79fcdef64148",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706641677319489000.87072750-6f96-43b5-87ee-83b63683ba11"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-iso-assigning-authority-no-namespace.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-iso-assigning-authority-no-namespace.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706641686754902000.c35fcc51-f20c-4937-ac45-7d3e75a6e73e",
+  "id" : "1706817767717322000.bac4faf1-648a-4f69-97b2-891e708c11d3",
   "meta" : {
-    "lastUpdated" : "2024-01-30T14:08:06.763-05:00"
+    "lastUpdated" : "2024-02-01T15:02:47.725-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,293 +10,413 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641687179555000.e9202652-18c7-45ec-8f15-30cb8c9b966f",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641687179555000.e9202652-18c7-45ec-8f15-30cb8c9b966f",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      }, {
-        "reference" : "DiagnosticReport/1706641687388791000.fdb16c80-3662-43fd-ad25-adb70e98cffc"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641687188434000.0e12074d-cec4-45fa-b0c9-291cce1d52e5",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641687188434000.0e12074d-cec4-45fa-b0c9-291cce1d52e5",
-      "recorded" : "2024-01-30T14:08:07Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706641687187873000.1b2f9166-7918-49a2-bcf2-aaea77bab2af"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706641687187873000.1b2f9166-7918-49a2-bcf2-aaea77bab2af",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641687187873000.1b2f9166-7918-49a2-bcf2-aaea77bab2af",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706641687215739000.848e59a4-82a5-47bc-b8b6-3c86d792267b",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706641687215739000.848e59a4-82a5-47bc-b8b6-3c86d792267b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
-        "extension" : [ {
-          "url" : "obr-10-collector-identifier",
-          "valueReference" : {
-            "reference" : "Practitioner/1706641687213759000.0985d853-7894-4c00-b16a-81d71197f3c6"
-          }
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706641687213759000.0985d853-7894-4c00-b16a-81d71197f3c6",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706641687213759000.0985d853-7894-4c00-b16a-81d71197f3c6",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "ISO"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706817768178027000.f7f01c2e-9af4-4aa3-842e-8ece42ee97b8",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817768178027000.f7f01c2e-9af4-4aa3-842e-8ece42ee97b8",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          },
+          {
+            "reference" : "DiagnosticReport/1706817768397111000.c9107561-b96f-414f-9ab0-d6fc702c7a34"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:oid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706641687388791000.fdb16c80-3662-43fd-ad25-adb70e98cffc",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706641687388791000.fdb16c80-3662-43fd-ad25-adb70e98cffc",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706641687215739000.848e59a4-82a5-47bc-b8b6-3c86d792267b"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817768186377000.2a6f9e6b-3dbe-4391-b236-a04b3916fc7d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817768186377000.2a6f9e6b-3dbe-4391-b236-a04b3916fc7d",
+        "recorded" : "2024-02-01T15:02:48Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817768185828000.9f4a7823-10cf-4f2a-9e44-3ed557756517"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817768185828000.9f4a7823-10cf-4f2a-9e44-3ed557756517",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817768185828000.9f4a7823-10cf-4f2a-9e44-3ed557756517",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706817768211058000.943884a6-17f2-44d8-a529-c56b09da1272",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706817768211058000.943884a6-17f2-44d8-a529-c56b09da1272",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+            "extension" : [
+              {
+                "url" : "obr-10-collector-identifier",
+                "valueReference" : {
+                  "reference" : "Practitioner/1706817768209421000.31df601f-7a80-465a-bb0b-da3b44f224e9"
+                }
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706817768209421000.31df601f-7a80-465a-bb0b-da3b44f224e9",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706817768209421000.31df601f-7a80-465a-bb0b-da3b44f224e9",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "ISO"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:oid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706817768397111000.c9107561-b96f-414f-9ab0-d6fc702c7a34",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706817768397111000.c9107561-b96f-414f-9ab0-d6fc702c7a34",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706817768211058000.943884a6-17f2-44d8-a529-c56b09da1272"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
       }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-uuid-assigning-authority-no-namespace.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-uuid-assigning-authority-no-namespace.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706641696388970000.65a76784-d7cf-440f-92c8-a41b3510587e",
+  "id" : "1706817779417422000.50fca45b-a4f7-4a9a-b0f1-372d7edbbe9d",
   "meta" : {
-    "lastUpdated" : "2024-01-30T14:08:16.393-05:00"
+    "lastUpdated" : "2024-02-01T15:02:59.427-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,293 +10,413 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641696768712000.2c7448ef-b7bb-4019-a682-f64bb0d05096",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641696768712000.2c7448ef-b7bb-4019-a682-f64bb0d05096",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      }, {
-        "reference" : "DiagnosticReport/1706641696963149000.903d5579-871a-4a00-8b8d-c24d517205e7"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641696777333000.1f233a91-a7ad-4cd5-a1c4-a724af1826b0",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641696777333000.1f233a91-a7ad-4cd5-a1c4-a724af1826b0",
-      "recorded" : "2024-01-30T14:08:16Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706641696776820000.217f250a-17a7-4150-a81f-6859fdc62380"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706641696776820000.217f250a-17a7-4150-a81f-6859fdc62380",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641696776820000.217f250a-17a7-4150-a81f-6859fdc62380",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706641696808603000.0818862f-3aa3-4a07-8457-2d59b0800267",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706641696808603000.0818862f-3aa3-4a07-8457-2d59b0800267",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
-        "extension" : [ {
-          "url" : "obr-10-collector-identifier",
-          "valueReference" : {
-            "reference" : "Practitioner/1706641696806734000.be7aef2a-a4d7-4bb3-8d93-60f60538ee51"
-          }
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706641696806734000.be7aef2a-a4d7-4bb3-8d93-60f60538ee51",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706641696806734000.be7aef2a-a4d7-4bb3-8d93-60f60538ee51",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706817779938918000.d2734868-7091-44df-bd0c-55bcf31acf78",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817779938918000.d2734868-7091-44df-bd0c-55bcf31acf78",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          },
+          {
+            "reference" : "DiagnosticReport/1706817780169520000.b609d9c4-4ded-4333-b2b0-3c5103690230"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "urn:uuid:AssigningSystem",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706641696963149000.903d5579-871a-4a00-8b8d-c24d517205e7",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706641696963149000.903d5579-871a-4a00-8b8d-c24d517205e7",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706641696808603000.0818862f-3aa3-4a07-8457-2d59b0800267"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817779951536000.883550ce-c588-474c-9f57-402b571a276d",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817779951536000.883550ce-c588-474c-9f57-402b571a276d",
+        "recorded" : "2024-02-01T15:02:59Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817779950868000.e12cbfe4-38cc-42ef-b1df-600eb1afde74"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817779950868000.e12cbfe4-38cc-42ef-b1df-600eb1afde74",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817779950868000.e12cbfe4-38cc-42ef-b1df-600eb1afde74",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706817779983808000.609be15a-91af-4ea4-b24c-eb0b49c746c2",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706817779983808000.609be15a-91af-4ea4-b24c-eb0b49c746c2",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+            "extension" : [
+              {
+                "url" : "obr-10-collector-identifier",
+                "valueReference" : {
+                  "reference" : "Practitioner/1706817779982071000.f4e987c1-1d8b-4afc-bf8e-5909e63eeeec"
+                }
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706817779982071000.f4e987c1-1d8b-4afc-bf8e-5909e63eeeec",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706817779982071000.f4e987c1-1d8b-4afc-bf8e-5909e63eeeec",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "urn:uuid:AssigningSystem",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706817780169520000.b609d9c4-4ded-4333-b2b0-3c5103690230",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706817780169520000.b609d9c4-4ded-4333-b2b0-3c5103690230",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706817779983808000.609be15a-91af-4ea4-b24c-eb0b49c746c2"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
       }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-uuid-assigning-authority.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-uuid-assigning-authority.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706641706238900000.917ade28-82f8-41ae-98d0-d86d71b15195",
+  "id" : "1706817790623434000.11a5fecc-522b-4438-9675-8c5d717ea500",
   "meta" : {
-    "lastUpdated" : "2024-01-30T14:08:26.244-05:00"
+    "lastUpdated" : "2024-02-01T15:03:10.630-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,294 +10,414 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641706638453000.350425a6-6b9d-489d-9d8a-33b681a13067",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641706638453000.350425a6-6b9d-489d-9d8a-33b681a13067",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      }, {
-        "reference" : "DiagnosticReport/1706641706825339000.b28cfcac-59d5-46a9-a80e-17730b7de912"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641706646888000.d735101c-2e52-47e8-8650-e0e5753dc752",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641706646888000.d735101c-2e52-47e8-8650-e0e5753dc752",
-      "recorded" : "2024-01-30T14:08:26Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706641706646448000.d621f3ae-e6d6-4824-a4ea-2be955f07990"
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706641706646448000.d621f3ae-e6d6-4824-a4ea-2be955f07990",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641706646448000.d621f3ae-e6d6-4824-a4ea-2be955f07990",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706641706670450000.1ac2b689-5dbe-406f-9ed9-7a760b4d446b",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706641706670450000.1ac2b689-5dbe-406f-9ed9-7a760b4d446b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
-        "extension" : [ {
-          "url" : "obr-10-collector-identifier",
-          "valueReference" : {
-            "reference" : "Practitioner/1706641706668842000.7a9833b3-387e-45d2-8f9e-90353d404f3b"
-          }
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706641706668842000.7a9833b3-387e-45d2-8f9e-90353d404f3b",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706641706668842000.7a9833b3-387e-45d2-8f9e-90353d404f3b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "AssigningSystem"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "UUID"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
+    },
+    {
+      "fullUrl" : "Provenance/1706817791040415000.6a244841-83ed-4d7d-8049-281049432aaf",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817791040415000.6a244841-83ed-4d7d-8049-281049432aaf",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          },
+          {
+            "reference" : "DiagnosticReport/1706817791262619000.eda78e32-60f4-4d03-897d-1d1e11fb7902"
           }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "system" : "Namespace",
-        "value" : "1"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706641706825339000.b28cfcac-59d5-46a9-a80e-17730b7de912",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706641706825339000.b28cfcac-59d5-46a9-a80e-17730b7de912",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706641706670450000.1ac2b689-5dbe-406f-9ed9-7a760b4d446b"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817791048948000.9b7a7cf6-f02c-41ac-90af-34592f2fac25",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817791048948000.9b7a7cf6-f02c-41ac-90af-34592f2fac25",
+        "recorded" : "2024-02-01T15:03:11Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817791048376000.46d560c4-e553-47e0-a39e-972fc921baab"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817791048376000.46d560c4-e553-47e0-a39e-972fc921baab",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817791048376000.46d560c4-e553-47e0-a39e-972fc921baab",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706817791078615000.df011a40-2fed-426c-a346-b5deaa144117",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706817791078615000.df011a40-2fed-426c-a346-b5deaa144117",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+            "extension" : [
+              {
+                "url" : "obr-10-collector-identifier",
+                "valueReference" : {
+                  "reference" : "Practitioner/1706817791076563000.0bcf8101-8368-4469-9c8a-e780fd21602f"
+                }
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706817791076563000.0bcf8101-8368-4469-9c8a-e780fd21602f",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706817791076563000.0bcf8101-8368-4469-9c8a-e780fd21602f",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "AssigningSystem"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "UUID"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "system" : "Namespace",
+            "value" : "1"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706817791262619000.eda78e32-60f4-4d03-897d-1d1e11fb7902",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706817791262619000.eda78e32-60f4-4d03-897d-1d1e11fb7902",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706817791078615000.df011a40-2fed-426c-a346-b5deaa144117"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
       }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-xcn17-populated-xcn19-20-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-xcn17-populated-xcn19-20-empty.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706641716169231000.38f3a268-23de-42cd-924f-02cabdc12158",
+  "id" : "1706817801769130000.f9e6739b-25f1-4f4c-85a1-f5dfcba4b9c8",
   "meta" : {
-    "lastUpdated" : "2024-01-30T14:08:36.175-05:00"
+    "lastUpdated" : "2024-02-01T15:03:21.776-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,322 +10,454 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641716577724000.9dc30b3e-72b2-4fdc-b223-dd81ada89488",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641716577724000.9dc30b3e-72b2-4fdc-b223-dd81ada89488",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      }, {
-        "reference" : "DiagnosticReport/1706641716767663000.e4ee7567-f325-43e4-8c06-ebbef8c84943"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817802222476000.77dd3430-dd58-424b-bca3-919c986308be",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817802222476000.77dd3430-dd58-424b-bca3-919c986308be",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          },
+          {
+            "reference" : "DiagnosticReport/1706817802442304000.da132229-c17a-406f-9ec8-f1161db56d35"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817802232493000.55e8f3fa-29ca-41c2-83ee-e8b44522174f",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817802232493000.55e8f3fa-29ca-41c2-83ee-e8b44522174f",
+        "recorded" : "2024-02-01T15:03:22Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817802231906000.c286f90d-9b4f-4666-91a1-acf4384623d3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817802231906000.c286f90d-9b4f-4666-91a1-acf4384623d3",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817802231906000.c286f90d-9b4f-4666-91a1-acf4384623d3",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706817802268174000.978f3894-acaa-464d-9d7f-e69e109defea",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706817802268174000.978f3894-acaa-464d-9d7f-e69e109defea",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+            "extension" : [
+              {
+                "url" : "obr-10-collector-identifier",
+                "valueReference" : {
+                  "reference" : "Practitioner/1706817802266159000.8490f747-ceaf-4318-86e3-a42d1914f395"
+                }
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817802250380000.721ad288-2ce5-4755-861a-db15b6412bae",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817802250380000.721ad288-2ce5-4755-861a-db15b6412bae",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Namespace"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "value" : "AssigningOrganization"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706817802266159000.8490f747-ceaf-4318-86e3-a42d1914f395",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706817802266159000.8490f747-ceaf-4318-86e3-a42d1914f395",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
+                "valueCode" : "AssigningOrganization"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "PHD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.17",
+                "extension" : [
+                  {
+                    "url" : "XCN.17.2",
+                    "valueString" : "20230501102531-0400"
+                  },
+                  {
+                    "url" : "XCN.17.1",
+                    "valueString" : "20220501102531-0400"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "value" : "123",
+            "assigner" : {
+              "reference" : "Organization/1706817802250380000.721ad288-2ce5-4755-861a-db15b6412bae"
+            }
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "PHD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706817802442304000.da132229-c17a-406f-9ec8-f1161db56d35",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706817802442304000.da132229-c17a-406f-9ec8-f1161db56d35",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706817802268174000.978f3894-acaa-464d-9d7f-e69e109defea"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706641716586482000.60b0452b-bdb3-49c5-b97f-b8ab81e53dc1",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641716586482000.60b0452b-bdb3-49c5-b97f-b8ab81e53dc1",
-      "recorded" : "2024-01-30T14:08:36Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706641716585777000.e623acdb-cf42-4047-b1cf-69fa4e3165e6"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706641716585777000.e623acdb-cf42-4047-b1cf-69fa4e3165e6",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641716585777000.e623acdb-cf42-4047-b1cf-69fa4e3165e6",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706641716612809000.09f3f640-0b6e-4468-ac6d-3937365787a6",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706641716612809000.09f3f640-0b6e-4468-ac6d-3937365787a6",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
-        "extension" : [ {
-          "url" : "obr-10-collector-identifier",
-          "valueReference" : {
-            "reference" : "Practitioner/1706641716611060000.af28f2ab-b20f-4491-917f-c585e6da0a9a"
-          }
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706641716602579000.d3c37b43-123e-405a-a2e2-06a09dd2a624",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641716602579000.d3c37b43-123e-405a-a2e2-06a09dd2a624",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Namespace"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "value" : "AssigningOrganization"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706641716611060000.af28f2ab-b20f-4491-917f-c585e6da0a9a",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706641716611060000.af28f2ab-b20f-4491-917f-c585e6da0a9a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
-          "valueCode" : "AssigningOrganization"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "PHD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.17",
-          "extension" : [ {
-            "url" : "XCN.17.2",
-            "valueString" : "20230501102531-0400"
-          }, {
-            "url" : "XCN.17.1",
-            "valueString" : "20220501102531-0400"
-          } ]
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "value" : "123",
-        "assigner" : {
-          "reference" : "Organization/1706641716602579000.d3c37b43-123e-405a-a2e2-06a09dd2a624"
-        }
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "PHD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706641716767663000.e4ee7567-f325-43e4-8c06-ebbef8c84943",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706641716767663000.e4ee7567-f325-43e4-8c06-ebbef8c84943",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706641716612809000.09f3f640-0b6e-4468-ac6d-3937365787a6"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-xcn19-20-populated-xcn17-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xcn/xcn-to-practitioner-xcn19-20-populated-xcn17-empty.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706641725910783000.6a0a4346-9bf8-454b-95c2-eca1e1866249",
+  "id" : "1706817812661180000.5f664241-3f87-437d-9311-12296f6872a0",
   "meta" : {
-    "lastUpdated" : "2024-01-30T14:08:45.917-05:00"
+    "lastUpdated" : "2024-02-01T15:03:32.670-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,321 +10,451 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706641726358216000.ec752da1-431a-4f0b-b1e3-2bc9ab7160d9",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641726358216000.ec752da1-431a-4f0b-b1e3-2bc9ab7160d9",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      }, {
-        "reference" : "DiagnosticReport/1706641726549997000.879f2952-277e-496a-9297-883b50473ead"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817813112419000.0afc3112-80e7-4354-b9c9-ad010ceae50b",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817813112419000.0afc3112-80e7-4354-b9c9-ad010ceae50b",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          },
+          {
+            "reference" : "DiagnosticReport/1706817813332782000.67a92cd8-ee1a-4368-b5ea-fce734be761e"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706817813122620000.2b11c1d2-8e6c-42c1-88f6-0589f86cde43",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706817813122620000.2b11c1d2-8e6c-42c1-88f6-0589f86cde43",
+        "recorded" : "2024-02-01T15:03:33Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706817813122118000.b7564168-d414-46e5-94bd-966f1ea1f4bd"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817813122118000.b7564168-d414-46e5-94bd-966f1ea1f4bd",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817813122118000.b7564168-d414-46e5-94bd-966f1ea1f4bd",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "ServiceRequest/1706817813159764000.d4a1b3d8-5170-4fbe-b276-b4457d14392b",
+      "resource" : {
+        "resourceType" : "ServiceRequest",
+        "id" : "1706817813159764000.d4a1b3d8-5170-4fbe-b276-b4457d14392b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+            "extension" : [
+              {
+                "url" : "obr-10-collector-identifier",
+                "valueReference" : {
+                  "reference" : "Practitioner/1706817813155373000.3a3e45fd-3b61-4ff6-a0d5-bdb6ef63a9a3"
+                }
+              }
+            ]
+          }
+        ],
+        "status" : "unknown",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706817813139930000.1955b8ce-e6a6-4f72-bc6d-7cff22c0c45d",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706817813139930000.1955b8ce-e6a6-4f72-bc6d-7cff22c0c45d",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Namespace"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "L"
+                }
+              ]
+            },
+            "value" : "AssigningOrganization"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Practitioner/1706817813155373000.3a3e45fd-3b61-4ff6-a0d5-bdb6ef63a9a3",
+      "resource" : {
+        "resourceType" : "Practitioner",
+        "id" : "1706817813155373000.3a3e45fd-3b61-4ff6-a0d5-bdb6ef63a9a3",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                "valueString" : "Namespace"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
+                "valueCode" : "AssigningOrganization"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueCode" : "L"
+              }
+            ]
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+            "extension" : [
+              {
+                "url" : "XCN.3",
+                "valueString" : "LUDWIG"
+              },
+              {
+                "url" : "XCN.4",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.20",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "XCN.21",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.22",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignJ"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.23",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "AssignA"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.5",
+                "valueString" : "2ND"
+              },
+              {
+                "url" : "XCN.7",
+                "valueString" : "MD"
+              },
+              {
+                "url" : "XCN.8",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "SRC"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.10",
+                "valueString" : "B"
+              },
+              {
+                "url" : "XCN.15",
+                "valueString" : "A"
+              },
+              {
+                "url" : "XCN.16",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "NameContext"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "XCN.19",
+                "valueString" : "20220501102531-0400"
+              }
+            ]
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+                "valueString" : "A"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+                "valueCode" : "NPI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                      "valueString" : "id-code"
+                    }
+                  ],
+                  "code" : "DL"
+                }
+              ]
+            },
+            "value" : "1",
+            "assigner" : {
+              "reference" : "Organization/1706817813139930000.1955b8ce-e6a6-4f72-bc6d-7cff22c0c45d"
+            }
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "G"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "DiagnosticReport/1706817813332782000.67a92cd8-ee1a-4368-b5ea-fce734be761e",
+      "resource" : {
+        "resourceType" : "DiagnosticReport",
+        "id" : "1706817813332782000.67a92cd8-ee1a-4368-b5ea-fce734be761e",
+        "basedOn" : [
+          {
+            "reference" : "ServiceRequest/1706817813159764000.d4a1b3d8-5170-4fbe-b276-b4457d14392b"
+          }
+        ],
+        "status" : "final",
+        "code" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
+              "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
+            }
+          ],
+          "coding" : [
+            {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                  "valueString" : "coding"
+                },
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                  "valueString" : "LN"
+                }
+              ],
+              "system" : "http://loinc.org",
+              "code" : "68991-9",
+              "display" : "Epidemiologically Important Information"
+            }
+          ]
+        }
       }
     }
-  }, {
-    "fullUrl" : "Provenance/1706641726367105000.0d813505-6146-431f-8d93-b97a76cfb672",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706641726367105000.0d813505-6146-431f-8d93-b97a76cfb672",
-      "recorded" : "2024-01-30T14:08:46Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706641726366353000.e74856d8-97e9-434b-9c2c-6a650b5aacf9"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706641726366353000.e74856d8-97e9-434b-9c2c-6a650b5aacf9",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641726366353000.e74856d8-97e9-434b-9c2c-6a650b5aacf9",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1706641726398289000.c6e46e2a-facb-4f64-98ff-6223071e0493",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1706641726398289000.c6e46e2a-facb-4f64-98ff-6223071e0493",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
-        "extension" : [ {
-          "url" : "obr-10-collector-identifier",
-          "valueReference" : {
-            "reference" : "Practitioner/1706641726396813000.8bb35863-1a4d-4147-ad09-6b7a8fc4cbe1"
-          }
-        } ]
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706641726385947000.b0ca15a3-c81b-4664-8f42-ff911f6f78bf",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706641726385947000.b0ca15a3-c81b-4664-8f42-ff911f6f78bf",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Namespace"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "L"
-          } ]
-        },
-        "value" : "AssigningOrganization"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Practitioner/1706641726396813000.8bb35863-1a4d-4147-ad09-6b7a8fc4cbe1",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1706641726396813000.8bb35863-1a4d-4147-ad09-6b7a8fc4cbe1",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "Namespace"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type",
-          "valueCode" : "AssigningOrganization"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueCode" : "L"
-        } ]
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
-        "extension" : [ {
-          "url" : "XCN.3",
-          "valueString" : "LUDWIG"
-        }, {
-          "url" : "XCN.4",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.20",
-          "valueString" : "20230501102531-0400"
-        }, {
-          "url" : "XCN.21",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.22",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignJ"
-            } ]
-          }
-        }, {
-          "url" : "XCN.23",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "AssignA"
-            } ]
-          }
-        }, {
-          "url" : "XCN.5",
-          "valueString" : "2ND"
-        }, {
-          "url" : "XCN.7",
-          "valueString" : "MD"
-        }, {
-          "url" : "XCN.8",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "SRC"
-            } ]
-          }
-        }, {
-          "url" : "XCN.10",
-          "valueString" : "B"
-        }, {
-          "url" : "XCN.15",
-          "valueString" : "A"
-        }, {
-          "url" : "XCN.16",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "NameContext"
-            } ]
-          }
-        }, {
-          "url" : "XCN.19",
-          "valueString" : "20220501102531-0400"
-        } ]
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
-          "valueString" : "A"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
-          "valueCode" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-              "valueString" : "id-code"
-            } ],
-            "code" : "DL"
-          } ]
-        },
-        "value" : "1",
-        "assigner" : {
-          "reference" : "Organization/1706641726385947000.b0ca15a3-c81b-4664-8f42-ff911f6f78bf"
-        }
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "G"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "DiagnosticReport/1706641726549997000.879f2952-277e-496a-9297-883b50473ead",
-    "resource" : {
-      "resourceType" : "DiagnosticReport",
-      "id" : "1706641726549997000.879f2952-277e-496a-9297-883b50473ead",
-      "basedOn" : [ {
-        "reference" : "ServiceRequest/1706641726398289000.c6e46e2a-facb-4f64-98ff-6223071e0493"
-      } ],
-      "status" : "final",
-      "code" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/coding-system-oid",
-          "valueOid" : "urn:oid:2.16.840.1.113883.6.1"
-        } ],
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-            "valueString" : "coding"
-          }, {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-            "valueString" : "LN"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "68991-9",
-          "display" : "Epidemiologically Important Information"
-        } ]
-      }
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xon/xon-to-organization-xon10-populated-xon3-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xon/xon-to-organization-xon10-populated-xon3-empty.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706634634995591000.5d8c6353-13ed-4546-acf8-10d9cab4d76e",
+  "id" : "1706818401565934000.c2e40965-35f7-46c7-a5a8-d13ceaea7495",
   "meta" : {
-    "lastUpdated" : "2024-01-30T12:10:35.005-05:00"
+    "lastUpdated" : "2024-02-01T15:13:21.571-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706634635070031000.d5be7a4d-5185-4b05-b57d-5826f1196a48"
+          "reference" : "Organization/1706818401639268000.ab2dd2d1-7d28-4947-8772-ae0d6401f463"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706634635067694000.9899008c-827e-4a29-990c-a5969675db21",
+      "fullUrl" : "Location/1706818401636731000.47bb2e72-1df6-41b9-b7cd-ef22ba95eecc",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706634635067694000.9899008c-827e-4a29-990c-a5969675db21",
+        "id" : "1706818401636731000.47bb2e72-1df6-41b9-b7cd-ef22ba95eecc",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -80,10 +85,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706634635070031000.d5be7a4d-5185-4b05-b57d-5826f1196a48",
+      "fullUrl" : "Organization/1706818401639268000.ab2dd2d1-7d28-4947-8772-ae0d6401f463",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634635070031000.d5be7a4d-5185-4b05-b57d-5826f1196a48",
+        "id" : "1706818401639268000.ab2dd2d1-7d28-4947-8772-ae0d6401f463",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -156,7 +161,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706634635067694000.9899008c-827e-4a29-990c-a5969675db21"
+                  "reference" : "Location/1706818401636731000.47bb2e72-1df6-41b9-b7cd-ef22ba95eecc"
                 }
               }
             ],
@@ -181,10 +186,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634635476784000.65a8660e-8f7d-47bd-9e92-c5f8000e72ba",
+      "fullUrl" : "Provenance/1706818401968224000.6a4e66cd-d6bb-4e42-a395-ef3e6c703ee2",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634635476784000.65a8660e-8f7d-47bd-9e92-c5f8000e72ba",
+        "id" : "1706818401968224000.6a4e66cd-d6bb-4e42-a395-ef3e6c703ee2",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -209,17 +214,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634635476516000.4f918961-60bf-4ea3-a996-8f601185d1b6"
+              "reference" : "Organization/1706818401967913000.b7691180-c997-4e84-90a5-a13d7dfbeae7"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706634635475012000.08e940bc-758d-4c56-8826-dbf03262a562",
+      "fullUrl" : "Location/1706818401965701000.a7382221-1c32-4b38-92cc-7c5538439229",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706634635475012000.08e940bc-758d-4c56-8826-dbf03262a562",
+        "id" : "1706818401965701000.a7382221-1c32-4b38-92cc-7c5538439229",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -249,10 +254,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706634635476516000.4f918961-60bf-4ea3-a996-8f601185d1b6",
+      "fullUrl" : "Organization/1706818401967913000.b7691180-c997-4e84-90a5-a13d7dfbeae7",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634635476516000.4f918961-60bf-4ea3-a996-8f601185d1b6",
+        "id" : "1706818401967913000.b7691180-c997-4e84-90a5-a13d7dfbeae7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -325,7 +330,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706634635475012000.08e940bc-758d-4c56-8826-dbf03262a562"
+                  "reference" : "Location/1706818401965701000.a7382221-1c32-4b38-92cc-7c5538439229"
                 }
               }
             ],
@@ -350,11 +355,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634635487698000.de610586-4be4-47e6-9cde-9f9f42bf9a1f",
+      "fullUrl" : "Provenance/1706818401979824000.2a18ee0a-82d9-43ce-b55b-010e79ff241a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634635487698000.de610586-4be4-47e6-9cde-9f9f42bf9a1f",
-        "recorded" : "2024-01-30T12:10:35Z",
+        "id" : "1706818401979824000.2a18ee0a-82d9-43ce-b55b-010e79ff241a",
+        "recorded" : "2024-02-01T15:13:21Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -376,17 +381,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634635487318000.a354d742-bab3-459d-88cd-ff8c7d38dcba"
+              "reference" : "Organization/1706818401979508000.4b9ca933-bc17-4645-a3d4-b9bf2eaf434f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706634635487318000.a354d742-bab3-459d-88cd-ff8c7d38dcba",
+      "fullUrl" : "Organization/1706818401979508000.4b9ca933-bc17-4645-a3d4-b9bf2eaf434f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634635487318000.a354d742-bab3-459d-88cd-ff8c7d38dcba",
+        "id" : "1706818401979508000.4b9ca933-bc17-4645-a3d4-b9bf2eaf434f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xon/xon-to-organization-xon10-populated.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xon/xon-to-organization-xon10-populated.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706634645550792000.fc699b6e-e69d-4f4c-be72-802d85f42d6e",
+  "id" : "1706818411179260000.6a974719-1751-4777-ba9a-b89eb0b84285",
   "meta" : {
-    "lastUpdated" : "2024-01-30T12:10:45.558-05:00"
+    "lastUpdated" : "2024-02-01T15:13:31.186-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706634645627813000.b840edac-0dea-4125-bba0-666d1172e19f"
+          "reference" : "Organization/1706818411253215000.b2358935-9817-4f38-a480-0792d815a260"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706634645623542000.4d7040ff-1eb9-48ff-a50d-22beda8fe5f1",
+      "fullUrl" : "Location/1706818411249914000.02569bda-4627-4cd4-a1bc-7fb58d1047bf",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706634645623542000.4d7040ff-1eb9-48ff-a50d-22beda8fe5f1",
+        "id" : "1706818411249914000.02569bda-4627-4cd4-a1bc-7fb58d1047bf",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -80,10 +85,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706634645627813000.b840edac-0dea-4125-bba0-666d1172e19f",
+      "fullUrl" : "Organization/1706818411253215000.b2358935-9817-4f38-a480-0792d815a260",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634645627813000.b840edac-0dea-4125-bba0-666d1172e19f",
+        "id" : "1706818411253215000.b2358935-9817-4f38-a480-0792d815a260",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -160,7 +165,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706634645623542000.4d7040ff-1eb9-48ff-a50d-22beda8fe5f1"
+                  "reference" : "Location/1706818411249914000.02569bda-4627-4cd4-a1bc-7fb58d1047bf"
                 }
               }
             ],
@@ -185,10 +190,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634645986150000.54e87245-4722-478d-9431-891a70ab30e9",
+      "fullUrl" : "Provenance/1706818411603465000.e516e69f-1646-48bb-b7f1-1a6a359f1e3e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634645986150000.54e87245-4722-478d-9431-891a70ab30e9",
+        "id" : "1706818411603465000.e516e69f-1646-48bb-b7f1-1a6a359f1e3e",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -213,17 +218,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634645985831000.1e8b6311-e4a8-49be-ac5c-823c10139033"
+              "reference" : "Organization/1706818411603190000.5ab3af40-e1b4-495f-8285-2f79f7b44eff"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706634645984120000.8d2e629c-ec1a-4898-a0a0-ee8379a17891",
+      "fullUrl" : "Location/1706818411601199000.9b79d3d3-9c48-4c75-bdbb-3411739a8043",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706634645984120000.8d2e629c-ec1a-4898-a0a0-ee8379a17891",
+        "id" : "1706818411601199000.9b79d3d3-9c48-4c75-bdbb-3411739a8043",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -253,10 +258,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706634645985831000.1e8b6311-e4a8-49be-ac5c-823c10139033",
+      "fullUrl" : "Organization/1706818411603190000.5ab3af40-e1b4-495f-8285-2f79f7b44eff",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634645985831000.1e8b6311-e4a8-49be-ac5c-823c10139033",
+        "id" : "1706818411603190000.5ab3af40-e1b4-495f-8285-2f79f7b44eff",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -333,7 +338,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706634645984120000.8d2e629c-ec1a-4898-a0a0-ee8379a17891"
+                  "reference" : "Location/1706818411601199000.9b79d3d3-9c48-4c75-bdbb-3411739a8043"
                 }
               }
             ],
@@ -358,11 +363,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634645994896000.831ba4e5-ed80-4820-a3ad-897987e326bf",
+      "fullUrl" : "Provenance/1706818411619331000.6293a1ad-b3ef-4064-98e6-949ba1b76f0c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634645994896000.831ba4e5-ed80-4820-a3ad-897987e326bf",
-        "recorded" : "2024-01-30T12:10:45Z",
+        "id" : "1706818411619331000.6293a1ad-b3ef-4064-98e6-949ba1b76f0c",
+        "recorded" : "2024-02-01T15:13:31Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -384,17 +389,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634645994587000.d4a42cac-772a-4bba-acbf-f421097c52b8"
+              "reference" : "Organization/1706818411618847000.d42b7492-d93c-468d-af4a-40d746c515d0"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706634645994587000.d4a42cac-772a-4bba-acbf-f421097c52b8",
+      "fullUrl" : "Organization/1706818411618847000.d42b7492-d93c-468d-af4a-40d746c515d0",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634645994587000.d4a42cac-772a-4bba-acbf-f421097c52b8",
+        "id" : "1706818411618847000.d42b7492-d93c-468d-af4a-40d746c515d0",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xon/xon-to-organization.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xon/xon-to-organization.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706634660784005000.6bf04130-2fb2-43fa-9eab-fc592606d0fd",
+  "id" : "1706818426082362000.de411384-46b7-4752-94ba-3d4fcfb60b9b",
   "meta" : {
-    "lastUpdated" : "2024-01-30T12:11:00.797-05:00"
+    "lastUpdated" : "2024-02-01T15:13:46.089-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -42,15 +47,15 @@
           }
         },
         "responsible" : {
-          "reference" : "Organization/1706634660883607000.81e6ea30-9cda-4504-aad3-8d2350351508"
+          "reference" : "Organization/1706818426161150000.335ca51a-3fce-4c79-a163-42244a70608e"
         }
       }
     },
     {
-      "fullUrl" : "Location/1706634660879160000.004af528-1ef2-472f-a7cc-82dc8a6ebb61",
+      "fullUrl" : "Location/1706818426157587000.7c52efe6-eb25-4c90-82b6-64b7cc0b0f46",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706634660879160000.004af528-1ef2-472f-a7cc-82dc8a6ebb61",
+        "id" : "1706818426157587000.7c52efe6-eb25-4c90-82b6-64b7cc0b0f46",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -80,10 +85,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706634660883607000.81e6ea30-9cda-4504-aad3-8d2350351508",
+      "fullUrl" : "Organization/1706818426161150000.335ca51a-3fce-4c79-a163-42244a70608e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634660883607000.81e6ea30-9cda-4504-aad3-8d2350351508",
+        "id" : "1706818426161150000.335ca51a-3fce-4c79-a163-42244a70608e",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -183,7 +188,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706634660879160000.004af528-1ef2-472f-a7cc-82dc8a6ebb61"
+                  "reference" : "Location/1706818426157587000.7c52efe6-eb25-4c90-82b6-64b7cc0b0f46"
                 }
               }
             ],
@@ -208,10 +213,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634661222984000.35f1a6b0-5ddc-4fcb-9e95-a09e67403e8f",
+      "fullUrl" : "Provenance/1706818426534097000.1bc435f9-769d-42e6-80a1-d99ecad77216",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634661222984000.35f1a6b0-5ddc-4fcb-9e95-a09e67403e8f",
+        "id" : "1706818426534097000.1bc435f9-769d-42e6-80a1-d99ecad77216",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -236,17 +241,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634661222691000.cbb236d5-734d-4545-846c-124932f9995e"
+              "reference" : "Organization/1706818426533815000.00917acf-4643-44c7-98df-d5d7e452580a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Location/1706634661221036000.d67dfd37-3101-4d28-a904-0ebc2e0980b7",
+      "fullUrl" : "Location/1706818426532125000.af1869da-a0e4-42fa-be6c-bf1de7d0cc94",
       "resource" : {
         "resourceType" : "Location",
-        "id" : "1706634661221036000.d67dfd37-3101-4d28-a904-0ebc2e0980b7",
+        "id" : "1706818426532125000.af1869da-a0e4-42fa-be6c-bf1de7d0cc94",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
@@ -276,10 +281,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706634661222691000.cbb236d5-734d-4545-846c-124932f9995e",
+      "fullUrl" : "Organization/1706818426533815000.00917acf-4643-44c7-98df-d5d7e452580a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634661222691000.cbb236d5-734d-4545-846c-124932f9995e",
+        "id" : "1706818426533815000.00917acf-4643-44c7-98df-d5d7e452580a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
@@ -379,7 +384,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-location",
                 "valueReference" : {
-                  "reference" : "Location/1706634661221036000.d67dfd37-3101-4d28-a904-0ebc2e0980b7"
+                  "reference" : "Location/1706818426532125000.af1869da-a0e4-42fa-be6c-bf1de7d0cc94"
                 }
               }
             ],
@@ -404,11 +409,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634661232711000.ddb86c7a-46b8-4f3a-aa19-35b9eaf454ac",
+      "fullUrl" : "Provenance/1706818426543723000.ef7959d1-6643-4804-9b63-36250aaec072",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634661232711000.ddb86c7a-46b8-4f3a-aa19-35b9eaf454ac",
-        "recorded" : "2024-01-30T12:11:01Z",
+        "id" : "1706818426543723000.ef7959d1-6643-4804-9b63-36250aaec072",
+        "recorded" : "2024-02-01T15:13:46Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -430,17 +435,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634661232445000.73549576-19ec-42ce-a76f-553aff2546a0"
+              "reference" : "Organization/1706818426543389000.7e28be43-85d9-486a-84f0-b21c2350ade6"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706634661232445000.73549576-19ec-42ce-a76f-553aff2546a0",
+      "fullUrl" : "Organization/1706818426543389000.7e28be43-85d9-486a-84f0-b21c2350ade6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634661232445000.73549576-19ec-42ce-a76f-553aff2546a0",
+        "id" : "1706818426543389000.7e28be43-85d9-486a-84f0-b21c2350ade6",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xpn/xpn-to-humanname-xpn10-populated-xpn12-13-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xpn/xpn-to-humanname-xpn10-populated-xpn12-13-empty.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706634753806302000.a2b565af-927d-469b-bec7-bc0f5a5cf349",
+  "id" : "1706818135776470000.9682a787-5286-4243-ac84-97debe1aea17",
   "meta" : {
-    "lastUpdated" : "2024-01-30T12:12:33.813-05:00"
+    "lastUpdated" : "2024-02-01T15:08:55.783-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,294 +10,419 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706634754242241000.913f9a53-1b21-45c3-b24d-eede60f29bf6",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706634754242241000.913f9a53-1b21-45c3-b24d-eede60f29bf6",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
-          "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706634754250334000.efce4202-00da-4ab1-a689-d26d616d984c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706634754250334000.efce4202-00da-4ab1-a689-d26d616d984c",
-      "recorded" : "2024-01-30T12:12:34Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706634754249019000.50f0c7ce-d1df-467f-879b-5e544eba1693"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706634754249019000.50f0c7ce-d1df-467f-879b-5e544eba1693",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706634754249019000.50f0c7ce-d1df-467f-879b-5e544eba1693",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706634754274290000.f03ec3d2-118d-4736-bec0-dc5ff82e1526",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706634754274290000.f03ec3d2-118d-4736-bec0-dc5ff82e1526",
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "BB SARAH"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "SMITH",
-        "given" : [ "BB SARAH" ]
-      } ],
-      "contact" : [ {
-        "name" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-            "extension" : [ {
-              "url" : "XPN.2",
-              "valueString" : "LUDWIG"
-            }, {
-              "url" : "XPN.3",
-              "valueString" : "B"
-            }, {
-              "url" : "XPN.14",
-              "valueString" : "MD"
-            }, {
-              "url" : "XPN.4",
-              "valueString" : "2ND"
-            }, {
-              "url" : "XPN.6",
-              "valueString" : "MD"
-            }, {
-              "url" : "XPN.7",
-              "valueString" : "B"
-            }, {
-              "url" : "XPN.8",
-              "valueString" : "A"
-            }, {
-              "url" : "XPN.9",
-              "valueCodeableConcept" : {
-                "coding" : [ {
-                  "extension" : [ {
-                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                    "valueString" : "coding"
-                  } ],
-                  "code" : "Coding"
-                } ]
-              }
-            }, {
-              "url" : "XPN.10",
-              "extension" : [ {
-                "url" : "XPN.10.2",
-                "valueString" : "20230501102531-0400"
-              }, {
-                "url" : "XPN.10.1",
-                "valueString" : "20220501102531-0400"
-              } ]
-            } ]
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-            "valueCode" : "F"
-          } ],
-          "use" : "official",
-          "family" : "BEETHOVEN",
-          "_family" : {
-            "extension" : [ {
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-              "valueString" : "VAN"
-            }, {
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-              "valueString" : "BEETHOVEN"
-            }, {
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-              "valueString" : "VAL"
-            }, {
-              "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-              "valueString" : "ROGER"
-            } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
           },
-          "given" : [ "LUDWIG", "B" ],
-          "prefix" : [ "DR" ],
-          "suffix" : [ "2ND", "MD", "MD" ],
-          "period" : {
-            "start" : "2022-05-01T10:25:31-04:00",
-            "end" : "2023-05-01T10:25:31-04:00"
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
+          "display" : "ORU^R01^ORU_R01"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
           }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706634754276300000.6417964c-d79a-4c9a-924e-e839bf7fedc8",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706634754276300000.6417964c-d79a-4c9a-924e-e839bf7fedc8",
-      "target" : [ {
-        "reference" : "Patient/1706634754274290000.f03ec3d2-118d-4736-bec0-dc5ff82e1526"
-      } ],
-      "recorded" : "2024-01-30T12:12:34Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
       }
-    }
-  }, {
-    "fullUrl" : "RelatedPerson/1706634754279341000.7270f0e7-e1f1-4049-b855-d23b7062293c",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706634754279341000.7270f0e7-e1f1-4049-b855-d23b7062293c",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706634754274290000.f03ec3d2-118d-4736-bec0-dc5ff82e1526"
-      },
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "name"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "LUDWIG"
-          }, {
-            "url" : "XPN.3",
-            "valueString" : "B"
-          }, {
-            "url" : "XPN.14",
-            "valueString" : "MD"
-          }, {
-            "url" : "XPN.4",
-            "valueString" : "2ND"
-          }, {
-            "url" : "XPN.6",
-            "valueString" : "MD"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "B"
-          }, {
-            "url" : "XPN.8",
-            "valueString" : "A"
-          }, {
-            "url" : "XPN.9",
-            "valueCodeableConcept" : {
-              "extension" : [ {
+    },
+    {
+      "fullUrl" : "Provenance/1706818136177759000.14d2b1bb-b37e-437c-a8b6-bce742a7f508",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818136177759000.14d2b1bb-b37e-437c-a8b6-bce742a7f508",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818136186060000.22a91d55-6843-4614-9acc-3310de452d97",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818136186060000.22a91d55-6843-4614-9acc-3310de452d97",
+        "recorded" : "2024-02-01T15:08:56Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706818136185555000.6802db58-62cb-43e1-8645-8b8b318e4b65"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818136185555000.6802db58-62cb-43e1-8645-8b8b318e4b65",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818136185555000.6802db58-62cb-43e1-8645-8b8b318e4b65",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706818136207481000.59db371f-7e24-418c-8809-24f65e021942",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706818136207481000.59db371f-7e24-418c-8809-24f65e021942",
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "BB SARAH"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "SMITH",
+            "given" : [
+              "BB SARAH"
+            ]
+          }
+        ],
+        "contact" : [
+          {
+            "name" : {
+              "extension" : [
+                {
+                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                  "extension" : [
+                    {
+                      "url" : "XPN.2",
+                      "valueString" : "LUDWIG"
+                    },
+                    {
+                      "url" : "XPN.3",
+                      "valueString" : "B"
+                    },
+                    {
+                      "url" : "XPN.14",
+                      "valueString" : "MD"
+                    },
+                    {
+                      "url" : "XPN.4",
+                      "valueString" : "2ND"
+                    },
+                    {
+                      "url" : "XPN.6",
+                      "valueString" : "MD"
+                    },
+                    {
+                      "url" : "XPN.7",
+                      "valueString" : "B"
+                    },
+                    {
+                      "url" : "XPN.8",
+                      "valueString" : "A"
+                    },
+                    {
+                      "url" : "XPN.9",
+                      "valueCodeableConcept" : {
+                        "coding" : [
+                          {
+                            "extension" : [
+                              {
+                                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                "valueString" : "coding"
+                              }
+                            ],
+                            "code" : "Coding"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "url" : "XPN.10",
+                      "extension" : [
+                        {
+                          "url" : "XPN.10.2",
+                          "valueString" : "20230501102531-0400"
+                        },
+                        {
+                          "url" : "XPN.10.1",
+                          "valueString" : "20220501102531-0400"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                  "valueCode" : "F"
+                }
+              ],
+              "use" : "official",
+              "family" : "BEETHOVEN",
+              "_family" : {
+                "extension" : [
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                    "valueString" : "VAN"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                    "valueString" : "BEETHOVEN"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                    "valueString" : "VAL"
+                  },
+                  {
+                    "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                    "valueString" : "ROGER"
+                  }
+                ]
+              },
+              "given" : [
+                "LUDWIG",
+                "B"
+              ],
+              "prefix" : [
+                "DR"
+              ],
+              "suffix" : [
+                "2ND",
+                "MD",
+                "MD"
+              ],
+              "period" : {
+                "start" : "2022-05-01T10:25:31-04:00",
+                "end" : "2023-05-01T10:25:31-04:00"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818136209587000.eedaed2f-aedd-4e99-b594-b155cf63c2f3",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818136209587000.eedaed2f-aedd-4e99-b594-b155cf63c2f3",
+        "target" : [
+          {
+            "reference" : "Patient/1706818136207481000.59db371f-7e24-418c-8809-24f65e021942"
+          }
+        ],
+        "recorded" : "2024-02-01T15:08:56Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706818136215152000.ccc97931-a14e-4a89-8339-a20965e35190",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706818136215152000.ccc97931-a14e-4a89-8339-a20965e35190",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706818136207481000.59db371f-7e24-418c-8809-24f65e021942"
+        },
+        "name" : [
+          {
+            "extension" : [
+              {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
                 "valueString" : "name"
-              } ],
-              "coding" : [ {
-                "extension" : [ {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                  "valueString" : "coding"
-                } ],
-                "code" : "Coding"
-              } ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "LUDWIG"
+                  },
+                  {
+                    "url" : "XPN.3",
+                    "valueString" : "B"
+                  },
+                  {
+                    "url" : "XPN.14",
+                    "valueString" : "MD"
+                  },
+                  {
+                    "url" : "XPN.4",
+                    "valueString" : "2ND"
+                  },
+                  {
+                    "url" : "XPN.6",
+                    "valueString" : "MD"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "B"
+                  },
+                  {
+                    "url" : "XPN.8",
+                    "valueString" : "A"
+                  },
+                  {
+                    "url" : "XPN.9",
+                    "valueCodeableConcept" : {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                          "valueString" : "name"
+                        }
+                      ],
+                      "coding" : [
+                        {
+                          "extension" : [
+                            {
+                              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                              "valueString" : "coding"
+                            }
+                          ],
+                          "code" : "Coding"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "url" : "XPN.10",
+                    "extension" : [
+                      {
+                        "url" : "XPN.10.2",
+                        "valueString" : "20230501102531-0400"
+                      },
+                      {
+                        "url" : "XPN.10.1",
+                        "valueString" : "20220501102531-0400"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
+                "valueCode" : "F"
+              }
+            ],
+            "use" : "official",
+            "family" : "BEETHOVEN",
+            "_family" : {
+              "extension" : [
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                  "valueString" : "VAN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString" : "BEETHOVEN"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
+                  "valueString" : "VAL"
+                },
+                {
+                  "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
+                  "valueString" : "ROGER"
+                }
+              ]
+            },
+            "given" : [
+              "LUDWIG",
+              "B"
+            ],
+            "prefix" : [
+              "DR"
+            ],
+            "suffix" : [
+              "2ND",
+              "MD",
+              "MD"
+            ],
+            "period" : {
+              "start" : "2022-05-01T10:25:31-04:00",
+              "end" : "2023-05-01T10:25:31-04:00"
             }
-          }, {
-            "url" : "XPN.10",
-            "extension" : [ {
-              "url" : "XPN.10.2",
-              "valueString" : "20230501102531-0400"
-            }, {
-              "url" : "XPN.10.1",
-              "valueString" : "20220501102531-0400"
-            } ]
-          } ]
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/humanname-assembly-order",
-          "valueCode" : "F"
-        } ],
-        "use" : "official",
-        "family" : "BEETHOVEN",
-        "_family" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
-            "valueString" : "VAN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
-            "valueString" : "BEETHOVEN"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-prefix",
-            "valueString" : "VAL"
-          }, {
-            "url" : "http://hl7.org/fhir/StructureDefinition/humanname-partner-name",
-            "valueString" : "ROGER"
-          } ]
-        },
-        "given" : [ "LUDWIG", "B" ],
-        "prefix" : [ "DR" ],
-        "suffix" : [ "2ND", "MD", "MD" ],
-        "period" : {
-          "start" : "2022-05-01T10:25:31-04:00",
-          "end" : "2023-05-01T10:25:31-04:00"
-        }
-      } ]
+          }
+        ]
+      }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xpn/xpn-to-humanname-xpn12-13-populated-xpn10-empty.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xpn/xpn-to-humanname-xpn12-13-populated-xpn10-empty.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706634764121018000.54a01a75-6941-4f26-94c2-4e403ca5793b",
+  "id" : "1706818146253506000.2241db72-6368-42ee-a35b-6d898b06273c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T12:12:44.127-05:00"
+    "lastUpdated" : "2024-02-01T15:09:06.260-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634764546598000.642e6e09-0b69-4e8f-8a20-36d8fb567826",
+      "fullUrl" : "Provenance/1706818146706445000.7a560808-4632-4cb6-9c5d-ddec3f1abe70",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634764546598000.642e6e09-0b69-4e8f-8a20-36d8fb567826",
+        "id" : "1706818146706445000.7a560808-4632-4cb6-9c5d-ddec3f1abe70",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634764555844000.070fdeb1-4195-4bac-8b2b-1c25ec3e3354",
+      "fullUrl" : "Provenance/1706818146716082000.bfaef2a0-8fba-4e81-bbc2-dd6f3ab567be",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634764555844000.070fdeb1-4195-4bac-8b2b-1c25ec3e3354",
-        "recorded" : "2024-01-30T12:12:44Z",
+        "id" : "1706818146716082000.bfaef2a0-8fba-4e81-bbc2-dd6f3ab567be",
+        "recorded" : "2024-02-01T15:09:06Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706634764554364000.0600f618-1666-4086-8488-786de3a00220"
+              "reference" : "Organization/1706818146715605000.0c820d33-8337-48cb-bf33-73f4d4f753f9"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706634764554364000.0600f618-1666-4086-8488-786de3a00220",
+      "fullUrl" : "Organization/1706818146715605000.0c820d33-8337-48cb-bf33-73f4d4f753f9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706634764554364000.0600f618-1666-4086-8488-786de3a00220",
+        "id" : "1706818146715605000.0c820d33-8337-48cb-bf33-73f4d4f753f9",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706634764581277000.fecc6aa1-cf7e-4dc3-8cc4-4d686c01f58e",
+      "fullUrl" : "Patient/1706818146740449000.9f07dc14-bc60-4370-a0e3-1db2dd1e61ba",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706634764581277000.fecc6aa1-cf7e-4dc3-8cc4-4d686c01f58e",
+        "id" : "1706818146740449000.9f07dc14-bc60-4370-a0e3-1db2dd1e61ba",
         "name" : [
           {
             "extension" : [
@@ -242,16 +247,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706634764583264000.6d5ec8b2-a3f3-401b-bb49-5ba6be67d188",
+      "fullUrl" : "Provenance/1706818146742660000.a15d0971-d44b-4ea4-ab0d-e46bd15f9139",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706634764583264000.6d5ec8b2-a3f3-401b-bb49-5ba6be67d188",
+        "id" : "1706818146742660000.a15d0971-d44b-4ea4-ab0d-e46bd15f9139",
         "target" : [
           {
-            "reference" : "Patient/1706634764581277000.fecc6aa1-cf7e-4dc3-8cc4-4d686c01f58e"
+            "reference" : "Patient/1706818146740449000.9f07dc14-bc60-4370-a0e3-1db2dd1e61ba"
           }
         ],
-        "recorded" : "2024-01-30T12:12:44Z",
+        "recorded" : "2024-02-01T15:09:06Z",
         "activity" : {
           "coding" : [
             {
@@ -263,10 +268,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706634764587857000.fba4063d-a54d-4d83-adf7-b823b5997d46",
+      "fullUrl" : "RelatedPerson/1706818146746817000.be29bb2e-a440-4282-a4ca-115818983be9",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706634764587857000.fba4063d-a54d-4d83-adf7-b823b5997d46",
+        "id" : "1706818146746817000.be29bb2e-a440-4282-a4ca-115818983be9",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -274,7 +279,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706634764581277000.fecc6aa1-cf7e-4dc3-8cc4-4d686c01f58e"
+          "reference" : "Patient/1706818146740449000.9f07dc14-bc60-4370-a0e3-1db2dd1e61ba"
         },
         "name" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_11_xtn6_has_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_11_xtn6_has_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655179530149000.2fef794e-bb78-4be5-85f6-6224b334f839",
+  "id" : "1706818469390234000.af012787-07d8-426c-9da3-98d42a7642ef",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:52:59.536-05:00"
+    "lastUpdated" : "2024-02-01T15:14:29.396-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655179599316000.8f820acc-3832-4e7a-be9f-62ac50ebf2ff"
+          "reference" : "Organization/1706818469437614000.ea80fd2b-eb2c-4e8b-9fb9-8f166a4d1e1c"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655179599316000.8f820acc-3832-4e7a-be9f-62ac50ebf2ff",
+      "fullUrl" : "Organization/1706818469437614000.ea80fd2b-eb2c-4e8b-9fb9-8f166a4d1e1c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655179599316000.8f820acc-3832-4e7a-be9f-62ac50ebf2ff",
+        "id" : "1706818469437614000.ea80fd2b-eb2c-4e8b-9fb9-8f166a4d1e1c",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655179922404000.eeb05bcf-e0ee-4a8e-bfec-102de103c742",
+      "fullUrl" : "Provenance/1706818469787830000.8d04eb87-5be5-4b2d-a67e-57cc5fd718c9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655179922404000.eeb05bcf-e0ee-4a8e-bfec-102de103c742",
+        "id" : "1706818469787830000.8d04eb87-5be5-4b2d-a67e-57cc5fd718c9",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655179930649000.6b2a016b-70d1-4b55-bd60-9d72f515bd0e",
+      "fullUrl" : "Provenance/1706818469795237000.205fd430-4871-4c55-88ab-d12179e72c17",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655179930649000.6b2a016b-70d1-4b55-bd60-9d72f515bd0e",
-        "recorded" : "2024-01-30T17:52:59Z",
+        "id" : "1706818469795237000.205fd430-4871-4c55-88ab-d12179e72c17",
+        "recorded" : "2024-02-01T15:14:29Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655179930135000.db192a95-2cf6-477c-9efc-ec678a3b01ff"
+              "reference" : "Organization/1706818469794732000.b58eab2c-cf2b-4396-868f-1f2944621882"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655179930135000.db192a95-2cf6-477c-9efc-ec678a3b01ff",
+      "fullUrl" : "Organization/1706818469794732000.b58eab2c-cf2b-4396-868f-1f2944621882",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655179930135000.db192a95-2cf6-477c-9efc-ec678a3b01ff",
+        "id" : "1706818469794732000.b58eab2c-cf2b-4396-868f-1f2944621882",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655179952356000.2962424e-f051-46c4-8145-e03e647faf9d",
+      "fullUrl" : "Patient/1706818469813155000.d3545574-3ca8-4a87-a14e-292189c531f5",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655179952356000.2962424e-f051-46c4-8145-e03e647faf9d",
+        "id" : "1706818469813155000.d3545574-3ca8-4a87-a14e-292189c531f5",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655179953252000.6ce209d5-45a0-4da1-978b-4182a747e3f3",
+      "fullUrl" : "Provenance/1706818469813931000.2c5d8a76-1213-4a03-be91-9e6314aa1851",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655179953252000.6ce209d5-45a0-4da1-978b-4182a747e3f3",
+        "id" : "1706818469813931000.2c5d8a76-1213-4a03-be91-9e6314aa1851",
         "target" : [
           {
-            "reference" : "Patient/1706655179952356000.2962424e-f051-46c4-8145-e03e647faf9d"
+            "reference" : "Patient/1706818469813155000.d3545574-3ca8-4a87-a14e-292189c531f5"
           }
         ],
-        "recorded" : "2024-01-30T17:52:59Z",
+        "recorded" : "2024-02-01T15:14:29Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655179955405000.abfce820-9140-4b5d-b985-5fdee70f44b7",
+      "fullUrl" : "RelatedPerson/1706818469815870000.de3899c5-961b-47df-b8de-fd20041530cb",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655179955405000.abfce820-9140-4b5d-b985-5fdee70f44b7",
+        "id" : "1706818469815870000.de3899c5-961b-47df-b8de-fd20041530cb",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655179952356000.2962424e-f051-46c4-8145-e03e647faf9d"
+          "reference" : "Patient/1706818469813155000.d3545574-3ca8-4a87-a14e-292189c531f5"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_12_xtn7_has_value_xtn3_is_Internet.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_12_xtn7_has_value_xtn3_is_Internet.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655188949807000.2c0f2df8-6fd8-4c11-b780-8ff9ac22434a",
+  "id" : "1706818479080166000.361435c8-4465-49fe-a645-44b1b6becb9d",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:53:08.957-05:00"
+    "lastUpdated" : "2024-02-01T15:14:39.087-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655189025566000.c8ef0eaf-b933-4218-a324-b3ba3d71e24c"
+          "reference" : "Organization/1706818479132330000.2319509a-9444-41d1-808a-3ebc7503a609"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655189025566000.c8ef0eaf-b933-4218-a324-b3ba3d71e24c",
+      "fullUrl" : "Organization/1706818479132330000.2319509a-9444-41d1-808a-3ebc7503a609",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655189025566000.c8ef0eaf-b933-4218-a324-b3ba3d71e24c",
+        "id" : "1706818479132330000.2319509a-9444-41d1-808a-3ebc7503a609",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655189344406000.a5426a0e-edfb-43dd-b1da-9d543e34d861",
+      "fullUrl" : "Provenance/1706818479493427000.dd14aabd-04d8-4cc6-b10e-5c501237e90d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655189344406000.a5426a0e-edfb-43dd-b1da-9d543e34d861",
+        "id" : "1706818479493427000.dd14aabd-04d8-4cc6-b10e-5c501237e90d",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655189351493000.2296f550-c748-4702-8261-d0645370bd7f",
+      "fullUrl" : "Provenance/1706818479502393000.b5c2f570-376b-4527-8cda-2a41fc13b77c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655189351493000.2296f550-c748-4702-8261-d0645370bd7f",
-        "recorded" : "2024-01-30T17:53:09Z",
+        "id" : "1706818479502393000.b5c2f570-376b-4527-8cda-2a41fc13b77c",
+        "recorded" : "2024-02-01T15:14:39Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655189350071000.9494f1cf-1904-4d44-b7c5-a1b1e758fc23"
+              "reference" : "Organization/1706818479501900000.b8e1059d-adf4-48f0-a8a4-45d78cbd4f07"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655189350071000.9494f1cf-1904-4d44-b7c5-a1b1e758fc23",
+      "fullUrl" : "Organization/1706818479501900000.b8e1059d-adf4-48f0-a8a4-45d78cbd4f07",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655189350071000.9494f1cf-1904-4d44-b7c5-a1b1e758fc23",
+        "id" : "1706818479501900000.b8e1059d-adf4-48f0-a8a4-45d78cbd4f07",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655189368229000.a6601bd2-3d76-4e17-8777-1de19c24079e",
+      "fullUrl" : "Patient/1706818479520573000.6d7eaf27-90f2-4619-bfeb-cfc8a70be81e",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655189368229000.a6601bd2-3d76-4e17-8777-1de19c24079e",
+        "id" : "1706818479520573000.6d7eaf27-90f2-4619-bfeb-cfc8a70be81e",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655189368972000.568fb4a3-5242-4a50-a343-6c1b30cb8145",
+      "fullUrl" : "Provenance/1706818479521451000.18efd406-2606-4122-ba85-698534b5d84b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655189368972000.568fb4a3-5242-4a50-a343-6c1b30cb8145",
+        "id" : "1706818479521451000.18efd406-2606-4122-ba85-698534b5d84b",
         "target" : [
           {
-            "reference" : "Patient/1706655189368229000.a6601bd2-3d76-4e17-8777-1de19c24079e"
+            "reference" : "Patient/1706818479520573000.6d7eaf27-90f2-4619-bfeb-cfc8a70be81e"
           }
         ],
-        "recorded" : "2024-01-30T17:53:09Z",
+        "recorded" : "2024-02-01T15:14:39Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655189371080000.3b5f6344-fa49-40da-997a-e0bcfcc42262",
+      "fullUrl" : "RelatedPerson/1706818479524132000.c7a057c3-6f37-435b-a65b-352da4953b1a",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655189371080000.3b5f6344-fa49-40da-997a-e0bcfcc42262",
+        "id" : "1706818479524132000.c7a057c3-6f37-435b-a65b-352da4953b1a",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655189368229000.a6601bd2-3d76-4e17-8777-1de19c24079e"
+          "reference" : "Patient/1706818479520573000.6d7eaf27-90f2-4619-bfeb-cfc8a70be81e"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_12_xtn7_has_value_xtn3_is_PH.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_12_xtn7_has_value_xtn3_is_PH.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655198269129000.69a8ebf5-adb1-415e-87f6-8db149ce37e6",
+  "id" : "1706818488709161000.b12dcf50-7769-45ad-834f-6a0f9eed189c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:53:18.276-05:00"
+    "lastUpdated" : "2024-02-01T15:14:48.716-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,159 +10,215 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
-        "valueString" : "UNICODE UTF-8"
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "sender" : {
-        "reference" : "Organization/1706655198346547000.94de534e-7844-48ca-a12f-2cbe06a17681"
-      },
-      "source" : {
-        "_endpoint" : {
-          "extension" : [ {
-            "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-            "valueCode" : "unknown"
-          } ]
-        }
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706655198346547000.94de534e-7844-48ca-a12f-2cbe06a17681",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655198346547000.94de534e-7844-48ca-a12f-2cbe06a17681",
-      "address" : [ {
-        "country" : "USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655198676192000.d317cf2c-4423-4630-8cf9-adf83f939d18",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655198676192000.d317cf2c-4423-4630-8cf9-adf83f939d18",
-      "target" : [ {
-        "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "827ccb0e-ea8a-306c-8c34-a16891f84e7b",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
+            "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655198685456000.0ad24368-2465-47de-85e7-892ab954deca",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655198685456000.0ad24368-2465-47de-85e7-892ab954deca",
-      "recorded" : "2024-01-30T17:53:18Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706655198684887000.892576e2-98d0-4f04-a517-a75922d20242"
+        "sender" : {
+          "reference" : "Organization/1706818488760113000.4a7f6d38-7f6e-43ff-85f3-beb7e271fb8d"
+        },
+        "source" : {
+          "_endpoint" : {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode" : "unknown"
+              }
+            ]
+          }
         }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655198684887000.892576e2-98d0-4f04-a517-a75922d20242",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655198684887000.892576e2-98d0-4f04-a517-a75922d20242",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818488760113000.4a7f6d38-7f6e-43ff-85f3-beb7e271fb8d",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818488760113000.4a7f6d38-7f6e-43ff-85f3-beb7e271fb8d",
+        "address" : [
+          {
+            "country" : "USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818489111729000.b791ff4b-0ce0-4ab9-92a1-7752b6df75de",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818489111729000.b791ff4b-0ce0-4ab9-92a1-7752b6df75de",
+        "target" : [
+          {
+            "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818489120062000.92f88263-fcdb-4f04-82c2-0c38e19f2570",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818489120062000.92f88263-fcdb-4f04-82c2-0c38e19f2570",
+        "recorded" : "2024-02-01T15:14:49Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706655198703255000.0ff4bfa6-4679-4663-91ff-24b4a6b09439",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706655198703255000.0ff4bfa6-4679-4663-91ff-24b4a6b09439",
-      "contact" : [ {
-        "name" : { }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655198704085000.f3960596-7167-4d30-99c5-0d0676c135b8",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655198704085000.f3960596-7167-4d30-99c5-0d0676c135b8",
-      "target" : [ {
-        "reference" : "Patient/1706655198703255000.0ff4bfa6-4679-4663-91ff-24b4a6b09439"
-      } ],
-      "recorded" : "2024-01-30T17:53:18Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706818489119585000.897644af-7a48-4fa5-822a-ba9137beeaa2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818489119585000.897644af-7a48-4fa5-822a-ba9137beeaa2",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818489119585000.897644af-7a48-4fa5-822a-ba9137beeaa2",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706818489136878000.4e59bce8-25a5-4511-a225-cffa922a5962",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706818489136878000.4e59bce8-25a5-4511-a225-cffa922a5962",
+        "contact" : [
+          {
+            "name" : {}
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818489137827000.6427631c-052a-43d3-8c3f-f98262bad4eb",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818489137827000.6427631c-052a-43d3-8c3f-f98262bad4eb",
+        "target" : [
+          {
+            "reference" : "Patient/1706818489136878000.4e59bce8-25a5-4511-a225-cffa922a5962"
+          }
+        ],
+        "recorded" : "2024-02-01T15:14:49Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl" : "RelatedPerson/1706818489140072000.6ad37ad1-baa8-46a2-907d-46aa5214bf25",
+      "resource" : {
+        "resourceType" : "RelatedPerson",
+        "id" : "1706818489140072000.6ad37ad1-baa8-46a2-907d-46aa5214bf25",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+            "valueString" : "NK1"
+          }
+        ],
+        "patient" : {
+          "reference" : "Patient/1706818489136878000.4e59bce8-25a5-4511-a225-cffa922a5962"
+        },
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "12813308004"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "PH"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "12813308004"
+                  }
+                ]
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
+                "valueString" : "next-of-kin-telecomm-info"
+              }
+            ],
+            "system" : "phone"
+          }
+        ]
       }
     }
-  }, {
-    "fullUrl" : "RelatedPerson/1706655198706111000.3ef021d5-3d27-4ea6-8122-f177ccf33b27",
-    "resource" : {
-      "resourceType" : "RelatedPerson",
-      "id" : "1706655198706111000.3ef021d5-3d27-4ea6-8122-f177ccf33b27",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-        "valueString" : "NK1"
-      } ],
-      "patient" : {
-        "reference" : "Patient/1706655198703255000.0ff4bfa6-4679-4663-91ff-24b4a6b09439"
-      },
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "12813308004"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.3",
-            "valueString" : "PH"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "12813308004"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
-          "valueString" : "next-of-kin-telecomm-info"
-        } ],
-        "system" : "phone"
-      } ]
-    }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_12_xtn7_has_value_xtn3_no_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_12_xtn7_has_value_xtn3_no_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655208014482000.4da4926e-8bcb-4175-8049-d79c75f3ef37",
+  "id" : "1706818498119947000.6045cea7-eaf2-4511-b375-a8eb8c5fd92b",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:53:28.025-05:00"
+    "lastUpdated" : "2024-02-01T15:14:58.129-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655208100615000.96fc632b-6c4f-4fa3-a8d2-cc406ab0b609"
+          "reference" : "Organization/1706818498171018000.5a028605-dc5d-40d8-90ab-2a5eadeec76e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655208100615000.96fc632b-6c4f-4fa3-a8d2-cc406ab0b609",
+      "fullUrl" : "Organization/1706818498171018000.5a028605-dc5d-40d8-90ab-2a5eadeec76e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655208100615000.96fc632b-6c4f-4fa3-a8d2-cc406ab0b609",
+        "id" : "1706818498171018000.5a028605-dc5d-40d8-90ab-2a5eadeec76e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655208466916000.1f5a4719-1782-4ad1-b8b4-d2e76f66fe99",
+      "fullUrl" : "Provenance/1706818498520202000.fc9a2b80-e49f-4bd6-8837-7ddefefa3a6f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655208466916000.1f5a4719-1782-4ad1-b8b4-d2e76f66fe99",
+        "id" : "1706818498520202000.fc9a2b80-e49f-4bd6-8837-7ddefefa3a6f",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655208475729000.c404bade-f511-4edc-923f-5d2de8e619cb",
+      "fullUrl" : "Provenance/1706818498528120000.f087bb41-5c02-431a-b4a2-49fa0691175d",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655208475729000.c404bade-f511-4edc-923f-5d2de8e619cb",
-        "recorded" : "2024-01-30T17:53:28Z",
+        "id" : "1706818498528120000.f087bb41-5c02-431a-b4a2-49fa0691175d",
+        "recorded" : "2024-02-01T15:14:58Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655208475089000.2ab5287e-eb6c-4360-9f6c-ccbd10b3bffb"
+              "reference" : "Organization/1706818498527654000.ef05caa4-578a-4a11-9cc7-f526f4be5fdf"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655208475089000.2ab5287e-eb6c-4360-9f6c-ccbd10b3bffb",
+      "fullUrl" : "Organization/1706818498527654000.ef05caa4-578a-4a11-9cc7-f526f4be5fdf",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655208475089000.2ab5287e-eb6c-4360-9f6c-ccbd10b3bffb",
+        "id" : "1706818498527654000.ef05caa4-578a-4a11-9cc7-f526f4be5fdf",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655208493874000.0421f395-db73-4d49-9aa1-9ad13d81e94b",
+      "fullUrl" : "Patient/1706818498545529000.18f962f6-e222-4061-bf9f-61df6965adc8",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655208493874000.0421f395-db73-4d49-9aa1-9ad13d81e94b",
+        "id" : "1706818498545529000.18f962f6-e222-4061-bf9f-61df6965adc8",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655208494674000.9e9f5459-094c-4ec3-9b1d-5e506bc3fe5b",
+      "fullUrl" : "Provenance/1706818498546254000.d4262d47-66f9-4a86-af18-770edf9151bc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655208494674000.9e9f5459-094c-4ec3-9b1d-5e506bc3fe5b",
+        "id" : "1706818498546254000.d4262d47-66f9-4a86-af18-770edf9151bc",
         "target" : [
           {
-            "reference" : "Patient/1706655208493874000.0421f395-db73-4d49-9aa1-9ad13d81e94b"
+            "reference" : "Patient/1706818498545529000.18f962f6-e222-4061-bf9f-61df6965adc8"
           }
         ],
-        "recorded" : "2024-01-30T17:53:28Z",
+        "recorded" : "2024-02-01T15:14:58Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655208496466000.f1ebfab5-c9e6-4cfa-b35d-b72651cecb18",
+      "fullUrl" : "RelatedPerson/1706818498548554000.802958c1-1f0d-4f98-8da8-724f52227dc8",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655208496466000.f1ebfab5-c9e6-4cfa-b35d-b72651cecb18",
+        "id" : "1706818498548554000.802958c1-1f0d-4f98-8da8-724f52227dc8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655208493874000.0421f395-db73-4d49-9aa1-9ad13d81e94b"
+          "reference" : "Patient/1706818498545529000.18f962f6-e222-4061-bf9f-61df6965adc8"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_13_xtn8_has_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_13_xtn8_has_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655217225629000.1d4ffb06-6acc-4765-80ad-bae90581c2b9",
+  "id" : "1706818507568410000.8f9fe713-70f0-425e-8dec-b7a2f5ae7066",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:53:37.233-05:00"
+    "lastUpdated" : "2024-02-01T15:15:07.577-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655217298961000.f680e0a5-d96c-452b-a9bf-d633bb3654a2"
+          "reference" : "Organization/1706818507618883000.04c2186f-ad3f-4762-81fa-bab418a5b495"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655217298961000.f680e0a5-d96c-452b-a9bf-d633bb3654a2",
+      "fullUrl" : "Organization/1706818507618883000.04c2186f-ad3f-4762-81fa-bab418a5b495",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655217298961000.f680e0a5-d96c-452b-a9bf-d633bb3654a2",
+        "id" : "1706818507618883000.04c2186f-ad3f-4762-81fa-bab418a5b495",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655217615766000.a7af7296-9970-4963-b8c2-5c70a43a65a8",
+      "fullUrl" : "Provenance/1706818507987274000.b391e8c6-121e-442f-8ac5-b0af68fbff2c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655217615766000.a7af7296-9970-4963-b8c2-5c70a43a65a8",
+        "id" : "1706818507987274000.b391e8c6-121e-442f-8ac5-b0af68fbff2c",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655217623745000.2cb39572-52b7-4af2-8d82-eeabe5ed8c37",
+      "fullUrl" : "Provenance/1706818507995225000.3a388e53-8dc8-4534-b133-257283c1454b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655217623745000.2cb39572-52b7-4af2-8d82-eeabe5ed8c37",
-        "recorded" : "2024-01-30T17:53:37Z",
+        "id" : "1706818507995225000.3a388e53-8dc8-4534-b133-257283c1454b",
+        "recorded" : "2024-02-01T15:15:07Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655217623237000.07820cde-7b18-4010-9693-ffde2cc6df7d"
+              "reference" : "Organization/1706818507994715000.a8805f7a-de98-45f2-bf43-16c08e36336b"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655217623237000.07820cde-7b18-4010-9693-ffde2cc6df7d",
+      "fullUrl" : "Organization/1706818507994715000.a8805f7a-de98-45f2-bf43-16c08e36336b",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655217623237000.07820cde-7b18-4010-9693-ffde2cc6df7d",
+        "id" : "1706818507994715000.a8805f7a-de98-45f2-bf43-16c08e36336b",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655217639023000.64da0182-8324-4986-933d-22b115380231",
+      "fullUrl" : "Patient/1706818508013164000.a6670277-318a-4ada-aa0d-da14da1f4d0c",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655217639023000.64da0182-8324-4986-933d-22b115380231",
+        "id" : "1706818508013164000.a6670277-318a-4ada-aa0d-da14da1f4d0c",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655217639770000.fd749836-f3c6-49d1-afbb-a3241bf9da9c",
+      "fullUrl" : "Provenance/1706818508013951000.8db042a6-7f2c-41d6-bdaa-434facd0b47e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655217639770000.fd749836-f3c6-49d1-afbb-a3241bf9da9c",
+        "id" : "1706818508013951000.8db042a6-7f2c-41d6-bdaa-434facd0b47e",
         "target" : [
           {
-            "reference" : "Patient/1706655217639023000.64da0182-8324-4986-933d-22b115380231"
+            "reference" : "Patient/1706818508013164000.a6670277-318a-4ada-aa0d-da14da1f4d0c"
           }
         ],
-        "recorded" : "2024-01-30T17:53:37Z",
+        "recorded" : "2024-02-01T15:15:08Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655217641883000.bbafaf6f-0eba-4796-a0bf-2e09d4f0841f",
+      "fullUrl" : "RelatedPerson/1706818508016262000.d5ea390d-8f57-4864-b610-14bc1d8a9250",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655217641883000.bbafaf6f-0eba-4796-a0bf-2e09d4f0841f",
+        "id" : "1706818508016262000.d5ea390d-8f57-4864-b610-14bc1d8a9250",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655217639023000.64da0182-8324-4986-933d-22b115380231"
+          "reference" : "Patient/1706818508013164000.a6670277-318a-4ada-aa0d-da14da1f4d0c"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_14_xtn9_has_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_14_xtn9_has_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655226353742000.3f9f17d5-7d16-468b-b253-3f0091fdb5a6",
+  "id" : "1706818517539372000.d25672d8-f6e2-4b0a-9602-280c5f911eab",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:53:46.361-05:00"
+    "lastUpdated" : "2024-02-01T15:15:17.545-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655226427715000.4a3e3b28-3ffe-4055-9663-95fd6d1af4fb"
+          "reference" : "Organization/1706818517590576000.fdb63d74-23ef-4e32-be26-9c065560b3d5"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655226427715000.4a3e3b28-3ffe-4055-9663-95fd6d1af4fb",
+      "fullUrl" : "Organization/1706818517590576000.fdb63d74-23ef-4e32-be26-9c065560b3d5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655226427715000.4a3e3b28-3ffe-4055-9663-95fd6d1af4fb",
+        "id" : "1706818517590576000.fdb63d74-23ef-4e32-be26-9c065560b3d5",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655226751820000.8873ad38-40ad-4206-bd21-b70c23ba549f",
+      "fullUrl" : "Provenance/1706818517977068000.3362068f-0575-4955-a4e5-3bea9c834ab5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655226751820000.8873ad38-40ad-4206-bd21-b70c23ba549f",
+        "id" : "1706818517977068000.3362068f-0575-4955-a4e5-3bea9c834ab5",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655226758697000.f4fed686-a2b0-449e-98e7-db70f688ee6a",
+      "fullUrl" : "Provenance/1706818517986904000.ac879a36-cbc9-498d-8afd-e124a10e86e6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655226758697000.f4fed686-a2b0-449e-98e7-db70f688ee6a",
-        "recorded" : "2024-01-30T17:53:46Z",
+        "id" : "1706818517986904000.ac879a36-cbc9-498d-8afd-e124a10e86e6",
+        "recorded" : "2024-02-01T15:15:17Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655226757315000.6a45e491-ea3e-4dc3-b188-ae862e35e367"
+              "reference" : "Organization/1706818517986179000.bbf0e1c8-624e-4c4f-9885-64f0c17e10e1"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655226757315000.6a45e491-ea3e-4dc3-b188-ae862e35e367",
+      "fullUrl" : "Organization/1706818517986179000.bbf0e1c8-624e-4c4f-9885-64f0c17e10e1",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655226757315000.6a45e491-ea3e-4dc3-b188-ae862e35e367",
+        "id" : "1706818517986179000.bbf0e1c8-624e-4c4f-9885-64f0c17e10e1",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655226775409000.172453ca-0bde-4728-929f-772d432622a4",
+      "fullUrl" : "Patient/1706818518006774000.e42f336a-e44f-4cc6-b808-6087ed7cf4d6",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655226775409000.172453ca-0bde-4728-929f-772d432622a4",
+        "id" : "1706818518006774000.e42f336a-e44f-4cc6-b808-6087ed7cf4d6",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655226776112000.08f4577f-07f8-4d5f-8f6c-56ccf327b2d2",
+      "fullUrl" : "Provenance/1706818518007991000.8fa4c18e-71ab-4a01-ab44-660f6aa8cca1",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655226776112000.08f4577f-07f8-4d5f-8f6c-56ccf327b2d2",
+        "id" : "1706818518007991000.8fa4c18e-71ab-4a01-ab44-660f6aa8cca1",
         "target" : [
           {
-            "reference" : "Patient/1706655226775409000.172453ca-0bde-4728-929f-772d432622a4"
+            "reference" : "Patient/1706818518006774000.e42f336a-e44f-4cc6-b808-6087ed7cf4d6"
           }
         ],
-        "recorded" : "2024-01-30T17:53:46Z",
+        "recorded" : "2024-02-01T15:15:18Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655226777971000.b8bde3af-dbc3-426e-9615-43b26f15fb9c",
+      "fullUrl" : "RelatedPerson/1706818518010598000.cf4bdf73-7380-47a4-965e-69a9745ee5f3",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655226777971000.b8bde3af-dbc3-426e-9615-43b26f15fb9c",
+        "id" : "1706818518010598000.cf4bdf73-7380-47a4-965e-69a9745ee5f3",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655226775409000.172453ca-0bde-4728-929f-772d432622a4"
+          "reference" : "Patient/1706818518006774000.e42f336a-e44f-4cc6-b808-6087ed7cf4d6"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_17_xtn12_has_value_xtn3_is_Internet.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_17_xtn12_has_value_xtn3_is_Internet.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655236058507000.e33971df-8fc3-43f6-ba16-481e4c620aa6",
+  "id" : "1706818527307247000.c5d98770-cd86-46ae-b63e-a9c33ebb9d52",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:53:56.068-05:00"
+    "lastUpdated" : "2024-02-01T15:15:27.314-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655236133159000.d5724b1a-7cef-4ac3-9d4b-de14c2df0185"
+          "reference" : "Organization/1706818527364608000.48cff549-f1bc-44f2-8ea5-a85ad68fa758"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655236133159000.d5724b1a-7cef-4ac3-9d4b-de14c2df0185",
+      "fullUrl" : "Organization/1706818527364608000.48cff549-f1bc-44f2-8ea5-a85ad68fa758",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655236133159000.d5724b1a-7cef-4ac3-9d4b-de14c2df0185",
+        "id" : "1706818527364608000.48cff549-f1bc-44f2-8ea5-a85ad68fa758",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655236445184000.9ba424a7-1867-455e-84c5-b8b40d68a155",
+      "fullUrl" : "Provenance/1706818527723890000.f1ca83a1-17b4-4a1b-a026-6994075c7f7a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655236445184000.9ba424a7-1867-455e-84c5-b8b40d68a155",
+        "id" : "1706818527723890000.f1ca83a1-17b4-4a1b-a026-6994075c7f7a",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655236454911000.f7409d89-aa18-4ea5-9e1f-e2ff7d5f66b0",
+      "fullUrl" : "Provenance/1706818527733338000.0253c630-2d8c-4d8a-ae7a-70e78b8d6bea",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655236454911000.f7409d89-aa18-4ea5-9e1f-e2ff7d5f66b0",
-        "recorded" : "2024-01-30T17:53:56Z",
+        "id" : "1706818527733338000.0253c630-2d8c-4d8a-ae7a-70e78b8d6bea",
+        "recorded" : "2024-02-01T15:15:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655236454134000.ead484ac-625a-4028-b8c9-655c57fc585e"
+              "reference" : "Organization/1706818527732160000.6a9aa77b-1f6f-41f1-a0d7-763f8c166901"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655236454134000.ead484ac-625a-4028-b8c9-655c57fc585e",
+      "fullUrl" : "Organization/1706818527732160000.6a9aa77b-1f6f-41f1-a0d7-763f8c166901",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655236454134000.ead484ac-625a-4028-b8c9-655c57fc585e",
+        "id" : "1706818527732160000.6a9aa77b-1f6f-41f1-a0d7-763f8c166901",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655236474676000.8722503e-25d6-4f51-ae46-d65fcf52bb48",
+      "fullUrl" : "Patient/1706818527749929000.73d43dec-94ed-4476-8eb9-e2cb19ea2068",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655236474676000.8722503e-25d6-4f51-ae46-d65fcf52bb48",
+        "id" : "1706818527749929000.73d43dec-94ed-4476-8eb9-e2cb19ea2068",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655236475446000.00ba0ca5-b8c8-4379-89c8-86c30ef42904",
+      "fullUrl" : "Provenance/1706818527750842000.d8e1cc08-b739-4185-a0e0-33d8b58ef0cd",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655236475446000.00ba0ca5-b8c8-4379-89c8-86c30ef42904",
+        "id" : "1706818527750842000.d8e1cc08-b739-4185-a0e0-33d8b58ef0cd",
         "target" : [
           {
-            "reference" : "Patient/1706655236474676000.8722503e-25d6-4f51-ae46-d65fcf52bb48"
+            "reference" : "Patient/1706818527749929000.73d43dec-94ed-4476-8eb9-e2cb19ea2068"
           }
         ],
-        "recorded" : "2024-01-30T17:53:56Z",
+        "recorded" : "2024-02-01T15:15:27Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655236477474000.477d02d1-de57-49cd-905a-1ea1e7ec3329",
+      "fullUrl" : "RelatedPerson/1706818527753399000.1bc44aa5-6c2c-40be-b4aa-da686e7fa610",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655236477474000.477d02d1-de57-49cd-905a-1ea1e7ec3329",
+        "id" : "1706818527753399000.1bc44aa5-6c2c-40be-b4aa-da686e7fa610",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655236474676000.8722503e-25d6-4f51-ae46-d65fcf52bb48"
+          "reference" : "Patient/1706818527749929000.73d43dec-94ed-4476-8eb9-e2cb19ea2068"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_17_xtn12_has_value_xtn3_is_PH.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_17_xtn12_has_value_xtn3_is_PH.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655245052059000.d9206464-d490-4544-9173-34b4d1bef395",
+  "id" : "1706818537070840000.4bed4f9f-5227-428a-99c5-323650140ad9",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:54:05.059-05:00"
+    "lastUpdated" : "2024-02-01T15:15:37.078-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655245126886000.90509296-d29b-4a9c-aa08-b71c0f76e5c9"
+          "reference" : "Organization/1706818537122645000.58221f6c-ae97-4e7e-91ec-0ee7a7ad5e9e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655245126886000.90509296-d29b-4a9c-aa08-b71c0f76e5c9",
+      "fullUrl" : "Organization/1706818537122645000.58221f6c-ae97-4e7e-91ec-0ee7a7ad5e9e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655245126886000.90509296-d29b-4a9c-aa08-b71c0f76e5c9",
+        "id" : "1706818537122645000.58221f6c-ae97-4e7e-91ec-0ee7a7ad5e9e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655245461201000.fb0c75c2-6412-4553-9413-088a0784b2e8",
+      "fullUrl" : "Provenance/1706818537483557000.f0715630-d030-4050-8040-dc2f4ff736ce",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655245461201000.fb0c75c2-6412-4553-9413-088a0784b2e8",
+        "id" : "1706818537483557000.f0715630-d030-4050-8040-dc2f4ff736ce",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655245470891000.005d2553-d0a3-4502-a6ec-4d22cfb1397f",
+      "fullUrl" : "Provenance/1706818537491199000.95e28fca-e2bb-42be-9616-e8ad9d049488",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655245470891000.005d2553-d0a3-4502-a6ec-4d22cfb1397f",
-        "recorded" : "2024-01-30T17:54:05Z",
+        "id" : "1706818537491199000.95e28fca-e2bb-42be-9616-e8ad9d049488",
+        "recorded" : "2024-02-01T15:15:37Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655245470210000.46ccbb16-ec07-485e-bef2-d8b4069f01bb"
+              "reference" : "Organization/1706818537490658000.25dcb848-face-4d67-afa8-dc860585c00c"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655245470210000.46ccbb16-ec07-485e-bef2-d8b4069f01bb",
+      "fullUrl" : "Organization/1706818537490658000.25dcb848-face-4d67-afa8-dc860585c00c",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655245470210000.46ccbb16-ec07-485e-bef2-d8b4069f01bb",
+        "id" : "1706818537490658000.25dcb848-face-4d67-afa8-dc860585c00c",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655245489272000.89f933a4-d9c5-411e-92cd-21a4eca75a87",
+      "fullUrl" : "Patient/1706818537510689000.acef70fd-31bd-41b8-b368-1dbd8f57b146",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655245489272000.89f933a4-d9c5-411e-92cd-21a4eca75a87",
+        "id" : "1706818537510689000.acef70fd-31bd-41b8-b368-1dbd8f57b146",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655245490220000.1dc3c3d7-4aab-4dbc-955e-382dc19ce311",
+      "fullUrl" : "Provenance/1706818537511968000.61b80892-c9a6-4ae9-b4b0-9c920b77ae31",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655245490220000.1dc3c3d7-4aab-4dbc-955e-382dc19ce311",
+        "id" : "1706818537511968000.61b80892-c9a6-4ae9-b4b0-9c920b77ae31",
         "target" : [
           {
-            "reference" : "Patient/1706655245489272000.89f933a4-d9c5-411e-92cd-21a4eca75a87"
+            "reference" : "Patient/1706818537510689000.acef70fd-31bd-41b8-b368-1dbd8f57b146"
           }
         ],
-        "recorded" : "2024-01-30T17:54:05Z",
+        "recorded" : "2024-02-01T15:15:37Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655245492345000.543913f2-d57e-4769-ad1c-06038c77a05b",
+      "fullUrl" : "RelatedPerson/1706818537514716000.3fe22317-6d79-433e-b95f-4175e48df6e7",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655245492345000.543913f2-d57e-4769-ad1c-06038c77a05b",
+        "id" : "1706818537514716000.3fe22317-6d79-433e-b95f-4175e48df6e7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655245489272000.89f933a4-d9c5-411e-92cd-21a4eca75a87"
+          "reference" : "Patient/1706818537510689000.acef70fd-31bd-41b8-b368-1dbd8f57b146"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_17_xtn12_has_value_xtn3_no_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_17_xtn12_has_value_xtn3_no_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655254223329000.bb891672-7503-4fa6-85c2-7a15f55c45ae",
+  "id" : "1706818546878694000.4b62164a-cac3-4a25-8de2-9de9c5249e16",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:54:14.230-05:00"
+    "lastUpdated" : "2024-02-01T15:15:46.885-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655254299810000.873116b4-a2ac-408f-9ef8-52b73a9608b8"
+          "reference" : "Organization/1706818546929995000.38b721a5-b4ad-45a9-b046-455035503389"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655254299810000.873116b4-a2ac-408f-9ef8-52b73a9608b8",
+      "fullUrl" : "Organization/1706818546929995000.38b721a5-b4ad-45a9-b046-455035503389",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655254299810000.873116b4-a2ac-408f-9ef8-52b73a9608b8",
+        "id" : "1706818546929995000.38b721a5-b4ad-45a9-b046-455035503389",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655254626870000.c40b6b4f-9137-4fec-8546-6d334e8ededb",
+      "fullUrl" : "Provenance/1706818547294073000.2cd9d4f1-2727-4ca4-980a-6349f83036c7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655254626870000.c40b6b4f-9137-4fec-8546-6d334e8ededb",
+        "id" : "1706818547294073000.2cd9d4f1-2727-4ca4-980a-6349f83036c7",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655254634870000.c248e9e4-c6fa-4927-a1da-2136e8457574",
+      "fullUrl" : "Provenance/1706818547302421000.0ab94fe0-86b9-495f-938b-674ed65d9a70",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655254634870000.c248e9e4-c6fa-4927-a1da-2136e8457574",
-        "recorded" : "2024-01-30T17:54:14Z",
+        "id" : "1706818547302421000.0ab94fe0-86b9-495f-938b-674ed65d9a70",
+        "recorded" : "2024-02-01T15:15:47Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655254634384000.9f5a2f03-f736-4691-adeb-af107c20eb36"
+              "reference" : "Organization/1706818547301931000.6e9afacf-5d58-452e-9b0e-f97509bd9b51"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655254634384000.9f5a2f03-f736-4691-adeb-af107c20eb36",
+      "fullUrl" : "Organization/1706818547301931000.6e9afacf-5d58-452e-9b0e-f97509bd9b51",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655254634384000.9f5a2f03-f736-4691-adeb-af107c20eb36",
+        "id" : "1706818547301931000.6e9afacf-5d58-452e-9b0e-f97509bd9b51",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655254651723000.8a002e72-2e9a-4ddb-bb7e-a733a369279a",
+      "fullUrl" : "Patient/1706818547321204000.2c7c7ba1-67e0-41bb-bda5-415704f997cb",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655254651723000.8a002e72-2e9a-4ddb-bb7e-a733a369279a",
+        "id" : "1706818547321204000.2c7c7ba1-67e0-41bb-bda5-415704f997cb",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655254652465000.d53933d9-cb17-4e24-aa0c-e7e70fa9576c",
+      "fullUrl" : "Provenance/1706818547322454000.53ff803e-4821-43c1-aec6-e36f300ab46b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655254652465000.d53933d9-cb17-4e24-aa0c-e7e70fa9576c",
+        "id" : "1706818547322454000.53ff803e-4821-43c1-aec6-e36f300ab46b",
         "target" : [
           {
-            "reference" : "Patient/1706655254651723000.8a002e72-2e9a-4ddb-bb7e-a733a369279a"
+            "reference" : "Patient/1706818547321204000.2c7c7ba1-67e0-41bb-bda5-415704f997cb"
           }
         ],
-        "recorded" : "2024-01-30T17:54:14Z",
+        "recorded" : "2024-02-01T15:15:47Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655254654491000.b970785b-6e5c-40d3-9080-ccce3be90b69",
+      "fullUrl" : "RelatedPerson/1706818547325030000.8446dbd7-f1ae-48af-b523-53e07b10a642",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655254654491000.b970785b-6e5c-40d3-9080-ccce3be90b69",
+        "id" : "1706818547325030000.8446dbd7-f1ae-48af-b523-53e07b10a642",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655254651723000.8a002e72-2e9a-4ddb-bb7e-a733a369279a"
+          "reference" : "Patient/1706818547321204000.2c7c7ba1-67e0-41bb-bda5-415704f997cb"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_18_xtn13_has_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_18_xtn13_has_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655263443503000.63b74cf9-0e2b-4a93-97f5-ca909c6621e1",
+  "id" : "1706818556673822000.16457239-d78b-48b2-9dd1-70923c0a9ba2",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:54:23.451-05:00"
+    "lastUpdated" : "2024-02-01T15:15:56.680-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655263525475000.4fb558de-b29f-4e61-9850-e2ef2e770e74"
+          "reference" : "Organization/1706818556725041000.ff6ebe1e-762c-46f0-9e41-d0e19d67a290"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655263525475000.4fb558de-b29f-4e61-9850-e2ef2e770e74",
+      "fullUrl" : "Organization/1706818556725041000.ff6ebe1e-762c-46f0-9e41-d0e19d67a290",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655263525475000.4fb558de-b29f-4e61-9850-e2ef2e770e74",
+        "id" : "1706818556725041000.ff6ebe1e-762c-46f0-9e41-d0e19d67a290",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655263861420000.bdc64d39-f453-40ef-909d-8a62a9145634",
+      "fullUrl" : "Provenance/1706818557114651000.50fd25e5-816a-4f83-b493-465911a80a22",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655263861420000.bdc64d39-f453-40ef-909d-8a62a9145634",
+        "id" : "1706818557114651000.50fd25e5-816a-4f83-b493-465911a80a22",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655263869841000.19f02adf-6da2-4e7a-903c-1055d2247906",
+      "fullUrl" : "Provenance/1706818557124032000.209f8408-1042-4eb7-8517-be8b56c85719",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655263869841000.19f02adf-6da2-4e7a-903c-1055d2247906",
-        "recorded" : "2024-01-30T17:54:23Z",
+        "id" : "1706818557124032000.209f8408-1042-4eb7-8517-be8b56c85719",
+        "recorded" : "2024-02-01T15:15:57Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655263869100000.2972c592-c212-4bce-89e4-6d407b931eaf"
+              "reference" : "Organization/1706818557123542000.53ec7b95-bc24-460b-a6df-05d0802787f3"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655263869100000.2972c592-c212-4bce-89e4-6d407b931eaf",
+      "fullUrl" : "Organization/1706818557123542000.53ec7b95-bc24-460b-a6df-05d0802787f3",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655263869100000.2972c592-c212-4bce-89e4-6d407b931eaf",
+        "id" : "1706818557123542000.53ec7b95-bc24-460b-a6df-05d0802787f3",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655263891054000.07d7c18d-f853-475a-b952-a8cd9bd4f902",
+      "fullUrl" : "Patient/1706818557144710000.fd964b13-3df2-4e1a-855b-1f22725b9b51",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655263891054000.07d7c18d-f853-475a-b952-a8cd9bd4f902",
+        "id" : "1706818557144710000.fd964b13-3df2-4e1a-855b-1f22725b9b51",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655263892205000.ab8e05b7-1c09-427a-8e79-6fc09124888e",
+      "fullUrl" : "Provenance/1706818557145594000.5e31a587-c4a4-4150-a538-78bd73dd929a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655263892205000.ab8e05b7-1c09-427a-8e79-6fc09124888e",
+        "id" : "1706818557145594000.5e31a587-c4a4-4150-a538-78bd73dd929a",
         "target" : [
           {
-            "reference" : "Patient/1706655263891054000.07d7c18d-f853-475a-b952-a8cd9bd4f902"
+            "reference" : "Patient/1706818557144710000.fd964b13-3df2-4e1a-855b-1f22725b9b51"
           }
         ],
-        "recorded" : "2024-01-30T17:54:23Z",
+        "recorded" : "2024-02-01T15:15:57Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655263894788000.1b2d7b93-8c6b-45ea-8e0f-1bf9025548d4",
+      "fullUrl" : "RelatedPerson/1706818557148279000.736b5b3b-33c9-46cb-b40f-959326c3d7b7",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655263894788000.1b2d7b93-8c6b-45ea-8e0f-1bf9025548d4",
+        "id" : "1706818557148279000.736b5b3b-33c9-46cb-b40f-959326c3d7b7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655263891054000.07d7c18d-f853-475a-b952-a8cd9bd4f902"
+          "reference" : "Patient/1706818557144710000.fd964b13-3df2-4e1a-855b-1f22725b9b51"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_19_xtn14_has_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_19_xtn14_has_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655272764003000.88ad7dc9-869b-4e38-8a84-1c89e52bbaed",
+  "id" : "1706818566544915000.2a74a147-474d-4202-9a18-3164bb65c73c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:54:32.771-05:00"
+    "lastUpdated" : "2024-02-01T15:16:06.552-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655272837198000.8d5847b6-5a9b-45f5-b504-484749813cb2"
+          "reference" : "Organization/1706818566595481000.049f0c49-93ab-472f-872a-97f786b203ed"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655272837198000.8d5847b6-5a9b-45f5-b504-484749813cb2",
+      "fullUrl" : "Organization/1706818566595481000.049f0c49-93ab-472f-872a-97f786b203ed",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655272837198000.8d5847b6-5a9b-45f5-b504-484749813cb2",
+        "id" : "1706818566595481000.049f0c49-93ab-472f-872a-97f786b203ed",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655273172399000.96666ad4-d70a-4fef-8e8c-5ea335ef8fc9",
+      "fullUrl" : "Provenance/1706818566958542000.4c1b389a-ad9c-422b-918e-b042da5a737e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655273172399000.96666ad4-d70a-4fef-8e8c-5ea335ef8fc9",
+        "id" : "1706818566958542000.4c1b389a-ad9c-422b-918e-b042da5a737e",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655273181298000.c07661d1-1a55-444d-8a5b-b25ed46c7eac",
+      "fullUrl" : "Provenance/1706818566966406000.4cc3172d-9372-4fe6-b865-cd534135cb41",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655273181298000.c07661d1-1a55-444d-8a5b-b25ed46c7eac",
-        "recorded" : "2024-01-30T17:54:33Z",
+        "id" : "1706818566966406000.4cc3172d-9372-4fe6-b865-cd534135cb41",
+        "recorded" : "2024-02-01T15:16:06Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655273180819000.4ff12a2d-f1c2-48bc-91d2-299e7580eaa2"
+              "reference" : "Organization/1706818566965952000.3cada911-3354-47b1-948b-706d036dca98"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655273180819000.4ff12a2d-f1c2-48bc-91d2-299e7580eaa2",
+      "fullUrl" : "Organization/1706818566965952000.3cada911-3354-47b1-948b-706d036dca98",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655273180819000.4ff12a2d-f1c2-48bc-91d2-299e7580eaa2",
+        "id" : "1706818566965952000.3cada911-3354-47b1-948b-706d036dca98",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655273197460000.ba3d2eab-d944-4f90-8ff0-b6ce0b5be179",
+      "fullUrl" : "Patient/1706818566983776000.48b90423-315c-420d-90fc-909f3b9bc3d0",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655273197460000.ba3d2eab-d944-4f90-8ff0-b6ce0b5be179",
+        "id" : "1706818566983776000.48b90423-315c-420d-90fc-909f3b9bc3d0",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655273198199000.961102c1-d5e5-4405-a0b2-34c1c7468eb8",
+      "fullUrl" : "Provenance/1706818566984718000.18b70ce7-84ef-4888-a2c9-39e74cfe9942",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655273198199000.961102c1-d5e5-4405-a0b2-34c1c7468eb8",
+        "id" : "1706818566984718000.18b70ce7-84ef-4888-a2c9-39e74cfe9942",
         "target" : [
           {
-            "reference" : "Patient/1706655273197460000.ba3d2eab-d944-4f90-8ff0-b6ce0b5be179"
+            "reference" : "Patient/1706818566983776000.48b90423-315c-420d-90fc-909f3b9bc3d0"
           }
         ],
-        "recorded" : "2024-01-30T17:54:33Z",
+        "recorded" : "2024-02-01T15:16:06Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655273200576000.0a4a4bcd-b88e-4f19-adee-f9f1e0d6083e",
+      "fullUrl" : "RelatedPerson/1706818566987260000.414a3584-99f8-43db-bb75-05d9656f17d4",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655273200576000.0a4a4bcd-b88e-4f19-adee-f9f1e0d6083e",
+        "id" : "1706818566987260000.414a3584-99f8-43db-bb75-05d9656f17d4",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655273197460000.ba3d2eab-d944-4f90-8ff0-b6ce0b5be179"
+          "reference" : "Patient/1706818566983776000.48b90423-315c-420d-90fc-909f3b9bc3d0"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_23_xtn18_has_negative_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_23_xtn18_has_negative_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655281960437000.b533e323-dc9d-4d50-bfdc-4aa82c482696",
+  "id" : "1706818576283899000.5b8e9fb8-a41e-4fa2-bc57-03e741fb60d2",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:54:41.966-05:00"
+    "lastUpdated" : "2024-02-01T15:16:16.290-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655282034639000.8c270228-e3e5-49ce-8ba2-7fa8f104c049"
+          "reference" : "Organization/1706818576338135000.5e0424ef-06d2-4e7d-80a8-0787d9a96213"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655282034639000.8c270228-e3e5-49ce-8ba2-7fa8f104c049",
+      "fullUrl" : "Organization/1706818576338135000.5e0424ef-06d2-4e7d-80a8-0787d9a96213",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655282034639000.8c270228-e3e5-49ce-8ba2-7fa8f104c049",
+        "id" : "1706818576338135000.5e0424ef-06d2-4e7d-80a8-0787d9a96213",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655282364183000.7733c1bf-97d7-41f0-b614-8f7420c52e5a",
+      "fullUrl" : "Provenance/1706818576710682000.71e89617-55d2-4324-88aa-e941d7154d7b",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655282364183000.7733c1bf-97d7-41f0-b614-8f7420c52e5a",
+        "id" : "1706818576710682000.71e89617-55d2-4324-88aa-e941d7154d7b",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655282371667000.2709ab53-3d7a-427d-b6e7-1a8408b5c5a4",
+      "fullUrl" : "Provenance/1706818576719433000.9b223da5-226e-40a2-893c-cb1175920797",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655282371667000.2709ab53-3d7a-427d-b6e7-1a8408b5c5a4",
-        "recorded" : "2024-01-30T17:54:42Z",
+        "id" : "1706818576719433000.9b223da5-226e-40a2-893c-cb1175920797",
+        "recorded" : "2024-02-01T15:16:16Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655282371148000.0c5fda90-55a0-4822-878f-be8d7c3511bf"
+              "reference" : "Organization/1706818576718931000.54ab2274-0a8f-48f9-8692-cc9771856260"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655282371148000.0c5fda90-55a0-4822-878f-be8d7c3511bf",
+      "fullUrl" : "Organization/1706818576718931000.54ab2274-0a8f-48f9-8692-cc9771856260",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655282371148000.0c5fda90-55a0-4822-878f-be8d7c3511bf",
+        "id" : "1706818576718931000.54ab2274-0a8f-48f9-8692-cc9771856260",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655282388091000.4c4ed210-23bc-4047-aada-2f5667fcb3ad",
+      "fullUrl" : "Patient/1706818576737843000.7e7d9598-6c0d-46f4-8e4f-2b11c914a5f0",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655282388091000.4c4ed210-23bc-4047-aada-2f5667fcb3ad",
+        "id" : "1706818576737843000.7e7d9598-6c0d-46f4-8e4f-2b11c914a5f0",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655282388985000.0ca7148a-05ae-499e-b652-3dadbf7f3262",
+      "fullUrl" : "Provenance/1706818576739154000.9efe24ca-60f4-4049-aa59-1668f90c151c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655282388985000.0ca7148a-05ae-499e-b652-3dadbf7f3262",
+        "id" : "1706818576739154000.9efe24ca-60f4-4049-aa59-1668f90c151c",
         "target" : [
           {
-            "reference" : "Patient/1706655282388091000.4c4ed210-23bc-4047-aada-2f5667fcb3ad"
+            "reference" : "Patient/1706818576737843000.7e7d9598-6c0d-46f4-8e4f-2b11c914a5f0"
           }
         ],
-        "recorded" : "2024-01-30T17:54:42Z",
+        "recorded" : "2024-02-01T15:16:16Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655282391236000.c62aa94f-2d94-4dcc-a258-5cbd5f213b96",
+      "fullUrl" : "RelatedPerson/1706818576741219000.e8ab0209-a89d-487e-823d-0745b4d2dc54",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655282391236000.c62aa94f-2d94-4dcc-a258-5cbd5f213b96",
+        "id" : "1706818576741219000.e8ab0209-a89d-487e-823d-0745b4d2dc54",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655282388091000.4c4ed210-23bc-4047-aada-2f5667fcb3ad"
+          "reference" : "Patient/1706818576737843000.7e7d9598-6c0d-46f4-8e4f-2b11c914a5f0"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_23_xtn18_has_positive_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_23_xtn18_has_positive_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655291165706000.7d8a54fe-4cf0-4036-8524-585d3edf8480",
+  "id" : "1706818586689291000.cb26c544-1d63-4346-9e70-98cd079a2364",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:54:51.173-05:00"
+    "lastUpdated" : "2024-02-01T15:16:26.696-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655291245098000.21a73762-ea91-4fca-b54a-2778bd848ed9"
+          "reference" : "Organization/1706818586743252000.657a632d-30e0-46cb-aeba-8731de0b9d26"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655291245098000.21a73762-ea91-4fca-b54a-2778bd848ed9",
+      "fullUrl" : "Organization/1706818586743252000.657a632d-30e0-46cb-aeba-8731de0b9d26",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655291245098000.21a73762-ea91-4fca-b54a-2778bd848ed9",
+        "id" : "1706818586743252000.657a632d-30e0-46cb-aeba-8731de0b9d26",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655291578478000.430e1d82-61d7-48ba-bf77-93ab3c7f6e0d",
+      "fullUrl" : "Provenance/1706818587105025000.347a2f9d-7d0b-4a1c-84d6-0e990865dc35",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655291578478000.430e1d82-61d7-48ba-bf77-93ab3c7f6e0d",
+        "id" : "1706818587105025000.347a2f9d-7d0b-4a1c-84d6-0e990865dc35",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655291585473000.f7bd3c0d-2ca3-413d-96c8-059f1bf36151",
+      "fullUrl" : "Provenance/1706818587113998000.c8b071b8-79f7-49fd-9ff7-cb6a2bb6a01e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655291585473000.f7bd3c0d-2ca3-413d-96c8-059f1bf36151",
-        "recorded" : "2024-01-30T17:54:51Z",
+        "id" : "1706818587113998000.c8b071b8-79f7-49fd-9ff7-cb6a2bb6a01e",
+        "recorded" : "2024-02-01T15:16:27Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655291585069000.d9b79e9d-3cb0-4575-b43f-7517e2ced00b"
+              "reference" : "Organization/1706818587113565000.6c88162d-b94d-46b9-bd38-0d5ab31647e2"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655291585069000.d9b79e9d-3cb0-4575-b43f-7517e2ced00b",
+      "fullUrl" : "Organization/1706818587113565000.6c88162d-b94d-46b9-bd38-0d5ab31647e2",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655291585069000.d9b79e9d-3cb0-4575-b43f-7517e2ced00b",
+        "id" : "1706818587113565000.6c88162d-b94d-46b9-bd38-0d5ab31647e2",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655291601159000.0f5c88c5-d2bd-481c-af90-6f8d3eca1d6c",
+      "fullUrl" : "Patient/1706818587135893000.03e692bc-9ffb-4c64-a074-5c63fa89b082",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655291601159000.0f5c88c5-d2bd-481c-af90-6f8d3eca1d6c",
+        "id" : "1706818587135893000.03e692bc-9ffb-4c64-a074-5c63fa89b082",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655291602010000.914d2e9b-474f-4fb7-bc56-e37dc4d05851",
+      "fullUrl" : "Provenance/1706818587136780000.003922e5-3cdb-4584-98be-909c487b8d83",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655291602010000.914d2e9b-474f-4fb7-bc56-e37dc4d05851",
+        "id" : "1706818587136780000.003922e5-3cdb-4584-98be-909c487b8d83",
         "target" : [
           {
-            "reference" : "Patient/1706655291601159000.0f5c88c5-d2bd-481c-af90-6f8d3eca1d6c"
+            "reference" : "Patient/1706818587135893000.03e692bc-9ffb-4c64-a074-5c63fa89b082"
           }
         ],
-        "recorded" : "2024-01-30T17:54:51Z",
+        "recorded" : "2024-02-01T15:16:27Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655291604085000.68e9b9e7-141c-4f45-ba65-daa4dacebbf8",
+      "fullUrl" : "RelatedPerson/1706818587139044000.7c0e14c1-e50d-44d7-b2d3-b5c591df0e05",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655291604085000.68e9b9e7-141c-4f45-ba65-daa4dacebbf8",
+        "id" : "1706818587139044000.7c0e14c1-e50d-44d7-b2d3-b5c591df0e05",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655291601159000.0f5c88c5-d2bd-481c-af90-6f8d3eca1d6c"
+          "reference" : "Patient/1706818587135893000.03e692bc-9ffb-4c64-a074-5c63fa89b082"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_5_test_value_in_xtn3_no_value_in_xtn7_xtn12.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_5_test_value_in_xtn3_no_value_in_xtn7_xtn12.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655300641762000.4e4c8c05-2249-4d50-9fff-425c9f377569",
+  "id" : "1706818596300240000.25fee5ce-5369-4edb-bf24-5b60a848386e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:00.648-05:00"
+    "lastUpdated" : "2024-02-01T15:16:36.306-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655300712309000.d1322c94-3e24-4b94-b18d-f5f770a906ff"
+          "reference" : "Organization/1706818596353733000.b5fe1b0d-950f-47dd-86cf-502862cdb99a"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655300712309000.d1322c94-3e24-4b94-b18d-f5f770a906ff",
+      "fullUrl" : "Organization/1706818596353733000.b5fe1b0d-950f-47dd-86cf-502862cdb99a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655300712309000.d1322c94-3e24-4b94-b18d-f5f770a906ff",
+        "id" : "1706818596353733000.b5fe1b0d-950f-47dd-86cf-502862cdb99a",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655301049631000.1d45a911-0656-4e5b-8f80-c3330a12d4be",
+      "fullUrl" : "Provenance/1706818596728980000.d4154cab-6ae8-4662-97ec-0501567f23c6",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655301049631000.1d45a911-0656-4e5b-8f80-c3330a12d4be",
+        "id" : "1706818596728980000.d4154cab-6ae8-4662-97ec-0501567f23c6",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655301057965000.de9a9692-b7a7-4906-b778-c3c8420111d4",
+      "fullUrl" : "Provenance/1706818596736286000.596619d3-8520-47a0-aeb3-98c351e9809e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655301057965000.de9a9692-b7a7-4906-b778-c3c8420111d4",
-        "recorded" : "2024-01-30T17:55:01Z",
+        "id" : "1706818596736286000.596619d3-8520-47a0-aeb3-98c351e9809e",
+        "recorded" : "2024-02-01T15:16:36Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655301056926000.d9793172-9072-4fa1-b331-3f8589c918e3"
+              "reference" : "Organization/1706818596735815000.af8548f7-a333-4a20-9d5e-aa31123700aa"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655301056926000.d9793172-9072-4fa1-b331-3f8589c918e3",
+      "fullUrl" : "Organization/1706818596735815000.af8548f7-a333-4a20-9d5e-aa31123700aa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655301056926000.d9793172-9072-4fa1-b331-3f8589c918e3",
+        "id" : "1706818596735815000.af8548f7-a333-4a20-9d5e-aa31123700aa",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655301076157000.5e9331e5-df6d-4f01-8364-609d041d6304",
+      "fullUrl" : "Patient/1706818596757026000.9ca171b0-a99c-4744-a679-47ecf24d6a03",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655301076157000.5e9331e5-df6d-4f01-8364-609d041d6304",
+        "id" : "1706818596757026000.9ca171b0-a99c-4744-a679-47ecf24d6a03",
         "contact" : [
           {
             "name" : {},
@@ -171,16 +176,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655301077008000.8a57e723-2b67-4810-a3da-41bdede38e71",
+      "fullUrl" : "Provenance/1706818596757955000.f0518f96-9562-4890-a9be-c8b677fba5ef",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655301077008000.8a57e723-2b67-4810-a3da-41bdede38e71",
+        "id" : "1706818596757955000.f0518f96-9562-4890-a9be-c8b677fba5ef",
         "target" : [
           {
-            "reference" : "Patient/1706655301076157000.5e9331e5-df6d-4f01-8364-609d041d6304"
+            "reference" : "Patient/1706818596757026000.9ca171b0-a99c-4744-a679-47ecf24d6a03"
           }
         ],
-        "recorded" : "2024-01-30T17:55:01Z",
+        "recorded" : "2024-02-01T15:16:36Z",
         "activity" : {
           "coding" : [
             {
@@ -192,10 +197,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655301078791000.ba076e3d-de64-423e-8fc3-e5bf7a1b54e5",
+      "fullUrl" : "RelatedPerson/1706818596764211000.136c091a-c9f3-4f09-a3ca-81055431a217",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655301078791000.ba076e3d-de64-423e-8fc3-e5bf7a1b54e5",
+        "id" : "1706818596764211000.136c091a-c9f3-4f09-a3ca-81055431a217",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -203,7 +208,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655301076157000.5e9331e5-df6d-4f01-8364-609d041d6304"
+          "reference" : "Patient/1706818596757026000.9ca171b0-a99c-4744-a679-47ecf24d6a03"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_no_value_in_xtn3_xtn7_xtn12.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_no_value_in_xtn3_xtn7_xtn12.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655309922432000.9375c296-d1f8-4f20-a3c3-77e26233bc92",
+  "id" : "1706818605889182000.04a8da13-4ed0-4865-b846-2047ac472767",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:09.929-05:00"
+    "lastUpdated" : "2024-02-01T15:16:45.896-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655309993243000.0cb7b629-e449-48fc-b64f-8d16ea58ba71"
+          "reference" : "Organization/1706818605945117000.48c5aeae-095f-40a1-bd67-ad738e86de4e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655309993243000.0cb7b629-e449-48fc-b64f-8d16ea58ba71",
+      "fullUrl" : "Organization/1706818605945117000.48c5aeae-095f-40a1-bd67-ad738e86de4e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655309993243000.0cb7b629-e449-48fc-b64f-8d16ea58ba71",
+        "id" : "1706818605945117000.48c5aeae-095f-40a1-bd67-ad738e86de4e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655310334278000.575693d7-1cb2-4874-99ee-9de17b580a0e",
+      "fullUrl" : "Provenance/1706818606304247000.918a7b55-9c3d-4101-8437-0f7226c689c3",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655310334278000.575693d7-1cb2-4874-99ee-9de17b580a0e",
+        "id" : "1706818606304247000.918a7b55-9c3d-4101-8437-0f7226c689c3",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655310346930000.32e4068a-be6c-4044-8258-cfa1e3294650",
+      "fullUrl" : "Provenance/1706818606312221000.90d36d2f-4691-4313-a2db-e4f46b80535a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655310346930000.32e4068a-be6c-4044-8258-cfa1e3294650",
-        "recorded" : "2024-01-30T17:55:10Z",
+        "id" : "1706818606312221000.90d36d2f-4691-4313-a2db-e4f46b80535a",
+        "recorded" : "2024-02-01T15:16:46Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655310346240000.d0aea41d-9f5a-473c-9857-fa17e5ed142b"
+              "reference" : "Organization/1706818606311680000.89218c73-fd9e-43c0-823d-e67cc1a52a5d"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655310346240000.d0aea41d-9f5a-473c-9857-fa17e5ed142b",
+      "fullUrl" : "Organization/1706818606311680000.89218c73-fd9e-43c0-823d-e67cc1a52a5d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655310346240000.d0aea41d-9f5a-473c-9857-fa17e5ed142b",
+        "id" : "1706818606311680000.89218c73-fd9e-43c0-823d-e67cc1a52a5d",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655310364686000.37aec489-9fb6-4695-a35a-0bf12e90f7cc",
+      "fullUrl" : "Patient/1706818606330469000.f5959d7c-dbce-42c0-b118-446a3c0f3bda",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655310364686000.37aec489-9fb6-4695-a35a-0bf12e90f7cc",
+        "id" : "1706818606330469000.f5959d7c-dbce-42c0-b118-446a3c0f3bda",
         "contact" : [
           {
             "name" : {},
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655310366035000.ddf46024-6071-4fb0-aeca-98536bf06267",
+      "fullUrl" : "Provenance/1706818606331659000.60b24f8b-aed9-4509-8d62-e856a9cef1ab",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655310366035000.ddf46024-6071-4fb0-aeca-98536bf06267",
+        "id" : "1706818606331659000.60b24f8b-aed9-4509-8d62-e856a9cef1ab",
         "target" : [
           {
-            "reference" : "Patient/1706655310364686000.37aec489-9fb6-4695-a35a-0bf12e90f7cc"
+            "reference" : "Patient/1706818606330469000.f5959d7c-dbce-42c0-b118-446a3c0f3bda"
           }
         ],
-        "recorded" : "2024-01-30T17:55:10Z",
+        "recorded" : "2024-02-01T15:16:46Z",
         "activity" : {
           "coding" : [
             {
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655310372475000.8f99db27-13ff-4db6-a508-5b6c43118171",
+      "fullUrl" : "RelatedPerson/1706818606333826000.cef1e88b-6501-42b5-9f40-587f968afe89",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655310372475000.8f99db27-13ff-4db6-a508-5b6c43118171",
+        "id" : "1706818606333826000.cef1e88b-6501-42b5-9f40-587f968afe89",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -207,7 +212,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655310364686000.37aec489-9fb6-4695-a35a-0bf12e90f7cc"
+          "reference" : "Patient/1706818606330469000.f5959d7c-dbce-42c0-b118-446a3c0f3bda"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_test_value_in_xtn3_xtn12_no_value_in_xtn7.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_test_value_in_xtn3_xtn12_no_value_in_xtn7.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655319156475000.ce7f1b9a-a4aa-4469-b04a-9425e0502607",
+  "id" : "1706818615472678000.45b5aa49-c414-4915-92b9-063837d4d93c",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:19.163-05:00"
+    "lastUpdated" : "2024-02-01T15:16:55.480-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655319233388000.0d844520-3570-4dfb-9928-b90379359176"
+          "reference" : "Organization/1706818615525491000.06b96896-71c2-4ad0-b830-794283edaacb"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655319233388000.0d844520-3570-4dfb-9928-b90379359176",
+      "fullUrl" : "Organization/1706818615525491000.06b96896-71c2-4ad0-b830-794283edaacb",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655319233388000.0d844520-3570-4dfb-9928-b90379359176",
+        "id" : "1706818615525491000.06b96896-71c2-4ad0-b830-794283edaacb",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655319546960000.01d5d6df-ca39-4d4a-9f2c-1641c90f7687",
+      "fullUrl" : "Provenance/1706818615891767000.f5308365-1c31-41b0-be29-0606df0c51de",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655319546960000.01d5d6df-ca39-4d4a-9f2c-1641c90f7687",
+        "id" : "1706818615891767000.f5308365-1c31-41b0-be29-0606df0c51de",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655319556396000.bd138d82-a463-4e59-91b3-b8f662263b21",
+      "fullUrl" : "Provenance/1706818615900035000.087f1591-8d74-4d4d-8dd5-9b5df74bdc13",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655319556396000.bd138d82-a463-4e59-91b3-b8f662263b21",
-        "recorded" : "2024-01-30T17:55:19Z",
+        "id" : "1706818615900035000.087f1591-8d74-4d4d-8dd5-9b5df74bdc13",
+        "recorded" : "2024-02-01T15:16:55Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655319555986000.ec2b2ef3-0cf7-4346-bf87-ce759c12225f"
+              "reference" : "Organization/1706818615899524000.5c26d015-ff37-400e-8a91-34380d4f5c95"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655319555986000.ec2b2ef3-0cf7-4346-bf87-ce759c12225f",
+      "fullUrl" : "Organization/1706818615899524000.5c26d015-ff37-400e-8a91-34380d4f5c95",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655319555986000.ec2b2ef3-0cf7-4346-bf87-ce759c12225f",
+        "id" : "1706818615899524000.5c26d015-ff37-400e-8a91-34380d4f5c95",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655319572468000.671b2edf-28a8-4c30-92bc-cffb1e690f54",
+      "fullUrl" : "Patient/1706818615920411000.f462592d-025c-4061-b969-ce882b2e109d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655319572468000.671b2edf-28a8-4c30-92bc-cffb1e690f54",
+        "id" : "1706818615920411000.f462592d-025c-4061-b969-ce882b2e109d",
         "contact" : [
           {
             "name" : {},
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655319573255000.7c8ace9e-b143-4d22-80c7-6e4430f865c1",
+      "fullUrl" : "Provenance/1706818615922030000.13786661-0efd-4e80-95a2-21541fde4f7a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655319573255000.7c8ace9e-b143-4d22-80c7-6e4430f865c1",
+        "id" : "1706818615922030000.13786661-0efd-4e80-95a2-21541fde4f7a",
         "target" : [
           {
-            "reference" : "Patient/1706655319572468000.671b2edf-28a8-4c30-92bc-cffb1e690f54"
+            "reference" : "Patient/1706818615920411000.f462592d-025c-4061-b969-ce882b2e109d"
           }
         ],
-        "recorded" : "2024-01-30T17:55:19Z",
+        "recorded" : "2024-02-01T15:16:55Z",
         "activity" : {
           "coding" : [
             {
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655319576005000.1d109484-0ae8-4945-8d63-bd315af201cb",
+      "fullUrl" : "RelatedPerson/1706818615924641000.3d69be62-a58b-41ee-816d-ec4857e944be",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655319576005000.1d109484-0ae8-4945-8d63-bd315af201cb",
+        "id" : "1706818615924641000.3d69be62-a58b-41ee-816d-ec4857e944be",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -207,7 +212,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655319572468000.671b2edf-28a8-4c30-92bc-cffb1e690f54"
+          "reference" : "Patient/1706818615920411000.f462592d-025c-4061-b969-ce882b2e109d"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_test_value_in_xtn3_xtn7_no_value_in_xtn12.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_3_test_value_in_xtn3_xtn7_no_value_in_xtn12.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655328367540000.bdd30147-5003-4b87-9d73-45ffec031c4f",
+  "id" : "1706818625007109000.8b991c83-107f-42bc-a8c3-128117af9e4f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:28.375-05:00"
+    "lastUpdated" : "2024-02-01T15:17:05.014-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655328443674000.a1befa6c-25df-48ea-93be-b9a97a33394d"
+          "reference" : "Organization/1706818625063548000.ee104ed3-5c9b-437a-a37c-8e14bb896212"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655328443674000.a1befa6c-25df-48ea-93be-b9a97a33394d",
+      "fullUrl" : "Organization/1706818625063548000.ee104ed3-5c9b-437a-a37c-8e14bb896212",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655328443674000.a1befa6c-25df-48ea-93be-b9a97a33394d",
+        "id" : "1706818625063548000.ee104ed3-5c9b-437a-a37c-8e14bb896212",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655328774923000.6b550541-0687-4ade-9dda-b92205849e57",
+      "fullUrl" : "Provenance/1706818625432898000.fa6aeaa0-c360-4597-9328-d135c2545497",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655328774923000.6b550541-0687-4ade-9dda-b92205849e57",
+        "id" : "1706818625432898000.fa6aeaa0-c360-4597-9328-d135c2545497",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655328783063000.54d1ee68-dfc7-4920-8f8a-709743c79d5c",
+      "fullUrl" : "Provenance/1706818625440454000.cd4a71b9-2c80-471b-87c5-1bd968786405",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655328783063000.54d1ee68-dfc7-4920-8f8a-709743c79d5c",
-        "recorded" : "2024-01-30T17:55:28Z",
+        "id" : "1706818625440454000.cd4a71b9-2c80-471b-87c5-1bd968786405",
+        "recorded" : "2024-02-01T15:17:05Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655328782640000.8532c01a-19fb-414e-9f83-b7e8d14a01bb"
+              "reference" : "Organization/1706818625439978000.512e274c-254f-4bdb-a62b-e08a6fba49ea"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655328782640000.8532c01a-19fb-414e-9f83-b7e8d14a01bb",
+      "fullUrl" : "Organization/1706818625439978000.512e274c-254f-4bdb-a62b-e08a6fba49ea",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655328782640000.8532c01a-19fb-414e-9f83-b7e8d14a01bb",
+        "id" : "1706818625439978000.512e274c-254f-4bdb-a62b-e08a6fba49ea",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655328800963000.bbe4f0e6-f45b-48a6-8e14-c36230a5a44b",
+      "fullUrl" : "Patient/1706818625458222000.95ebedd2-06e2-4257-9d2b-0641d81fa1a9",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655328800963000.bbe4f0e6-f45b-48a6-8e14-c36230a5a44b",
+        "id" : "1706818625458222000.95ebedd2-06e2-4257-9d2b-0641d81fa1a9",
         "contact" : [
           {
             "name" : {},
@@ -178,16 +183,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655328801888000.f042d042-d628-4d96-8eb4-48e020720ed0",
+      "fullUrl" : "Provenance/1706818625459288000.e37c7b2a-8613-48a4-8ea4-0a222d92724e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655328801888000.f042d042-d628-4d96-8eb4-48e020720ed0",
+        "id" : "1706818625459288000.e37c7b2a-8613-48a4-8ea4-0a222d92724e",
         "target" : [
           {
-            "reference" : "Patient/1706655328800963000.bbe4f0e6-f45b-48a6-8e14-c36230a5a44b"
+            "reference" : "Patient/1706818625458222000.95ebedd2-06e2-4257-9d2b-0641d81fa1a9"
           }
         ],
-        "recorded" : "2024-01-30T17:55:28Z",
+        "recorded" : "2024-02-01T15:17:05Z",
         "activity" : {
           "coding" : [
             {
@@ -199,10 +204,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655328804741000.42e11d28-f456-4218-b49f-1c060a55ef9f",
+      "fullUrl" : "RelatedPerson/1706818625461654000.4b735795-7825-47c0-af06-ea5e66372ca8",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655328804741000.42e11d28-f456-4218-b49f-1c060a55ef9f",
+        "id" : "1706818625461654000.4b735795-7825-47c0-af06-ea5e66372ca8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -210,7 +215,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655328800963000.bbe4f0e6-f45b-48a6-8e14-c36230a5a44b"
+          "reference" : "Patient/1706818625458222000.95ebedd2-06e2-4257-9d2b-0641d81fa1a9"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_ORN_in_xtn2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_ORN_in_xtn2.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655337414155000.3f31fe9c-fad5-45be-b179-d38ba4219fab",
+  "id" : "1706818634553807000.eeff2536-3fe5-44b8-be90-cf1d161ecfea",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:37.421-05:00"
+    "lastUpdated" : "2024-02-01T15:17:14.561-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655337488353000.ddb99293-9daa-4c19-a6e0-5cdab6ce1804"
+          "reference" : "Organization/1706818634608173000.8575450e-f891-433e-ba60-b5d1f4e07baa"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655337488353000.ddb99293-9daa-4c19-a6e0-5cdab6ce1804",
+      "fullUrl" : "Organization/1706818634608173000.8575450e-f891-433e-ba60-b5d1f4e07baa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655337488353000.ddb99293-9daa-4c19-a6e0-5cdab6ce1804",
+        "id" : "1706818634608173000.8575450e-f891-433e-ba60-b5d1f4e07baa",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655337803017000.9950fa0c-8f8c-41b6-897e-3944c5c1cdc3",
+      "fullUrl" : "Provenance/1706818634953293000.bdd6b43c-69f2-4e8a-9801-493fa6a70b17",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655337803017000.9950fa0c-8f8c-41b6-897e-3944c5c1cdc3",
+        "id" : "1706818634953293000.bdd6b43c-69f2-4e8a-9801-493fa6a70b17",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655337811210000.2b596bfc-11f3-4c92-adea-a2365aa84b18",
+      "fullUrl" : "Provenance/1706818634960632000.5a87dc41-7ad1-49b4-866d-79b520f625fc",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655337811210000.2b596bfc-11f3-4c92-adea-a2365aa84b18",
-        "recorded" : "2024-01-30T17:55:37Z",
+        "id" : "1706818634960632000.5a87dc41-7ad1-49b4-866d-79b520f625fc",
+        "recorded" : "2024-02-01T15:17:14Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655337810570000.2536239f-6d61-4342-ac70-4c4cdab95d8c"
+              "reference" : "Organization/1706818634960175000.880b1daf-88aa-438a-a26f-9a6c0364a8b5"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655337810570000.2536239f-6d61-4342-ac70-4c4cdab95d8c",
+      "fullUrl" : "Organization/1706818634960175000.880b1daf-88aa-438a-a26f-9a6c0364a8b5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655337810570000.2536239f-6d61-4342-ac70-4c4cdab95d8c",
+        "id" : "1706818634960175000.880b1daf-88aa-438a-a26f-9a6c0364a8b5",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655337827635000.b6824ceb-838e-4035-a01d-fa3b7b4dc1f9",
+      "fullUrl" : "Patient/1706818634979724000.982cbe38-368a-4f55-9f04-fcfdfecda60d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655337827635000.b6824ceb-838e-4035-a01d-fa3b7b4dc1f9",
+        "id" : "1706818634979724000.982cbe38-368a-4f55-9f04-fcfdfecda60d",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655337828477000.1637f702-6409-4112-9d6e-95ffab3975aa",
+      "fullUrl" : "Provenance/1706818634980571000.4a782151-adf6-4c96-aff7-98ad6e617231",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655337828477000.1637f702-6409-4112-9d6e-95ffab3975aa",
+        "id" : "1706818634980571000.4a782151-adf6-4c96-aff7-98ad6e617231",
         "target" : [
           {
-            "reference" : "Patient/1706655337827635000.b6824ceb-838e-4035-a01d-fa3b7b4dc1f9"
+            "reference" : "Patient/1706818634979724000.982cbe38-368a-4f55-9f04-fcfdfecda60d"
           }
         ],
-        "recorded" : "2024-01-30T17:55:37Z",
+        "recorded" : "2024-02-01T15:17:14Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655337830490000.4e6ac369-1f4a-4f88-9b83-06a455a8b6e6",
+      "fullUrl" : "RelatedPerson/1706818634983242000.37423e9c-9fff-4599-8c18-74763260e3a4",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655337830490000.4e6ac369-1f4a-4f88-9b83-06a455a8b6e6",
+        "id" : "1706818634983242000.37423e9c-9fff-4599-8c18-74763260e3a4",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655337827635000.b6824ceb-838e-4035-a01d-fa3b7b4dc1f9"
+          "reference" : "Patient/1706818634979724000.982cbe38-368a-4f55-9f04-fcfdfecda60d"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_PRN_in_xtn2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_PRN_in_xtn2.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655346596027000.bc16eba5-b80a-401f-8264-c0628b7fe267",
+  "id" : "1706818644197570000.64960007-355e-404c-8680-185b7669423e",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:46.602-05:00"
+    "lastUpdated" : "2024-02-01T15:17:24.204-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655346668559000.dfca2f39-d37f-4723-846a-663b35fc099d"
+          "reference" : "Organization/1706818644249944000.b95270e3-fc1c-4b3c-9bb4-91159ce18b2e"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655346668559000.dfca2f39-d37f-4723-846a-663b35fc099d",
+      "fullUrl" : "Organization/1706818644249944000.b95270e3-fc1c-4b3c-9bb4-91159ce18b2e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655346668559000.dfca2f39-d37f-4723-846a-663b35fc099d",
+        "id" : "1706818644249944000.b95270e3-fc1c-4b3c-9bb4-91159ce18b2e",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655346988466000.38cacd32-8b3e-4fde-98dc-ed2817d37c9c",
+      "fullUrl" : "Provenance/1706818644615071000.6ae3c878-4d94-4d10-8cf1-215295299184",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655346988466000.38cacd32-8b3e-4fde-98dc-ed2817d37c9c",
+        "id" : "1706818644615071000.6ae3c878-4d94-4d10-8cf1-215295299184",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655346996163000.b295e7a5-40de-4249-a474-626debc96ef6",
+      "fullUrl" : "Provenance/1706818644622935000.cb632977-5278-4c59-af40-2ec4b16d21a4",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655346996163000.b295e7a5-40de-4249-a474-626debc96ef6",
-        "recorded" : "2024-01-30T17:55:46Z",
+        "id" : "1706818644622935000.cb632977-5278-4c59-af40-2ec4b16d21a4",
+        "recorded" : "2024-02-01T15:17:24Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655346995549000.c26cd243-49d3-4569-a20b-09c147ce4655"
+              "reference" : "Organization/1706818644622426000.4fcedfba-d01b-4cdf-a309-2bc68f7fc9f9"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655346995549000.c26cd243-49d3-4569-a20b-09c147ce4655",
+      "fullUrl" : "Organization/1706818644622426000.4fcedfba-d01b-4cdf-a309-2bc68f7fc9f9",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655346995549000.c26cd243-49d3-4569-a20b-09c147ce4655",
+        "id" : "1706818644622426000.4fcedfba-d01b-4cdf-a309-2bc68f7fc9f9",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655347015375000.d969f47f-99f6-4623-b0fc-4f228b184360",
+      "fullUrl" : "Patient/1706818644640373000.32392c84-1730-4b6b-8a7c-0eb9f32c9d19",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655347015375000.d969f47f-99f6-4623-b0fc-4f228b184360",
+        "id" : "1706818644640373000.32392c84-1730-4b6b-8a7c-0eb9f32c9d19",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655347016190000.888e19c8-587a-4643-8a1d-5ff1e6adeb7c",
+      "fullUrl" : "Provenance/1706818644641131000.2eaa20f0-21f2-4ff0-9243-67ded5129412",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655347016190000.888e19c8-587a-4643-8a1d-5ff1e6adeb7c",
+        "id" : "1706818644641131000.2eaa20f0-21f2-4ff0-9243-67ded5129412",
         "target" : [
           {
-            "reference" : "Patient/1706655347015375000.d969f47f-99f6-4623-b0fc-4f228b184360"
+            "reference" : "Patient/1706818644640373000.32392c84-1730-4b6b-8a7c-0eb9f32c9d19"
           }
         ],
-        "recorded" : "2024-01-30T17:55:47Z",
+        "recorded" : "2024-02-01T15:17:24Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655347018590000.ad077a95-5879-463e-a61b-516613892d92",
+      "fullUrl" : "RelatedPerson/1706818644643874000.9a208261-4f6b-415d-b527-e85b7c791e7b",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655347018590000.ad077a95-5879-463e-a61b-516613892d92",
+        "id" : "1706818644643874000.9a208261-4f6b-415d-b527-e85b7c791e7b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655347015375000.d969f47f-99f6-4623-b0fc-4f228b184360"
+          "reference" : "Patient/1706818644640373000.32392c84-1730-4b6b-8a7c-0eb9f32c9d19"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_PRS_in_xtn2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_PRS_in_xtn2.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655355825385000.e1174727-8b2f-4c09-af72-5ebe7c53265f",
+  "id" : "1706818653720166000.a1338025-12f3-4498-9598-c569fc4565ea",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:55:55.832-05:00"
+    "lastUpdated" : "2024-02-01T15:17:33.727-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655355898769000.8f0de432-89de-40ad-82d0-895ed1e67e63"
+          "reference" : "Organization/1706818653772674000.7c440992-b393-4912-946a-8716cee20b64"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655355898769000.8f0de432-89de-40ad-82d0-895ed1e67e63",
+      "fullUrl" : "Organization/1706818653772674000.7c440992-b393-4912-946a-8716cee20b64",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655355898769000.8f0de432-89de-40ad-82d0-895ed1e67e63",
+        "id" : "1706818653772674000.7c440992-b393-4912-946a-8716cee20b64",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655356219895000.28ae9bf1-27e1-4c2d-bf3b-f948cf4e09f3",
+      "fullUrl" : "Provenance/1706818654140677000.6bdeffd0-35ac-4b10-ba0a-9055b6d007d5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655356219895000.28ae9bf1-27e1-4c2d-bf3b-f948cf4e09f3",
+        "id" : "1706818654140677000.6bdeffd0-35ac-4b10-ba0a-9055b6d007d5",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655356228524000.f16ecc95-b4a0-4b01-847b-6f94017a43f7",
+      "fullUrl" : "Provenance/1706818654148923000.df780fff-5edf-4a7d-b814-749eef10aa5e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655356228524000.f16ecc95-b4a0-4b01-847b-6f94017a43f7",
-        "recorded" : "2024-01-30T17:55:56Z",
+        "id" : "1706818654148923000.df780fff-5edf-4a7d-b814-749eef10aa5e",
+        "recorded" : "2024-02-01T15:17:34Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655356227963000.b4703275-08c9-4200-8d29-fd7658b3f06c"
+              "reference" : "Organization/1706818654148462000.5cdd14dd-40a6-47ad-bfea-e10205c5f0c8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655356227963000.b4703275-08c9-4200-8d29-fd7658b3f06c",
+      "fullUrl" : "Organization/1706818654148462000.5cdd14dd-40a6-47ad-bfea-e10205c5f0c8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655356227963000.b4703275-08c9-4200-8d29-fd7658b3f06c",
+        "id" : "1706818654148462000.5cdd14dd-40a6-47ad-bfea-e10205c5f0c8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655356245762000.2bf577df-91c5-46a6-83f5-93ddaf90d05f",
+      "fullUrl" : "Patient/1706818654167633000.68724098-a7e2-4635-b9c2-f3ffc57ac826",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655356245762000.2bf577df-91c5-46a6-83f5-93ddaf90d05f",
+        "id" : "1706818654167633000.68724098-a7e2-4635-b9c2-f3ffc57ac826",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655356246640000.eb85aa57-c4d1-4fec-b167-a7836d26db80",
+      "fullUrl" : "Provenance/1706818654168458000.4f2f0b33-534f-4868-a901-094bc97cc57a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655356246640000.eb85aa57-c4d1-4fec-b167-a7836d26db80",
+        "id" : "1706818654168458000.4f2f0b33-534f-4868-a901-094bc97cc57a",
         "target" : [
           {
-            "reference" : "Patient/1706655356245762000.2bf577df-91c5-46a6-83f5-93ddaf90d05f"
+            "reference" : "Patient/1706818654167633000.68724098-a7e2-4635-b9c2-f3ffc57ac826"
           }
         ],
-        "recorded" : "2024-01-30T17:55:56Z",
+        "recorded" : "2024-02-01T15:17:34Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655356248487000.623bdf73-ad64-410a-82dd-325df3984c25",
+      "fullUrl" : "RelatedPerson/1706818654171033000.5aae812f-3d42-46b7-a322-e73480b1e663",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655356248487000.623bdf73-ad64-410a-82dd-325df3984c25",
+        "id" : "1706818654171033000.5aae812f-3d42-46b7-a322-e73480b1e663",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655356245762000.2bf577df-91c5-46a6-83f5-93ddaf90d05f"
+          "reference" : "Patient/1706818654167633000.68724098-a7e2-4635-b9c2-f3ffc57ac826"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_WPN_in_xtn2.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_4_WPN_in_xtn2.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655365364662000.218f7021-283d-4cb5-840c-9e7192e8ca0e",
+  "id" : "1706818663440641000.02852df6-6aa0-4c0f-9229-7849c77cd89d",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:05.372-05:00"
+    "lastUpdated" : "2024-02-01T15:17:43.448-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655365439082000.8c08b4c0-7cde-444c-8a2c-77a0ead279a1"
+          "reference" : "Organization/1706818663494247000.5c75f3d0-ef95-42de-afe9-cc71232aeeb3"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655365439082000.8c08b4c0-7cde-444c-8a2c-77a0ead279a1",
+      "fullUrl" : "Organization/1706818663494247000.5c75f3d0-ef95-42de-afe9-cc71232aeeb3",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655365439082000.8c08b4c0-7cde-444c-8a2c-77a0ead279a1",
+        "id" : "1706818663494247000.5c75f3d0-ef95-42de-afe9-cc71232aeeb3",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655365758822000.0cf0957d-31df-4de1-ab98-8d9a51d9d022",
+      "fullUrl" : "Provenance/1706818663863066000.126b0b97-f97c-4458-8800-d2b78a9ae0c9",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655365758822000.0cf0957d-31df-4de1-ab98-8d9a51d9d022",
+        "id" : "1706818663863066000.126b0b97-f97c-4458-8800-d2b78a9ae0c9",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655365766464000.02d889e7-ef58-4ee5-97f8-00ce6b38e8ff",
+      "fullUrl" : "Provenance/1706818663871932000.fb152d7c-c8a9-4282-aad1-16105031bb01",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655365766464000.02d889e7-ef58-4ee5-97f8-00ce6b38e8ff",
-        "recorded" : "2024-01-30T17:56:05Z",
+        "id" : "1706818663871932000.fb152d7c-c8a9-4282-aad1-16105031bb01",
+        "recorded" : "2024-02-01T15:17:43Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655365765855000.e9648c29-87be-45cd-8ba1-68a62ab0878a"
+              "reference" : "Organization/1706818663871399000.c68a8fe2-14e5-406d-9d5a-8b83f682df57"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655365765855000.e9648c29-87be-45cd-8ba1-68a62ab0878a",
+      "fullUrl" : "Organization/1706818663871399000.c68a8fe2-14e5-406d-9d5a-8b83f682df57",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655365765855000.e9648c29-87be-45cd-8ba1-68a62ab0878a",
+        "id" : "1706818663871399000.c68a8fe2-14e5-406d-9d5a-8b83f682df57",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655365783671000.ffe14f70-8bfa-4e52-aec9-f6f5fe91ad4d",
+      "fullUrl" : "Patient/1706818663892957000.085764c3-46cb-4ad9-99c1-f679aa7174cf",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655365783671000.ffe14f70-8bfa-4e52-aec9-f6f5fe91ad4d",
+        "id" : "1706818663892957000.085764c3-46cb-4ad9-99c1-f679aa7174cf",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655365784497000.2f00757e-edc4-4088-bc1f-9cd70c10740b",
+      "fullUrl" : "Provenance/1706818663894349000.5c4665af-fd38-4452-a112-fba64c0fb648",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655365784497000.2f00757e-edc4-4088-bc1f-9cd70c10740b",
+        "id" : "1706818663894349000.5c4665af-fd38-4452-a112-fba64c0fb648",
         "target" : [
           {
-            "reference" : "Patient/1706655365783671000.ffe14f70-8bfa-4e52-aec9-f6f5fe91ad4d"
+            "reference" : "Patient/1706818663892957000.085764c3-46cb-4ad9-99c1-f679aa7174cf"
           }
         ],
-        "recorded" : "2024-01-30T17:56:05Z",
+        "recorded" : "2024-02-01T15:17:43Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655365786814000.92d91a39-7b28-4a8a-bc5c-f1e4610be224",
+      "fullUrl" : "RelatedPerson/1706818663897730000.81286ae8-57ac-480b-8b1f-50903756a28b",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655365786814000.92d91a39-7b28-4a8a-bc5c-f1e4610be224",
+        "id" : "1706818663897730000.81286ae8-57ac-480b-8b1f-50903756a28b",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655365783671000.ffe14f70-8bfa-4e52-aec9-f6f5fe91ad4d"
+          "reference" : "Patient/1706818663892957000.085764c3-46cb-4ad9-99c1-f679aa7174cf"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_6_xtn3_no_value_xtn4_valued.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_6_xtn3_no_value_xtn4_valued.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655374368763000.c4799e91-3eb5-462a-a5df-623a207381a0",
+  "id" : "1706818673132667000.e56106b4-7240-4265-ae95-e14f48be9e1f",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:14.375-05:00"
+    "lastUpdated" : "2024-02-01T15:17:53.139-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655374443602000.0b111299-f445-4297-bc17-b653447177d5"
+          "reference" : "Organization/1706818673183708000.f985ff87-6165-4bdf-b600-23720187ffa3"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655374443602000.0b111299-f445-4297-bc17-b653447177d5",
+      "fullUrl" : "Organization/1706818673183708000.f985ff87-6165-4bdf-b600-23720187ffa3",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655374443602000.0b111299-f445-4297-bc17-b653447177d5",
+        "id" : "1706818673183708000.f985ff87-6165-4bdf-b600-23720187ffa3",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655374756671000.4f2e9450-8f1d-4845-a8fb-2409d3905c80",
+      "fullUrl" : "Provenance/1706818673550846000.ffd09df5-a55f-4701-a24c-b7d3c83ad6a8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655374756671000.4f2e9450-8f1d-4845-a8fb-2409d3905c80",
+        "id" : "1706818673550846000.ffd09df5-a55f-4701-a24c-b7d3c83ad6a8",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655374764166000.2a7ab5e6-416e-4135-bf4b-82b1387bed40",
+      "fullUrl" : "Provenance/1706818673559270000.54f20b4b-50f1-40b0-84e5-60eb7e81e662",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655374764166000.2a7ab5e6-416e-4135-bf4b-82b1387bed40",
-        "recorded" : "2024-01-30T17:56:14Z",
+        "id" : "1706818673559270000.54f20b4b-50f1-40b0-84e5-60eb7e81e662",
+        "recorded" : "2024-02-01T15:17:53Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655374763714000.29fc3ea9-7bda-4ec6-b023-4052e9d816a3"
+              "reference" : "Organization/1706818673558613000.a547b573-d78b-4cf5-934b-b0bb0548d8e8"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655374763714000.29fc3ea9-7bda-4ec6-b023-4052e9d816a3",
+      "fullUrl" : "Organization/1706818673558613000.a547b573-d78b-4cf5-934b-b0bb0548d8e8",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655374763714000.29fc3ea9-7bda-4ec6-b023-4052e9d816a3",
+        "id" : "1706818673558613000.a547b573-d78b-4cf5-934b-b0bb0548d8e8",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655374780506000.a341b277-cd67-4bb1-8c97-63a80ded66f6",
+      "fullUrl" : "Patient/1706818673585838000.ddcbbec6-1646-482f-bdd0-7a49c8738939",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655374780506000.a341b277-cd67-4bb1-8c97-63a80ded66f6",
+        "id" : "1706818673585838000.ddcbbec6-1646-482f-bdd0-7a49c8738939",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655374781243000.866c1be1-e48c-4261-a076-79cc1b2b2b8e",
+      "fullUrl" : "Provenance/1706818673586628000.413a0107-713c-4936-a59c-1cbd588d32b7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655374781243000.866c1be1-e48c-4261-a076-79cc1b2b2b8e",
+        "id" : "1706818673586628000.413a0107-713c-4936-a59c-1cbd588d32b7",
         "target" : [
           {
-            "reference" : "Patient/1706655374780506000.a341b277-cd67-4bb1-8c97-63a80ded66f6"
+            "reference" : "Patient/1706818673585838000.ddcbbec6-1646-482f-bdd0-7a49c8738939"
           }
         ],
-        "recorded" : "2024-01-30T17:56:14Z",
+        "recorded" : "2024-02-01T15:17:53Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655374782958000.4552ebac-166b-461e-b3bc-e92d16168328",
+      "fullUrl" : "RelatedPerson/1706818673588460000.2c3fa2f6-66be-4651-8637-af90910f5696",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655374782958000.4552ebac-166b-461e-b3bc-e92d16168328",
+        "id" : "1706818673588460000.2c3fa2f6-66be-4651-8637-af90910f5696",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655374780506000.a341b277-cd67-4bb1-8c97-63a80ded66f6"
+          "reference" : "Patient/1706818673585838000.ddcbbec6-1646-482f-bdd0-7a49c8738939"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_7_xtn3_no_value_xtn4_no_value.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_7_xtn3_no_value_xtn4_no_value.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655383407402000.8fae5a87-6605-4b64-aa8b-7206e00f2614",
+  "id" : "1706818682770800000.fc02ab36-33a1-4c06-80b4-e22795a47539",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:23.413-05:00"
+    "lastUpdated" : "2024-02-01T15:18:02.778-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655383477908000.c27a430d-236d-4cdf-a5a3-ac472e8fa919"
+          "reference" : "Organization/1706818682823135000.e86eff18-e037-4166-820a-7641df6d5079"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655383477908000.c27a430d-236d-4cdf-a5a3-ac472e8fa919",
+      "fullUrl" : "Organization/1706818682823135000.e86eff18-e037-4166-820a-7641df6d5079",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655383477908000.c27a430d-236d-4cdf-a5a3-ac472e8fa919",
+        "id" : "1706818682823135000.e86eff18-e037-4166-820a-7641df6d5079",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655383792939000.2535eddb-df97-4c92-9e81-8cc3e26195c1",
+      "fullUrl" : "Provenance/1706818683201988000.9284a6b7-c306-401b-a925-14c33f7434fb",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655383792939000.2535eddb-df97-4c92-9e81-8cc3e26195c1",
+        "id" : "1706818683201988000.9284a6b7-c306-401b-a925-14c33f7434fb",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655383801582000.1259731b-75d4-4c4f-9c38-c3487d1f3aab",
+      "fullUrl" : "Provenance/1706818683210413000.fd85ffd8-7b82-4f6e-91b5-b39c1a902b62",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655383801582000.1259731b-75d4-4c4f-9c38-c3487d1f3aab",
-        "recorded" : "2024-01-30T17:56:23Z",
+        "id" : "1706818683210413000.fd85ffd8-7b82-4f6e-91b5-b39c1a902b62",
+        "recorded" : "2024-02-01T15:18:03Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655383801030000.8405b4b4-70a1-41f9-a403-1afa9338e925"
+              "reference" : "Organization/1706818683209932000.b4aedc09-8b1a-4d2b-a4c5-5bd480dfcd8f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655383801030000.8405b4b4-70a1-41f9-a403-1afa9338e925",
+      "fullUrl" : "Organization/1706818683209932000.b4aedc09-8b1a-4d2b-a4c5-5bd480dfcd8f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655383801030000.8405b4b4-70a1-41f9-a403-1afa9338e925",
+        "id" : "1706818683209932000.b4aedc09-8b1a-4d2b-a4c5-5bd480dfcd8f",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655383818532000.c28d5767-7133-42e7-9528-4380c0d5d415",
+      "fullUrl" : "Patient/1706818683231024000.2606c5ee-26c8-4b62-8b7f-9e6ab5c162ba",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655383818532000.c28d5767-7133-42e7-9528-4380c0d5d415",
+        "id" : "1706818683231024000.2606c5ee-26c8-4b62-8b7f-9e6ab5c162ba",
         "contact" : [
           {
             "name" : {},
@@ -175,16 +180,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655383820039000.49e41d2e-8892-4b79-b448-e1245b7dd8cb",
+      "fullUrl" : "Provenance/1706818683232162000.ce011830-78e6-4a41-8615-ec1804aca56c",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655383820039000.49e41d2e-8892-4b79-b448-e1245b7dd8cb",
+        "id" : "1706818683232162000.ce011830-78e6-4a41-8615-ec1804aca56c",
         "target" : [
           {
-            "reference" : "Patient/1706655383818532000.c28d5767-7133-42e7-9528-4380c0d5d415"
+            "reference" : "Patient/1706818683231024000.2606c5ee-26c8-4b62-8b7f-9e6ab5c162ba"
           }
         ],
-        "recorded" : "2024-01-30T17:56:23Z",
+        "recorded" : "2024-02-01T15:18:03Z",
         "activity" : {
           "coding" : [
             {
@@ -196,10 +201,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655383821697000.e8a528de-1895-408c-abdb-facecfc68ca8",
+      "fullUrl" : "RelatedPerson/1706818683234246000.6c948f1a-bdbe-49c2-bade-11d565b129a5",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655383821697000.e8a528de-1895-408c-abdb-facecfc68ca8",
+        "id" : "1706818683234246000.6c948f1a-bdbe-49c2-bade-11d565b129a5",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -207,7 +212,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655383818532000.c28d5767-7133-42e7-9528-4380c0d5d415"
+          "reference" : "Patient/1706818683231024000.2606c5ee-26c8-4b62-8b7f-9e6ab5c162ba"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_8_xtn3_internet_xtn4_test_email.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_8_xtn3_internet_xtn4_test_email.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655392585054000.8ad543df-b481-4571-823d-9d3c5fdfc0d3",
+  "id" : "1706818692429376000.c03b89b8-5322-49b0-ba76-fda255f58de6",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:32.592-05:00"
+    "lastUpdated" : "2024-02-01T15:18:12.436-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655392659029000.cfc18930-3174-4e02-a86c-cdc507961525"
+          "reference" : "Organization/1706818692482876000.def0042c-95b6-4f90-91e6-678fd2037d03"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655392659029000.cfc18930-3174-4e02-a86c-cdc507961525",
+      "fullUrl" : "Organization/1706818692482876000.def0042c-95b6-4f90-91e6-678fd2037d03",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655392659029000.cfc18930-3174-4e02-a86c-cdc507961525",
+        "id" : "1706818692482876000.def0042c-95b6-4f90-91e6-678fd2037d03",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655392991192000.8fb26463-0111-4bef-9e6d-8eed70cdf4fb",
+      "fullUrl" : "Provenance/1706818692851276000.64e7a14c-7e1e-4f8c-b506-73f3176df375",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655392991192000.8fb26463-0111-4bef-9e6d-8eed70cdf4fb",
+        "id" : "1706818692851276000.64e7a14c-7e1e-4f8c-b506-73f3176df375",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655392998293000.23b438b9-5531-4aaa-94cc-42fbe47e1ea6",
+      "fullUrl" : "Provenance/1706818692859315000.2bff5b63-cdf9-493b-bf8e-31467a98d841",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655392998293000.23b438b9-5531-4aaa-94cc-42fbe47e1ea6",
-        "recorded" : "2024-01-30T17:56:33Z",
+        "id" : "1706818692859315000.2bff5b63-cdf9-493b-bf8e-31467a98d841",
+        "recorded" : "2024-02-01T15:18:12Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655392997348000.c6c92b06-75c8-4af0-ac10-6c9b03551e63"
+              "reference" : "Organization/1706818692858743000.24241789-5e74-41ff-a7aa-a00179113d1e"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655392997348000.c6c92b06-75c8-4af0-ac10-6c9b03551e63",
+      "fullUrl" : "Organization/1706818692858743000.24241789-5e74-41ff-a7aa-a00179113d1e",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655392997348000.c6c92b06-75c8-4af0-ac10-6c9b03551e63",
+        "id" : "1706818692858743000.24241789-5e74-41ff-a7aa-a00179113d1e",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655393015605000.335e6539-2baf-4c95-ab26-55c9de21ce70",
+      "fullUrl" : "Patient/1706818692878259000.d045a33f-ae78-4c1b-852c-271269fd9cde",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655393015605000.335e6539-2baf-4c95-ab26-55c9de21ce70",
+        "id" : "1706818692878259000.d045a33f-ae78-4c1b-852c-271269fd9cde",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655393016494000.1883d848-036e-45af-bed0-431e95801347",
+      "fullUrl" : "Provenance/1706818692879014000.982d323e-2226-48a2-845f-cadc0673350a",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655393016494000.1883d848-036e-45af-bed0-431e95801347",
+        "id" : "1706818692879014000.982d323e-2226-48a2-845f-cadc0673350a",
         "target" : [
           {
-            "reference" : "Patient/1706655393015605000.335e6539-2baf-4c95-ab26-55c9de21ce70"
+            "reference" : "Patient/1706818692878259000.d045a33f-ae78-4c1b-852c-271269fd9cde"
           }
         ],
-        "recorded" : "2024-01-30T17:56:33Z",
+        "recorded" : "2024-02-01T15:18:12Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655393018526000.6ff25d9f-56d3-4dde-afc1-208fe6b346aa",
+      "fullUrl" : "RelatedPerson/1706818692881214000.c953739a-f432-45bc-a834-c342aad71f3d",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655393018526000.6ff25d9f-56d3-4dde-afc1-208fe6b346aa",
+        "id" : "1706818692881214000.c953739a-f432-45bc-a834-c342aad71f3d",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655393015605000.335e6539-2baf-4c95-ab26-55c9de21ce70"
+          "reference" : "Patient/1706818692878259000.d045a33f-ae78-4c1b-852c-271269fd9cde"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_8_xtn3_x400_xtn4_test_email.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_8_xtn3_x400_xtn4_test_email.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655401642253000.ea2a8981-fca8-45d6-9030-8615aead1402",
+  "id" : "1706818701971252000.99d7ec17-dd46-46ca-8308-1bb96a372aff",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:41.649-05:00"
+    "lastUpdated" : "2024-02-01T15:18:21.978-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655401716827000.b97401a8-448c-4c24-a654-74caa35b19b0"
+          "reference" : "Organization/1706818702027012000.ade81dd7-d846-46a1-bbe8-07f84bb6bcbe"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655401716827000.b97401a8-448c-4c24-a654-74caa35b19b0",
+      "fullUrl" : "Organization/1706818702027012000.ade81dd7-d846-46a1-bbe8-07f84bb6bcbe",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655401716827000.b97401a8-448c-4c24-a654-74caa35b19b0",
+        "id" : "1706818702027012000.ade81dd7-d846-46a1-bbe8-07f84bb6bcbe",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655402027916000.3fa72e3a-1166-420f-aad3-32d174189d75",
+      "fullUrl" : "Provenance/1706818702383652000.faee162e-b0bd-4e19-811c-d747a69a0835",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655402027916000.3fa72e3a-1166-420f-aad3-32d174189d75",
+        "id" : "1706818702383652000.faee162e-b0bd-4e19-811c-d747a69a0835",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655402035685000.fe88e192-d7fe-4f69-afd6-5ffca1776cca",
+      "fullUrl" : "Provenance/1706818702391707000.267ba54e-4040-463f-8607-c5698d4928e8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655402035685000.fe88e192-d7fe-4f69-afd6-5ffca1776cca",
-        "recorded" : "2024-01-30T17:56:42Z",
+        "id" : "1706818702391707000.267ba54e-4040-463f-8607-c5698d4928e8",
+        "recorded" : "2024-02-01T15:18:22Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655402035254000.8e1504bc-b335-4d6b-8d59-7c08f141a48f"
+              "reference" : "Organization/1706818702391220000.5a7124c9-339f-4f44-92f3-6e71780bcfe6"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655402035254000.8e1504bc-b335-4d6b-8d59-7c08f141a48f",
+      "fullUrl" : "Organization/1706818702391220000.5a7124c9-339f-4f44-92f3-6e71780bcfe6",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655402035254000.8e1504bc-b335-4d6b-8d59-7c08f141a48f",
+        "id" : "1706818702391220000.5a7124c9-339f-4f44-92f3-6e71780bcfe6",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655402051823000.a7af770a-5fe1-4d22-ac01-9f15130431f1",
+      "fullUrl" : "Patient/1706818702409806000.3367c57d-2471-4809-92cd-ee0de2be725d",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655402051823000.a7af770a-5fe1-4d22-ac01-9f15130431f1",
+        "id" : "1706818702409806000.3367c57d-2471-4809-92cd-ee0de2be725d",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655402052527000.1254d67c-e97c-4f64-b437-d225f1620e81",
+      "fullUrl" : "Provenance/1706818702410642000.e496755a-70ec-4b5b-a4fd-a23a860a845e",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655402052527000.1254d67c-e97c-4f64-b437-d225f1620e81",
+        "id" : "1706818702410642000.e496755a-70ec-4b5b-a4fd-a23a860a845e",
         "target" : [
           {
-            "reference" : "Patient/1706655402051823000.a7af770a-5fe1-4d22-ac01-9f15130431f1"
+            "reference" : "Patient/1706818702409806000.3367c57d-2471-4809-92cd-ee0de2be725d"
           }
         ],
-        "recorded" : "2024-01-30T17:56:42Z",
+        "recorded" : "2024-02-01T15:18:22Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655402054568000.69f5bf98-78d6-4547-8653-f4d195a6f7df",
+      "fullUrl" : "RelatedPerson/1706818702413774000.1862b5e2-0926-4e35-8d85-e1cafe3836d0",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655402054568000.69f5bf98-78d6-4547-8653-f4d195a6f7df",
+        "id" : "1706818702413774000.1862b5e2-0926-4e35-8d85-e1cafe3836d0",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655402051823000.a7af770a-5fe1-4d22-ac01-9f15130431f1"
+          "reference" : "Patient/1706818702409806000.3367c57d-2471-4809-92cd-ee0de2be725d"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_9_10_xtn5_value_of_1.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/contact-point/xtn_9_10_xtn5_value_of_1.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655410723002000.585301e2-d293-4739-84dc-08155f1558a0",
+  "id" : "1706818711384401000.6df97c90-a598-4491-a9c0-c44a23b9e254",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:50.729-05:00"
+    "lastUpdated" : "2024-02-01T15:18:31.391-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,12 +22,17 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/character-set",
             "valueString" : "UNICODE UTF-8"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -36,7 +41,7 @@
           "display" : "ORU^R01^ORU_R01"
         },
         "sender" : {
-          "reference" : "Organization/1706655410796916000.b82009ac-2e66-4d29-b1f6-acd389e0f065"
+          "reference" : "Organization/1706818711437720000.209e20b1-500e-4b8a-992c-b40e2ad917dd"
         },
         "source" : {
           "_endpoint" : {
@@ -51,10 +56,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655410796916000.b82009ac-2e66-4d29-b1f6-acd389e0f065",
+      "fullUrl" : "Organization/1706818711437720000.209e20b1-500e-4b8a-992c-b40e2ad917dd",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655410796916000.b82009ac-2e66-4d29-b1f6-acd389e0f065",
+        "id" : "1706818711437720000.209e20b1-500e-4b8a-992c-b40e2ad917dd",
         "address" : [
           {
             "country" : "USA"
@@ -63,10 +68,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655411116387000.9efcb6f2-f578-41e2-9704-33e8eec29098",
+      "fullUrl" : "Provenance/1706818711805935000.7efd681d-c80c-488d-9de3-70622078ef01",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655411116387000.9efcb6f2-f578-41e2-9704-33e8eec29098",
+        "id" : "1706818711805935000.7efd681d-c80c-488d-9de3-70622078ef01",
         "target" : [
           {
             "reference" : "MessageHeader/827ccb0e-ea8a-306c-8c34-a16891f84e7b"
@@ -83,11 +88,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655411124235000.d073c502-d510-4623-a796-57140d81163c",
+      "fullUrl" : "Provenance/1706818711815284000.2b608666-11a4-4af6-8d40-afae73567146",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655411124235000.d073c502-d510-4623-a796-57140d81163c",
-        "recorded" : "2024-01-30T17:56:51Z",
+        "id" : "1706818711815284000.2b608666-11a4-4af6-8d40-afae73567146",
+        "recorded" : "2024-02-01T15:18:31Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -109,17 +114,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655411123844000.00b2e6da-b9b6-48d6-8a47-5d842eb8165c"
+              "reference" : "Organization/1706818711814738000.ffbcfafb-b0e7-4e05-a48c-7f61083e3894"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655411123844000.00b2e6da-b9b6-48d6-8a47-5d842eb8165c",
+      "fullUrl" : "Organization/1706818711814738000.ffbcfafb-b0e7-4e05-a48c-7f61083e3894",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655411123844000.00b2e6da-b9b6-48d6-8a47-5d842eb8165c",
+        "id" : "1706818711814738000.ffbcfafb-b0e7-4e05-a48c-7f61083e3894",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -139,10 +144,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655411140281000.d0d3d2ae-5fdc-44a3-8ffe-adfc8fdc211a",
+      "fullUrl" : "Patient/1706818711833091000.6f7f61e8-d08f-4290-b6db-9bc1d5bc74d1",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655411140281000.d0d3d2ae-5fdc-44a3-8ffe-adfc8fdc211a",
+        "id" : "1706818711833091000.6f7f61e8-d08f-4290-b6db-9bc1d5bc74d1",
         "contact" : [
           {
             "name" : {}
@@ -151,16 +156,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655411140953000.aa668d2a-ce9e-40ee-82c7-9f5691032702",
+      "fullUrl" : "Provenance/1706818711833894000.09268738-0b80-45b9-ba62-c15036890a89",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655411140953000.aa668d2a-ce9e-40ee-82c7-9f5691032702",
+        "id" : "1706818711833894000.09268738-0b80-45b9-ba62-c15036890a89",
         "target" : [
           {
-            "reference" : "Patient/1706655411140281000.d0d3d2ae-5fdc-44a3-8ffe-adfc8fdc211a"
+            "reference" : "Patient/1706818711833091000.6f7f61e8-d08f-4290-b6db-9bc1d5bc74d1"
           }
         ],
-        "recorded" : "2024-01-30T17:56:51Z",
+        "recorded" : "2024-02-01T15:18:31Z",
         "activity" : {
           "coding" : [
             {
@@ -172,10 +177,10 @@
       }
     },
     {
-      "fullUrl" : "RelatedPerson/1706655411143001000.c9874ce7-548b-4a75-9870-e6144d04cf98",
+      "fullUrl" : "RelatedPerson/1706818711835780000.95f7baa8-76f6-4a90-aa25-47f8fa65b4a5",
       "resource" : {
         "resourceType" : "RelatedPerson",
-        "id" : "1706655411143001000.c9874ce7-548b-4a75-9870-e6144d04cf98",
+        "id" : "1706818711835780000.95f7baa8-76f6-4a90-aa25-47f8fa65b4a5",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Name",
@@ -183,7 +188,7 @@
           }
         ],
         "patient" : {
-          "reference" : "Patient/1706655411140281000.d0d3d2ae-5fdc-44a3-8ffe-adfc8fdc211a"
+          "reference" : "Patient/1706818711833091000.6f7f61e8-d08f-4290-b6db-9bc1d5bc74d1"
         },
         "telecom" : [
           {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_3_use_code_no_use_system_email.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_3_use_code_no_use_system_email.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655419770547000.17d64775-a3a7-43c6-9d0f-3bddc32ecd98",
+  "id" : "1706818720986990000.f8fd4e86-519c-44cd-afe0-683447570401",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:56:59.777-05:00"
+    "lastUpdated" : "2024-02-01T15:18:40.994-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,386 +10,551 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "meta" : {
-        "tag" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "T"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-        "valueString" : "NE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-        "valueString" : "NE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-        "valueIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueOid" : "urn:oid:2.16.840.1.113883.9.11"
-          } ],
-          "system" : "PHIN",
-          "value" : "PHLabReport-NoAck"
-        }
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.16.840.1.114222.4.3.3.6.2.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "MEDSS-ELR ",
-        "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.6.2.1",
-        "receiver" : {
-          "reference" : "Organization/1706655419838215000.1ec9d2e6-adab-44c4-947d-3f2314aa5339"
-        }
-      } ],
-      "sender" : {
-        "reference" : "Organization/1706655419841853000.8a3d08bd-ad03-4ff3-9967-61e14d84f5b3"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "STARLIMS.CDC.Stag"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.16.840.1.114222.4.3.3.2.1.2"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.2.1.2"
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706655419838215000.1ec9d2e6-adab-44c4-947d-3f2314aa5339",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655419838215000.1ec9d2e6-adab-44c4-947d-3f2314aa5339",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "MNDOH"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "meta" : {
+          "tag" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
+              "code" : "T"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.3661"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655419841853000.8a3d08bd-ad03-4ff3-9967-61e14d84f5b3",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655419841853000.8a3d08bd-ad03-4ff3-9967-61e14d84f5b3",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Atlanta"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIA"
-          } ]
-        },
-        "value" : "11D0668319"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655420148477000.c6936dd5-a345-4199-ad5f-e1695b5a53b1",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655420148477000.c6936dd5-a345-4199-ad5f-e1695b5a53b1",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id",
+                          "valueString" : "PHIN"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.11"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "PHLabReport-NoAck"
+                }
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "author"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706655420147736000.b12dc6be-3181-47c8-b7fa-cd82983120a4"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655420147736000.b12dc6be-3181-47c8-b7fa-cd82983120a4",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655420147736000.b12dc6be-3181-47c8-b7fa-cd82983120a4",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Atlanta"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIA"
-          } ]
-        },
-        "value" : "11D0668319"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655420155893000.d6cd1c0a-4269-48b2-a956-de9dcd916716",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655420155893000.d6cd1c0a-4269-48b2-a956-de9dcd916716",
-      "recorded" : "2024-01-30T17:57:00Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706655420155586000.f82d9eb2-29d4-4bf7-8e02-4867ecc8c71c"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655420155586000.f82d9eb2-29d4-4bf7-8e02-4867ecc8c71c",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655420155586000.f82d9eb2-29d4-4bf7-8e02-4867ecc8c71c",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706655420177761000.f5349d7e-dcba-47fc-b460-6f8a6314a95a",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706655420177761000.f5349d7e-dcba-47fc-b460-6f8a6314a95a",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
-        "extension" : [ {
-          "url" : "pid-8-administrative-sex",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "U"
-            } ]
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.16.840.1.114222.4.3.3.6.2.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "MEDSS-ELR ",
+            "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.6.2.1",
+            "receiver" : {
+              "reference" : "Organization/1706818721062985000.b9b9a0f8-8cb8-4622-a768-589b1b059f70"
+            }
           }
-        }, {
-          "url" : "pid-30-patient-death-indicator",
-          "valueString" : "N"
-        } ]
-      }, {
-        "url" : "http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-              "valueString" : "NULLFL"
-            } ],
-            "version" : "2.5.1",
-            "code" : "ASKU",
-            "display" : "Asked, but unknown"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ethnic-group",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-              "valueString" : "HL70189"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0189",
-            "version" : "2.9",
-            "code" : "N",
-            "display" : "Non Hispanic or Latino"
-          } ]
-        }
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706655420162067000.11484c6e-04c5-422a-8092-5a2eaf42abd7"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "patient-identifier-list"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "PI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "PI"
-          } ]
+        ],
+        "sender" : {
+          "reference" : "Organization/1706818721040136000.3104e71d-0e58-44b0-9897-79682766d058"
         },
-        "value" : "kc3oy"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "Stephenie"
-          }, {
-            "url" : "XPN.3",
-            "valueString" : "Davis"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Schaefer",
-        "given" : [ "Stephenie", "Davis" ]
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "NET"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "Internet"
-          }, {
-            "url" : "XTN.4",
-            "valueString" : "otto.daugherty@email.com"
-          } ]
-        } ],
-        "system" : "email",
-        "value" : "otto.daugherty@email.com",
-        "use" : "home"
-      } ],
-      "gender" : "unknown",
-      "deceasedBoolean" : false,
-      "address" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "96633 Gilberto Course"
-            } ]
-          } ]
-        } ],
-        "line" : [ "96633 Gilberto Course" ],
-        "state" : "IG"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655420162067000.11484c6e-04c5-422a-8092-5a2eaf42abd7",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655420162067000.11484c6e-04c5-422a-8092-5a2eaf42abd7",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Any lab USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655420184302000.4a1c6511-5723-4578-9167-994bc3e612c9",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655420184302000.4a1c6511-5723-4578-9167-994bc3e612c9",
-      "target" : [ {
-        "reference" : "Patient/1706655420177761000.f5349d7e-dcba-47fc-b460-6f8a6314a95a"
-      } ],
-      "recorded" : "2024-01-30T17:57:00Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "STARLIMS.CDC.Stag"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "2.16.840.1.114222.4.3.3.2.1.2"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.2.1.2"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818721040136000.3104e71d-0e58-44b0-9897-79682766d058",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818721040136000.3104e71d-0e58-44b0-9897-79682766d058",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Atlanta"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIA"
+                }
+              ]
+            },
+            "value" : "11D0668319"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818721062985000.b9b9a0f8-8cb8-4622-a768-589b1b059f70",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818721062985000.b9b9a0f8-8cb8-4622-a768-589b1b059f70",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "MNDOH"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.3661"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818721408254000.b4fea5d9-5979-41d3-ad2f-efb13fa43cd9",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818721408254000.b4fea5d9-5979-41d3-ad2f-efb13fa43cd9",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "author"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706818721407377000.ce48a672-7629-44c4-b362-fced0bbfefc7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818721407377000.ce48a672-7629-44c4-b362-fced0bbfefc7",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818721407377000.ce48a672-7629-44c4-b362-fced0bbfefc7",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Atlanta"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIA"
+                }
+              ]
+            },
+            "value" : "11D0668319"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818721418378000.00b4cd0a-be59-4d3d-b0c3-f5413bbf421a",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818721418378000.00b4cd0a-be59-4d3d-b0c3-f5413bbf421a",
+        "recorded" : "2024-02-01T15:18:41Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706818721417877000.cf3c7af3-250a-4655-ad26-874954ea000f"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818721417877000.cf3c7af3-250a-4655-ad26-874954ea000f",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818721417877000.cf3c7af3-250a-4655-ad26-874954ea000f",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706818721443934000.ef37d53a-e310-4c38-b82e-1f481b678233",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706818721443934000.ef37d53a-e310-4c38-b82e-1f481b678233",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
+            "extension" : [
+              {
+                "url" : "pid-8-administrative-sex",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "U"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pid-30-patient-death-indicator",
+                "valueString" : "N"
+              }
+            ]
+          },
+          {
+            "url" : "http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    },
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                      "valueString" : "NULLFL"
+                    }
+                  ],
+                  "version" : "2.5.1",
+                  "code" : "ASKU",
+                  "display" : "Asked, but unknown"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ethnic-group",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    },
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                      "valueString" : "HL70189"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0189",
+                  "version" : "2.9",
+                  "code" : "N",
+                  "display" : "Non Hispanic or Latino"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706818721425027000.94bb62cf-963d-4200-8963-8c4abd032e97"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "patient-identifier-list"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "PI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "PI"
+                }
+              ]
+            },
+            "value" : "kc3oy"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "Stephenie"
+                  },
+                  {
+                    "url" : "XPN.3",
+                    "valueString" : "Davis"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Schaefer",
+            "given" : [
+              "Stephenie",
+              "Davis"
+            ]
+          }
+        ],
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "NET"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "Internet"
+                  },
+                  {
+                    "url" : "XTN.4",
+                    "valueString" : "otto.daugherty@email.com"
+                  }
+                ]
+              }
+            ],
+            "system" : "email",
+            "value" : "otto.daugherty@email.com",
+            "use" : "home"
+          }
+        ],
+        "gender" : "unknown",
+        "deceasedBoolean" : false,
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "96633 Gilberto Course"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "line" : [
+              "96633 Gilberto Course"
+            ],
+            "state" : "IG"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818721425027000.94bb62cf-963d-4200-8963-8c4abd032e97",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818721425027000.94bb62cf-963d-4200-8963-8c4abd032e97",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Any lab USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818721446968000.8d2a9347-4d11-47e0-acb8-dc5f951110da",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818721446968000.8d2a9347-4d11-47e0-acb8-dc5f951110da",
+        "target" : [
+          {
+            "reference" : "Patient/1706818721443934000.ef37d53a-e310-4c38-b82e-1f481b678233"
+          }
+        ],
+        "recorded" : "2024-02-01T15:18:41Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
       }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_3_use_code_no_use_system_pager.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_3_use_code_no_use_system_pager.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655428927783000.01c866cb-f3bc-4b82-93bd-525187fdd48d",
+  "id" : "1706818730554492000.a8a8393f-161d-420f-a234-89c09c3972ee",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:57:08.934-05:00"
+    "lastUpdated" : "2024-02-01T15:18:50.562-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -10,398 +10,567 @@
   },
   "type" : "message",
   "timestamp" : "2023-05-01T10:25:31.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
-      "meta" : {
-        "tag" : [ {
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "T"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
-        "valueString" : "^~\\&#"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-        "valueString" : "20230501102531-0400"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-        "valueString" : "NE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-        "valueString" : "NE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-        "valueIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueOid" : "urn:oid:2.16.840.1.113883.9.11"
-          } ],
-          "system" : "PHIN",
-          "value" : "PHLabReport-NoAck"
-        }
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "R01",
-        "display" : "ORU^R01^ORU_R01"
-      },
-      "destination" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.16.840.1.114222.4.3.3.6.2.1"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "receiving-application"
-        } ],
-        "name" : "MEDSS-ELR ",
-        "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.6.2.1",
-        "receiver" : {
-          "reference" : "Organization/1706655429000776000.ceceff9b-e6f1-4aca-94f7-53515501d46e"
-        }
-      } ],
-      "sender" : {
-        "reference" : "Organization/1706655429005316000.35cef48b-db3d-46e5-a343-b7ef3f22d6fd"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-          "valueString" : "STARLIMS.CDC.Stag"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueString" : "2.16.840.1.114222.4.3.3.2.1.2"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
-          "valueString" : "ISO"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "sending-application"
-        } ],
-        "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.2.1.2"
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1706655429000776000.ceceff9b-e6f1-4aca-94f7-53515501d46e",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655429000776000.ceceff9b-e6f1-4aca-94f7-53515501d46e",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-        "valueString" : "receiving-facility"
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "MNDOH"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "ISO"
-          } ]
+  "entry" : [
+    {
+      "fullUrl" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+      "resource" : {
+        "resourceType" : "MessageHeader",
+        "id" : "0993dd0b-6ce5-3caf-a177-0b81cc780c18",
+        "meta" : {
+          "tag" : [
+            {
+              "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
+              "code" : "T"
+            }
+          ]
         },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.3661"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655429005316000.35cef48b-db3d-46e5-a343-b7ef3f22d6fd",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655429005316000.35cef48b-db3d-46e5-a343-b7ef3f22d6fd",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Atlanta"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIA"
-          } ]
-        },
-        "value" : "11D0668319"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655429330877000.a1eed304-3530-4efc-b4e5-a8902ea42852",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655429330877000.a1eed304-3530-4efc-b4e5-a8902ea42852",
-      "target" : [ {
-        "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
-      } ],
-      "recorded" : "2023-05-01T10:25:31-04:00",
-      "activity" : {
-        "coding" : [ {
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/encoding-characters",
+            "valueString" : "^~\\&#"
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id",
+                          "valueString" : "PHIN"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.11"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "PHLabReport-NoAck"
+                }
+              }
+            ]
+          }
+        ],
+        "eventCoding" : {
+          "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
+          "code" : "R01",
           "display" : "ORU^R01^ORU_R01"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "author"
-          } ]
         },
-        "who" : {
-          "reference" : "Organization/1706655429330144000.4122f4c2-9e84-472f-b57e-e4b44d77e40f"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655429330144000.4122f4c2-9e84-472f-b57e-e4b44d77e40f",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655429330144000.4122f4c2-9e84-472f-b57e-e4b44d77e40f",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "CDC Atlanta"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-          "valueBoolean" : true
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "CLIA"
-          } ]
-        },
-        "value" : "11D0668319"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655429339677000.e1198ff8-57c6-4660-8104-da2c2a21633c",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655429339677000.e1198ff8-57c6-4660-8104-da2c2a21633c",
-      "recorded" : "2024-01-30T17:57:09Z",
-      "policy" : [ "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle" ],
-      "activity" : {
-        "coding" : [ {
-          "code" : "v2-FHIR transformation"
-        } ]
-      },
-      "agent" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-            "code" : "assembler"
-          } ]
-        },
-        "who" : {
-          "reference" : "Organization/1706655429339334000.2c6fef13-e9c5-416d-be5d-1938cd960835"
-        }
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655429339334000.2c6fef13-e9c5-416d-be5d-1938cd960835",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655429339334000.2c6fef13-e9c5-416d-be5d-1938cd960835",
-      "identifier" : [ {
-        "value" : "CDC PRIME - Atlanta"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
-          } ]
-        },
-        "system" : "urn:ietf:rfc:3986",
-        "value" : "2.16.840.1.114222.4.1.237821"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Patient/1706655429364927000.dec62a43-1438-45cc-865a-ebac8d02348d",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1706655429364927000.dec62a43-1438-45cc-865a-ebac8d02348d",
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
-        "extension" : [ {
-          "url" : "pid-8-administrative-sex",
-          "valueCodeableConcept" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-                "valueString" : "coding"
-              } ],
-              "code" : "U"
-            } ]
+        "destination" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                "valueString" : "2.16.840.1.114222.4.3.3.6.2.1"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                "valueString" : "ISO"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "receiving-application"
+              }
+            ],
+            "name" : "MEDSS-ELR ",
+            "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.6.2.1",
+            "receiver" : {
+              "reference" : "Organization/1706818730630474000.f989cc89-0499-42b7-be33-52adabf7190e"
+            }
           }
-        }, {
-          "url" : "pid-30-patient-death-indicator",
-          "valueString" : "N"
-        } ]
-      }, {
-        "url" : "http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-              "valueString" : "NULLFL"
-            } ],
-            "version" : "2.5.1",
-            "code" : "ASKU",
-            "display" : "Asked, but unknown"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ethnic-group",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
-              "valueString" : "coding"
-            }, {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
-              "valueString" : "HL70189"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0189",
-            "version" : "2.9",
-            "code" : "N",
-            "display" : "Non Hispanic or Latino"
-          } ]
-        }
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Organization/1706655429347592000.d17bc788-c5b0-4eb1-8e8f-7282f8973c54"
-          }
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
-          "valueString" : "patient-identifier-list"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
-          "valueString" : "PI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "code" : "PI"
-          } ]
+        ],
+        "sender" : {
+          "reference" : "Organization/1706818730606379000.d7cae63f-4e71-420c-921e-8eb0df2973ad"
         },
-        "value" : "kc3oy"
-      } ],
-      "name" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
-          "extension" : [ {
-            "url" : "XPN.2",
-            "valueString" : "Stephenie"
-          }, {
-            "url" : "XPN.3",
-            "valueString" : "Davis"
-          }, {
-            "url" : "XPN.7",
-            "valueString" : "L"
-          } ]
-        } ],
-        "use" : "official",
-        "family" : "Schaefer",
-        "given" : [ "Stephenie", "Davis" ]
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
-          "valueString" : "1"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
-          "valueString" : "260"
-        }, {
-          "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
-          "valueString" : "7595016"
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
-          "extension" : [ {
-            "url" : "XTN.2",
-            "valueString" : "BPN"
-          }, {
-            "url" : "XTN.3",
-            "valueString" : "BP"
-          }, {
-            "url" : "XTN.7",
-            "valueString" : "7595016"
-          }, {
-            "url" : "XTN.12",
-            "valueString" : "+1 260 759 5016"
-          } ]
-        } ],
-        "system" : "pager",
-        "value" : "+1 260 759 5016",
-        "use" : "home"
-      } ],
-      "gender" : "unknown",
-      "deceasedBoolean" : false,
-      "address" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
-            "extension" : [ {
-              "url" : "SAD.1",
-              "valueString" : "96633 Gilberto Course"
-            } ]
-          } ]
-        } ],
-        "line" : [ "96633 Gilberto Course" ],
-        "state" : "IG"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/1706655429347592000.d17bc788-c5b0-4eb1-8e8f-7282f8973c54",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1706655429347592000.d17bc788-c5b0-4eb1-8e8f-7282f8973c54",
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-          "valueBoolean" : true
-        } ],
-        "value" : "Any lab USA"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Provenance/1706655429368871000.8f3bc493-f6a6-471b-9025-920bc6f711af",
-    "resource" : {
-      "resourceType" : "Provenance",
-      "id" : "1706655429368871000.8f3bc493-f6a6-471b-9025-920bc6f711af",
-      "target" : [ {
-        "reference" : "Patient/1706655429364927000.dec62a43-1438-45cc-865a-ebac8d02348d"
-      } ],
-      "recorded" : "2024-01-30T17:57:09Z",
-      "activity" : {
-        "coding" : [ {
-          "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
-          "code" : "UPDATE"
-        } ]
+        "source" : {
+          "extension" : [
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+              "valueString" : "STARLIMS.CDC.Stag"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+              "valueString" : "2.16.840.1.114222.4.3.3.2.1.2"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+              "valueString" : "ISO"
+            },
+            {
+              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+              "valueString" : "sending-application"
+            }
+          ],
+          "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.2.1.2"
+        }
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818730606379000.d7cae63f-4e71-420c-921e-8eb0df2973ad",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818730606379000.d7cae63f-4e71-420c-921e-8eb0df2973ad",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Atlanta"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIA"
+                }
+              ]
+            },
+            "value" : "11D0668319"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818730630474000.f989cc89-0499-42b7-be33-52adabf7190e",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818730630474000.f989cc89-0499-42b7-be33-52adabf7190e",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+            "valueString" : "receiving-facility"
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "MNDOH"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "ISO"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.3661"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818730976822000.a4ebada3-c17e-404b-b033-b705ab64b611",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818730976822000.a4ebada3-c17e-404b-b033-b705ab64b611",
+        "target" : [
+          {
+            "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
+          }
+        ],
+        "recorded" : "2023-05-01T10:25:31-04:00",
+        "activity" : {
+          "coding" : [
+            {
+              "display" : "ORU^R01^ORU_R01"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "author"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706818730975937000.aede41f7-6d7e-44c4-9ce2-1e8df38a5dba"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818730975937000.aede41f7-6d7e-44c4-9ce2-1e8df38a5dba",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818730975937000.aede41f7-6d7e-44c4-9ce2-1e8df38a5dba",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Atlanta"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIA"
+                }
+              ]
+            },
+            "value" : "11D0668319"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818730984552000.3b2f07ea-335a-4c46-8975-7234bef70ab2",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818730984552000.3b2f07ea-335a-4c46-8975-7234bef70ab2",
+        "recorded" : "2024-02-01T15:18:50Z",
+        "policy" : [
+          "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
+        ],
+        "activity" : {
+          "coding" : [
+            {
+              "code" : "v2-FHIR transformation"
+            }
+          ]
+        },
+        "agent" : [
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                  "code" : "assembler"
+                }
+              ]
+            },
+            "who" : {
+              "reference" : "Organization/1706818730984176000.ce500855-1944-4ad6-afa1-4f1e318b3ceb"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818730984176000.ce500855-1944-4ad6-afa1-4f1e318b3ceb",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818730984176000.ce500855-1944-4ad6-afa1-4f1e318b3ceb",
+        "identifier" : [
+          {
+            "value" : "CDC PRIME - Atlanta"
+          },
+          {
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301"
+                }
+              ]
+            },
+            "system" : "urn:ietf:rfc:3986",
+            "value" : "2.16.840.1.114222.4.1.237821"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Patient/1706818731017779000.b977a181-aba4-482c-9afe-eed66bce0b2d",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "1706818731017779000.b977a181-aba4-482c-9afe-eed66bce0b2d",
+        "extension" : [
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
+            "extension" : [
+              {
+                "url" : "pid-8-administrative-sex",
+                "valueCodeableConcept" : {
+                  "coding" : [
+                    {
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                          "valueString" : "coding"
+                        }
+                      ],
+                      "code" : "U"
+                    }
+                  ]
+                }
+              },
+              {
+                "url" : "pid-30-patient-death-indicator",
+                "valueString" : "N"
+              }
+            ]
+          },
+          {
+            "url" : "http://ibm.com/fhir/cdm/StructureDefinition/local-race-cd",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    },
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                      "valueString" : "NULLFL"
+                    }
+                  ],
+                  "version" : "2.5.1",
+                  "code" : "ASKU",
+                  "display" : "Asked, but unknown"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/ethnic-group",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                      "valueString" : "coding"
+                    },
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                      "valueString" : "HL70189"
+                    }
+                  ],
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0189",
+                  "version" : "2.9",
+                  "code" : "N",
+                  "display" : "Non Hispanic or Latino"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
+                "valueReference" : {
+                  "reference" : "Organization/1706818730994558000.804cbd8d-d78a-4e7c-9cd1-6ecae26b35df"
+                }
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
+                "valueString" : "patient-identifier-list"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type-code",
+                "valueString" : "PI"
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "code" : "PI"
+                }
+              ]
+            },
+            "value" : "kc3oy"
+          }
+        ],
+        "name" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                "extension" : [
+                  {
+                    "url" : "XPN.2",
+                    "valueString" : "Stephenie"
+                  },
+                  {
+                    "url" : "XPN.3",
+                    "valueString" : "Davis"
+                  },
+                  {
+                    "url" : "XPN.7",
+                    "valueString" : "L"
+                  }
+                ]
+              }
+            ],
+            "use" : "official",
+            "family" : "Schaefer",
+            "given" : [
+              "Stephenie",
+              "Davis"
+            ]
+          }
+        ],
+        "telecom" : [
+          {
+            "extension" : [
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+                "valueString" : "1"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                "valueString" : "260"
+              },
+              {
+                "url" : "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                "valueString" : "7595016"
+              },
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                "extension" : [
+                  {
+                    "url" : "XTN.2",
+                    "valueString" : "BPN"
+                  },
+                  {
+                    "url" : "XTN.3",
+                    "valueString" : "BP"
+                  },
+                  {
+                    "url" : "XTN.7",
+                    "valueString" : "7595016"
+                  },
+                  {
+                    "url" : "XTN.12",
+                    "valueString" : "+1 260 759 5016"
+                  }
+                ]
+              }
+            ],
+            "system" : "pager",
+            "value" : "+1 260 759 5016",
+            "use" : "home"
+          }
+        ],
+        "gender" : "unknown",
+        "deceasedBoolean" : false,
+        "address" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                "extension" : [
+                  {
+                    "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                    "extension" : [
+                      {
+                        "url" : "SAD.1",
+                        "valueString" : "96633 Gilberto Course"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "line" : [
+              "96633 Gilberto Course"
+            ],
+            "state" : "IG"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818730994558000.804cbd8d-d78a-4e7c-9cd1-6ecae26b35df",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818730994558000.804cbd8d-d78a-4e7c-9cd1-6ecae26b35df",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "Any lab USA"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Provenance/1706818731021238000.f29695c2-627d-473c-9bbf-b7e286b9aabf",
+      "resource" : {
+        "resourceType" : "Provenance",
+        "id" : "1706818731021238000.f29695c2-627d-473c-9bbf-b7e286b9aabf",
+        "target" : [
+          {
+            "reference" : "Patient/1706818731017779000.b977a181-aba4-482c-9afe-eed66bce0b2d"
+          }
+        ],
+        "recorded" : "2024-02-01T15:18:51Z",
+        "activity" : {
+          "coding" : [
+            {
+              "system" : "https://terminology.hl7.org/CodeSystem/v3-DataOperation",
+              "code" : "UPDATE"
+            }
+          ]
+        }
       }
     }
-  } ]
+  ]
 }

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_home.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_home.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655438063601000.0c9d99d0-57bf-4b6a-8804-fba82dbd83cd",
+  "id" : "1706818740043990000.a7318449-0343-4394-ac97-ec897e9be486",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:57:18.070-05:00"
+    "lastUpdated" : "2024-02-01T15:19:00.051-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655438481668000.754e5ec1-4598-40e5-ab46-f45b02a52609",
+      "fullUrl" : "Provenance/1706818740458552000.91da0bdb-de1f-45e6-8a8a-e1024b83b0fa",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655438481668000.754e5ec1-4598-40e5-ab46-f45b02a52609",
+        "id" : "1706818740458552000.91da0bdb-de1f-45e6-8a8a-e1024b83b0fa",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655438489679000.747c2bff-c05b-4dda-8115-f415de771926",
+      "fullUrl" : "Provenance/1706818740468422000.038a3347-9e7e-4ab9-a2c4-248f1595df8f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655438489679000.747c2bff-c05b-4dda-8115-f415de771926",
-        "recorded" : "2024-01-30T17:57:18Z",
+        "id" : "1706818740468422000.038a3347-9e7e-4ab9-a2c4-248f1595df8f",
+        "recorded" : "2024-02-01T15:19:00Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655438489048000.edc8209b-0fa8-4530-9684-2e88a0143884"
+              "reference" : "Organization/1706818740467706000.8f236c19-9fac-4f36-a172-939a91dd505a"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655438489048000.edc8209b-0fa8-4530-9684-2e88a0143884",
+      "fullUrl" : "Organization/1706818740467706000.8f236c19-9fac-4f36-a172-939a91dd505a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655438489048000.edc8209b-0fa8-4530-9684-2e88a0143884",
+        "id" : "1706818740467706000.8f236c19-9fac-4f36-a172-939a91dd505a",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655438520161000.6eb160c3-d49f-4899-bce1-ad91c8cc303f",
+      "fullUrl" : "Patient/1706818740496058000.c5a805d8-8e51-41bc-9324-6b2920df834c",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655438520161000.6eb160c3-d49f-4899-bce1-ad91c8cc303f",
+        "id" : "1706818740496058000.c5a805d8-8e51-41bc-9324-6b2920df834c",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -202,7 +207,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655438496363000.db327d39-be69-478b-a6c2-3f8432652e34"
+                  "reference" : "Organization/1706818740475505000.89ac3ef9-ad9f-458a-a71a-a007f3ecf77f"
                 }
               },
               {
@@ -348,10 +353,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655438496363000.db327d39-be69-478b-a6c2-3f8432652e34",
+      "fullUrl" : "Organization/1706818740475505000.89ac3ef9-ad9f-458a-a71a-a007f3ecf77f",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655438496363000.db327d39-be69-478b-a6c2-3f8432652e34",
+        "id" : "1706818740475505000.89ac3ef9-ad9f-458a-a71a-a007f3ecf77f",
         "identifier" : [
           {
             "extension" : [
@@ -366,16 +371,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655438523976000.c3209a39-5b02-4ba6-90c0-24e6ed993ed6",
+      "fullUrl" : "Provenance/1706818740500327000.d50814b6-dbeb-470b-ad0b-f8a41b7b4202",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655438523976000.c3209a39-5b02-4ba6-90c0-24e6ed993ed6",
+        "id" : "1706818740500327000.d50814b6-dbeb-470b-ad0b-f8a41b7b4202",
         "target" : [
           {
-            "reference" : "Patient/1706655438520161000.6eb160c3-d49f-4899-bce1-ad91c8cc303f"
+            "reference" : "Patient/1706818740496058000.c5a805d8-8e51-41bc-9324-6b2920df834c"
           }
         ],
-        "recorded" : "2024-01-30T17:57:18Z",
+        "recorded" : "2024-02-01T15:19:00Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_mobile.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_mobile.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655447170923000.9feed070-5313-47d2-9dd1-14819ba079a9",
+  "id" : "1706818749734541000.6d0484fd-2500-454e-8836-3c84d9b583f8",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:57:27.178-05:00"
+    "lastUpdated" : "2024-02-01T15:19:09.741-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655447568009000.9ebf2ac3-bc73-47e4-97d6-d723f5ebe505",
+      "fullUrl" : "Provenance/1706818750145405000.c582549f-fd62-4f8a-b42a-808f263e665f",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655447568009000.9ebf2ac3-bc73-47e4-97d6-d723f5ebe505",
+        "id" : "1706818750145405000.c582549f-fd62-4f8a-b42a-808f263e665f",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655447576029000.e5ffc916-d375-4540-9617-281e4bafb181",
+      "fullUrl" : "Provenance/1706818750154557000.d9925dc2-3498-470b-8cc3-879c983fde24",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655447576029000.e5ffc916-d375-4540-9617-281e4bafb181",
-        "recorded" : "2024-01-30T17:57:27Z",
+        "id" : "1706818750154557000.d9925dc2-3498-470b-8cc3-879c983fde24",
+        "recorded" : "2024-02-01T15:19:10Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655447575430000.f10cab80-85b0-4a25-8fbc-fb0b1f298206"
+              "reference" : "Organization/1706818750154069000.ee427633-760c-417b-a34e-81636719028d"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655447575430000.f10cab80-85b0-4a25-8fbc-fb0b1f298206",
+      "fullUrl" : "Organization/1706818750154069000.ee427633-760c-417b-a34e-81636719028d",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655447575430000.f10cab80-85b0-4a25-8fbc-fb0b1f298206",
+        "id" : "1706818750154069000.ee427633-760c-417b-a34e-81636719028d",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655447602990000.fbf12ace-5f90-4c7a-8ce2-81614614be0d",
+      "fullUrl" : "Patient/1706818750184895000.d3a0d2dd-60c2-4091-9d50-8db7bec211dc",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655447602990000.fbf12ace-5f90-4c7a-8ce2-81614614be0d",
+        "id" : "1706818750184895000.d3a0d2dd-60c2-4091-9d50-8db7bec211dc",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -202,7 +207,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655447583581000.e9e65c6e-2cc1-4d5a-9788-2616f9325cfb"
+                  "reference" : "Organization/1706818750163244000.78b4c3b0-d0a1-4eb4-b343-183a271e84d5"
                 }
               },
               {
@@ -324,10 +329,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655447583581000.e9e65c6e-2cc1-4d5a-9788-2616f9325cfb",
+      "fullUrl" : "Organization/1706818750163244000.78b4c3b0-d0a1-4eb4-b343-183a271e84d5",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655447583581000.e9e65c6e-2cc1-4d5a-9788-2616f9325cfb",
+        "id" : "1706818750163244000.78b4c3b0-d0a1-4eb4-b343-183a271e84d5",
         "identifier" : [
           {
             "extension" : [
@@ -342,16 +347,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655447609293000.56f3673c-de21-4457-83ca-6b4dc0ba1a0f",
+      "fullUrl" : "Provenance/1706818750188133000.13c16672-f3b2-444f-a14d-d7e2154d1148",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655447609293000.56f3673c-de21-4457-83ca-6b4dc0ba1a0f",
+        "id" : "1706818750188133000.13c16672-f3b2-444f-a14d-d7e2154d1148",
         "target" : [
           {
-            "reference" : "Patient/1706655447602990000.fbf12ace-5f90-4c7a-8ce2-81614614be0d"
+            "reference" : "Patient/1706818750184895000.d3a0d2dd-60c2-4091-9d50-8db7bec211dc"
           }
         ],
-        "recorded" : "2024-01-30T17:57:27Z",
+        "recorded" : "2024-02-01T15:19:10Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_temp.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_temp.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655456367525000.5fa76759-c9a5-43e8-a0ff-613bf6d73b2f",
+  "id" : "1706818759308758000.a24a458f-513f-42d2-9421-42199522ed39",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:57:36.374-05:00"
+    "lastUpdated" : "2024-02-01T15:19:19.316-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -30,29 +30,46 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-15-accept-acknowledgement-type",
-            "valueString" : "NE"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-16-application-acknowledgement-type",
-            "valueString" : "NE"
-          },
-          {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh21-source-message-profile-id",
-            "valueIdentifier" : {
-              "extension" : [
-                {
-                  "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-                  "valueOid" : "urn:oid:2.16.840.1.113883.9.11"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              },
+              {
+                "url" : "MSH.15",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.16",
+                "valueString" : "NE"
+              },
+              {
+                "url" : "MSH.21",
+                "valueIdentifier" : {
+                  "extension" : [
+                    {
+                      "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                      "extension" : [
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id",
+                          "valueString" : "PHIN"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-universal-id",
+                          "valueString" : "2.16.840.1.113883.9.11"
+                        },
+                        {
+                          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                          "valueCode" : "ISO"
+                        }
+                      ]
+                    }
+                  ],
+                  "value" : "PHLabReport-NoAck"
                 }
-              ],
-              "system" : "PHIN",
-              "value" : "PHLabReport-NoAck"
-            }
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -79,12 +96,12 @@
             "name" : "MEDSS-ELR ",
             "endpoint" : "urn:oid:2.16.840.1.114222.4.3.3.6.2.1",
             "receiver" : {
-              "reference" : "Organization/1706655456436672000.c84c9bb5-9112-4477-9a07-4fef125103fe"
+              "reference" : "Organization/1706818759383093000.c90690e1-3898-43a4-81a7-bc62ee8773f8"
             }
           }
         ],
         "sender" : {
-          "reference" : "Organization/1706655456441130000.15f0d936-5b4f-4cd2-b637-217dbb8f37d8"
+          "reference" : "Organization/1706818759357946000.b03da52f-0fd7-4112-ba5b-44f1236dfe15"
         },
         "source" : {
           "extension" : [
@@ -110,10 +127,45 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655456436672000.c84c9bb5-9112-4477-9a07-4fef125103fe",
+      "fullUrl" : "Organization/1706818759357946000.b03da52f-0fd7-4112-ba5b-44f1236dfe15",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655456436672000.c84c9bb5-9112-4477-9a07-4fef125103fe",
+        "id" : "1706818759357946000.b03da52f-0fd7-4112-ba5b-44f1236dfe15",
+        "identifier" : [
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
+                "valueBoolean" : true
+              }
+            ],
+            "value" : "CDC Atlanta"
+          },
+          {
+            "extension" : [
+              {
+                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
+                "valueBoolean" : true
+              }
+            ],
+            "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
+                  "code" : "CLIA"
+                }
+              ]
+            },
+            "value" : "11D0668319"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl" : "Organization/1706818759383093000.c90690e1-3898-43a4-81a7-bc62ee8773f8",
+      "resource" : {
+        "resourceType" : "Organization",
+        "id" : "1706818759383093000.c90690e1-3898-43a4-81a7-bc62ee8773f8",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7-use",
@@ -152,45 +204,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655456441130000.15f0d936-5b4f-4cd2-b637-217dbb8f37d8",
-      "resource" : {
-        "resourceType" : "Organization",
-        "id" : "1706655456441130000.15f0d936-5b4f-4cd2-b637-217dbb8f37d8",
-        "identifier" : [
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-namespace-id",
-                "valueBoolean" : true
-              }
-            ],
-            "value" : "CDC Atlanta"
-          },
-          {
-            "extension" : [
-              {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-universal-id",
-                "valueBoolean" : true
-              }
-            ],
-            "type" : {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-                  "code" : "CLIA"
-                }
-              ]
-            },
-            "value" : "11D0668319"
-          }
-        ]
-      }
-    },
-    {
-      "fullUrl" : "Provenance/1706655456751021000.f5fb9f25-94ac-4348-9c54-6d0f4379aea0",
+      "fullUrl" : "Provenance/1706818759733989000.15772e88-47c3-4626-add7-7c8f515504f5",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655456751021000.f5fb9f25-94ac-4348-9c54-6d0f4379aea0",
+        "id" : "1706818759733989000.15772e88-47c3-4626-add7-7c8f515504f5",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -215,17 +232,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655456750288000.92088894-08aa-432e-84c0-34924bfa4243"
+              "reference" : "Organization/1706818759732574000.ca36f11c-5bb7-46db-ab15-227dd495b3aa"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655456750288000.92088894-08aa-432e-84c0-34924bfa4243",
+      "fullUrl" : "Organization/1706818759732574000.ca36f11c-5bb7-46db-ab15-227dd495b3aa",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655456750288000.92088894-08aa-432e-84c0-34924bfa4243",
+        "id" : "1706818759732574000.ca36f11c-5bb7-46db-ab15-227dd495b3aa",
         "identifier" : [
           {
             "extension" : [
@@ -257,11 +274,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655456759126000.dbce9725-e9cd-4cac-a6b7-f079f96395a2",
+      "fullUrl" : "Provenance/1706818759742937000.b5ef22d8-2185-4bbf-b49b-ae607ff46134",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655456759126000.dbce9725-e9cd-4cac-a6b7-f079f96395a2",
-        "recorded" : "2024-01-30T17:57:36Z",
+        "id" : "1706818759742937000.b5ef22d8-2185-4bbf-b49b-ae607ff46134",
+        "recorded" : "2024-02-01T15:19:19Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -283,17 +300,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655456758790000.91cd0283-411d-4b2e-bb91-393313456f2f"
+              "reference" : "Organization/1706818759742530000.3ae2e61a-8398-4e1f-88b2-c8a1df8fdb43"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655456758790000.91cd0283-411d-4b2e-bb91-393313456f2f",
+      "fullUrl" : "Organization/1706818759742530000.3ae2e61a-8398-4e1f-88b2-c8a1df8fdb43",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655456758790000.91cd0283-411d-4b2e-bb91-393313456f2f",
+        "id" : "1706818759742530000.3ae2e61a-8398-4e1f-88b2-c8a1df8fdb43",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -313,10 +330,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655456784389000.0b1e636e-3bd6-44a1-a45b-530de86cd7cc",
+      "fullUrl" : "Patient/1706818759771933000.5b3dafd4-333a-4cfd-b830-a366d5fe3c73",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655456784389000.0b1e636e-3bd6-44a1-a45b-530de86cd7cc",
+        "id" : "1706818759771933000.5b3dafd4-333a-4cfd-b830-a366d5fe3c73",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -395,7 +412,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655456766545000.575cb69c-3b04-494d-acfc-b2980c68c00a"
+                  "reference" : "Organization/1706818759750148000.e2aa302e-3bba-4a9c-8ed4-3c9e928c4e0a"
                 }
               },
               {
@@ -517,10 +534,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655456766545000.575cb69c-3b04-494d-acfc-b2980c68c00a",
+      "fullUrl" : "Organization/1706818759750148000.e2aa302e-3bba-4a9c-8ed4-3c9e928c4e0a",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655456766545000.575cb69c-3b04-494d-acfc-b2980c68c00a",
+        "id" : "1706818759750148000.e2aa302e-3bba-4a9c-8ed4-3c9e928c4e0a",
         "identifier" : [
           {
             "extension" : [
@@ -535,16 +552,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655456787129000.299ef534-22d4-4e63-a341-9dc12769da20",
+      "fullUrl" : "Provenance/1706818759778727000.5bf2f4f2-1b7c-42d9-859c-ef6de35bff56",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655456787129000.299ef534-22d4-4e63-a341-9dc12769da20",
+        "id" : "1706818759778727000.5bf2f4f2-1b7c-42d9-859c-ef6de35bff56",
         "target" : [
           {
-            "reference" : "Patient/1706655456784389000.0b1e636e-3bd6-44a1-a45b-530de86cd7cc"
+            "reference" : "Patient/1706818759771933000.5b3dafd4-333a-4cfd-b830-a366d5fe3c73"
           }
         ],
-        "recorded" : "2024-01-30T17:57:36Z",
+        "recorded" : "2024-02-01T15:19:19Z",
         "activity" : {
           "coding" : [
             {

--- a/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_work.fhir
+++ b/prime-router/src/testIntegration/resources/datatests/mappinginventory/xtn/xtn_2_use_code_work.fhir
@@ -1,8 +1,8 @@
 {
   "resourceType" : "Bundle",
-  "id" : "1706655465433892000.758ddd69-c108-472b-956f-794bb65ac125",
+  "id" : "1706818768900507000.aa107677-39ca-47ed-ad2b-5183adda6c51",
   "meta" : {
-    "lastUpdated" : "2024-01-30T17:57:45.440-05:00"
+    "lastUpdated" : "2024-02-01T15:19:28.907-05:00"
   },
   "identifier" : {
     "system" : "https://reportstream.cdc.gov/prime-router",
@@ -22,8 +22,13 @@
             "valueString" : "^~\\&#"
           },
           {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-7-datetime-of-message",
-            "valueString" : "20230501102531-0400"
+            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+            "extension" : [
+              {
+                "url" : "MSH.7",
+                "valueString" : "20230501102531-0400"
+              }
+            ]
           }
         ],
         "eventCoding" : {
@@ -44,10 +49,10 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655465820414000.9333f77b-fb1c-4266-a541-dfeace63ca8a",
+      "fullUrl" : "Provenance/1706818769309331000.c9861e6e-8729-4d20-88a6-db5bf2f959f8",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655465820414000.9333f77b-fb1c-4266-a541-dfeace63ca8a",
+        "id" : "1706818769309331000.c9861e6e-8729-4d20-88a6-db5bf2f959f8",
         "target" : [
           {
             "reference" : "MessageHeader/0993dd0b-6ce5-3caf-a177-0b81cc780c18"
@@ -64,11 +69,11 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655465827952000.11025a72-50ef-4596-b175-fdd5b8d481f6",
+      "fullUrl" : "Provenance/1706818769318577000.b8467074-c99c-4a64-bd5d-91d60a45d8a7",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655465827952000.11025a72-50ef-4596-b175-fdd5b8d481f6",
-        "recorded" : "2024-01-30T17:57:45Z",
+        "id" : "1706818769318577000.b8467074-c99c-4a64-bd5d-91d60a45d8a7",
+        "recorded" : "2024-02-01T15:19:29Z",
         "policy" : [
           "http://hl7.org/fhir/uv/v2mappings/message-oru-r01-to-bundle"
         ],
@@ -90,17 +95,17 @@
               ]
             },
             "who" : {
-              "reference" : "Organization/1706655465827355000.d59935cb-ed85-4707-875e-5ac9b9bb97ad"
+              "reference" : "Organization/1706818769318056000.552e36a8-d474-4e8f-88c1-e52a742e3dbe"
             }
           }
         ]
       }
     },
     {
-      "fullUrl" : "Organization/1706655465827355000.d59935cb-ed85-4707-875e-5ac9b9bb97ad",
+      "fullUrl" : "Organization/1706818769318056000.552e36a8-d474-4e8f-88c1-e52a742e3dbe",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655465827355000.d59935cb-ed85-4707-875e-5ac9b9bb97ad",
+        "id" : "1706818769318056000.552e36a8-d474-4e8f-88c1-e52a742e3dbe",
         "identifier" : [
           {
             "value" : "CDC PRIME - Atlanta"
@@ -120,10 +125,10 @@
       }
     },
     {
-      "fullUrl" : "Patient/1706655465853440000.afd03e1a-ea6c-4750-97ac-ca1bb6e4858e",
+      "fullUrl" : "Patient/1706818769348110000.d0c92272-4deb-4873-825a-150c4cd4d7b7",
       "resource" : {
         "resourceType" : "Patient",
-        "id" : "1706655465853440000.afd03e1a-ea6c-4750-97ac-ca1bb6e4858e",
+        "id" : "1706818769348110000.d0c92272-4deb-4873-825a-150c4cd4d7b7",
         "extension" : [
           {
             "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
@@ -202,7 +207,7 @@
               {
                 "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
                 "valueReference" : {
-                  "reference" : "Organization/1706655465834471000.099ad07a-cae4-4138-9122-6765e7494d4a"
+                  "reference" : "Organization/1706818769325994000.b5e6d104-7686-48d4-923b-19a3d0d42889"
                 }
               },
               {
@@ -348,10 +353,10 @@
       }
     },
     {
-      "fullUrl" : "Organization/1706655465834471000.099ad07a-cae4-4138-9122-6765e7494d4a",
+      "fullUrl" : "Organization/1706818769325994000.b5e6d104-7686-48d4-923b-19a3d0d42889",
       "resource" : {
         "resourceType" : "Organization",
-        "id" : "1706655465834471000.099ad07a-cae4-4138-9122-6765e7494d4a",
+        "id" : "1706818769325994000.b5e6d104-7686-48d4-923b-19a3d0d42889",
         "identifier" : [
           {
             "extension" : [
@@ -366,16 +371,16 @@
       }
     },
     {
-      "fullUrl" : "Provenance/1706655465856910000.6bf3ccec-4046-4439-a59b-71f477cd0e1d",
+      "fullUrl" : "Provenance/1706818769351875000.3d8eee8f-d684-453f-bc87-791f510d2b70",
       "resource" : {
         "resourceType" : "Provenance",
-        "id" : "1706655465856910000.6bf3ccec-4046-4439-a59b-71f477cd0e1d",
+        "id" : "1706818769351875000.3d8eee8f-d684-453f-bc87-791f510d2b70",
         "target" : [
           {
-            "reference" : "Patient/1706655465853440000.afd03e1a-ea6c-4750-97ac-ca1bb6e4858e"
+            "reference" : "Patient/1706818769348110000.d0c92272-4deb-4873-825a-150c4cd4d7b7"
           }
         ],
-        "recorded" : "2024-01-30T17:57:45Z",
+        "recorded" : "2024-02-01T15:19:29Z",
         "activity" : {
           "coding" : [
             {


### PR DESCRIPTION
This PR covers collapsing the extensions for the HL7 segments and datatypes that were missed from the previous PR

Test Steps:
1. CI should cover the changes

## Changes
- Updates the segment mappings to follow the standard extension pattern
- Fixes the ED<->Attachment mapping

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- #12905 

## To Be Done


## Specific Security-related subjects a reviewer should pay specific attention to
