### PR TITLE
Platform/14349/david navapbc/14349/empty report

### DIFF
--- a/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
+++ b/prime-router/src/main/kotlin/azure/WorkflowEngine.kt
@@ -393,7 +393,7 @@ class WorkflowEngine(
         actionHistory: ActionHistory,
         receiver: Receiver,
     ) {
-        // generate empty report for receiver's specified foramt
+        // generate empty report for receiver's specified format
         val toSchema = metadata.findSchema(receiver.schemaName)
             ?: error("${receiver.schemaName} schema is missing from catalog")
         val clientSource = ClientSource("ReportStream", "EmptyBatch")

--- a/prime-router/src/test/kotlin/common/UniversalPipelineTestUtils.kt
+++ b/prime-router/src/test/kotlin/common/UniversalPipelineTestUtils.kt
@@ -565,5 +565,4 @@ object UniversalPipelineTestUtils {
             }
         }
     }
-
 }

--- a/prime-router/src/test/kotlin/common/UniversalPipelineTestUtils.kt
+++ b/prime-router/src/test/kotlin/common/UniversalPipelineTestUtils.kt
@@ -565,4 +565,5 @@ object UniversalPipelineTestUtils {
             }
         }
     }
+
 }

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
@@ -345,14 +345,6 @@ class FHIRDestinationFilterIntegrationTests : Logging {
         // set up
         val reportContents = File(VALID_FHIR_URL).readText()
 
-//        val receiveReport = UniversalPipelineTestUtils.createReport(
-//            reportContents,
-//            TaskAction.receive,
-//            Event.EventAction.DESTINATION_FILTER,
-//            azuriteContainer,
-//            fileName = "receive.fhir"
-//        )
-
         val convertReport = UniversalPipelineTestUtils.createReport(
             reportContents,
             TaskAction.convert,


### PR DESCRIPTION
This PR ...

adds verification of item lineage to integration tests in receiver and destination filters to ensure empty reports are created properly. 

** THIS IS DRAFT PR BECAUSE I WANT TO CHECK IN WITH THE TEAM BEFORE COMPLETING ALL THE REFACTORING IN RECEIVER_FILTER INTEGRATION TESTS ** 

## Changes
- adds call to `UniversalPipelineTestUtils.verifyLineageAndFetchCreatedReportFiles(...)` to integration tests for destination and receiver filters to ensure, when a message is fully pruned, a properly lineaged empty report is generated. 

### Testing
- [ x] Tested locally?
- [x ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
