### PR TITLE
Bug fix for truncateHl7Fields setting

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/engine/CustomTranslationFunctions.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/CustomTranslationFunctions.kt
@@ -105,7 +105,9 @@ class CustomTranslationFunctions(
             val truncationConfig = config.truncationConfig
 
             val hl7Field = hl7FieldPath.substringAfterLast("/")
+            val path = hl7FieldPath.substringBeforeLast("/")
             val cleanedHL7Field = HL7Utils.removeIndexFromHL7Field(hl7Field).trim()
+            val cleanedHL7FieldPath = "$path/$cleanedHL7Field"
 
             val shouldTruncateHDNamespaceIds = truncationConfig.truncateHDNamespaceIds &&
                 HL7Constants.HD_FIELDS_LOCAL.contains(cleanedHL7Field)
@@ -116,7 +118,7 @@ class CustomTranslationFunctions(
             if (shouldTruncateHDNamespaceIds || shouldTruncateHl7Fields) {
                 hl7Truncator.trimAndTruncateValue(
                     value,
-                    hl7FieldPath,
+                    cleanedHL7FieldPath,
                     terser,
                     truncationConfig
                 )

--- a/prime-router/src/test/kotlin/fhirengine/engine/CustomTranslationFunctionsTest.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/CustomTranslationFunctionsTest.kt
@@ -158,21 +158,77 @@ class CustomTranslationFunctionsTest {
             config = HL7TranslationConfig(
                 hl7Configuration = UnitTestUtils.createConfig(
                     truncateHDNamespaceIds = true,
-                    truncateHl7Fields = "MSH-4-1,MSH-3-1",
+                    truncateHl7Fields = "MSH-4-1, ORC-12-1, OBX-15-2",
                 ),
                 null
             )
         )
 
-        val inputAndExpected = mapOf(
+        val msh4InputAndExpected = mapOf(
             "short" to "short",
             "Test & Value ~ Text ^ String" to "Test & Value ~ T",
         )
 
-        inputAndExpected.forEach { (input, expected) ->
+        val orc12InputAndExpected = mapOf(
+            "short" to "short",
+            "Test value test value" to "Test value test",
+        )
+
+        val obx15InputAndExpected = mapOf(
+            "short" to "short",
+            "Test value test value longer Test value test value longer Test value test value longer" +
+                "Test value test value longer Test value test value longer Test value test value longer" +
+                "Test value test value Test TRUNCATE THIS"
+            to
+            "Test value test value longer Test value test value longer Test value test value longer" +
+                "Test value test value longer Test value test value longer Test value test value longer" +
+                "Test value test value Test"
+        )
+
+        msh4InputAndExpected.forEach { (input, expected) ->
             val actual = translationFunctions.maybeTruncateHL7Field(
                 input,
                 "/PATIENT_RESULT/PATIENT/MSH-4-1",
+                emptyTerser,
+                customContext
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        orc12InputAndExpected.forEach { (input, expected) ->
+            val actual = translationFunctions.maybeTruncateHL7Field(
+                input,
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/ORC-12(0)-1",
+                emptyTerser,
+                customContext
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        orc12InputAndExpected.forEach { (input, expected) ->
+            val actual = translationFunctions.maybeTruncateHL7Field(
+                input,
+                "/PATIENT_RESULT/ORDER_OBSERVATION/ORC-12-1",
+                emptyTerser,
+                customContext
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        obx15InputAndExpected.forEach { (input, expected) ->
+            val actual = translationFunctions.maybeTruncateHL7Field(
+                input,
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/OBSERVATION(0)/OBX-15(0)-2",
+                emptyTerser,
+                customContext
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        obx15InputAndExpected.forEach { (input, expected) ->
+            val actual = translationFunctions.maybeTruncateHL7Field(
+                input,
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/OBSERVATION(0)/OBX-15-2",
                 emptyTerser,
                 customContext
             )
@@ -196,10 +252,25 @@ class CustomTranslationFunctionsTest {
             "Test & Value ~ Text ^ String" to "Test & Value ~ Text ^ String",
         )
 
+        val obr16InputAndExpected = mapOf(
+            "short" to "short",
+            "Test value test value do not truncate" to "Test value test value do not truncate",
+        )
+
         inputAndExpected.forEach { (input, expected) ->
             val actual = translationFunctions.maybeTruncateHL7Field(
                 input,
                 "/PATIENT_RESULT/PATIENT/MSH-4-1",
+                emptyTerser,
+                customContext
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        obr16InputAndExpected.forEach { (input, expected) ->
+            val actual = translationFunctions.maybeTruncateHL7Field(
+                input,
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/OBR-16(0)-1",
                 emptyTerser,
                 customContext
             )


### PR DESCRIPTION
This PR fixes a bug where values for fields specified in the `truncateHl7Fields` setting were being completely removed instead of being truncated.

Test Steps:
1. add fields to a receiver's `truncateHl7Fields` setting. For example: 
```     
translation: !<HL7>
    schemaName: "classpath:/metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml"
    truncateHl7Fields: "ORC-12-3, OBR-16-3, ORC-12-1, OBX-15-2"
```
2. Note each field's maximum length. Use https://hl7-definition.caristix.com/v2/HL7v2.5/Segments as a reference.
3. Use a sample fhir bundle and replace values for the fields that were specified in the `truncateHl7Fields` setting with strings that are the size of each field's maximum length. Add "TRUNCATE THIS" at the end of each string.
4. Use http://localhost:7071/api/reports to send a report to the receiver
5. Verify that the HL7 file that was created contains the original values for the fields without the "TRUNCATE THIS" strings.

## Changes
- bug fix: remove index from path before sending to terser
- added tests for truncation with different ways that an hl7FieldPath can be formed

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes https://github.com/CDCgov/prime-reportstream/issues/14264
