### PR TITLE
14415: clean up exception logging for hl7 parsing

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -12,10 +12,10 @@ import ca.uhn.hl7v2.util.Hl7InputStreamMessageStringIterator
 import ca.uhn.hl7v2.util.Terser
 import ca.uhn.hl7v2.validation.ValidationException
 import ca.uhn.hl7v2.validation.impl.ValidationContextFactory
-import com.jcraft.jsch.Logger
 import gov.cdc.prime.router.ActionLogger
 import gov.cdc.prime.router.InvalidReportMessage
 import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.kotlin.Logging
 import java.util.Date
 import ca.uhn.hl7v2.model.v251.message.ORU_R01 as v251_ORU_R01
@@ -97,7 +97,7 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
             }
 
             // if it was able to parse the message through one of the models, then we do not want to log it as an error
-            val parseLogLevel = if (parseError.size == messageModelsToTry.size) Logger.ERROR else Logger.WARN
+            val parseLogLevel = if (parseError.size == messageModelsToTry.size) Level.ERROR else Level.WARN
             parseError.forEach { currentError ->
                 logHL7ParseFailure(currentError, messages.isEmpty(), parseLogLevel)
             }
@@ -163,13 +163,9 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
     private fun logHL7ParseFailure(
         exception: Hl7InputStreamMessageStringIterator.ParseFailureError,
         isError: Boolean = true,
-        logLevel: Int = Logger.ERROR,
+        logLevel: Level = Level.ERROR,
     ) {
-        if (logLevel == Logger.ERROR) {
-            logger.error("Failed to parse message", exception)
-        } else {
-            logger.warn("Failed to parse message", exception)
-        }
+        logger.log(logLevel, "Failed to parse message: ${exception.message}")
 
         // Get the exception root cause and log it accordingly
         when (val rootCause = ExceptionUtils.getRootCause(exception)) {


### PR DESCRIPTION
This PR stops logging the expected exception during HL7 parsing to reduce PagerDuty alerts.

I also took the liberty of cleaning up the logging logic to use the log4j `Level` class rather than depending on some logging class found in an SSH library.

Test Steps:
1. See that parsing errors are no longer ending up in the exceptions table in Azure

## Changes
- Remove exception from logger call
- Use `Level` class from log4j

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

## Linked Issues
- Fixes #13315 