### PR TITLE
disable smoke tests for receiver status temporarily

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/daily-data-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/daily-data-page-user-flow.spec.ts
@@ -74,7 +74,8 @@ const SMOKE_RECEIVERS = [TEST_ORG_UP_RECEIVER_UP, TEST_ORG_CP_RECEIVER_CP, TEST_
 test.describe(
     "Daily Data page - user flow smoke tests",
     {
-        tag: "@smoke",
+        // TODO: Investigate Daily Data page - user flow smoke tests › admin user › ignore org - FULL_ELR receiver › filter › on 'Apply' › clears 'Report ID'
+        //tag: "@smoke",
     },
     () => {
         test.describe("admin user", () => {

--- a/frontend-react/e2e/spec/chromium-only/authenticated/daily-data-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/daily-data-page-user-flow.spec.ts
@@ -207,7 +207,7 @@ test.describe(
                             );
                         });
 
-                        test("clears 'Report ID'", async ({ dailyDataPage }) => {
+                        test.skip("clears 'Report ID'", async ({ dailyDataPage }) => {
                             // Search by Report ID
                             const reportId = await tableDataCellValue(dailyDataPage.page, 0, 0);
                             await searchInput(dailyDataPage.page).fill(reportId);

--- a/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
@@ -38,7 +38,8 @@ const test = baseTest.extend<AdminReceiverStatusPageFixtures>({
 
 test.describe("Admin Receiver Status Page",
     {
-        tag: "@smoke",
+        // TODO: Investigate time errors, and unexpected status message in modal
+        // tag: "@smoke",
     }, () => {
         test.use({ storageState: logins.admin.path });
         test.describe("displays correctly", () => {

--- a/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
@@ -38,7 +38,7 @@ const test = baseTest.extend<AdminReceiverStatusPageFixtures>({
 
 test.describe("Admin Receiver Status Page",
     {
-        // TODO: Investigate time errors, and unexpected status message in modal
+        // TODO: Investigate Admin Receiver Status Page › functions correctly › receiver statuses › time period modals
         // tag: "@smoke",
     }, () => {
         test.use({ storageState: logins.admin.path });

--- a/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
@@ -320,7 +320,7 @@ test.describe("Admin Receiver Status Page",
                     });
                 });
 
-                test("time period modals", async ({ adminReceiverStatusPage }) => {
+                test.skip("time period modals", async ({ adminReceiverStatusPage }) => {
                     const result = await adminReceiverStatusPage.testReceiverTimePeriodModals(true);
                     expect(result).toBe(true);
                 });


### PR DESCRIPTION
This PR disables smoke tests for receiver status temporarily to investigate errors.