### PR TITLE
15397 valueset loading fix

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/engine/LookupTableValueSet.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/LookupTableValueSet.kt
@@ -40,7 +40,7 @@ class LookupTableValueSet
             throw SchemaException("Value column not found in specified lookup table")
         }
 
-        val filterTable = lookupTable.table.copy().retainColumns(configData.keyColumn, configData.valueColumn)
+        val filterTable = lookupTable.table.selectColumns(configData.keyColumn, configData.valueColumn)
         val result = mutableMapOf<String, String>()
         filterTable.forEach { row ->
             result[row.getString(configData.keyColumn)] = row.getString(configData.valueColumn)

--- a/prime-router/src/main/kotlin/fhirengine/engine/LookupTableValueSet.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/LookupTableValueSet.kt
@@ -40,8 +40,9 @@ class LookupTableValueSet
             throw SchemaException("Value column not found in specified lookup table")
         }
 
+        val filterTable = lookupTable.table.retainColumns(configData.keyColumn, configData.valueColumn)
         val result = mutableMapOf<String, String>()
-        lookupTable.table.forEach { row ->
+        filterTable.forEach { row ->
             result[row.getString(configData.keyColumn)] = row.getString(configData.valueColumn)
         }
 

--- a/prime-router/src/main/kotlin/fhirengine/engine/LookupTableValueSet.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/LookupTableValueSet.kt
@@ -40,7 +40,7 @@ class LookupTableValueSet
             throw SchemaException("Value column not found in specified lookup table")
         }
 
-        val filterTable = lookupTable.table.retainColumns(configData.keyColumn, configData.valueColumn)
+        val filterTable = lookupTable.table.copy().retainColumns(configData.keyColumn, configData.valueColumn)
         val result = mutableMapOf<String, String>()
         filterTable.forEach { row ->
             result[row.getString(configData.keyColumn)] = row.getString(configData.valueColumn)

--- a/prime-router/src/test/kotlin/fhirengine/engine/LookupTableValueSetTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/LookupTableValueSetTests.kt
@@ -67,8 +67,7 @@ class LookupTableValueSetTests {
         val testTable = Table.create(
             "table",
             StringColumn.create("key", "abc123", "def456"),
-            StringColumn.create("value", "ghi789", ""),
-            StringColumn.create("secondValue", "ijk012", "lmn345")
+            StringColumn.create("value", "ghi789", "")
         )
         val testLookupTable = LookupTable(name = "table", table = testTable)
 
@@ -77,21 +76,21 @@ class LookupTableValueSetTests {
         mockkObject(Metadata)
         every { Metadata.getInstance() } returns UnitTestUtils.simpleMetadata
 
-        var bundle = Bundle()
+        val bundle = Bundle()
         bundle.id = "bundle1"
-        var resource = Patient()
+        val resource = Patient()
         resource.addName(HumanName().setTextElement(StringType("abc123")))
         bundle.addEntry().resource = resource
-        var resource2 = Patient()
+        val resource2 = Patient()
         resource2.addName(HumanName().setTextElement(StringType("def456")))
         bundle.addEntry().resource = resource2
-        var resource3 = Patient()
+        val resource3 = Patient()
         resource3.addName(HumanName().setTextElement(StringType("jkl369")))
         bundle.addEntry().resource = resource3
 
-        var valueConfig = LookupTableValueSetConfig(tableName = "table", keyColumn = "key", valueColumn = "value")
+        val valueConfig = LookupTableValueSetConfig(tableName = "table", keyColumn = "key", valueColumn = "value")
 
-        var patientElement = FhirTransformSchemaElement(
+        val patientElement = FhirTransformSchemaElement(
             "patientElement",
             value = listOf("%resource.name.text"),
             resource = "%resource",
@@ -100,7 +99,7 @@ class LookupTableValueSetTests {
                 valueConfig
             )
         )
-        var childSchema = FhirTransformSchema(elements = mutableListOf(patientElement))
+        val childSchema = FhirTransformSchema(elements = mutableListOf(patientElement))
 
         val elemA = FhirTransformSchemaElement(
             "elementA",
@@ -109,55 +108,12 @@ class LookupTableValueSetTests {
             resourceIndex = "patientIndex",
         )
 
-        var schema = FhirTransformSchema(elements = mutableListOf(elemA))
+        val schema = FhirTransformSchema(elements = mutableListOf(elemA))
 
         FhirTransformer(schema).process(bundle)
 
         assertThat(resource.name[0].text).isEqualTo("ghi789")
         assertThat(resource2.name[0].text).isEqualTo("")
-        assertThat(resource3.name[0].text).isEqualTo("jkl369")
-
-        // Test getting the second column from the same table.
-
-        bundle = Bundle()
-        bundle.id = "bundle2"
-        resource = Patient()
-        resource.addName(HumanName().setTextElement(StringType("def456")))
-        bundle.addEntry().resource = resource
-        resource2 = Patient()
-        resource2.addName(HumanName().setTextElement(StringType("abc123")))
-        bundle.addEntry().resource = resource2
-        resource3 = Patient()
-        resource3.addName(HumanName().setTextElement(StringType("jkl369")))
-        bundle.addEntry().resource = resource3
-
-        valueConfig = LookupTableValueSetConfig(tableName = "table", keyColumn = "key", valueColumn = "secondValue")
-
-        patientElement = FhirTransformSchemaElement(
-            "patientElement",
-            value = listOf("%resource.name.text"),
-            resource = "%resource",
-            bundleProperty = "%resource.name.text",
-            valueSet = LookupTableValueSet(
-                valueConfig
-            )
-        )
-
-        childSchema = FhirTransformSchema(elements = mutableListOf(patientElement))
-
-        val elemB = FhirTransformSchemaElement(
-            "elementB",
-            resource = "Bundle.entry.resource.ofType(Patient)",
-            schemaRef = childSchema,
-            resourceIndex = "patientIndex",
-        )
-
-        schema = FhirTransformSchema(elements = mutableListOf(elemB))
-
-        FhirTransformer(schema).process(bundle)
-
-        assertThat(resource.name[0].text).isEqualTo("lmn345")
-        assertThat(resource2.name[0].text).isEqualTo("ijk012")
         assertThat(resource3.name[0].text).isEqualTo("jkl369")
 
         unmockkAll()

--- a/prime-router/src/test/kotlin/fhirengine/engine/LookupTableValueSetTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/LookupTableValueSetTests.kt
@@ -19,6 +19,7 @@ import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.ContactPoint
 import org.hl7.fhir.r4.model.HumanName
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.StringType
@@ -67,7 +68,8 @@ class LookupTableValueSetTests {
         val testTable = Table.create(
             "table",
             StringColumn.create("key", "abc123", "def456"),
-            StringColumn.create("value", "ghi789", "")
+            StringColumn.create("value", "ghi789", ""),
+            StringColumn.create("secondValue", "ijk012", "lmn345")
         )
         val testLookupTable = LookupTable(name = "table", table = testTable)
 
@@ -80,18 +82,20 @@ class LookupTableValueSetTests {
         bundle.id = "bundle1"
         val resource = Patient()
         resource.addName(HumanName().setTextElement(StringType("abc123")))
+        resource.addTelecom(ContactPoint().setValueElement(StringType("abc123")))
         bundle.addEntry().resource = resource
         val resource2 = Patient()
         resource2.addName(HumanName().setTextElement(StringType("def456")))
+        resource2.addTelecom(ContactPoint().setValueElement(StringType("def456")))
         bundle.addEntry().resource = resource2
         val resource3 = Patient()
         resource3.addName(HumanName().setTextElement(StringType("jkl369")))
+        resource3.addTelecom(ContactPoint().setValueElement(StringType("jkl369")))
         bundle.addEntry().resource = resource3
 
         val valueConfig = LookupTableValueSetConfig(tableName = "table", keyColumn = "key", valueColumn = "value")
-
-        val patientElement = FhirTransformSchemaElement(
-            "patientElement",
+        val patientNameElement = FhirTransformSchemaElement(
+            "patientNameElement",
             value = listOf("%resource.name.text"),
             resource = "%resource",
             bundleProperty = "%resource.name.text",
@@ -99,7 +103,18 @@ class LookupTableValueSetTests {
                 valueConfig
             )
         )
-        val childSchema = FhirTransformSchema(elements = mutableListOf(patientElement))
+        val valueConfig2 =
+            LookupTableValueSetConfig(tableName = "table", keyColumn = "key", valueColumn = "secondValue")
+        val patientTelecomElement = FhirTransformSchemaElement(
+            "patientTelecomElement",
+            value = listOf("%resource.telecom.value"),
+            resource = "%resource",
+            bundleProperty = "%resource.telecom.value",
+            valueSet = LookupTableValueSet(
+                valueConfig2
+            )
+        )
+        val childSchema = FhirTransformSchema(elements = mutableListOf(patientNameElement, patientTelecomElement))
 
         val elemA = FhirTransformSchemaElement(
             "elementA",
@@ -113,8 +128,11 @@ class LookupTableValueSetTests {
         FhirTransformer(schema).process(bundle)
 
         assertThat(resource.name[0].text).isEqualTo("ghi789")
+        assertThat(resource.telecom[0].value).isEqualTo("ijk012")
         assertThat(resource2.name[0].text).isEqualTo("")
+        assertThat(resource2.telecom[0].value).isEqualTo("lmn345")
         assertThat(resource3.name[0].text).isEqualTo("jkl369")
+        assertThat(resource3.telecom[0].value).isEqualTo("jkl369")
 
         unmockkAll()
     }


### PR DESCRIPTION
This PR reverts the previously merged fix to an issue with multiple valuesets using the same source table and implements a new fix.

Test Steps:
1. Covered by tests, but another reproduction of the issue is detailed in #14901

## Changes
- Reverted #14933
- A copy of the lookup table is now made instead of processing the lookup table in metadata directly
- Updated tests

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

## Linked Issues
- #15397