### PR TITLE
move initializeQueueMessages to companion object

### DIFF
--- a/prime-router/src/main/kotlin/common/BaseEngine.kt
+++ b/prime-router/src/main/kotlin/common/BaseEngine.kt
@@ -7,6 +7,7 @@ import gov.cdc.prime.router.SettingsProvider
 import gov.cdc.prime.router.azure.DatabaseAccess
 import gov.cdc.prime.router.azure.QueueAccess
 import gov.cdc.prime.router.azure.SettingsFacade
+import gov.cdc.prime.router.fhirengine.engine.initializeQueueMessages
 import gov.cdc.prime.router.serializers.CsvSerializer
 import gov.cdc.prime.router.serializers.Hl7Serializer
 import org.apache.logging.log4j.kotlin.Logging
@@ -22,6 +23,11 @@ abstract class BaseEngine(
 ) : Logging {
     companion object {
         val sequentialLimit = 500
+
+        // initialize the json types in PrimeRouterQueueMessage
+        init {
+            initializeQueueMessages()
+        }
 
         /**
          * These are all potentially heavyweight objects that

--- a/prime-router/src/main/kotlin/fhirengine/azure/FHIRFunctions.kt
+++ b/prime-router/src/main/kotlin/fhirengine/azure/FHIRFunctions.kt
@@ -22,7 +22,6 @@ import gov.cdc.prime.router.fhirengine.engine.FHIRTranslator
 import gov.cdc.prime.router.fhirengine.engine.FhirReceiveQueueMessage
 import gov.cdc.prime.router.fhirengine.engine.PrimeRouterQueueMessage
 import gov.cdc.prime.router.fhirengine.engine.ReportPipelineMessage
-import gov.cdc.prime.router.fhirengine.engine.initializeQueueMessages
 import org.apache.commons.lang3.StringUtils
 import org.apache.logging.log4j.kotlin.Logging
 
@@ -158,8 +157,6 @@ class FHIRFunctions(
         logger.debug(
             "${StringUtils.removeEnd(engineType, "e")}ing message: $message for the $dequeueCount time"
         )
-        // initialize the json types in PrimeRouterQueueMessage
-        initializeQueueMessages()
 
         return when (val queueMessage = QueueMessage.deserialize(message)) {
             is QueueMessage.ReceiveQueueMessage -> {


### PR DESCRIPTION
This PR moves initializeQueueMessages to companion object in BaseEngine

Test Steps:
1. run integration and unit tests