### PR TITLE
Fixes for flexion org yaml file

### DIFF
--- a/prime-router/settings/STLTs/Flexion/flexion.yml
+++ b/prime-router/settings/STLTs/Flexion/flexion.yml
@@ -60,7 +60,6 @@
         initialTime: "00:00"
       translation:
         type: "FHIR"
-        schemaName: "classpath:/metadata/fhir_transforms/receivers/fhir-transform-sample.yml"
         useBatching: false
       transport:
         type: "REST"
@@ -127,7 +126,6 @@
         initialTime: "00:00"
       translation:
         type: "FHIR"
-        schemaName: "classpath:/metadata/fhir_transforms/receivers/fhir-transform-sample.yml"
         useBatching: false
       transport:
         type: "REST"


### PR DESCRIPTION
Removed sample translation schema for FHIR conversion, which was adding `TestValue` to the Patient resource