### PR TITLE
permit urn:dns in logs

### DIFF
--- a/.github/runleaks/exclusions.txt
+++ b/.github/runleaks/exclusions.txt
@@ -21,5 +21,6 @@
 .*[A-Z0-9]{20}.tmp
 # gov.cdc.prime.router.datatests.TranslationTests
 .*Actual.*.Actual.*
+.*urn:dns.*
 
 ####################################################################


### PR DESCRIPTION
This PR updates the scan log action to permit `urn:dns` in the build logs.

Test Steps:
1. Run scan action logs workflow

## Changes
- Set `urn:dns` as a scan exclusion

## Checklist

## Linked Issues
- Fixes #13768
