### PR TITLE
BUG: Login state param initialization of state for widget isn't passed to auth client

### DIFF
--- a/frontend-react/src/AppRouter.tsx
+++ b/frontend-react/src/AppRouter.tsx
@@ -103,6 +103,7 @@ const ReportStreamApiDocumentationPayloads = lazy(
 
 /* Public Pages */
 const TermsOfService = lazy(() => import("./pages/TermsOfService"));
+
 const LoginCallback = lazy(
     () => import("./shared/LoginCallback/LoginCallback"),
 );
@@ -110,6 +111,7 @@ const LogoutCallback = lazy(
     () => import("./shared/LogoutCallback/LogoutCallback"),
 );
 const Login = lazy(() => import("./pages/Login"));
+
 const FileHandler = lazy(() => import("./components/FileHandlers/FileHandler"));
 const ErrorNoPage = lazy(
     () => import("./pages/error/legacy-content/ErrorNoPage"),

--- a/frontend-react/src/components/header/ReportStreamHeader.tsx
+++ b/frontend-react/src/components/header/ReportStreamHeader.tsx
@@ -388,7 +388,7 @@ const ReportStreamHeader = ({
         <>
             <GovBanner aria-label="Official government website" />
             {!isNavHidden && <SenderModeBanner />}
-            {!isNavHidden && activeMembership && (
+            {!isNavHidden && (activeMembership ?? user.claims) && (
                 <Header
                     data-testid="auth-header"
                     basic={true}

--- a/frontend-react/src/pages/Login.tsx
+++ b/frontend-react/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import type { Tokens } from "@okta/okta-auth-js";
-import { useCallback, useMemo } from "react";
+import type { WidgetOptions } from "@okta/okta-signin-widget";
+import { useCallback, useEffect, useMemo } from "react";
 import { Helmet } from "react-helmet-async";
 import { Navigate, useLocation, useSearchParams } from "react-router-dom";
 import type { Location } from "react-router-dom";
@@ -14,12 +15,15 @@ export function Login() {
         useLocation();
     const [searchParams] = useSearchParams();
     const finalConfig = useMemo(
-        () => ({
-            ...config.OKTA_WIDGET,
-            otp: searchParams.get("otp"),
-            token: searchParams.get("token"),
-        }),
-        [config.OKTA_WIDGET, searchParams],
+        () =>
+            ({
+                ...config.OKTA_WIDGET,
+                // use our existing auth client, instead of the widget creating another one
+                authClient: oktaAuth,
+                otp: searchParams.get("otp") ?? undefined,
+                token: searchParams.get("token") ?? undefined,
+            }) satisfies WidgetOptions & { otp?: string; token?: string },
+        [config.OKTA_WIDGET, oktaAuth, searchParams],
     );
 
     const onSuccess = useCallback(
@@ -34,6 +38,15 @@ export function Login() {
     );
 
     const onError = useCallback((_: any) => void 0, []);
+
+    // Assign state from url params to oktaAuth client (widget doesn't seem to modify a provided
+    // auth client)
+    useEffect(() => {
+        const state = searchParams.get("state") ?? undefined;
+        if (state !== oktaAuth.options.state) {
+            oktaAuth.options.state = state;
+        }
+    }, [oktaAuth.options, searchParams]);
 
     if (authState.isAuthenticated) {
         return <Navigate replace to={"/"} />;

--- a/frontend-react/src/pages/Login.tsx
+++ b/frontend-react/src/pages/Login.tsx
@@ -21,8 +21,8 @@ export function Login() {
                 // use our existing auth client, instead of the widget creating another one
                 authClient: oktaAuth,
                 otp: searchParams.get("otp") ?? undefined,
-                token: searchParams.get("token") ?? undefined,
-            }) satisfies WidgetOptions & { otp?: string; token?: string },
+                state: searchParams.get("state") ?? undefined,
+            }) satisfies WidgetOptions & { otp?: string },
         [config.OKTA_WIDGET, oktaAuth, searchParams],
     );
 


### PR DESCRIPTION
Fixes #15018 #14701

This PR (hopefully) fixes magiclinks so that state is properly passed to the okta auth client. It also fixes the nav bar so that it will appear for all authenticated users (regardless of groups). The bar only shows the email and logout buttons for users that do not have the necessary groups for anything else.