### PR TITLE
15905 - Implement user flow for e2e smoke test for Sender Settings Page

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/organization-settings-edit-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/organization-settings-edit-page-user-flow.spec.ts
@@ -70,6 +70,20 @@ test.describe("Organization Edit Page", {
                 const rowCount = await organizationEditPage.page.locator("#orgsendersettings .usa-table tbody tr").count();
                 expect(rowCount).toBeGreaterThanOrEqual(1);
             });
+
+            test("can edit an organization sender", async ({ organizationEditPage }) => {
+                const firstOrgSender = await organizationEditPage.page.locator("#orgsendersettings").nth(0).locator("td").nth(0).innerText();
+                await organizationEditPage.page.locator('#orgsendersettings').getByRole('link', { name: 'Edit' }).nth(0).click();
+                await expect(organizationEditPage.page).toHaveURL(`/admin/orgsendersettings/org/ignore/sender/${firstOrgSender}/action/edit`);
+                await expect(organizationEditPage.page.getByText(`Org name: ignore`)).toBeVisible();
+                await expect(organizationEditPage.page.getByText(`Sender name: ${firstOrgSender}`)).toBeVisible();
+
+                await expect(organizationEditPage.page.getByTestId("name")).not.toBeEmpty();
+                await expect(organizationEditPage.page.getByTestId("format")).not.toBeEmpty();
+                await expect(organizationEditPage.page.getByTestId("topic")).not.toBeEmpty();
+                await expect(organizationEditPage.page.getByTestId("customerStatus")).not.toBeEmpty();
+                await expect(organizationEditPage.page.getByTestId("processingType")).not.toBeEmpty();
+            });
         });
 
         test.describe("'Organization Receiver Settings' section", () => {


### PR DESCRIPTION
This PR ...

Implement user flow for e2e smoke test for Sender Settings Page

Test Steps:
1. Run e2e


### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?

## Linked Issues
- Fixes #15905 
