### PR TITLE
Add dummy filters to avoid routing all ETOR ORUs to these receivers

### DIFF
--- a/prime-router/settings/STLTs/LA/la-ochsner.yml
+++ b/prime-router/settings/STLTs/LA/la-ochsner.yml
@@ -36,7 +36,8 @@
       jurisdictionalFilter:
         - "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"  # ORU_R01
         - "Bundle.entry.resource.ofType(MessageHeader).meta.tag.where(system = 'http://localcodes.org/ETOR').code = 'ETOR'"  # required to avoid looping issue with TI
-        # Pending: add filter(s) for routing
+        # Pending: add correct filter(s) for routing
+        - "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(value = 'la-ochsner-simulated-lab-id').exists()"
       qualityFilter:
         - "true"
       timing:

--- a/prime-router/settings/STLTs/Oracle/oracle-rln.yml
+++ b/prime-router/settings/STLTs/Oracle/oracle-rln.yml
@@ -35,7 +35,8 @@
       jurisdictionalFilter:
         - "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"  # ORU_R01
         - "Bundle.entry.resource.ofType(MessageHeader).meta.tag.where(system = 'http://localcodes.org/ETOR').code = 'ETOR'"  # required to avoid looping issue with TI
-        # Pending: add filter(s) for routing
+        # Pending: add correct filter(s) for routing
+        - "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(value = 'oracle-rln-simulated-lab-id').exists()"
       qualityFilter:
         - "true"
       timing:


### PR DESCRIPTION
We currently don't have the receiver identifier information for the Ochsner and Oracle recivers. In the meantime, we need to add a dummy filter so all ETOR ORUs are not routed to them