### PR TITLE
Disable sending events except for local environments

### DIFF
--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
@@ -5,6 +5,7 @@ import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.azure.db.tables.pojos.ReportFile
 import gov.cdc.prime.router.azure.observability.context.withLoggingContext
+import gov.cdc.prime.router.common.Environment
 import org.apache.logging.log4j.kotlin.Logging
 import org.hl7.fhir.r4.model.Bundle
 import java.util.UUID
@@ -36,6 +37,10 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
     private val theTopic: Topic,
     private val pipelineStepName: TaskAction,
 ) : Logging {
+
+    companion object {
+        val sendEventEnabled = Environment.isLocal()
+    }
 
     constructor(
         reportEventService: IReportStreamEventService,
@@ -92,9 +97,11 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
     }
 
     fun send() {
-        val event = buildEvent()
-        sendToAzure(event)
-        logEvent(event)
+        if (sendEventEnabled) {
+            val event = buildEvent()
+            sendToAzure(event)
+            logEvent(event)
+        }
     }
 
     private fun sendToAzure(event: T): AbstractReportStreamEventBuilder<T> {


### PR DESCRIPTION
This PR disables sending events outside of local environment as the query is taking a very long time in staging.

Test Steps:
Covered by CI

## Changes
- Adds a check to only build and send events in a local environment

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues

## To Be Done

## Specific Security-related subjects a reviewer should pay specific attention to

