### PR TITLE
set default timezone for playwright

### DIFF
--- a/frontend-react/playwright.config.ts
+++ b/frontend-react/playwright.config.ts
@@ -62,6 +62,7 @@ export default defineConfig<TestOptions>({
     reporter: [["html", { outputFolder: "e2e-data/report" }]],
     outputDir: "e2e-data/results",
     use: {
+        timezoneId: "UTC",
         baseURL: "http://localhost:4173",
         trace: "on-first-retry",
         screenshot: "only-on-failure",


### PR DESCRIPTION
Sets a default timezone for Playwright so CI and local development are congruent.

Fixes #13865 