### PR TITLE
Fix item graph recursive query and re-enable event sending

### DIFF
--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
@@ -5,7 +5,6 @@ import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.azure.db.tables.pojos.ReportFile
 import gov.cdc.prime.router.azure.observability.context.withLoggingContext
-import gov.cdc.prime.router.common.Environment
 import org.apache.logging.log4j.kotlin.Logging
 import org.hl7.fhir.r4.model.Bundle
 import java.util.UUID
@@ -37,10 +36,6 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
     private val theTopic: Topic,
     private val pipelineStepName: TaskAction,
 ) : Logging {
-
-    companion object {
-        val sendEventEnabled = Environment.isLocal()
-    }
 
     constructor(
         reportEventService: IReportStreamEventService,
@@ -97,11 +92,9 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
     }
 
     fun send() {
-        if (sendEventEnabled) {
             val event = buildEvent()
             sendToAzure(event)
             logEvent(event)
-        }
     }
 
     private fun sendToAzure(event: T): AbstractReportStreamEventBuilder<T> {

--- a/prime-router/src/main/kotlin/history/db/ReportGraph.kt
+++ b/prime-router/src/main/kotlin/history/db/ReportGraph.kt
@@ -312,13 +312,8 @@ class ReportGraph(
         )
             .from(ITEM_LINEAGE)
             .where(
-                ITEM_LINEAGE.CHILD_REPORT_ID.`in`(
-                    DSL.select(REPORT_FILE.REPORT_ID)
-                        .from(REPORT_FILE)
-                        .where(ITEM_LINEAGE.CHILD_REPORT_ID.eq(childId))
-                        .and(ITEM_LINEAGE.CHILD_INDEX.eq(childIndex))
-                )
-            )
+                ITEM_LINEAGE.CHILD_REPORT_ID.eq(childId)
+            ).and(ITEM_LINEAGE.CHILD_INDEX.eq(childIndex))
         return DSL
             .name(ItemGraphTable.ITEM_GRAPH.name)
             .`as`(


### PR DESCRIPTION
This PR adjusts the item lineage recursive query to get postgres to use the index after the table has been vacuumed and analyzed

Test Steps:
CI covers it

## Changes
- Re-enables sending events 
- Updates the item lineage recursive query to that postgres will optimize it correctly
## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues


## To Be Done



## Specific Security-related subjects a reviewer should pay specific attention to
