### PR TITLE
Bug: use the metadata container for loading fhir transform schemas

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/FhirTransformer.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/FhirTransformer.kt
@@ -1,6 +1,7 @@
 package gov.cdc.prime.router.fhirengine.translation.hl7
 
 import gov.cdc.prime.router.azure.BlobAccess
+import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.fhirengine.translation.hl7.schema.ConfigSchemaElementProcessingException
 import gov.cdc.prime.router.fhirengine.translation.hl7.schema.fhirTransform.FhirTransformSchema
 import gov.cdc.prime.router.fhirengine.translation.hl7.schema.fhirTransform.FhirTransformSchemaElement
@@ -26,7 +27,10 @@ class FhirTransformer(
      */
     constructor(
         schema: String,
-        blobConnectionInfo: BlobAccess.BlobContainerMetadata = BlobAccess.defaultBlobMetadata,
+        blobConnectionInfo: BlobAccess.BlobContainerMetadata = BlobAccess.BlobContainerMetadata.build(
+            "metadata",
+            Environment.get().blobEnvVar
+        ),
     ) : this(
         schemaRef = fhirTransformSchemaFromFile(schema, blobConnectionInfo),
     )


### PR DESCRIPTION
This PR uses the correct default container for loading fhir transform schemas from azure

Test Steps:
n/a

## Changes
- Changes the default azure blob info to use metadata container

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues


## To Be Done


## Specific Security-related subjects a reviewer should pay specific attention to

