### PR TITLE
13578 - Fix to Daily Data API to include ELIMS files

### DIFF
--- a/prime-router/src/main/kotlin/history/azure/DatabaseDeliveryAccess.kt
+++ b/prime-router/src/main/kotlin/history/azure/DatabaseDeliveryAccess.kt
@@ -1,6 +1,7 @@
 package gov.cdc.prime.router.history.azure
 
 import gov.cdc.prime.router.ReportId
+import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.DatabaseAccess
 import gov.cdc.prime.router.azure.db.Tables.ACTION
 import gov.cdc.prime.router.azure.db.Tables.REPORT_FACILITIES
@@ -41,8 +42,12 @@ class DatabaseDeliveryAccess(
         organization: String,
         orgService: String?,
     ): Condition {
-        var filter = ACTION.ACTION_NAME.eq(TaskAction.batch)
-            .and(REPORT_FILE.RECEIVING_ORG.eq(organization))
+        var filter = (
+            ACTION.ACTION_NAME.eq(TaskAction.batch)
+            .or(ACTION.ACTION_NAME.eq(TaskAction.send).and(REPORT_FILE.SCHEMA_TOPIC.eq(Topic.ELR_ELIMS)))
+            )
+
+        filter = filter.and(REPORT_FILE.RECEIVING_ORG.eq(organization))
 
         if (orgService != null) {
             filter = filter.and(REPORT_FILE.RECEIVING_ORG_SVC.eq(orgService))

--- a/prime-router/src/main/kotlin/history/azure/DatabaseDeliveryAccess.kt
+++ b/prime-router/src/main/kotlin/history/azure/DatabaseDeliveryAccess.kt
@@ -42,6 +42,7 @@ class DatabaseDeliveryAccess(
         organization: String,
         orgService: String?,
     ): Condition {
+//        This is a temporary fix to make the daily data page show data for reports routed through the ELR ELIMS topic since reports routed through the ELR-ELIMS topic skip the batch step. There are plans to have a dashboard for receivers that works for all messages routed through RS.
         var filter = (
             ACTION.ACTION_NAME.eq(TaskAction.batch)
             .or(ACTION.ACTION_NAME.eq(TaskAction.send).and(REPORT_FILE.SCHEMA_TOPIC.eq(Topic.ELR_ELIMS)))

--- a/prime-router/src/test/kotlin/history/azure/HistoryDatabaseAccessTests.kt
+++ b/prime-router/src/test/kotlin/history/azure/HistoryDatabaseAccessTests.kt
@@ -1,0 +1,26 @@
+package gov.cdc.prime.router.history.azure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HistoryDatabaseAccessTests {
+    @Test
+    fun `test organizationFilter`() {
+        var conditionExpected = """
+            (
+              (
+                "public"."action"."action_name" = 'batch'
+                or (
+                  "public"."action"."action_name" = 'send'
+                  and "public"."report_file"."schema_topic" = 'ELR_ELIMS'
+                )
+              )
+              and "public"."report_file"."receiving_org" = 'test'
+              and "public"."report_file"."receiving_org_svc" = 'test'
+            )
+        """.trimIndent()
+
+        var conditionActual = DatabaseDeliveryAccess().organizationFilter("test", "test")
+        assertEquals(conditionExpected, conditionActual.toString())
+    }
+}


### PR DESCRIPTION
This PR ...

Fix to Daily Data API to include ELIMS files

Test Steps:
1. Log into RS
2. All ELIMS sent items appear in the Daily Data table alongside other data in accordance with existing logic

## Changes
Added additional logic to the organizationFilter method

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?


## Linked Issues
- Fixes #13578 
