### PR TITLE
Pump the TI ETOR Base URL Values into the Function Application

### DIFF
--- a/operations/app/terraform/modules/function_app/~inputs.tf
+++ b/operations/app/terraform/modules/function_app/~inputs.tf
@@ -88,6 +88,7 @@ variable "RS_okta_base_url" {}
 variable "RS_OKTA_authKey" {}
 variable "RS_OKTA_clientId" {}
 variable "RS_OKTA_scope" {}
+variable "etor_ti_base_url" {}
 
 variable "subnets" {
   description = "A set of all available subnet combinations"

--- a/operations/app/terraform/vars/demo/main.tf
+++ b/operations/app/terraform/vars/demo/main.tf
@@ -181,6 +181,7 @@ module "function_app" {
   OKTA_authKey                      = data.azurerm_key_vault_secret.OKTA_authKey.value
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
+  etor_ti_base_url                  = local.init.etor_ti_base_url
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/prod/main.tf
+++ b/operations/app/terraform/vars/prod/main.tf
@@ -159,6 +159,7 @@ module "function_app" {
   OKTA_authKey                      = data.azurerm_key_vault_secret.OKTA_authKey.value
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
+  etor_ti_base_url                  = local.init.etor_ti_base_url
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/staging/main.tf
+++ b/operations/app/terraform/vars/staging/main.tf
@@ -158,6 +158,7 @@ module "function_app" {
   OKTA_authKey                      = data.azurerm_key_vault_secret.OKTA_authKey.value
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
+  etor_ti_base_url                  = local.init.etor_ti_base_url
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/test/main.tf
+++ b/operations/app/terraform/vars/test/main.tf
@@ -162,6 +162,7 @@ module "function_app" {
   OKTA_authKey                      = data.azurerm_key_vault_secret.OKTA_authKey.value
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
+  etor_ti_base_url                  = local.init.etor_ti_base_url
 }
 
 module "front_door" {


### PR DESCRIPTION
This PR fixes the build by pumping the TI ETOR base URL into the function application in the `function_app` Terraform module.

Test Steps:
1. Do a Terraform apply.

## Changes
- Updated Terraform.

## Checklist

### Testing
- IntelliJ with the Terraform plugin seems happy.

## Linked Issues

https://github.com/CDCgov/trusted-intermediary/issues/690