### PR TITLE
Bug: add receiver and bundle digest to item routed

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRDestinationFilter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRDestinationFilter.kt
@@ -179,6 +179,7 @@ class FHIRDestinationFilter(
                         pipelineStepName = TaskAction.destination_filter
                     ) {
                         parentReportId(queueMessage.reportId)
+                        params(mapOf(ReportStreamEventProperties.RECEIVER_NAME to receiver.fullName))
                         trackingId(bundle)
                     }
 

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRDestinationFilter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRDestinationFilter.kt
@@ -173,13 +173,29 @@ class FHIRDestinationFilter(
                     // ensure tracking is set
                     actionHistory.trackCreatedReport(nextEvent, report, blobInfo = blobInfo)
 
+                    val bundleDigestExtractor = BundleDigestExtractor(
+                        FhirPathBundleDigestLabResultExtractorStrategy(
+                            CustomContext(
+                                bundle,
+                                bundle,
+                                mutableMapOf(),
+                                CustomFhirPathFunctions()
+                            )
+                        )
+                    )
                     reportEventService.sendItemEvent(
                         eventName = ReportStreamEventName.ITEM_ROUTED,
                         childReport = report,
                         pipelineStepName = TaskAction.destination_filter
                     ) {
                         parentReportId(queueMessage.reportId)
-                        params(mapOf(ReportStreamEventProperties.RECEIVER_NAME to receiver.fullName))
+                        params(
+                            mapOf(
+                            ReportStreamEventProperties.RECEIVER_NAME to receiver.fullName,
+                            ReportStreamEventProperties.BUNDLE_DIGEST
+                                to bundleDigestExtractor.generateDigest(bundle)
+                        )
+                        )
                         trackingId(bundle)
                     }
 

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
@@ -332,7 +332,7 @@ class FHIRDestinationFilterIntegrationTests : Logging {
                     "phd.Test Sender"
                 )
             )
-            assertThat(event.params).isEqualTo(emptyMap())
+            assertThat(event.params).isEqualTo(mapOf(ReportStreamEventProperties.RECEIVER_NAME to "phd.x"))
 
             // check action table
             UniversalPipelineTestUtils.checkActionTable(listOf(TaskAction.receive, TaskAction.destination_filter))

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
@@ -304,6 +304,7 @@ class FHIRDestinationFilterIntegrationTests : Logging {
             }
 
             // check events
+            val bundle = FhirTranscoder.decode(reportContents)
             assertThat(azureEventsService.reportStreamEvents[ReportStreamEventName.ITEM_ROUTED]!!).hasSize(1)
             assertThat(
                 azureEventsService
@@ -332,7 +333,18 @@ class FHIRDestinationFilterIntegrationTests : Logging {
                     "phd.Test Sender"
                 )
             )
-            assertThat(event.params).isEqualTo(mapOf(ReportStreamEventProperties.RECEIVER_NAME to "phd.x"))
+            assertThat(event.params).isEqualTo(
+                mapOf(
+                ReportStreamEventProperties.RECEIVER_NAME to "phd.x",
+                ReportStreamEventProperties.BUNDLE_DIGEST to BundleDigestLabResult(
+                    observationSummaries = AzureEventUtils.getObservationSummaries(bundle),
+                    eventType = "ORU/ACK - Unsolicited transmission of an observation message",
+                    patientState = listOf("CO"),
+                    performerState = emptyList(),
+                    orderingFacilityState = listOf("CO")
+                )
+            )
+            )
 
             // check action table
             UniversalPipelineTestUtils.checkActionTable(listOf(TaskAction.receive, TaskAction.destination_filter))

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
@@ -351,7 +351,8 @@ class FhirDestinationFilterTests {
                     "sendingOrg.sendingOrgClient"
                 )
             )
-            assertThat(event.params).isEqualTo(emptyMap())
+            assertThat(event.params)
+                .isEqualTo(mapOf(ReportStreamEventProperties.RECEIVER_NAME to "co-phd.full-elr-hl7"))
         }
 
         // assert

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
@@ -352,7 +352,67 @@ class FhirDestinationFilterTests {
                 )
             )
             assertThat(event.params)
-                .isEqualTo(mapOf(ReportStreamEventProperties.RECEIVER_NAME to "co-phd.full-elr-hl7"))
+                .isEqualTo(
+                    mapOf(
+                    ReportStreamEventProperties.RECEIVER_NAME to "co-phd.full-elr-hl7",
+                    ReportStreamEventProperties.BUNDLE_DIGEST to BundleDigestLabResult(
+                        observationSummaries = listOf(
+                            ObservationSummary(
+                                listOf(
+                                    TestSummary(
+                                        listOf(
+                                            CodeSummary(
+                                                snomedSystem,
+                                                "840539006",
+                                                @Suppress("ktlint:standard:max-line-length")
+                                                "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+                                            )
+                                        ),
+                                        loincSystem,
+                                        "94558-4",
+                                    )
+                                )
+                            ),
+                            ObservationSummary(
+                                listOf(
+                                    TestSummary(
+                                        testPerformedCode = "95418-0",
+                                        testPerformedSystem = loincSystem
+                                    )
+                                )
+                            ),
+                            ObservationSummary(
+                                listOf(
+                                    TestSummary(
+                                        testPerformedCode = "95417-2",
+                                        testPerformedSystem = loincSystem
+                                    )
+                                )
+                            ),
+                            ObservationSummary(
+                                listOf(
+                                    TestSummary(
+                                        testPerformedCode = "95421-4",
+                                        testPerformedSystem = loincSystem
+                                    )
+                                )
+                            ),
+                            ObservationSummary(
+                                listOf(
+                                    TestSummary(
+                                        testPerformedCode = "95419-8",
+                                        testPerformedSystem = loincSystem
+                                    )
+                                )
+                            ),
+                        ),
+                        patientState = listOf("CA"),
+                        performerState = emptyList(),
+                        orderingFacilityState = listOf("CA"),
+                        eventType = "ORU/ACK - Unsolicited transmission of an observation message"
+                    )
+                )
+                )
         }
 
         // assert


### PR DESCRIPTION
This PR adds some more data to the ITEM_ROUTED event that was missed during the initial implementation.

Test Steps:
1. Run the end2end_up smoketest
2. Verify the emitted ITEM_ROUTED event in the logs includes the receiver name and a bundle digest

## Changes
- Adds receiver and bundle digest to the ITEM_ROUTED event

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues

## To Be Done


## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
