### PR TITLE
Fixes a bug while truncating OBX-23-1.

### DIFF
--- a/prime-router/src/main/resources/metadata/hl7_mapping/receivers/STLTs/CA/ca-observation-result.yml
+++ b/prime-router/src/main/resources/metadata/hl7_mapping/receivers/STLTs/CA/ca-observation-result.yml
@@ -33,7 +33,7 @@ elements:
 
   - name: ca-organization-performer-identifier
     resource: '%resource.performer.resolve()'
-    value: [ '(%resource.name + "-"+ %resource.identifier[0].value).substring(0,50) ' ]
+    value: [ '(%resource.name.substring(0,39) + "-"+ %resource.identifier[0].value.substring(0,10)) ' ]
     hl7Spec: [ '%{hl7ObservationPath}/OBX-23-1' ]
 
   - name: ca-organization-namespace-id


### PR DESCRIPTION
This PR fixes an issue CA identified when OBX-23-1  is longer than 50 characters and the NPI was being truncated. The facility name needs to be truncated and not the NPI. 