### PR TITLE
14210 - [DNM] [SPIKE] to show how to switch b/w mock and server data for e2e

### DIFF
--- a/frontend-react/README.md
+++ b/frontend-react/README.md
@@ -56,8 +56,10 @@ yarn run storybook # Runs a local instance of Storybook showcase of all of the c
 yarn run lint # Runs the front-end linter
 yarn run lint:fix # Runs the front-end linter and fixes style errors
 
-yarn run test:e2e-ui # Runs a local instance of Playwright UI where you can view and run the e2e tests
+yarn run test:e2e-ui # Runs a local instance of Playwright UI where you can view and run the e2e tests. This will run using mock data.
 CI=true yarn run test:e2e-ui # Runs a local instance of Playwright UI that mimics Github integration
+
+yarn run test:e2e-smoke # Runs the e2e tests that have the tag = @smoke and are meant to run against non mock data.
 ```
 
 ## Static build info
@@ -140,9 +142,12 @@ npx playwright install # Installs supported default browsers
 
 npx playwright install-deps # Installs system dependencies
 
-yarn run test:e2e-ui # Runs a local instance of Playwright UI where you can view and run the e2e tests
+yarn run test:e2e-ui # Runs a local instance of Playwright UI where you can view and run the e2e tests. This will run using mock data.
 
-CI=true yarn run test:e2e-ui # Runs a local instance of Playwright UI that mimics Github integration
+CI=true yarn run test:e2e-ui # Runs a local instance of Playwright UI that mimics Github integration.
+
+yarn run test:e2e-smoke # Runs the e2e tests that have the tag = @smoke and are meant to run against non mock data.
+
 ```
 
 Currently, the tests are running each time a pull request is made and must pass before the pull request can be merged into master.

--- a/frontend-react/e2e/mocks/organizations.ts
+++ b/frontend-react/e2e/mocks/organizations.ts
@@ -383,7 +383,7 @@ export const MOCK_GET_RECEIVERS_IGNORE = [
     },
 ];
 
-export const mockOrganizationSettingsList = [
+export const MOCK_GET_ORGANIZATION_SETTINGS_LIST = [
     {
         name: "waters",
         description: "Test Sender from Waters",

--- a/frontend-react/e2e/pages/BasePage.ts
+++ b/frontend-react/e2e/pages/BasePage.ts
@@ -1,5 +1,4 @@
-import appInsightsConfig from "../mocks/appInsightsConfig.json" assert { type:
-    "json" };
+import appInsightsConfig from "../mocks/appInsightsConfig.json" assert { type: "json" };
 import { Locator, Page, Request, Response, Route, TestArgs } from "../test";
 
 export type RouteHandlers = Record<string, Parameters<Page["route"]>[1]>;
@@ -85,7 +84,6 @@ export abstract class BasePage {
     }
 
     get isMocked() {
-        console.log("isMockDisabled", this.testArgs.isMockDisabled);
         return !this.testArgs.isMockDisabled;
     }
 

--- a/frontend-react/e2e/pages/BasePage.ts
+++ b/frontend-react/e2e/pages/BasePage.ts
@@ -1,4 +1,5 @@
-import appInsightsConfig from "../mocks/appInsightsConfig.json" assert { type: "json" };
+import appInsightsConfig from "../mocks/appInsightsConfig.json" assert { type:
+    "json" };
 import { Locator, Page, Request, Response, Route, TestArgs } from "../test";
 
 export type RouteHandlers = Record<string, Parameters<Page["route"]>[1]>;
@@ -84,6 +85,7 @@ export abstract class BasePage {
     }
 
     get isMocked() {
+        console.log("isMockDisabled", this.testArgs.isMockDisabled);
         return !this.testArgs.isMockDisabled;
     }
 

--- a/frontend-react/e2e/pages/daily-data.ts
+++ b/frontend-react/e2e/pages/daily-data.ts
@@ -1,7 +1,12 @@
 import { expect, Page } from "@playwright/test";
 import { format } from "date-fns";
+import {
+    MOCK_GET_RECEIVERS_AK,
+    MOCK_GET_RECEIVERS_IGNORE,
+} from "../mocks/organizations";
 
 const URL_DAILY_DATA = "/daily-data";
+const API_ORGANIZATIONS = "**/api/settings/organizations";
 
 export async function goto(page: Page) {
     await page.goto(URL_DAILY_DATA, {
@@ -155,4 +160,24 @@ export function filterStatus(page: Page, filters: (string | undefined)[]) {
         }
     }
     return filterStatus;
+}
+
+export async function mockGetOrgAlaskaReceiversResponse(
+    page: Page,
+    responseStatus = 200,
+) {
+    await page.route(`${API_ORGANIZATIONS}/ak-phd/receivers`, async (route) => {
+        const json = MOCK_GET_RECEIVERS_AK;
+        await route.fulfill({ json, status: responseStatus });
+    });
+}
+
+export async function mockGetOrgIgnoreReceiversResponse(
+    page: Page,
+    responseStatus = 200,
+) {
+    await page.route(`${API_ORGANIZATIONS}/ignore/receivers`, async (route) => {
+        const json = MOCK_GET_RECEIVERS_IGNORE;
+        await route.fulfill({ json, status: responseStatus });
+    });
 }

--- a/frontend-react/e2e/pages/organization.ts
+++ b/frontend-react/e2e/pages/organization.ts
@@ -1,11 +1,6 @@
 import { Response } from "@playwright/test";
 
-import {
-    BasePage,
-    BasePageTestArgs,
-    GotoOptions,
-    RouteHandlerEntry,
-} from "./BasePage";
+import { BasePage, BasePageTestArgs, RouteHandlerEntry } from "./BasePage";
 import { RSOrganizationSettings } from "../../src/config/endpoints/settings";
 import { MOCK_GET_ORGANIZATION_SETTINGS_LIST } from "../mocks/organizations";
 
@@ -37,8 +32,8 @@ export class OrganizationPage extends BasePage {
         );
     }
 
-    async handlePageLoad(res: Response | null) {
-        if (this.isErrorExpected) return res;
+    async handlePageLoad(res: Promise<Response | null>) {
+        if (this.isErrorExpected) return await res;
 
         const apiOrganizationSettingsRes = await this.page.waitForResponse(
             OrganizationPage.API_ORGANIZATIONS,
@@ -48,24 +43,13 @@ export class OrganizationPage extends BasePage {
             await apiOrganizationSettingsRes.json();
         this._organizationSettings = organizationSettingsData;
 
-        return res;
+        return await super.handlePageLoad(res);
     }
 
-    async reload() {
+    resetRouteHandler(): void {
         if (this.isMocked) {
             this.addMockRouteHandlers([this.createMockOrganizationHandler()]);
         }
-
-        return await this.handlePageLoad(await super.reload());
-    }
-
-    async goto(opts?: GotoOptions) {
-        console.log("this.isMocked ", this.isMocked);
-        if (this.isMocked) {
-            this.addMockRouteHandlers([this.createMockOrganizationHandler()]);
-        }
-
-        return await this.handlePageLoad(await super.goto(opts));
     }
 
     createMockOrganizationHandler(): RouteHandlerEntry {

--- a/frontend-react/e2e/pages/organization.ts
+++ b/frontend-react/e2e/pages/organization.ts
@@ -31,9 +31,6 @@ export class OrganizationPage extends BasePage {
         this.addMockRouteHandlers([this.createMockOrganizationHandler()]);
     }
 
-    /**
-     * Error expected additionally if user context isn't admin
-     */
     get isPageLoadExpected() {
         return (
             super.isPageLoadExpected ||
@@ -42,6 +39,7 @@ export class OrganizationPage extends BasePage {
     }
 
     createMockOrganizationHandler(): RouteHandlerFulfillEntry {
+        console.log("createMockOrganizationHandler ");
         return [
             OrganizationPage.API_ORGANIZATIONS,
             () => {

--- a/frontend-react/e2e/pages/organization.ts
+++ b/frontend-react/e2e/pages/organization.ts
@@ -33,13 +33,12 @@ export class OrganizationPage extends BasePage {
 
     get isPageLoadExpected() {
         return (
-            super.isPageLoadExpected ||
-            this.testArgs.storageState !== this.testArgs.adminLogin.path
+            super.isPageLoadExpected &&
+            this.testArgs.storageState === this.testArgs.adminLogin.path
         );
     }
 
     createMockOrganizationHandler(): RouteHandlerFulfillEntry {
-        console.log("createMockOrganizationHandler ");
         return [
             OrganizationPage.API_ORGANIZATIONS,
             () => {

--- a/frontend-react/e2e/pages/organization.ts
+++ b/frontend-react/e2e/pages/organization.ts
@@ -1,33 +1,81 @@
-import { Page } from "@playwright/test";
+import { Response } from "@playwright/test";
 
 import {
-    MOCK_GET_RECEIVERS_AK,
-    MOCK_GET_RECEIVERS_IGNORE,
-} from "../mocks/organizations";
+    BasePage,
+    BasePageTestArgs,
+    GotoOptions,
+    RouteHandlerEntry,
+} from "./BasePage";
+import { RSOrganizationSettings } from "../../src/config/endpoints/settings";
+import { MOCK_GET_ORGANIZATION_SETTINGS_LIST } from "../mocks/organizations";
 
-export const API_ORGANIZATIONS = "**/api/settings/organizations";
-export async function goto(page: Page) {
-    await page.goto("/admin/settings", {
-        waitUntil: "domcontentloaded",
-    });
-}
+export class OrganizationPage extends BasePage {
+    static readonly API_ORGANIZATIONS = "/api/settings/organizations";
+    protected _organizationSettings: RSOrganizationSettings[];
+    constructor(testArgs: BasePageTestArgs) {
+        super(
+            {
+                url: "/admin/settings",
+                title: "Organizations",
+                heading: testArgs.page.getByRole("heading", {
+                    name: "Organizations",
+                }),
+            },
+            testArgs,
+        );
 
-export async function mockGetOrgAlaskaReceiversResponse(
-    page: Page,
-    responseStatus = 200,
-) {
-    await page.route(`${API_ORGANIZATIONS}/ak-phd/receivers`, async (route) => {
-        const json = MOCK_GET_RECEIVERS_AK;
-        await route.fulfill({ json, status: responseStatus });
-    });
-}
+        this._organizationSettings = [];
+    }
 
-export async function mockGetOrgIgnoreReceiversResponse(
-    page: Page,
-    responseStatus = 200,
-) {
-    await page.route(`${API_ORGANIZATIONS}/ignore/receivers`, async (route) => {
-        const json = MOCK_GET_RECEIVERS_IGNORE;
-        await route.fulfill({ json, status: responseStatus });
-    });
+    /**
+     * Error expected additionally if user context isn't admin
+     */
+    get isErrorExpected() {
+        return (
+            super.isErrorExpected ||
+            this.testArgs.storageState !== this.testArgs.adminLogin.path
+        );
+    }
+
+    async handlePageLoad(res: Response | null) {
+        if (this.isErrorExpected) return res;
+
+        const apiOrganizationSettingsRes = await this.page.waitForResponse(
+            OrganizationPage.API_ORGANIZATIONS,
+        );
+
+        const organizationSettingsData: RSOrganizationSettings[] =
+            await apiOrganizationSettingsRes.json();
+        this._organizationSettings = organizationSettingsData;
+
+        return res;
+    }
+
+    async reload() {
+        if (this.isMocked) {
+            this.addMockRouteHandlers([this.createMockOrganizationHandler()]);
+        }
+
+        return await this.handlePageLoad(await super.reload());
+    }
+
+    async goto(opts?: GotoOptions) {
+        console.log("this.isMocked ", this.isMocked);
+        if (this.isMocked) {
+            this.addMockRouteHandlers([this.createMockOrganizationHandler()]);
+        }
+
+        return await this.handlePageLoad(await super.goto(opts));
+    }
+
+    createMockOrganizationHandler(): RouteHandlerEntry {
+        return [
+            OrganizationPage.API_ORGANIZATIONS,
+            () => {
+                return {
+                    json: MOCK_GET_ORGANIZATION_SETTINGS_LIST,
+                };
+            },
+        ];
+    }
 }

--- a/frontend-react/e2e/spec/BasePage.spec.ts
+++ b/frontend-react/e2e/spec/BasePage.spec.ts
@@ -1,0 +1,98 @@
+import { BasePage, type BasePageTestArgs } from "../pages/BasePage";
+import { test as baseTest, expect, Response } from "../test";
+
+export interface MockPageFixtures {
+    mockPage: MockPage;
+}
+
+class MockPage extends BasePage {
+    data?: any;
+
+    constructor(testArgs: BasePageTestArgs) {
+        super(
+            {
+                url: "/",
+                title: "",
+            },
+            testArgs,
+        );
+    }
+
+    resetRouteHandler() {
+        super.resetRouteHandler();
+
+        if (this.isMocked) {
+            this.addMockRouteHandlers([["/fake", { json: { foo: "bar" } }]]);
+        } else {
+            this.addRouteHandlers([["/fake", { json: { bar: "foo" } }]]);
+        }
+
+        this.addRouteHandlers([
+            [
+                "/",
+                () => {
+                    return {
+                        body: "<body><h1>Fake</h1><script>fetch('/fake')</script></body>",
+                        contentType: "text/html",
+                    };
+                },
+            ],
+        ]);
+    }
+
+    async handlePageLoad(res: Promise<Response | null>) {
+        const mockRes = await this.page.waitForResponse("fake");
+        this.data = await mockRes.json();
+
+        return await super.handlePageLoad(res);
+    }
+}
+
+const test = baseTest.extend<MockPageFixtures>({
+    mockPage: async (
+        {
+            page: _page,
+            isMockDisabled,
+            adminLogin,
+            senderLogin,
+            receiverLogin,
+            storageState,
+        },
+        use,
+    ) => {
+        const page = new MockPage({
+            page: _page,
+            isMockDisabled,
+            adminLogin,
+            senderLogin,
+            receiverLogin,
+            storageState,
+        });
+        await page.goto();
+        await use(page);
+    },
+});
+
+test.describe("mocking", () => {
+    test.describe("enabled", () => {
+        test.use({ isMockDisabled: false });
+
+        test("renders", async ({ mockPage }) => {
+            await expect(mockPage.page.getByText("Fake")).toBeVisible();
+        });
+        test("returns mocked data", ({ mockPage }) => {
+            expect(mockPage.data).toEqual({ foo: "bar" });
+        });
+    });
+
+    test.describe("mocking disabled", () => {
+        test.use({ isMockDisabled: true });
+
+        test("renders", async ({ mockPage }) => {
+            await expect(mockPage.page.getByText("Fake")).toBeVisible();
+        });
+        test("returns real data", ({ mockPage }) => {
+            expect(mockPage.data).toEqual({ bar: "foo" });
+        });
+    });
+});

--- a/frontend-react/e2e/spec/daily-data-page.spec.ts
+++ b/frontend-react/e2e/spec/daily-data-page.spec.ts
@@ -18,6 +18,8 @@ import {
     endTimeClear,
     filterReset,
     filterStatus,
+    mockGetOrgAlaskaReceiversResponse,
+    mockGetOrgIgnoreReceiversResponse,
     receiverDropdown,
     searchButton,
     searchInput,
@@ -29,10 +31,6 @@ import {
     startTimeClear,
     tableHeaders,
 } from "../pages/daily-data";
-import {
-    mockGetOrgAlaskaReceiversResponse,
-    mockGetOrgIgnoreReceiversResponse,
-} from "../pages/organization";
 import {
     mockGetDeliveriesForOrgAlaskaResponse,
     mockGetDeliveriesForOrgIgnoreResponse,

--- a/frontend-react/e2e/spec/idletimeout.spec.ts
+++ b/frontend-react/e2e/spec/idletimeout.spec.ts
@@ -1,26 +1,59 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 import process from "node:process";
 
-import * as organization from "../pages/organization";
+import { OrganizationPage } from "../pages/organization";
+import { test as baseTest } from "../test";
 
 const timeout = parseInt(process.env.VITE_IDLE_TIMEOUT ?? "20000");
 // Add/Sub 500 ms to account for variance
 const timeoutLow = timeout - 500;
 const timeoutHigh = timeout + 500;
 
+export interface OrganizationPageFixtures {
+    organizationPage: OrganizationPage;
+}
+
+const test = baseTest.extend<OrganizationPageFixtures>({
+    organizationPage: async (
+        {
+            page: _page,
+            isMockDisabled,
+            adminLogin,
+            senderLogin,
+            receiverLogin,
+            storageState,
+        },
+        use,
+    ) => {
+        const page = new OrganizationPage({
+            page: _page,
+            isMockDisabled,
+            adminLogin,
+            senderLogin,
+            receiverLogin,
+            storageState,
+        });
+        await page.goto();
+        await use(page);
+    },
+});
+
 test.use({ storageState: "e2e/.auth/admin.json" });
 
-test.skip("Does not trigger early", async ({ page }) => {
-    await organization.goto(page);
-
-    await expect(page.getByRole("banner").first()).toBeVisible();
-    await page.keyboard.down("Tab");
+test.skip("Does not trigger early", async ({ organizationPage }) => {
+    await expect(
+        organizationPage.page.getByRole("banner").first(),
+    ).toBeVisible();
+    await organizationPage.page.keyboard.down("Tab");
 
     const start = new Date();
 
-    await page.waitForRequest(/\/oauth2\/default\/v1\/revoke/, {
-        timeout: timeoutHigh,
-    });
+    await organizationPage.page.waitForRequest(
+        /\/oauth2\/default\/v1\/revoke/,
+        {
+            timeout: timeoutHigh,
+        },
+    );
 
     const end = new Date();
 

--- a/frontend-react/e2e/spec/organization-settings-page.spec.ts
+++ b/frontend-react/e2e/spec/organization-settings-page.spec.ts
@@ -37,7 +37,7 @@ const test = baseTest.extend<OrganizationPageFixtures>({
     },
 });
 
-test.describe.only("Admin Organization Settings Page", () => {
+test.describe("Admin Organization Settings Page", () => {
     test.describe("not authenticated", () => {
         test("redirects to login", async ({ organizationPage }) => {
             await expect(organizationPage.page).toHaveURL("/login");
@@ -71,213 +71,231 @@ test.describe.only("Admin Organization Settings Page", () => {
             ).toBeVisible();
         });
 
-        test.describe("When there is no error", () => {
-            test("nav contains the 'Admin tools' dropdown with 'Organization Settings' option", async ({
-                organizationPage,
-            }) => {
-                const navItems = organizationPage.page.locator(".usa-nav  li");
-                await expect(navItems).toContainText(["Admin tools"]);
+        test.describe(
+            "When there is no error",
+            {
+                tag: "@smoke",
+            },
+            () => {
+                test("nav contains the 'Admin tools' dropdown with 'Organization Settings' option", async ({
+                    organizationPage,
+                }) => {
+                    const navItems =
+                        organizationPage.page.locator(".usa-nav  li");
+                    await expect(navItems).toContainText(["Admin tools"]);
 
-                await organizationPage.page
-                    .getByTestId("auth-header")
-                    .getByTestId("navDropDownButton")
-                    .getByText("Admin tools")
-                    .click();
+                    await organizationPage.page
+                        .getByTestId("auth-header")
+                        .getByTestId("navDropDownButton")
+                        .getByText("Admin tools")
+                        .click();
 
-                expect(
-                    organizationPage.page.getByText("Organization Settings"),
-                ).toBeTruthy();
+                    expect(
+                        organizationPage.page.getByText(
+                            "Organization Settings",
+                        ),
+                    ).toBeTruthy();
 
-                await organizationPage.page
-                    .getByText("Organization Settings")
-                    .click();
-                await expect(organizationPage.page).toHaveURL(
-                    "/admin/settings",
-                );
-            });
+                    await organizationPage.page
+                        .getByText("Organization Settings")
+                        .click();
+                    await expect(organizationPage.page).toHaveURL(
+                        "/admin/settings",
+                    );
+                });
 
-            test("Has correct title", async ({ organizationPage }) => {
-                await expect(organizationPage.page).toHaveURL(/settings/);
-                await expect(organizationPage.page).toHaveTitle(
-                    /Admin-Organizations/,
-                );
-            });
+                test("Has correct title", async ({ organizationPage }) => {
+                    await expect(organizationPage.page).toHaveURL(/settings/);
+                    await expect(organizationPage.page).toHaveTitle(
+                        /Admin-Organizations/,
+                    );
+                });
 
-            test("Displays data", async ({ organizationPage }) => {
-                // Heading with result length
-                await expect(
-                    organizationPage.page.getByRole("heading", {
-                        name: `Organizations (${MOCK_GET_ORGANIZATION_SETTINGS_LIST.length})`,
-                    }),
-                ).toBeVisible();
+                test("Displays data", async ({ organizationPage }) => {
+                    // Heading with result length
+                    await expect(
+                        organizationPage.page.getByRole("heading", {
+                            name: `Organizations (${MOCK_GET_ORGANIZATION_SETTINGS_LIST.length})`,
+                        }),
+                    ).toBeVisible();
 
-                // Table
-                // empty is button column
-                const colHeaders = [
-                    "Name",
-                    "Description",
-                    "Jurisdiction",
-                    "State",
-                    "County",
-                    "",
-                ];
-                // include header row
-                const rowCount = MOCK_GET_ORGANIZATION_SETTINGS_LIST.length + 1;
-                const table = organizationPage.page.getByRole("table");
-                await expect(table).toBeVisible();
-                const rows = await table.getByRole("row").all();
-                expect(rows).toHaveLength(rowCount);
-                for (const [i, row] of rows.entries()) {
-                    const cols = await row.getByRole("cell").allTextContents();
-                    expect(cols).toHaveLength(colHeaders.length);
+                    // Table
+                    // empty is button column
+                    const colHeaders = [
+                        "Name",
+                        "Description",
+                        "Jurisdiction",
+                        "State",
+                        "County",
+                        "",
+                    ];
+                    // include header row
+                    const rowCount =
+                        MOCK_GET_ORGANIZATION_SETTINGS_LIST.length + 1;
+                    const table = organizationPage.page.getByRole("table");
+                    await expect(table).toBeVisible();
+                    const rows = await table.getByRole("row").all();
+                    expect(rows).toHaveLength(rowCount);
+                    for (const [i, row] of rows.entries()) {
+                        const cols = await row
+                            .getByRole("cell")
+                            .allTextContents();
+                        expect(cols).toHaveLength(colHeaders.length);
 
-                    const { description, jurisdiction, name, stateCode } =
-                        i === 0
-                            ? MOCK_GET_ORGANIZATION_SETTINGS_LIST[0]
-                            : MOCK_GET_ORGANIZATION_SETTINGS_LIST.find(
-                                  (i) => i.name === cols[0],
-                              ) ?? { name: "INVALID" };
-                    // if first row, we expect column headers. else, the data row matching id (name)
-                    // SetEdit is text of buttons in button column
-                    const expectedColContents =
-                        i === 0
-                            ? colHeaders
-                            : [
-                                  name,
-                                  description ?? "",
-                                  jurisdiction ?? "",
-                                  stateCode ?? "",
-                                  "",
-                                  "SetEdit",
-                              ];
+                        const { description, jurisdiction, name, stateCode } =
+                            i === 0
+                                ? MOCK_GET_ORGANIZATION_SETTINGS_LIST[0]
+                                : MOCK_GET_ORGANIZATION_SETTINGS_LIST.find(
+                                      (i) => i.name === cols[0],
+                                  ) ?? { name: "INVALID" };
+                        // if first row, we expect column headers. else, the data row matching id (name)
+                        // SetEdit is text of buttons in button column
+                        const expectedColContents =
+                            i === 0
+                                ? colHeaders
+                                : [
+                                      name,
+                                      description ?? "",
+                                      jurisdiction ?? "",
+                                      stateCode ?? "",
+                                      "",
+                                      "SetEdit",
+                                  ];
 
-                    for (const [i, col] of cols.entries()) {
+                        for (const [i, col] of cols.entries()) {
+                            expect(col).toBe(expectedColContents[i]);
+                        }
+                    }
+                });
+
+                test("Create new organization navigation works", async ({
+                    organizationPage,
+                }) => {
+                    const link = organizationPage.page.getByRole("link", {
+                        name: "Create New Organization",
+                    });
+                    const expectedUrl = "/admin/new/org";
+
+                    await expect(link).toBeVisible();
+                    await link.click();
+                    await organizationPage.page.waitForURL(expectedUrl);
+                    await expect(
+                        organizationPage.page.getByRole("heading"),
+                    ).toBeVisible();
+
+                    expect(organizationPage.page.url()).toContain(expectedUrl);
+                });
+
+                test("Save CSV button downloads a file", async ({
+                    organizationPage,
+                }) => {
+                    const downloadProm =
+                        organizationPage.page.waitForEvent("download");
+                    const saveButton = organizationPage.page.getByRole(
+                        "button",
+                        {
+                            name: "Save List to CSV",
+                        },
+                    );
+
+                    await expect(saveButton).toBeVisible();
+                    await saveButton.click();
+                    const download = await downloadProm;
+
+                    const expectedFile = readFileSync(
+                        join(__dirname, "../../mocks/prime-orgs.csv"),
+                        { encoding: "utf-8" },
+                    );
+                    const stream = await download.createReadStream();
+                    const file = (await stream.toArray()).toString();
+                    expect(file).toBe(expectedFile);
+                    expect(download.suggestedFilename()).toBe("prime-orgs.csv");
+                });
+
+                test("Filtering works", async ({ organizationPage }) => {
+                    const table = organizationPage.page.getByRole("table");
+                    const { description, name, jurisdiction, stateCode } =
+                        MOCK_GET_ORGANIZATION_SETTINGS_LIST[2];
+                    const filterBox = organizationPage.page.getByRole(
+                        "textbox",
+                        {
+                            name: "Filter:",
+                        },
+                    );
+
+                    await expect(filterBox).toBeVisible();
+
+                    await filterBox.fill(name);
+                    const rows = await table.getByRole("row").all();
+                    expect(rows).toHaveLength(2);
+                    const cols = rows[1].getByRole("cell").allTextContents();
+                    const expectedColContents = [
+                        name,
+                        description ?? "",
+                        jurisdiction ?? "",
+                        stateCode ?? "",
+                        "",
+                        "SetEdit",
+                    ];
+
+                    for (const [i, col] of (await cols).entries()) {
                         expect(col).toBe(expectedColContents[i]);
                     }
-                }
-            });
-
-            test("Create new organization navigation works", async ({
-                organizationPage,
-            }) => {
-                const link = organizationPage.page.getByRole("link", {
-                    name: "Create New Organization",
-                });
-                const expectedUrl = "/admin/new/org";
-
-                await expect(link).toBeVisible();
-                await link.click();
-                await organizationPage.page.waitForURL(expectedUrl);
-                await expect(
-                    organizationPage.page.getByRole("heading"),
-                ).toBeVisible();
-
-                expect(organizationPage.page.url()).toContain(expectedUrl);
-            });
-
-            test("Save CSV button downloads a file", async ({
-                organizationPage,
-            }) => {
-                const downloadProm =
-                    organizationPage.page.waitForEvent("download");
-                const saveButton = organizationPage.page.getByRole("button", {
-                    name: "Save List to CSV",
                 });
 
-                await expect(saveButton).toBeVisible();
-                await saveButton.click();
-                const download = await downloadProm;
+                test('Clicking "Set" updates link label', async ({
+                    organizationPage,
+                }) => {
+                    const firstDataRow = organizationPage.page
+                        .getByRole("table")
+                        .getByRole("row")
+                        .nth(1);
+                    const firstDataRowName =
+                        (await firstDataRow
+                            .getByRole("cell")
+                            .nth(0)
+                            .textContent()) ?? "INVALID";
+                    const setButton = firstDataRow.getByRole("button", {
+                        name: "Set",
+                    });
 
-                const expectedFile = readFileSync(
-                    join(__dirname, "../../mocks/prime-orgs.csv"),
-                    { encoding: "utf-8" },
-                );
-                const stream = await download.createReadStream();
-                const file = (await stream.toArray()).toString();
-                expect(file).toBe(expectedFile);
-                expect(download.suggestedFilename()).toBe("prime-orgs.csv");
-            });
+                    await expect(setButton).toBeVisible();
+                    await setButton.click();
 
-            test("Filtering works", async ({ organizationPage }) => {
-                const table = organizationPage.page.getByRole("table");
-                const { description, name, jurisdiction, stateCode } =
-                    MOCK_GET_ORGANIZATION_SETTINGS_LIST[2];
-                const filterBox = organizationPage.page.getByRole("textbox", {
-                    name: "Filter:",
+                    const orgLink = organizationPage.page.getByRole("link", {
+                        name: firstDataRowName,
+                    });
+                    await expect(orgLink).toBeVisible();
+                    await expect(orgLink).toHaveAttribute(
+                        "href",
+                        "/admin/settings",
+                    );
                 });
 
-                await expect(filterBox).toBeVisible();
-
-                await filterBox.fill(name);
-                const rows = await table.getByRole("row").all();
-                expect(rows).toHaveLength(2);
-                const cols = rows[1].getByRole("cell").allTextContents();
-                const expectedColContents = [
-                    name,
-                    description ?? "",
-                    jurisdiction ?? "",
-                    stateCode ?? "",
-                    "",
-                    "SetEdit",
-                ];
-
-                for (const [i, col] of (await cols).entries()) {
-                    expect(col).toBe(expectedColContents[i]);
-                }
-            });
-
-            test('Clicking "Set" updates link label', async ({
-                organizationPage,
-            }) => {
-                const firstDataRow = organizationPage.page
-                    .getByRole("table")
-                    .getByRole("row")
-                    .nth(1);
-                const firstDataRowName =
-                    (await firstDataRow
+                test("Edit navigation works", async ({ organizationPage }) => {
+                    const firstDataRow = organizationPage.page
+                        .getByRole("table")
+                        .getByRole("row")
+                        .nth(1);
+                    const firstDataRowName = await firstDataRow
                         .getByRole("cell")
                         .nth(0)
-                        .textContent()) ?? "INVALID";
-                const setButton = firstDataRow.getByRole("button", {
-                    name: "Set",
+                        .textContent();
+                    const expectedUrl = `/admin/orgsettings/org/${firstDataRowName}`;
+                    const editButton = firstDataRow.getByRole("button", {
+                        name: "Edit",
+                    });
+
+                    await expect(editButton).toBeVisible();
+                    await editButton.click();
+                    await organizationPage.page.waitForURL(expectedUrl);
+                    await expect(
+                        organizationPage.page.getByRole("heading"),
+                    ).toBeVisible();
+
+                    expect(organizationPage.page.url()).toContain(expectedUrl);
                 });
-
-                await expect(setButton).toBeVisible();
-                await setButton.click();
-
-                const orgLink = organizationPage.page.getByRole("link", {
-                    name: firstDataRowName,
-                });
-                await expect(orgLink).toBeVisible();
-                await expect(orgLink).toHaveAttribute(
-                    "href",
-                    "/admin/settings",
-                );
-            });
-
-            test("Edit navigation works", async ({ organizationPage }) => {
-                const firstDataRow = organizationPage.page
-                    .getByRole("table")
-                    .getByRole("row")
-                    .nth(1);
-                const firstDataRowName = await firstDataRow
-                    .getByRole("cell")
-                    .nth(0)
-                    .textContent();
-                const expectedUrl = `/admin/orgsettings/org/${firstDataRowName}`;
-                const editButton = firstDataRow.getByRole("button", {
-                    name: "Edit",
-                });
-
-                await expect(editButton).toBeVisible();
-                await editButton.click();
-                await organizationPage.page.waitForURL(expectedUrl);
-                await expect(
-                    organizationPage.page.getByRole("heading"),
-                ).toBeVisible();
-
-                expect(organizationPage.page.url()).toContain(expectedUrl);
-            });
-        });
+            },
+        );
     });
 });

--- a/frontend-react/e2e/test.ts
+++ b/frontend-react/e2e/test.ts
@@ -6,6 +6,9 @@ import {
     PlaywrightWorkerOptions,
 } from "@playwright/test";
 
+// eslint-disable-next-line import/export
+export * from "@playwright/test";
+
 export interface TestLogin {
     username: string;
     password: string;
@@ -32,6 +35,7 @@ export type TestArgs<P extends keyof PlaywrightAllTestArgs> = Pick<
 > &
     CustomFixtures;
 
+// eslint-disable-next-line import/export
 export const test = base.extend<CustomFixtures>({
     // Define an option and provide a default value.
     // We can later override it in the config.
@@ -67,5 +71,3 @@ export const test = base.extend<CustomFixtures>({
     ],
     isMockDisabled: false,
 });
-
-export { expect } from "@playwright/test";

--- a/frontend-react/e2e/test.ts
+++ b/frontend-react/e2e/test.ts
@@ -5,10 +5,12 @@ import {
     PlaywrightWorkerArgs,
     PlaywrightWorkerOptions,
 } from "@playwright/test";
+import process from "process";
 
 // eslint-disable-next-line import/export
 export * from "@playwright/test";
 
+const isMockDisabled = Boolean(process.env.MOCK_DISABLED);
 export interface TestLogin {
     username: string;
     password: string;
@@ -69,5 +71,5 @@ export const test = base.extend<CustomFixtures>({
         },
         { option: true },
     ],
-    isMockDisabled: false,
+    isMockDisabled,
 });

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -74,6 +74,7 @@
         "test:e2e": "playwright test",
         "test:e2e-smoke": "MOCK_DISABLED=true playwright test --grep @smoke",
         "test:e2e-ui": "playwright test --ui",
+        "test:e2e-ui:smoke": "MOCK_DISABLED=true playwright test --grep @smoke --ui",
         "test:e2e-ui:debug": "PWDEBUG=1 playwright test --ui",
         "lint": "eslint \"**/*.{js,ts,jsx,tsx}\" && prettier \"*\" --check --ignore-unknown && tsc",
         "lint:errors-only": "eslint \"**/*.{js,ts,jsx,tsx}\" --quiet && prettier \"*\" --check --ignore-unknown && tsc",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -72,6 +72,7 @@
         "test:ci": "cross-env VITE_BACKEND_URL=http://localhost vitest --coverage",
         "test:ui": "cross-env vitest --ui",
         "test:e2e": "playwright test",
+        "test:e2e-smoke": "MOCK_DISABLED=true playwright test --grep @smoke",
         "test:e2e-ui": "playwright test --ui",
         "test:e2e-ui:debug": "PWDEBUG=1 playwright test --ui",
         "lint": "eslint \"**/*.{js,ts,jsx,tsx}\" && prettier \"*\" --check --ignore-unknown && tsc",

--- a/frontend-react/playwright.config.ts
+++ b/frontend-react/playwright.config.ts
@@ -77,7 +77,7 @@ export default defineConfig<CustomFixtures>({
         },
         receiverLogin: {
             ...logins.receiver,
-            landingPage: "/",
+            landingPage: "/daily-data",
         },
         isMockDisabled,
     },

--- a/frontend-react/playwright.config.ts
+++ b/frontend-react/playwright.config.ts
@@ -11,7 +11,6 @@ dotenvflow.config({
 });
 
 const isCi = Boolean(process.env.CI);
-const isMockDisabled = Boolean(process.env.MOCK_DISABLED);
 
 function createLogins<const T extends Array<string>>(
     loginTypes: T,
@@ -79,7 +78,6 @@ export default defineConfig<CustomFixtures>({
             ...logins.receiver,
             landingPage: "/daily-data",
         },
-        isMockDisabled,
     },
 
     projects: [


### PR DESCRIPTION


This PR ...

Demonstrated how to run e2e smoke tests that are tagged as @smoke. This will run those specific tests against the  dataset of the server that the tests are on.

Test Steps:
1. Run mock e2e `yarn run test:e2e`
2. Run smoke test e2e `yarn run test:e2e-smoke`

## Changes
![Screenshot 2024-06-17 at 12 53 49 PM](https://github.com/CDCgov/prime-reportstream/assets/102491809/65e5aa75-a4e5-4065-a889-4cf1b24e8250)


## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Linked Issues
- Fixes #14210 
