### PR TITLE
Build Hub intermittent failure

### DIFF
--- a/.github/actions/build-backend/action.yml
+++ b/.github/actions/build-backend/action.yml
@@ -129,12 +129,13 @@ runs:
       run: docker compose -f docker-compose.yml up -d prime_dev sftp azurite azurite-stage
       shell: bash
 
+      # Important to give enough time here in order to avoid a race described in https://github.com/CDCgov/prime-reportstream/issues/13961#issuecomment-2065217386
     - name: Give some time for the container to start
       if: inputs.run-integration-tests == 'true'
       working-directory: prime-router
       run: |
-        echo "sleeping 30"
-        sleep 30
+        echo "sleeping 90"
+        sleep 90
         echo "wake up"
       shell: bash
 


### PR DESCRIPTION
This PR increases the delay before running `reloadTables` from 30 to 90s.


Test Steps:
1. Run Build Hub GHA

## Changes
It appears the 30 seconds delay between containers startup and subsequent reloadTables is too small to prevent a race condition. In rare circumstances, ./gradlew reloadTables is refreshing the observation-mapping table at the same instant the API container is loading the metadata. 

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

### Process
NA
## Linked Issues
- Fixes #13961

## To Be Done
- Watch GHA to ensure the issue does not re-occur.

## Specific Security-related subjects a reviewer should pay specific attention to
NA