### PR TITLE
reduce log scan runtime

### DIFF
--- a/.github/workflows/scan_action_logs.yml
+++ b/.github/workflows/scan_action_logs.yml
@@ -16,9 +16,9 @@ jobs:
         id: scan
         with:
           github-token: ${{ secrets.RUNLEAKS_TOKEN }}
-          run-limit: 500
+          run-limit: 300
           min-days-old: 0
-          max-days-old: 2
+          max-days-old: 1
           patterns-path: ".github/runleaks/patterns.txt"
           exclusions-path: ".github/runleaks/exclusions.txt"
           fail-on-leak: false


### PR DESCRIPTION
This PR reduces the scope of action log scans to prevent timeout

## Linked Issues
- Fixes #15971
