### PR TITLE
BUG: e2e_tests job of frontend_ci workflow doesn't properly reflect skip status when required

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -135,6 +135,7 @@ jobs:
             else
               exit 1
             fi
+          working-directory: /
 
   # Merge reports after e2e-tests, even if some shards have failed
   merge_e2e_data:

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -122,10 +122,10 @@ jobs:
 
   # the e2e_tests job doesn't properly reflect being skipped when set as required on the repo.
   # this step will always run and provide a status
-  e2e_tests_proxy:
+  e2e_tests_result:
       if: ${{ always() }}
       runs-on: ubuntu-latest
-      name: E2E Tests Proxy
+      name: E2E Tests Result
       needs: [e2e_tests]
       steps:
         - run: |

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -77,6 +77,7 @@ jobs:
   e2e_tests:
     name: E2E tests
     needs: lint
+    if: needs.lint.result == 'success'
     runs-on: ubuntu-latest
     # Keep shards under 6 minutes (1 minute dedicated to playwright install, 5 to tests)
     timeout-minutes: 7

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -77,7 +77,6 @@ jobs:
   e2e_tests:
     name: E2E tests
     needs: lint
-    if: needs.lint.result == 'success'
     runs-on: ubuntu-latest
     # Keep shards under 6 minutes (1 minute dedicated to playwright install, 5 to tests)
     timeout-minutes: 7
@@ -120,6 +119,22 @@ jobs:
           name: frontend-e2e-data--shard-${{ matrix.shardIndex }}
           path: frontend-react/e2e-data
           retention-days: 1
+
+  # the e2e_tests job doesn't properly reflect being skipped when set as required on the repo.
+  # this step will always run and provide a status
+  e2e_tests_proxy:
+      if: ${{ always() }}
+      runs-on: ubuntu-latest
+      name: E2E Tests Proxy
+      needs: [e2e_tests]
+      steps:
+        - run: |
+            result="${{ needs.e2e_tests.result }}"
+            if [[ $result == "success" || $result == "skipped" ]]; then
+              exit 0
+            else
+              exit 1
+            fi
 
   # Merge reports after e2e-tests, even if some shards have failed
   merge_e2e_data:


### PR DESCRIPTION
Fixes #15160

This PR adds a dummy proxy job after e2e_tests that will always run and provide a status that can be used as a requirement for PRs.