### PR TITLE
13825: quiet JWT exception logging

### DIFF
--- a/prime-router/src/main/kotlin/tokens/OktaAuthentication.kt
+++ b/prime-router/src/main/kotlin/tokens/OktaAuthentication.kt
@@ -57,10 +57,10 @@ class OktaAuthentication(private val minimumLevel: PrincipalLevel = PrincipalLev
                 logger.info("Authenticated request by ${claims.userName}: $httpMethod:$path")
                 return claims
             } catch (e: JwtVerificationException) {
-                logger.warn("JWT token failed to authenticate for call: $httpMethod: $path", e)
+                logger.warn("JWT token failed to authenticate for call: $httpMethod: $path reason: ${e.message}")
                 return null
             } catch (e: Exception) {
-                logger.warn("Failure while authenticating, for call: $httpMethod: $path", e)
+                logger.warn("Failure while authenticating, for call: $httpMethod: $path reason: ${e.message}")
                 return null
             }
         }


### PR DESCRIPTION
This PR quiets down JWT exception logging. This should solve the issue of constant PagerDuty alerting.

Test Steps:
1. Attempt to authenticate without a valid JWT
2. Check the exceptions table to ensure no `JWTVerificationException` shows up

## Changes
- Move exception out of parameters and add the message directly to the string

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

## Linked Issues
- Fixes #13825