### PR TITLE
BUG: Chromatic Analysis step running for dependabot

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -194,6 +194,8 @@ jobs:
 
   chromatic:
     name: Chromatic Analysis
+    # remove this if statement whenever dependabot has access to secrets
+    if: github.event.sender.login != 'dependabot[bot]'
     needs: lint
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fixes #14966

This PR prevents the chromatic analysis step from running on frontend PRs from dependabot, as dependabot does not have access to secrets.