### PR TITLE
Bump jacoco from 0.8.10 to 0.8.12

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -64,7 +64,7 @@ val javaVersion = when (appJvmTarget) {
 val ktorVersion = "2.3.8"
 val kotlinVersion by System.getProperties()
 val jacksonVersion = "2.17.0"
-jacoco.toolVersion = "0.8.10"
+jacoco.toolVersion = "0.8.12"
 
 // Local database information, first one wins:
 // 1. Project properties (-P<VAR>=<VALUE> flag)


### PR DESCRIPTION
This PR updates `JaCoCo` from 0.8.10 to 0.8.12.

Changelog: https://www.jacoco.org/jacoco/trunk/doc/changes.html

Test Steps:
1. Verify the build is successful.

## Changes
- Update `JaCoCo` from 0.8.10 to 0.8.12.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?
