### PR TITLE
13020 load schema mapping support

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -852,7 +852,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:2.2")
     implementation("io.github.linuxforhealth:hl7v2-fhir-converter") {
         version {
-            branch = "master"
+            branch = "platform/jwang/13020-runtime-constructors"
         }
     }
     implementation("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.10.4")

--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -852,7 +852,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:2.2")
     implementation("io.github.linuxforhealth:hl7v2-fhir-converter") {
         version {
-            branch = "platform/jwang/13020-runtime-constructors"
+            branch = "master"
         }
     }
     implementation("ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.10.4")

--- a/prime-router/metadata/test_fhir_mapping/config.properties
+++ b/prime-router/metadata/test_fhir_mapping/config.properties
@@ -1,0 +1,5 @@
+base.path.resource=./metadata/test_fhir_mapping
+supported.hl7.messages=ORU_R01,ORM_O01
+default.zoneid=+00:00
+additional.conceptmap.file=
+additional.resources.location=./metadata/fhir_mapping

--- a/prime-router/metadata/test_fhir_mapping/config.properties
+++ b/prime-router/metadata/test_fhir_mapping/config.properties
@@ -2,4 +2,4 @@ base.path.resource=./metadata/test_fhir_mapping
 supported.hl7.messages=ORU_R01,ORM_O01
 default.zoneid=+00:00
 additional.conceptmap.file=
-additional.resources.location=./metadata/fhir_mapping
+additional.resources.location=

--- a/prime-router/metadata/test_fhir_mapping/hl7/message/ORM_O01.yml
+++ b/prime-router/metadata/test_fhir_mapping/hl7/message/ORM_O01.yml
@@ -1,0 +1,9 @@
+resources:
+
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: segments/MSH/MessageHeader
+    repeats: false
+    isReferenced: false
+
+# This test should only process MSH to produce minimal results

--- a/prime-router/metadata/test_fhir_mapping/hl7/message/ORU_R01.yml
+++ b/prime-router/metadata/test_fhir_mapping/hl7/message/ORU_R01.yml
@@ -1,0 +1,12 @@
+resources:
+
+  - resourceName: MessageHeader
+    segment: MSH
+    resourcePath: segments/MSH/MessageHeader
+    repeats: false
+    isReferenced: true
+    additionalSegments:
+      - SFT
+
+
+# This test should only process MSH to produce minimal results

--- a/prime-router/metadata/test_fhir_mapping/hl7/segments/MSH/MessageHeader.yml
+++ b/prime-router/metadata/test_fhir_mapping/hl7/segments/MSH/MessageHeader.yml
@@ -1,0 +1,23 @@
+resourceType: MessageHeader
+
+# This test version of MSH has most elements removed so that the result will be different
+
+id:
+  type: NAMED_UUID
+  valueOf: MSH.10
+  expressionType: HL7Spec
+
+language:
+  vars:
+    cwe1: MSH.19.1
+  expressionType: nested
+  expressions:
+    - condition: $cwe1 NOT_NULL
+      valueOf: MSH.19.1
+      type: STRING
+      expressionType: HL7Spec
+    - condition: $cwe1 NULL
+      valueOf: MSH.19.4
+      type: STRING
+      expressionType: HL7Spec
+

--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -467,9 +467,7 @@ class BlobAccess() : Logging {
          * @return the blob container client
          */
         internal fun getBlobContainer(blobConnInfo: BlobContainerMetadata): BlobContainerClient {
-            return if (blobContainerClients.containsKey(blobConnInfo)) {
-                blobContainerClients[blobConnInfo]!!
-            } else {
+            return blobContainerClients.getOrElse(blobConnInfo) {
                 val blobServiceClient = BlobServiceClientBuilder()
                     .connectionString(blobConnInfo.connectionString)
                     .buildClient()

--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -234,7 +234,7 @@ class ProcessFhirCommands : CliktCommand(
             val msh = message.get("MSH") as Segment
             Terser.set(msh, 2, 0, 1, 1, "^~\\&#")
         }
-        return Pair(HL7toFhirTranslator.getInstance().translate(message), message)
+        return Pair(HL7toFhirTranslator().translate(message), message)
     }
 
     /**

--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -236,7 +236,7 @@ class ProcessFhirCommands : CliktCommand(
         }
         val hl7profile = HL7Reader.getMessageProfile(message.toString())
         // search hl7 profile map and create translator with config path if found
-        return when (val configPath = HL7Reader.messageProfileMap[hl7profile]) {
+        return when (val configPath = HL7Reader.profileDirectoryMap[hl7profile]) {
             null -> Pair(HL7toFhirTranslator().translate(message), message)
             else -> Pair(HL7toFhirTranslator(configPath).translate(message), message)
         }

--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -234,7 +234,12 @@ class ProcessFhirCommands : CliktCommand(
             val msh = message.get("MSH") as Segment
             Terser.set(msh, 2, 0, 1, 1, "^~\\&#")
         }
-        return Pair(HL7toFhirTranslator().translate(message), message)
+        val hl7profile = HL7Reader.getMessageProfile(message.toString())
+        // search hl7 profile map and create translator with config path if found
+        return when (val configPath = HL7Reader.messageProfileMap[hl7profile]) {
+            null -> Pair(HL7toFhirTranslator().translate(message), message)
+            else -> Pair(HL7toFhirTranslator(configPath).translate(message), message)
+        }
     }
 
     /**

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -204,7 +204,9 @@ class FHIRConverter(
         // create the hl7 reader
         val hl7Reader = HL7Reader(actionLogger)
         // get the hl7 from the blob store
-        val hl7messages = hl7Reader.getMessages(queueMessage.downloadContent())
+        val hl7rawmessages = queueMessage.downloadContent()
+        val hl7profile = HL7Reader.getMessageProfile(hl7rawmessages)
+        val hl7messages = hl7Reader.getMessages(hl7rawmessages)
 
         val bundles = if (actionLogger.hasErrors()) {
             val errMessage = actionLogger.errors.joinToString("\n") { it.detail.message }
@@ -213,8 +215,14 @@ class FHIRConverter(
             emptyList()
         } else {
             // use fhir transcoder to turn hl7 into FHIR
-            hl7messages.map {
-                HL7toFhirTranslator.getInstance().translate(it)
+            // search hl7 profile map and create translator with config path if found
+            when (val configPath = HL7Reader.messageProfileMap[hl7profile]) {
+                null -> hl7messages.map {
+                    HL7toFhirTranslator().translate(it)
+                }
+                else -> hl7messages.map {
+                    HL7toFhirTranslator(configPath).translate(it)
+                }
             }
         }
 

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -216,7 +216,7 @@ class FHIRConverter(
         } else {
             // use fhir transcoder to turn hl7 into FHIR
             // search hl7 profile map and create translator with config path if found
-            when (val configPath = HL7Reader.messageProfileMap[hl7profile]) {
+            when (val configPath = HL7Reader.profileDirectoryMap[hl7profile]) {
                 null -> hl7messages.map {
                     HL7toFhirTranslator().translate(it)
                 }

--- a/prime-router/src/main/kotlin/fhirengine/translation/HL7toFhirTranslator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/HL7toFhirTranslator.kt
@@ -7,6 +7,7 @@ import gov.cdc.prime.router.fhirengine.utils.FhirTranscoder
 import gov.cdc.prime.router.fhirengine.utils.addProvenanceReference
 import gov.cdc.prime.router.fhirengine.utils.enhanceBundleMetadata
 import gov.cdc.prime.router.fhirengine.utils.handleBirthTime
+import io.github.linuxforhealth.core.config.ConverterConfiguration
 import io.github.linuxforhealth.hl7.message.HL7MessageEngine
 import io.github.linuxforhealth.hl7.message.HL7MessageModel
 import io.github.linuxforhealth.hl7.resource.ResourceReader
@@ -16,37 +17,17 @@ import org.hl7.fhir.r4.model.Bundle
 /**
  * Translate an HL7 message to FHIR.
  */
-class HL7toFhirTranslator internal constructor(
+class HL7toFhirTranslator(
+    private val configFolderPath: String = "./metadata/fhir_mapping",
     private val messageEngine: HL7MessageEngine = FhirTranscoder.getMessageEngine(),
 ) : Logging {
-    companion object {
-        init {
-            // TODO Change to use the local classpath per documentation
-            val props = System.getProperties()
-            props.setProperty("hl7converter.config.home", "./metadata/fhir_mapping")
-        }
-
-        /**
-         * A Default set of message templates for HL7 -> FHIR translation
-         */
-        internal val defaultMessageTemplates: MutableMap<String, HL7MessageModel> =
-            ResourceReader.getInstance().messageTemplates
-
-        /**
-         * Singleton object
-         */
-        private val singletonInstance: HL7toFhirTranslator by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
-            HL7toFhirTranslator()
-        }
-
-        /**
-         * Get the singleton instance.
-         * @return the translator instance
-         */
-        fun getInstance(): HL7toFhirTranslator {
-            return singletonInstance
-        }
-    }
+    /**
+     * A Default set of message templates for HL7 -> FHIR translation
+     */
+    internal val defaultMessageTemplates: MutableMap<String, HL7MessageModel> =
+        ResourceReader(
+            ConverterConfiguration(configFolderPath)
+        ).messageTemplates
 
     /**
      * Get the HL7 Message Model used to translate an [hl7Message] between HL7 and FHIR.

--- a/prime-router/src/main/kotlin/fhirengine/translation/HL7toFhirTranslator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/HL7toFhirTranslator.kt
@@ -40,9 +40,7 @@ class HL7toFhirTranslator(
 
         // if the requested message templates have been previously loaded, return the stored templates.
         // otherwise, load the templates
-        val messageTemplate = if (messageTemplates.containsKey(configFolderPath)) {
-            messageTemplates[configFolderPath]!!
-        } else {
+        val messageTemplate = messageTemplates.getOrElse(configFolderPath) {
             val newMessageTemplate = ResourceReader(ConverterConfiguration(configFolderPath)).messageTemplates
             messageTemplates[configFolderPath] = newMessageTemplate
             newMessageTemplate
@@ -68,10 +66,6 @@ class HL7toFhirTranslator(
         // extracted from
         // https://github.com/LinuxForHealth/hl7v2-fhir-converter/blob/d5e43fffa96654e7c5bc896e020ff2fa8aac4ff2/src/main/java/io/github/linuxforhealth/hl7/HL7ToFHIRConverter.java#L135-L159
         // If timezone specification is needed it can be provided via a custom HL7MessageEngine with a custom FHIRContext that has the time zone ID set
-
-        // reinitialize the ResourceReader to ensure the correct singleton instance for the job is loaded
-        ResourceReader(ConverterConfiguration(configFolderPath))
-
         val messageModel = getHL7MessageModel(hl7Message)
         val bundle = messageModel.convert(hl7Message, messageEngine)
         bundle.enhanceBundleMetadata(hl7Message)

--- a/prime-router/src/main/kotlin/fhirengine/translation/HL7toFhirTranslator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/HL7toFhirTranslator.kt
@@ -15,7 +15,9 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.hl7.fhir.r4.model.Bundle
 
 /**
- * Translate an HL7 message to FHIR.
+ * Creates a HL7toFhirTranslator object to perform HL7v2 to FHIR translations.
+ * @param configFolderPath path to a config.properties file. A default is used if none is provided.
+ * @param messageEngine HL7MessageEngine to be used. A default is used if none is provided.
  */
 class HL7toFhirTranslator(
     private val configFolderPath: String = "./metadata/fhir_mapping",

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -196,8 +196,8 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
     }
 
     companion object {
-        // map of HL7 message profiles: maps name of profile to configuration directory path
-        val messageProfileMap: Map<MessageProfile, String> = emptyMap()
+        // map of HL7 message profiles: maps profile to configuration directory path
+        val profileDirectoryMap: Map<MessageProfile, String> = emptyMap()
 
         // data class to uniquely identify a message profile
         data class MessageProfile(val typeID: String, val profileID: String)

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -196,6 +196,11 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
     }
 
     companion object {
+        // map of HL7 message profiles: maps name of profile to configuration directory path
+        val messageProfileMap: Map<MessageProfile, String> = emptyMap()
+
+        data class MessageProfile(val msh9: String, val msh21: String)
+
         /**
          * Get the [message] timestamp from MSH-7.
          * @return the timestamp or null if not specified
@@ -218,6 +223,19 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
                 is v251_MSH -> structure.msh9_MessageType.msg1_MessageCode.toString()
                 else -> ""
             }
+        }
+
+        /**
+         * Get the profile of the [message]
+         * @return the profile of message
+         */
+        fun getMessageProfile(message: String): MessageProfile? {
+            val iterator = Hl7InputStreamMessageIterator(message.byteInputStream())
+            if (!iterator.hasNext()) return null
+            val hl7message = iterator.next()
+            val msh9 = Terser(hl7message).get("MSH-9")
+            val msh21 = Terser(hl7message).get("MSH-21")
+            return MessageProfile(msh9, msh21)
         }
 
         /**

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -228,7 +228,9 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
 
         /**
          * Get the profile of the [rawmessage]
-         * @return the message profile
+         * If there are multiple HL7 messages the first message's data will be returned
+         * @param rawmessage string representative of hl7 messages
+         * @return the message profile, or null if there is no message
          */
         fun getMessageProfile(rawmessage: String): MessageProfile? {
             val iterator = Hl7InputStreamMessageIterator(rawmessage.byteInputStream())

--- a/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/HL7Reader.kt
@@ -199,7 +199,8 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
         // map of HL7 message profiles: maps name of profile to configuration directory path
         val messageProfileMap: Map<MessageProfile, String> = emptyMap()
 
-        data class MessageProfile(val msh9: String, val msh21: String)
+        // data class to uniquely identify a message profile
+        data class MessageProfile(val typeID: String, val profileID: String)
 
         /**
          * Get the [message] timestamp from MSH-7.
@@ -226,16 +227,16 @@ class HL7Reader(private val actionLogger: ActionLogger) : Logging {
         }
 
         /**
-         * Get the profile of the [message]
-         * @return the profile of message
+         * Get the profile of the [rawmessage]
+         * @return the message profile
          */
-        fun getMessageProfile(message: String): MessageProfile? {
-            val iterator = Hl7InputStreamMessageIterator(message.byteInputStream())
+        fun getMessageProfile(rawmessage: String): MessageProfile? {
+            val iterator = Hl7InputStreamMessageIterator(rawmessage.byteInputStream())
             if (!iterator.hasNext()) return null
             val hl7message = iterator.next()
             val msh9 = Terser(hl7message).get("MSH-9")
             val msh21 = Terser(hl7message).get("MSH-21")
-            return MessageProfile(msh9, msh21)
+            return MessageProfile(msh9 ?: "", msh21 ?: "")
         }
 
         /**

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirConverterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirConverterTests.kt
@@ -3,6 +3,7 @@ package gov.cdc.prime.router.fhirengine.engine
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -275,10 +276,6 @@ class FhirConverterTests {
     fun `test getContentFromHL7 alternate profile`() {
         val testProfile = HL7Reader.Companion.MessageProfile("ORU", "PHLabReport-NoAck")
 
-        mockkClass(HL7Reader::class)
-        mockkObject(HL7Reader.Companion)
-        every { HL7Reader.Companion.messageProfileMap.get(testProfile) } returns "./metadata/test_fhir_mapping"
-
         val actionLogger = spyk(ActionLogger())
         val engine = spyk(makeFhirEngine(metadata, settings, TaskAction.process) as FHIRConverter)
         val message = spyk(
@@ -296,9 +293,15 @@ class FhirConverterTests {
 
         val result = engine.getContentFromHL7(message, actionLogger)
 
+        mockkClass(HL7Reader::class)
+        mockkObject(HL7Reader.Companion)
+        every { HL7Reader.Companion.messageProfileMap.get(testProfile) } returns "./metadata/test_fhir_mapping"
+
+        val result2 = engine.getContentFromHL7(message, actionLogger)
+
         // the test fhir mappings produce far fewer entries than the production ones
-        assertThat(result).isNotEmpty()
-        assertThat(result[0].entry.size).isEqualTo(5)
+        assertThat(result2).isNotEmpty()
+        assertThat(result2[0].entry.size).isLessThan(result[0].entry.size)
     }
 
     @Test

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirConverterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirConverterTests.kt
@@ -3,7 +3,6 @@ package gov.cdc.prime.router.fhirengine.engine
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import assertk.assertions.isLessThan
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -295,13 +294,14 @@ class FhirConverterTests {
 
         mockkClass(HL7Reader::class)
         mockkObject(HL7Reader.Companion)
-        every { HL7Reader.Companion.messageProfileMap.get(testProfile) } returns "./metadata/test_fhir_mapping"
+        every { HL7Reader.Companion.profileDirectoryMap[testProfile] } returns "./metadata/test_fhir_mapping"
 
         val result2 = engine.getContentFromHL7(message, actionLogger)
 
         // the test fhir mappings produce far fewer entries than the production ones
         assertThat(result2).isNotEmpty()
-        assertThat(result2[0].entry.size).isLessThan(result[0].entry.size)
+        assertThat(result2[0].entry.filter { it.resource is Observation }).isEmpty()
+        assertThat(result[0].entry.filter { it.resource is Observation }).isNotEmpty()
     }
 
     @Test

--- a/prime-router/src/test/kotlin/fhirengine/utils/HL7ReaderTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/utils/HL7ReaderTests.kt
@@ -283,6 +283,17 @@ OBX|1|test|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen b
                 "PHLabReportNoAck"
             )
         )
+
+        val noProfile = """           
+            MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|PRIME_DOH|Prime ReportStream|20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA                                   
+        """.trimIndent()
+        val messages2 = HL7Reader.getMessageProfile(noProfile)
+        assertThat(messages2).isEqualTo(
+            HL7Reader.Companion.MessageProfile(
+                "ORU",
+                ""
+            )
+        )
     }
 
     @Test

--- a/prime-router/src/test/kotlin/fhirengine/utils/HL7ReaderTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/utils/HL7ReaderTests.kt
@@ -272,6 +272,20 @@ OBX|1|test|94558-4^SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen b
     }
 
     @Test
+    fun `test getMessageProfile`() {
+        val justMSH = """           
+            MSH|^~\&|CDC PRIME - Atlanta, Georgia (Dekalb)^2.16.840.1.114222.4.1.237821^ISO|Avante at Ormond Beach^10D0876999^CLIA|PRIME_DOH|Prime ReportStream|20210210170737||ORU^R01^ORU_R01|371784|P|2.5.1|||NE|NE|USA||||PHLabReportNoAck^ELR_Receiver^2.16.840.1.113883.9.11^ISO                                   
+        """.trimIndent()
+        val messages = HL7Reader.getMessageProfile(justMSH)
+        assertThat(messages).isEqualTo(
+            HL7Reader.Companion.MessageProfile(
+                "ORU",
+                "PHLabReportNoAck"
+            )
+        )
+    }
+
+    @Test
     fun `test getBirthTime_DateTime`() {
         val actionLogger = ActionLogger()
         val hL7Reader = HL7Reader(actionLogger)

--- a/prime-router/src/testIntegration/kotlin/datatests/TranslationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/datatests/TranslationTests.kt
@@ -434,7 +434,7 @@ class TranslationTests {
         private fun translateToFhir(hl7: InputStream): InputStream {
             val hl7messages = HL7Reader(ActionLogger()).getMessages(hl7.bufferedReader().readText())
             val fhirBundles = hl7messages.map { message ->
-                HL7toFhirTranslator.getInstance().translate(message)
+                HL7toFhirTranslator().translate(message)
             }
             check(fhirBundles.size == 1)
             val fhirJson = FhirTranscoder.encode(fhirBundles[0])


### PR DESCRIPTION
This PR introduces the ability to dynamically configure the location of HL7 to FHIR conversion schemas based on the message type and profile.

This should be reviewed with https://github.com/CDCgov/hl7v2-fhir-converter/pull/8

Test Steps:
1. Run Integration tests and confirm they pass.

## Changes
- Added data structures to support dynamic schema mapping by MSH9/MSH21
- Refactored HL7toFhirTranslator to not rely on a singleton instance
- HL7toFhirTranslator instances can now be constructed with a configuration file path

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

## Linked Issues
- #13020