### PR TITLE
Changing how get code sources map handles non Codeable Concepts

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
@@ -71,7 +71,7 @@ fun Observation.getCodeSourcesMap(): Map<String, List<Coding>> {
         toReturn[ObservationMappingConstants.BUNDLE_CODE_IDENTIFIER] = this.code.coding
     }
 
-    if (this.valueCodeableConcept is CodeableConcept) {
+    if (this.value is CodeableConcept) {
         toReturn[ObservationMappingConstants.BUNDLE_VALUE_IDENTIFIER] = this.valueCodeableConcept.coding
     }
 

--- a/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
@@ -14,9 +14,9 @@ import gov.cdc.prime.router.fhirengine.translation.hl7.utils.CustomContext
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
 import gov.cdc.prime.router.fhirengine.utils.FHIRBundleHelpers.Companion.getChildProperties
 import io.github.linuxforhealth.hl7.data.Hl7RelatedGeneralUtils
-import org.hl7.fhir.exceptions.FHIRException
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.DiagnosticReport
@@ -67,24 +67,14 @@ private fun lookupCondition(code: Coding, metadata: Metadata): Coding? {
  */
 fun Observation.getCodeSourcesMap(): Map<String, List<Coding>> {
     val toReturn = mutableMapOf<String, List<Coding>>()
-    try {
+    if (this.code is CodeableConcept) {
         toReturn[ObservationMappingConstants.BUNDLE_CODE_IDENTIFIER] = this.code.coding
-    } catch (error: FHIRException) {
-        if (error.message == null ||
-            !error.message!!.startsWith("Type mismatch: the type CodeableConcept was expected")
-            ) {
-            throw error
-        }
     }
-    try {
+
+    if (this.valueCodeableConcept is CodeableConcept) {
         toReturn[ObservationMappingConstants.BUNDLE_VALUE_IDENTIFIER] = this.valueCodeableConcept.coding
-    } catch (error: FHIRException) {
-        if (error.message == null ||
-            !error.message!!.startsWith("Type mismatch: the type CodeableConcept was expected")
-            ) {
-            throw error
-        }
     }
+
     return toReturn
 }
 


### PR DESCRIPTION
This PR changes how we handle getting the code sources map handles non codeable concepts.

Test Steps:
1. Send a message through the system (I will attach an example) that will send a non codeable concept through and make sure it does not fail.

## Changes
- It changes how we handle getting the code sources map handles non codeable concepts.

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #issue

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
