### PR TITLE
Revert to using ktor bearer auth handler

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -891,6 +891,7 @@ dependencies {
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-apache:$ktorVersion")
+    implementation("io.ktor:ktor-client-auth:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
     implementation("io.ktor:ktor-client-encoding:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")

--- a/prime-router/src/main/kotlin/azure/CheckFunction.kt
+++ b/prime-router/src/main/kotlin/azure/CheckFunction.kt
@@ -20,6 +20,7 @@ import gov.cdc.prime.router.tokens.AuthenticatedClaims
 import gov.cdc.prime.router.tokens.authenticationFailure
 import gov.cdc.prime.router.transport.RESTTransport
 import gov.cdc.prime.router.transport.SftpTransport
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import net.schmizz.sshj.sftp.RemoteResourceFilter
@@ -353,7 +354,7 @@ class CheckFunction : Logging {
             val aLogger: Logger = Logger.getLogger(this.toString())
             runBlocking {
                 launch {
-                    var (httpHeaders, accessToken: String?) =
+                    var (httpHeaders, tokens: BearerTokens?) =
                         theRESTTransport.getOAuthToken(
                             restTransportType,
                             reportId,
@@ -363,7 +364,7 @@ class CheckFunction : Logging {
                         )
 
                     val msg = when {
-                        accessToken != null -> "${receiver.fullName}: Success: received OAuth token"
+                        tokens != null -> "${receiver.fullName}: Success: received OAuth token"
                         httpHeaders.isNotEmpty() -> "${receiver.fullName}: Success: received Authentication header"
                         else -> error("${receiver.fullName}: Failure: no valid response from RESTTransport")
                     }

--- a/prime-router/src/main/kotlin/cli/CommandUtilities.kt
+++ b/prime-router/src/main/kotlin/cli/CommandUtilities.kt
@@ -6,6 +6,7 @@ import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
 import gov.cdc.prime.router.common.JacksonMapperUtilities.jacksonObjectMapper
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -69,7 +70,7 @@ class CommandUtilities {
             return runBlocking {
                 val response = HttpClientUtils.head(
                     url.toString(),
-                    accessToken = accessToken,
+                    tokens = BearerTokens(accessToken, refreshToken = ""),
                     httpClient = httpClient
                 )
                 response.status == HttpStatusCode.OK

--- a/prime-router/src/main/kotlin/cli/LookupTableCommands.kt
+++ b/prime-router/src/main/kotlin/cli/LookupTableCommands.kt
@@ -30,6 +30,7 @@ import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
 import gov.cdc.prime.router.common.JacksonMapperUtilities
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.async
@@ -75,7 +76,7 @@ class LookupTableEndpointUtilities(
     fun fetchList(listInactive: Boolean = false): List<LookupTableVersion> {
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = environment.formUrl("$endpointRoot/list").toString(),
-            accessToken = accessToken,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
             timeout = requestTimeoutMillis.toLong(),
             queryParameters = mapOf(
                 Pair(LookupTableFunctions.showInactiveParamName, listInactive.toString())
@@ -111,7 +112,7 @@ class LookupTableEndpointUtilities(
         // seems need to destruct a pair by assignment
         val (response, respStr) = HttpClientUtils.putWithStringResponse(
             url = url,
-            accessToken = accessToken,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
             timeout = requestTimeoutMillis.toLong(),
             httpClient = httpClient
         )
@@ -149,7 +150,7 @@ class LookupTableEndpointUtilities(
         val url = environment.formUrl("$endpointRoot/$tableName/$version/content").toString()
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = url,
-            accessToken = accessToken,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
             timeout = requestTimeoutMillis.toLong(),
             httpClient = httpClient
         )
@@ -179,7 +180,7 @@ class LookupTableEndpointUtilities(
         val url = environment.formUrl("$endpointRoot/$tableName/$version/info").toString()
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = url,
-            accessToken = accessToken,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
             timeout = requestTimeoutMillis.toLong(),
             httpClient = httpClient
         )
@@ -201,7 +202,7 @@ class LookupTableEndpointUtilities(
         val (response, respStr) =
             HttpClientUtils.postWithStringResponse(
                 url = url,
-                accessToken = accessToken,
+                tokens = BearerTokens(accessToken, refreshToken = ""),
                 timeout = requestTimeoutMillis.toLong(),
                 jsonPayload = mapper.writeValueAsString(tableData),
                 httpClient = httpClient

--- a/prime-router/src/main/kotlin/cli/OktaCommands.kt
+++ b/prime-router/src/main/kotlin/cli/OktaCommands.kt
@@ -10,6 +10,7 @@ import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
 import gov.cdc.prime.router.common.JacksonMapperUtilities
 import gov.cdc.prime.router.transport.TokenInfo
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.http.isSuccess
 import org.apache.commons.codec.binary.Base64
 import java.awt.Desktop
@@ -258,7 +259,7 @@ abstract class OktaCommand(name: String, help: String) : CliktCommand(name = nam
             // Try out the token with Otka for the final confirmation
             val response = HttpClientUtils.get(
                 url = "$oktaBaseUrl$oktaUserInfoPath",
-                accessToken = accessTokenFile.token
+                tokens = BearerTokens(accessTokenFile.token, refreshToken = "")
             )
             return response.status.isSuccess()
         }

--- a/prime-router/src/main/kotlin/cli/SenderFilesCommand.kt
+++ b/prime-router/src/main/kotlin/cli/SenderFilesCommand.kt
@@ -12,6 +12,7 @@ import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
 import gov.cdc.prime.router.common.JacksonMapperUtilities
 import gov.cdc.prime.router.messages.ReportFileMessage
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.LocalDateTime
@@ -112,7 +113,7 @@ class SenderFilesCommand : CliktCommand(
         verbose("GET $path with $params")
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = path.toString(),
-            accessToken = accessToken.value,
+            tokens = BearerTokens(accessToken.value, refreshToken = ""),
             queryParameters = params.associate {
                 Pair(it.first, it.second.toString())
             },

--- a/prime-router/src/main/kotlin/cli/SettingCommands.kt
+++ b/prime-router/src/main/kotlin/cli/SettingCommands.kt
@@ -33,6 +33,7 @@ import gov.cdc.prime.router.azure.ReceiverAPI
 import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
 import gov.cdc.prime.router.common.JacksonMapperUtilities
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.lastModified
 import org.json.JSONArray
@@ -151,8 +152,8 @@ abstract class SettingCommand(
         val path = formPath(environment, Operation.PUT, settingType, settingName)
         verbose("PUT $path :: $payload")
         val (response, respStr) = HttpClientUtils.putWithStringResponse(
-            url = path.toString(),
-            accessToken = accessToken,
+            url = path,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
             jsonPayload = payload
         )
 
@@ -181,8 +182,8 @@ abstract class SettingCommand(
         val path = formPath(environment, Operation.DELETE, settingType, settingName)
         verbose("DELETE $path")
         val (response, respStr) = HttpClientUtils.deleteWithStringResponse(
-            url = path.toString(),
-            accessToken = accessToken,
+            url = path,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
         )
 
         return when (response.status) {
@@ -207,7 +208,7 @@ abstract class SettingCommand(
         verbose("GET $path")
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = accessToken,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
         )
 
         return if (response.status == HttpStatusCode.OK) {
@@ -231,8 +232,8 @@ abstract class SettingCommand(
         val path = formPath(environment, Operation.LIST, settingType, settingName)
         verbose("GET $path")
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
-            url = path.toString(),
-            accessToken = accessToken,
+            url = path,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
         )
 
         if (response.status == HttpStatusCode.OK) {
@@ -254,8 +255,8 @@ abstract class SettingCommand(
         val path = formPath(environment, Operation.LIST, settingType, settingName)
         verbose("GET $path")
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
-            url = path.toString(),
-            accessToken = accessToken,
+            url = path,
+            tokens = BearerTokens(accessToken, refreshToken = ""),
             timeout = HttpClientUtils.SETTINGS_REQUEST_TIMEOUT_MILLIS.toLong()
         )
         if (response.status == HttpStatusCode.OK) {
@@ -915,7 +916,7 @@ class PutMultipleSettings : SettingCommand(
     private fun isFileUpdated(): Boolean {
         val (response, respStr) = HttpClientUtils.headWithStringResponse(
             url = formPath(environment, Operation.LIST, SettingType.ORGANIZATION, "").toString(),
-            accessToken = oktaAccessToken,
+            tokens = BearerTokens(oktaAccessToken, refreshToken = ""),
             timeout = HttpClientUtils.SETTINGS_REQUEST_TIMEOUT_MILLIS.toLong()
         )
 

--- a/prime-router/src/main/kotlin/cli/tests/AuthTests.kt
+++ b/prime-router/src/main/kotlin/cli/tests/AuthTests.kt
@@ -25,6 +25,7 @@ import gov.cdc.prime.router.common.JacksonMapperUtilities.jacksonObjectMapper
 import gov.cdc.prime.router.tokens.AuthUtils
 import gov.cdc.prime.router.tokens.DatabaseJtiCache
 import gov.cdc.prime.router.tokens.Scope
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
@@ -1173,11 +1174,11 @@ class Server2ServerAuthTests : CoolTest() {
         val orgEndpoint = "${environment.url}/api/settings/organizations"
 
         val client = HttpClientUtils.createDefaultHttpClient(
-            userToken
+            BearerTokens(userToken, refreshToken = "")
         )
 
         val clientAdmin = HttpClientUtils.createDefaultHttpClient(
-            adminToken
+            BearerTokens(adminToken, refreshToken = "")
         )
 
         // Case: GET All Org Settings (Admin-only endpoint)

--- a/prime-router/src/main/kotlin/cli/tests/HistoryApiTest.kt
+++ b/prime-router/src/main/kotlin/cli/tests/HistoryApiTest.kt
@@ -9,6 +9,7 @@ import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
 import gov.cdc.prime.router.common.JacksonMapperUtilities.jacksonObjectMapper
 import gov.cdc.prime.router.history.DetailedSubmissionHistory
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.http.HttpStatusCode
 import java.net.HttpURLConnection
 import java.time.OffsetDateTime
@@ -123,7 +124,7 @@ class HistoryApiTest : CoolTest() {
     private fun historyApiQuery(testCase: HistoryApiTestCase): Pair<Boolean, String?> {
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = testCase.path,
-            accessToken = testCase.bearer,
+            tokens = BearerTokens(testCase.bearer, refreshToken = ""),
             timeout = 45000,
             queryParameters = testCase.parameters?.associate {
                 Pair(it.first, it.second.toString())

--- a/prime-router/src/main/kotlin/cli/tests/SettingsTest.kt
+++ b/prime-router/src/main/kotlin/cli/tests/SettingsTest.kt
@@ -5,6 +5,7 @@ import gov.cdc.prime.router.cli.FileUtilities
 import gov.cdc.prime.router.cli.SettingCommand
 import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.http.HttpStatusCode
 
 /**
@@ -94,14 +95,14 @@ class SettingsTest : CoolTest() {
 
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
             timeout = HttpClientUtils.SETTINGS_REQUEST_TIMEOUT_MILLIS.toLong(),
         )
 
         if (response.status != HttpStatusCode.NotFound) {
             val (delResp, delRespStr) = HttpClientUtils.deleteWithStringResponse(
                 url = path,
-                accessToken = dummyAccessToken,
+                tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
                 timeout = HttpClientUtils.SETTINGS_REQUEST_TIMEOUT_MILLIS.toLong(),
             )
             when (delResp.status) {
@@ -120,7 +121,7 @@ class SettingsTest : CoolTest() {
         echo("CREATE the new dummy organization...")
         val (putResponse, putRespStr) = HttpClientUtils.putWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
             jsonPayload = newDummyOrganization,
         )
         when (putResponse.status) {
@@ -140,7 +141,7 @@ class SettingsTest : CoolTest() {
         echo("VERITY the new dummy organization was created...")
         val (getResponse, getRespStr) = HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
         )
 
         if (getResponse.status == HttpStatusCode.NotFound) {
@@ -163,7 +164,7 @@ class SettingsTest : CoolTest() {
          */
         val (updResponse, updRespStr) = HttpClientUtils.putWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
             jsonPayload = updateDummyOrganization
         )
 
@@ -182,7 +183,7 @@ class SettingsTest : CoolTest() {
         echo("VERIFY it is the new dummy organization is updated...")
         val (newDummyResponse, newDummyRespStr) = HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
         )
         if (newDummyResponse.status == HttpStatusCode.NotFound) {
             return bad(
@@ -208,7 +209,7 @@ class SettingsTest : CoolTest() {
         echo("DELETE the updated dummy organization...")
         val (delNewDummyResponse, delNewDummyRespStr) = HttpClientUtils.deleteWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
             timeout = HttpClientUtils.SETTINGS_REQUEST_TIMEOUT_MILLIS.toLong(),
         )
 
@@ -226,7 +227,7 @@ class SettingsTest : CoolTest() {
         echo("VERIFY it is the new dummy organization is deleted...")
         val (getNewDummyDelResp, getNewDummyDelRespStr) = HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = dummyAccessToken,
+            tokens = BearerTokens(dummyAccessToken, refreshToken = ""),
             timeout = HttpClientUtils.SETTINGS_REQUEST_TIMEOUT_MILLIS.toLong(),
         )
         if (getNewDummyDelResp.status != HttpStatusCode.NotFound) {

--- a/prime-router/src/main/kotlin/cli/tests/SftpcheckTest.kt
+++ b/prime-router/src/main/kotlin/cli/tests/SftpcheckTest.kt
@@ -2,6 +2,7 @@ package gov.cdc.prime.router.cli.tests
 
 import gov.cdc.prime.router.common.Environment
 import gov.cdc.prime.router.common.HttpClientUtils
+import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import org.json.JSONObject
@@ -88,7 +89,7 @@ class SftpcheckTest : CoolTest() {
     ): List<String> {
         val (response, respStr) = HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = accessToken
+            tokens = BearerTokens(accessToken, refreshToken = "")
         )
         return when {
             response.status != HttpStatusCode.OK -> emptyList()
@@ -118,7 +119,7 @@ class SftpcheckTest : CoolTest() {
     ): Pair<HttpResponse, String> {
         return HttpClientUtils.getWithStringResponse(
             url = path,
-            accessToken = accessToken
+            tokens = BearerTokens(accessToken, refreshToken = "")
         )
     }
 }

--- a/prime-router/src/main/kotlin/common/HttpClientUtils.kt
+++ b/prime-router/src/main/kotlin/common/HttpClientUtils.kt
@@ -4,12 +4,13 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.apache.Apache
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.accept
 import io.ktor.client.request.forms.submitForm
-import io.ktor.client.request.header
 import io.ktor.client.request.headers
 import io.ktor.client.request.parameter
 import io.ktor.client.request.request
@@ -46,7 +47,7 @@ class HttpClientUtils {
          */
         fun getWithStringResponse(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -55,7 +56,7 @@ class HttpClientUtils {
         ): Pair<HttpResponse, String> {
             val response = get(
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -84,7 +85,7 @@ class HttpClientUtils {
          */
         fun get(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -94,7 +95,7 @@ class HttpClientUtils {
             return invoke(
                 HttpMethod.Get,
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -118,7 +119,7 @@ class HttpClientUtils {
          */
         fun putWithStringResponse(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -128,7 +129,7 @@ class HttpClientUtils {
         ): Pair<HttpResponse, String> {
             val response = put(
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -159,7 +160,7 @@ class HttpClientUtils {
          */
         fun put(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -170,7 +171,7 @@ class HttpClientUtils {
             return invoke(
                 method = HttpMethod.Put,
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -195,7 +196,7 @@ class HttpClientUtils {
          */
         fun postWithStringResponse(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -205,7 +206,7 @@ class HttpClientUtils {
         ): Pair<HttpResponse, String> {
             val response = post(
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -235,7 +236,7 @@ class HttpClientUtils {
          */
         fun post(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long? = REQUEST_TIMEOUT_MILLIS,
@@ -246,7 +247,7 @@ class HttpClientUtils {
             return invoke(
                 method = HttpMethod.Post,
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -270,7 +271,7 @@ class HttpClientUtils {
          */
         inline fun <reified T> submitFormT(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -280,7 +281,7 @@ class HttpClientUtils {
             return runBlocking {
                 submitForm(
                     url = url,
-                    accessToken = accessToken,
+                    tokens = tokens,
                     headers = headers,
                     acceptedContent = acceptedContent,
                     timeout = timeout,
@@ -304,7 +305,7 @@ class HttpClientUtils {
          */
         fun submitForm(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -312,7 +313,7 @@ class HttpClientUtils {
             httpClient: HttpClient? = null,
         ): HttpResponse {
             return runBlocking {
-                (httpClient ?: createDefaultHttpClient(accessToken)).submitForm(
+                (httpClient ?: createDefaultHttpClient(tokens)).submitForm(
                     url,
                     formParameters = Parameters.build {
                         formParams?.forEach { param ->
@@ -351,7 +352,7 @@ class HttpClientUtils {
          */
         fun headWithStringResponse(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType? = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -360,7 +361,7 @@ class HttpClientUtils {
         ): Pair<HttpResponse, String> {
             val response = head(
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -387,7 +388,7 @@ class HttpClientUtils {
          */
         fun head(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType? = ContentType.Application.Json,
             timeout: Long? = REQUEST_TIMEOUT_MILLIS,
@@ -397,7 +398,7 @@ class HttpClientUtils {
             return invoke(
                 method = HttpMethod.Head,
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -423,7 +424,7 @@ class HttpClientUtils {
          */
         fun deleteWithStringResponse(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -432,7 +433,7 @@ class HttpClientUtils {
         ): Pair<HttpResponse, String> {
             val response = delete(
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -462,7 +463,7 @@ class HttpClientUtils {
          */
         fun delete(
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType = ContentType.Application.Json,
             timeout: Long = REQUEST_TIMEOUT_MILLIS,
@@ -472,7 +473,7 @@ class HttpClientUtils {
             return invoke(
                 method = HttpMethod.Delete,
                 url = url,
-                accessToken = accessToken,
+                tokens = tokens,
                 headers = headers,
                 acceptedContent = acceptedContent,
                 timeout = timeout,
@@ -487,7 +488,7 @@ class HttpClientUtils {
         private fun invoke(
             method: HttpMethod,
             url: String,
-            accessToken: String? = null,
+            tokens: BearerTokens? = null,
             headers: Map<String, String>? = null,
             acceptedContent: ContentType? = ContentType.Application.Json,
             timeout: Long? = REQUEST_TIMEOUT_MILLIS,
@@ -496,7 +497,7 @@ class HttpClientUtils {
             httpClient: HttpClient? = null,
         ): HttpResponse {
             return runBlocking {
-                (httpClient ?: createDefaultHttpClient(accessToken)).request(url) {
+                (httpClient ?: createDefaultHttpClient(tokens)).request(url) {
                     this.method = method
                     timeout {
                         requestTimeoutMillis = timeout
@@ -533,7 +534,7 @@ class HttpClientUtils {
          * @param bearerTokens null default, the access token needed to call the endpoint
          * @return a HttpClient with all sensible defaults
          */
-        fun createDefaultHttpClient(accessToken: String?): HttpClient {
+        fun createDefaultHttpClient(tokens: BearerTokens?): HttpClient {
             return HttpClient(Apache) {
                 // installs logging into the call to post to the server
                 // commented out - not to override underlying default logger settings
@@ -542,10 +543,16 @@ class HttpClientUtils {
                 //     logger = Logger.SIMPLE
                 //     level = LogLevel.INFO
                 // }
-                // not using Bearer Auth handler due to refresh token behavior
-                accessToken?.let {
-                    defaultRequest {
-                        header("Authorization", "Bearer $it")
+                tokens?.let {
+                    install(Auth) {
+                        bearer {
+                            loadTokens {
+                                tokens
+                            }
+                            refreshTokens {
+                                tokens
+                            }
+                        }
                     }
                 }
                 install(ContentNegotiation) {


### PR DESCRIPTION
This PR reverts a previous change that manually added bearer auth headers instead of delegating that to the `ktor` library. That change was made because `ktor` automatically calls a refresh callback when receiving a 401. Since the refresh callback was not registered, this behavior was clearing the accessToken.

Test Steps:
1. Run test suite to include server2server auth tests against staging

## Changes
- Adds the ktor auth handler dependency and uses it to perform bearer auth
  - Registers the refresh callback to prevent clearing tokens
 
## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

## Linked Issues
- Fixes #issue

## To Be Done
(maybe)
- Figure out why the server2server auth tests didn't catch this
- Further investigate the failure condition when manually setting the header