### PR TITLE
Bug: create blob endpoint from suffix and account name

### DIFF
--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -81,8 +81,8 @@ class BlobAccess() : Logging {
             /**
              * Regex used to extract the URL for blob storage
              */
-            private val blobEndpointRegex = Regex(";BlobEndpoint=(?<blobEndpoint>[^;]+);")
-            private val blobAccountNameRegex = Regex(";AccountName=(?<accountName>[^;]+);")
+            private val blobEndpointRegex = Regex(";BlobEndpoint=(?<blobEndpoint>[^;]+);?")
+            private val blobAccountNameRegex = Regex(";AccountName=(?<accountName>[^;]+);?")
             private val blobEndpointSuffixRegex = Regex(";EndpointSuffix=(?<endpointSuffix>[^;]+);?")
 
             /**

--- a/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
+++ b/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
@@ -439,31 +439,31 @@ class BlobAccessTests {
 
     @Test
     fun `test get blob endpoint URL from BlobContainerMetadata`() {
-        val endpoint =
+        val localEndpoint =
             """
                 DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=keydevstoreaccount1;BlobEndpoint=http://localhost:54321/devstoreaccount1;QueueEndpoint=http://localhost:12345/devstoreaccount1;
                 """.trimIndent()
 
-        val metadata = BlobAccess.BlobContainerMetadata("test", endpoint)
+        val metadata = BlobAccess.BlobContainerMetadata("test", localEndpoint)
         assertThat(metadata.getBlobEndpoint()).isEqualTo("http://localhost:54321/devstoreaccount1/test")
     }
 
     @Test
     fun `test get blob endpoint when accountname and suffix are used`() {
-        val endpoint =
+        val deployedEndpoint =
             """
                 DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=keydevstoreaccount1;EndpointSuffix=core.windows.net
                 """.trimIndent()
 
-        val metadata = BlobAccess.BlobContainerMetadata("test", endpoint)
+        val metadata = BlobAccess.BlobContainerMetadata("test", deployedEndpoint)
         assertThat(metadata.getBlobEndpoint()).isEqualTo("https://devstoreaccount1.blob.core.windows.net/test")
 
-        val endpoint2 =
+        val deployedEndpoint2 =
             """
                 DefaultEndpointsProtocol=http;AccountKey=keydevstoreaccount1;EndpointSuffix=core.windows.net;AccountName=devstoreaccount1;
                 """.trimIndent()
 
-        val metadata2 = BlobAccess.BlobContainerMetadata("test", endpoint2)
+        val metadata2 = BlobAccess.BlobContainerMetadata("test", deployedEndpoint2)
         assertThat(metadata2.getBlobEndpoint()).isEqualTo("https://devstoreaccount1.blob.core.windows.net/test")
     }
 

--- a/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
+++ b/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
@@ -457,6 +457,14 @@ class BlobAccessTests {
 
         val metadata = BlobAccess.BlobContainerMetadata("test", endpoint)
         assertThat(metadata.getBlobEndpoint()).isEqualTo("https://devstoreaccount1.blob.core.windows.net/test")
+
+        val endpoint2 =
+            """
+                DefaultEndpointsProtocol=http;AccountKey=keydevstoreaccount1;EndpointSuffix=core.windows.net;AccountName=devstoreaccount1;
+                """.trimIndent()
+
+        val metadata2 = BlobAccess.BlobContainerMetadata("test", endpoint2)
+        assertThat(metadata2.getBlobEndpoint()).isEqualTo("https://devstoreaccount1.blob.core.windows.net/test")
     }
 
     @Test

--- a/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
+++ b/prime-router/src/test/kotlin/azure/BlobAccessTests.kt
@@ -449,6 +449,17 @@ class BlobAccessTests {
     }
 
     @Test
+    fun `test get blob endpoint when accountname and suffix are used`() {
+        val endpoint =
+            """
+                DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=keydevstoreaccount1;EndpointSuffix=core.windows.net
+                """.trimIndent()
+
+        val metadata = BlobAccess.BlobContainerMetadata("test", endpoint)
+        assertThat(metadata.getBlobEndpoint()).isEqualTo("https://devstoreaccount1.blob.core.windows.net/test")
+    }
+
+    @Test
     fun `test blob endpoint URL missing from connection string for BlobContainerMetadata`() {
         val endpoint =
             """


### PR DESCRIPTION
This PR accounts for the the fact that azure connection strings have a different shape local vs. the higher environments. 

Test Steps:
1. CI should cover this

## Changes
- Updates the `getBlobEndpoint` method to look for account name and endpointsuffix in the higher environments

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues


## To Be Done


## Specific Security-related subjects a reviewer should pay specific attention to

