### PR TITLE
Bug: eagerly intialize FhirPathUtils in the convert step

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -31,6 +31,7 @@ import gov.cdc.prime.router.azure.observability.event.AzureEventServiceImpl
 import gov.cdc.prime.router.azure.observability.event.ReportCreatedEvent
 import gov.cdc.prime.router.fhirengine.translation.HL7toFhirTranslator
 import gov.cdc.prime.router.fhirengine.translation.hl7.FhirTransformer
+import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
 import gov.cdc.prime.router.fhirengine.utils.FhirTranscoder
 import gov.cdc.prime.router.fhirengine.utils.HL7Reader
 import gov.cdc.prime.router.fhirengine.utils.HL7Reader.Companion.parseHL7Message
@@ -101,6 +102,18 @@ class FHIRConverter(
         actionHistory.trackExistingInputReport(queueMessage.reportId)
         val format = Report.getFormatFromBlobURL(queueMessage.blobURL)
         logger.trace("Processing $format data for FHIR conversion.")
+
+        // This line is a workaround for a defect in the hapi-fhir library
+        // Specifically https://github.com/hapifhir/hapi-fhir/blob/b555498c9b7824af67b219e5b7b85f7992aec991/hapi-fhir-serviceloaders/hapi-fhir-caching-api/src/main/java/ca/uhn/fhir/sl/cache/CacheFactory.java#L32
+        // which creates a static instance of ServiceLoader which the documentation indicates is not safe to use in a
+        // concurrent setting https://arc.net/l/quote/hauavetq.  See also this closed issue https://github.com/jakartaee/jsonp-api/issues/26#issuecomment-364844610
+        // for someone requesting a similar change in another library and the reasoning why it can't be done that way
+        //
+        // This line exists so that FhirPathUtils (an object) is instantiated before any of the multi-threaded code run
+        // (kotlin objects are instantiated at first access https://arc.net/l/quote/tbvpqnlh)
+        // TODO: ticket to create a more permanent fix or upgrade the HAPI FHIR library if they fix it
+        FhirPathUtils
+
 
         val fhirBundles = process(format, queueMessage, actionLogger)
 

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -111,9 +111,8 @@ class FHIRConverter(
         //
         // This line exists so that FhirPathUtils (an object) is instantiated before any of the multi-threaded code run
         // (kotlin objects are instantiated at first access https://arc.net/l/quote/tbvpqnlh)
-        // TODO: ticket to create a more permanent fix or upgrade the HAPI FHIR library if they fix it
+        // TODO: https://github.com/CDCgov/prime-reportstream/issues/14287
         FhirPathUtils
-
 
         val fhirBundles = process(format, queueMessage, actionLogger)
 


### PR DESCRIPTION
This PR provides a temporary fix for underlying issue in the HAPI Fhir library (See the comment in the code for more details

Test Steps:
[large-bulk-fhir.txt](https://github.com/CDCgov/prime-reportstream/files/15200407/large-bulk-fhir.txt)

1. On master, send the above bulk JSON through, verify that the exceptions occur (look for HAPI-2200)
2. Check out this branch, do the same and no errors should occur

## Changes
- FhirConverter will not initialize FhirPathUtils before running any of the converting

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- https://github.com/CDCgov/prime-reportstream/issues/14287

## Specific Security-related subjects a reviewer should pay specific attention to

