### PR TITLE
Generating a version.txt file with the current short commit id and pu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ hs_err_pid*
 **/build/**
 **/log/**
 **/dependency-reduced-pom.xml
+**/version.txt
 
 # Frontend build output
 **/node_modules/**

--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -23,7 +23,9 @@ import org.apache.commons.io.FilenameUtils
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jooq.meta.jaxb.ForcedType
+import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
+import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Properties
@@ -497,9 +499,22 @@ tasks.azureFunctionsPackage {
     finalizedBy("copyAzureScripts")
 }
 
+tasks.register("generateVersionFile") {
+    doLast {
+        val stdout = ByteArrayOutputStream()
+        exec {
+            commandLine("git", "rev-parse", "--short", "HEAD")
+            standardOutput = stdout
+        }
+        val currentCommit = stdout.toString(StandardCharsets.UTF_8)
+        File("./version.txt").writeText("Commit ID: $currentCommit")
+    }
+}
+
 val azureResourcesTmpDir = File(buildDir, "$azureFunctionsDir-resources/$azureAppName")
 val azureResourcesFinalDir = File(buildDir, "$azureFunctionsDir/$azureAppName")
 tasks.register<Copy>("gatherAzureResources") {
+    dependsOn("generateVersionFile")
     from("./")
     into(azureResourcesTmpDir)
     include("metadata/**/*.yml")
@@ -509,6 +524,7 @@ tasks.register<Copy>("gatherAzureResources") {
     include("metadata/**/*.csv")
     include("settings/**/*.yml")
     include("assets/**/*__inline.html")
+    include("version.txt")
 }
 
 tasks.register("copyAzureResources") {


### PR DESCRIPTION
This PR ...

Generates a version.txt file with the current short commit id and puts it in with the Azure resources on build.

Test Steps:
1. Run git rev-parse --short HEAD in the terminal, note the output
2. Run gradle package or quickPackage
3. Check that prime-router/build/azure-functions-resources/version.txt exists
4. Check that the commit id in version.txt matches what was output in step 1

## Changes
- Added task to prime-router's build.gradle file to create a version.txt file with the current commit id and include it when gathering the Azure resources.
- Added the version.txt file to the .gitignore so it won't be committed since it's generated by Gradle.

## Checklist

### Testing
- [X] Tested locally?
- [X] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [X] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #12928 