### PR TITLE
Platform/david navapbc/14568/update fhir resource delete strategy

### DIFF
--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverFilter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverFilter.kt
@@ -29,7 +29,6 @@ import gov.cdc.prime.router.azure.observability.event.AzureEventService
 import gov.cdc.prime.router.azure.observability.event.AzureEventServiceImpl
 import gov.cdc.prime.router.azure.observability.event.ReportStreamEventName
 import gov.cdc.prime.router.azure.observability.event.ReportStreamEventProperties
-import gov.cdc.prime.router.codes
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.CustomContext
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
 import gov.cdc.prime.router.fhirengine.utils.FhirTranscoder
@@ -37,7 +36,6 @@ import gov.cdc.prime.router.fhirengine.utils.filterMappedObservations
 import gov.cdc.prime.router.fhirengine.utils.filterObservations
 import gov.cdc.prime.router.fhirengine.utils.getMappedConditionCodes
 import gov.cdc.prime.router.fhirengine.utils.getObservations
-import gov.cdc.prime.router.fhirengine.utils.getObservationsWithCondition
 import gov.cdc.prime.router.history.db.ReportGraph
 import gov.cdc.prime.router.logging.LogMeasuredTime
 import gov.cdc.prime.router.report.ReportService
@@ -243,86 +241,6 @@ class FHIRReceiverFilter(
         // we survived the gauntlet - result success
         return ReceiverFilterEvaluationResult.Success(filteredBundle)
     }
-
-
-//        val allObservations = bundle.getObservations()
-//        val result: ReceiverFilterEvaluationResult = if (conditionFilters.isNotEmpty()) {
-//            val (keptObservations, filteredObservations) = allObservations.partition { observation ->
-//                conditionFilters.any { filter ->
-//                    FhirPathUtils.evaluateCondition(
-//                        CustomContext(bundle, observation, shorthandLookupTable, CustomFhirPathFunctions()),
-//                        observation,
-//                        bundle,
-//                        bundle,
-//                        filter
-//                    )
-//                }
-//            }
-//            val allRemainingObservationsAreAoe = keptObservations
-//                .all {
-//                    val conditions = it.getMappedConditionCodes()
-//                    conditions.isNotEmpty() && conditions.all { code -> code == "AOE" }
-//                }
-//            if (keptObservations.isEmpty() || allRemainingObservationsAreAoe) {
-//                actionLogger.getItemLogger(1, trackingId).warn(
-//                    ReceiverItemFilteredActionLogDetail(
-//                        conditionFilters.joinToString(","),
-//                        ReportStreamFilterType.CONDITION_FILTER,
-//                        receiver.organizationName,
-//                        receiver.name,
-//                        1
-//                    )
-//                )
-//                ReceiverFilterEvaluationResult.Failure(
-//                    FilterDetails(conditionFilters, ReportStreamFilterType.CONDITION_FILTER)
-//                )
-//            } else {
-//                filteredObservations.forEach { observation ->
-//                    withLoggingContext(mapOf(MDCUtils.MDCProperty.OBSERVATION_ID to observation.id.toString())) {
-//                        logger.info("Observations were filtered from the bundle")
-//                    }
-//                }
-//                ReceiverFilterEvaluationResult.Success(
-//                    bundle.filterObservations(conditionFilters, shorthandLookupTable)
-//                )
-//            }
-//        } else if (mappedConditionFilters.isNotEmpty()) {
-//            val codes = mappedConditionFilters.codes()
-//            val keptObservations = bundle.getObservationsWithCondition(codes)
-//            if (keptObservations.isEmpty() ||
-//                keptObservations.all {
-//                    it.getMappedConditionCodes().all { code -> code == "AOE" }
-//                }
-//            ) {
-//                actionLogger.getItemLogger(1, trackingId).warn(
-//                    ReceiverItemFilteredActionLogDetail(
-//                        mappedConditionFilters.joinToString(","),
-//                        ReportStreamFilterType.MAPPED_CONDITION_FILTER,
-//                        receiver.organizationName,
-//                        receiver.name,
-//                        1
-//                    )
-//                )
-//                ReceiverFilterEvaluationResult.Failure(
-//                    FilterDetails(
-//                        mappedConditionFilters.map { it.value },
-//                        ReportStreamFilterType.MAPPED_CONDITION_FILTER
-//                    )
-//                )
-//            } else {
-//                filteredMappedResult.first.forEach { observationId ->
-//                    withLoggingContext(mapOf(MDCUtils.MDCProperty.OBSERVATION_ID to observationId)) {
-//                        logger.info("Observations were filtered from the bundle")
-//                    }
-//                }
-//                return ReceiverFilterEvaluationResult.Success(filteredBundle)
-//            }
-//        } else {
-//            ReceiverFilterEvaluationResult.Success(bundle)
-//        }
-//
-//        return result
-//    }
 
     /**
      * Evaluates a list of FHIR expression [filters] for a [receiver] on a [bundle].

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverFilter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverFilter.kt
@@ -190,8 +190,10 @@ class FHIRReceiverFilter(
         val filteredBundle: Bundle
         if (conditionFilters.isNotEmpty()) {
             filteredBundle = bundle.filterObservations(conditionFilters, shorthandLookupTable)
-        } else {
+        } else if (mappedConditionFilters.isNotEmpty()) {
             filteredBundle = bundle.filterMappedObservations(mappedConditionFilters).second
+        } else {
+            return ReceiverFilterEvaluationResult.Success(bundle)
         }
 
         val allRemainingObservationsAreAoe =

--- a/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
+++ b/prime-router/src/main/kotlin/fhirengine/utils/FHIRBundleHelpers.kt
@@ -317,6 +317,10 @@ fun Bundle.filterObservations(
     val listToKeep = observationsToKeep.map { it.idBase }
     allObservations.forEach {
         if (it.idBase !in listToKeep) {
+            val asObservation = it as Observation
+            withLoggingContext(mapOf(MDCUtils.MDCProperty.OBSERVATION_ID to asObservation.id)) {
+                logger.info("Observations were filtered from the bundle")
+            }
             filteredBundle.deleteResource(it)
         }
     }
@@ -379,11 +383,6 @@ private fun getFilteredObservations(
 
         if (passes) {
             observationsToKeep.add(observation)
-        } else {
-            val asObservation = observation as Observation
-            withLoggingContext(mapOf(MDCUtils.MDCProperty.OBSERVATION_ID to asObservation.id.toString())) {
-                logger.info("Observations were filtered from the bundle")
-            }
         }
     }
 

--- a/prime-router/src/test/kotlin/fhirengine/utils/FHIRBundleHelpersTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/utils/FHIRBundleHelpersTests.kt
@@ -477,8 +477,7 @@ class FHIRBundleHelpersTests {
     @Test
     fun `test filterObservations`() {
         val actionLogger = ActionLogger()
-        val fhirBundle = File(MULTIPLE_OBSERVATIONS_URL)
-            .readText()
+        val fhirBundle = File(MULTIPLE_OBSERVATIONS_URL).readText()
         val messages = FhirTranscoder.getBundles(fhirBundle, actionLogger)
 
         val bundle = messages[0].filterObservations(


### PR DESCRIPTION
This PR ...
Updates the logic in `FHIRReceiverFilter.evaluateObservationConditionFilters()` to be functionally equivalent but more succinct and more computationally efficient. As per the scope of the ticket I did not address upstream refactoring (ie - how condition filtering works) and nor did I change any of the methods in FHIRBundleHelpers. 

No new methods added so no new tests. Existing tests cover changes in this PR: 
```

FHIRBundleHelperTests
--
"test filterObservations"
"test filterMappedObservations"

FhirReceiverFilterTests
---
"test filterMappedObservations"
"fail - mapped condition filter fails"
"fail - bundle of only AOEs do not pass mappedConditionFilter"
"success - jurisfilter, qualfilter, routing filter, proc mode passes, and condition filter passes"
"test the bundle queued for the translate function is filtered to conditions the receiver wants"
"test the bundle queued for the translate function is filtered to mapped conditions the receiver wants"
"test a receiver can receive a report when no condition filters are configured"

FhirReceiverFilterIntegrationTests
---
"should send valid FHIR report filtered by condition filter"
"should not send report fully pruned by condition filter"
"should send valid FHIR report with no condition related filtering"
"should not send report where the only unpruned observations are AOE"
"should send valid FHIR report filtered by mapped condition filter"
"should not send report fully pruned by mapped condition filter"
```


### Testing
- [x ] Tested locally?
- [x ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?


