### PR TITLE
Fix for truncating sub-components

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/HL7Truncator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/HL7Truncator.kt
@@ -184,6 +184,10 @@ class CovidPipelineHL7Truncator : HL7Truncator {
         val segment = terser.getSegment(segmentSpec)
         val parts = HL7Truncator.HL7FieldComponents.parse(hl7FieldOrPath)
         val field = segment.getField(parts.first, 0)
+        if (parts.third != null && parts.second != null && field is Composite) {
+            val subComponent = field.components[parts.second - 1]
+            return getHl7MaxLength(segment, subComponent, parts)
+        }
         return getHl7MaxLength(segment, field, parts)
     }
 }

--- a/prime-router/src/test/kotlin/fhirengine/engine/CustomTranslationFunctionsTest.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/CustomTranslationFunctionsTest.kt
@@ -158,7 +158,7 @@ class CustomTranslationFunctionsTest {
             config = HL7TranslationConfig(
                 hl7Configuration = UnitTestUtils.createConfig(
                     truncateHDNamespaceIds = true,
-                    truncateHl7Fields = "MSH-4-1, ORC-12-1, OBX-15-2",
+                    truncateHl7Fields = "MSH-4-1, ORC-12-1, OBX-15-2, SPM-2-2-2",
                 ),
                 null
             )
@@ -183,6 +183,11 @@ class CustomTranslationFunctionsTest {
             "Test value test value longer Test value test value longer Test value test value longer" +
                 "Test value test value longer Test value test value longer Test value test value longer" +
                 "Test value test value Test"
+        )
+
+        val spm2InputAndExpected = mapOf(
+            "short" to "short",
+            "Test value test testTRUNCATE" to "Test value test test",
         )
 
         msh4InputAndExpected.forEach { (input, expected) ->
@@ -229,6 +234,16 @@ class CustomTranslationFunctionsTest {
             val actual = translationFunctions.maybeTruncateHL7Field(
                 input,
                 "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/OBSERVATION(0)/OBX-15-2",
+                emptyTerser,
+                customContext
+            )
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        spm2InputAndExpected.forEach { (input, expected) ->
+            val actual = translationFunctions.maybeTruncateHL7Field(
+                input,
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/SPECIMEN/SPM-2-2-2",
                 emptyTerser,
                 customContext
             )

--- a/prime-router/src/test/kotlin/fhirengine/translation/hl7/HL7TrucatorTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/translation/hl7/HL7TrucatorTests.kt
@@ -51,8 +51,9 @@ class HL7TrucatorTests {
         assertThat(covidHL7Truncator.getHl7MaxLength("OBX-18-1", emptyTerser)).isEqualTo(199)
         assertThat(covidHL7Truncator.getHl7MaxLength("OBX-19", emptyTerser)).isEqualTo(26)
         assertThat(covidHL7Truncator.getHl7MaxLength("OBX-23-1", emptyTerser)).isEqualTo(50)
-        // Test that a subcomponent returns null
+        // Test subcomponent length
         assertThat(covidHL7Truncator.getHl7MaxLength("OBR-16-1-2", emptyTerser)).isNull()
+        assertThat(covidHL7Truncator.getHl7MaxLength("SPM-2-2-2", emptyTerser)).isEqualTo(20)
     }
 
     @Test
@@ -61,6 +62,25 @@ class HL7TrucatorTests {
         assertThat(
             upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-12-1", emptyTerser)
         ).isEqualTo(15)
+        assertThat(
+            upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT/ORDER_OBSERVATION/ORC-12-3", emptyTerser)
+        ).isEqualTo(30)
+        assertThat(
+            upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/ORC-21-1", emptyTerser)
+        ).isEqualTo(50)
+        // Test OBX and OBR
+        assertThat(
+            upHL7Truncator.getHl7MaxLength(
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/OBSERVATION(0)/OBX-15-1",
+                emptyTerser
+            )
+        ).isEqualTo(20)
+        assertThat(
+            upHL7Truncator.getHl7MaxLength(
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/OBSERVATION(0)/OBX-23-1",
+                emptyTerser
+            )
+        ).isEqualTo(50)
         assertThat(
             upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT/ORDER_OBSERVATION/OBR-16-1", emptyTerser)
         ).isEqualTo(15)
@@ -103,10 +123,20 @@ class HL7TrucatorTests {
         assertThat(
             upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT/ORDER_OBSERVATION/SPECIMEN/OBX-23-1", emptyTerser)
         ).isEqualTo(50)
-        // Test that a subcomponent returns null
+        // Test that a subcomponent that doesn't exist returns null
         assertThat(
             upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT/ORDER_OBSERVATION/OBR-16-1-2", emptyTerser)
         ).isNull()
+        // Test sub-component length
+        assertThat(
+            upHL7Truncator.getHl7MaxLength("/PATIENT_RESULT(0)/PATIENT/PID-3-6-1", emptyTerser)
+        ).isEqualTo(20)
+        assertThat(
+            upHL7Truncator.getHl7MaxLength(
+                "/PATIENT_RESULT(0)/ORDER_OBSERVATION(0)/SPECIMEN/SPM-2-2-2",
+                emptyTerser
+            )
+        ).isEqualTo(20)
     }
 
     @Test


### PR DESCRIPTION
This PR fixes truncating sub-components for HL7 fields.

Test Steps:
1. add fields and subcomponents to a receiver's `truncateHl7Fields` setting. For example: 
```     
translation: !<HL7>
    schemaName: "classpath:/metadata/hl7_mapping/ORU_R01/ORU_R01-base.yml"
    truncateHl7Fields: "ORC-12-3, SPM-2-2-2"
```
2. Note each field's maximum length. Use https://hl7-definition.caristix.com/v2/HL7v2.5/Segments as a reference.
3. Use a sample HL7 report and replace values for the fields that were specified in the `truncateHl7Fields` setting with strings that are the size of each field's maximum length. Add "TRUNCATE THIS" at the end of each of these strings.
4. Use http://localhost:7071/api/reports to send a report to the receiver
5. Verify that the HL7 file that was created contains the original values for the fields without the "TRUNCATE THIS" strings.

## Changes
- fixed truncation of sub-components by grabbing the parent component's data-type instead of the field in order to determine its max length
- added more test cases that include sub-components

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- #15110

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue
