### PR TITLE
14609: findDetailedDeliveryHistory handles actions that produce multiple reports

### DIFF
--- a/prime-router/src/main/kotlin/history/DeliveryHistory.kt
+++ b/prime-router/src/main/kotlin/history/DeliveryHistory.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import gov.cdc.prime.router.Receiver
 import gov.cdc.prime.router.Topic
+import gov.cdc.prime.router.azure.db.tables.pojos.Action
+import gov.cdc.prime.router.azure.db.tables.pojos.ReportFile
 import java.time.OffsetDateTime
 
 /**
@@ -65,6 +67,28 @@ class DeliveryHistory(
     schema_topic,
     itemCount
 ) {
+
+    companion object {
+        fun createDeliveryHistoryFromReportAndAction(
+            reportFile: ReportFile,
+            action: Action,
+        ): DeliveryHistory {
+            return DeliveryHistory(
+                actionId = action.actionId,
+                createdAt = action.createdAt,
+                receivingOrg = reportFile.receivingOrg,
+                receivingOrgSvc = reportFile.receivingOrgSvc,
+                externalName = action.externalName,
+                reportId = reportFile.reportId.toString(),
+                schema_topic = reportFile.schemaTopic,
+                itemCount = reportFile.itemCount,
+                bodyUrl = reportFile.bodyUrl,
+                schemaName = reportFile.schemaName,
+                bodyFormat = reportFile.bodyFormat
+            )
+        }
+    }
+
     @JsonIgnore
     private val DAYS_TO_SHOW = 30L
 

--- a/prime-router/src/main/kotlin/history/azure/DeliveryFacade.kt
+++ b/prime-router/src/main/kotlin/history/azure/DeliveryFacade.kt
@@ -91,6 +91,7 @@ class DeliveryFacade(
     /**
      * Get expanded details for a single report
      *
+     * @param id  either a report id (UUID) or action id (Long)
      * @param deliveryId id for the delivery being used
      * @return Report details
      */

--- a/prime-router/src/main/kotlin/history/azure/DeliveryFacade.kt
+++ b/prime-router/src/main/kotlin/history/azure/DeliveryFacade.kt
@@ -19,7 +19,7 @@ import java.util.*
  */
 class DeliveryFacade(
     private val dbDeliveryAccess: DatabaseDeliveryAccess = DatabaseDeliveryAccess(),
-    val dbAccess: DatabaseAccess = BaseEngine.databaseAccessSingleton,
+    private val dbAccess: DatabaseAccess = BaseEngine.databaseAccessSingleton,
     val reportService: ReportService = ReportService(),
 ) : ReportFileFacade(
     dbAccess
@@ -99,6 +99,8 @@ class DeliveryFacade(
         id: String,
         deliveryId: Long,
     ): DeliveryHistory? {
+        // This functionality is handling the fact that the calling function supports loading the history either
+        // by the action id or report id
         val reportFileId = try {
             UUID.fromString(id)
         } catch (ex: IllegalArgumentException) {

--- a/prime-router/src/main/kotlin/history/azure/DeliveryFunction.kt
+++ b/prime-router/src/main/kotlin/history/azure/DeliveryFunction.kt
@@ -167,7 +167,7 @@ class DeliveryFunction(
      * @return
      */
     override fun singleDetailedHistory(id: String, txn: DataAccessTransaction, action: Action): DeliveryHistory? {
-        return deliveryFacade.findDetailedDeliveryHistory(action.actionId)
+        return deliveryFacade.findDetailedDeliveryHistory(id, action.actionId)
     }
 
     @FunctionName("getDeliveriesV1")

--- a/prime-router/src/test/kotlin/history/azure/DeliveryFunctionTests.kt
+++ b/prime-router/src/test/kotlin/history/azure/DeliveryFunctionTests.kt
@@ -497,7 +497,7 @@ class DeliveryFunctionTests : Logging {
         action.actionName = TaskAction.batch
         every { mockDeliveryFacade.fetchActionForReportId(any()) } returns action
         every { mockDeliveryFacade.fetchAction(any()) } returns null // not used for a UUID
-        every { mockDeliveryFacade.findDetailedDeliveryHistory(any()) } returns returnBody
+        every { mockDeliveryFacade.findDetailedDeliveryHistory(any(), any()) } returns returnBody
         every { mockDeliveryFacade.checkAccessAuthorizationForAction(any(), any(), any()) } returns true
         response = function.getDeliveryDetails(mockRequest, goodUuid)
         assertThat(response.status).isEqualTo(HttpStatus.OK)
@@ -536,7 +536,7 @@ class DeliveryFunctionTests : Logging {
         // Happy path with a good actionId
         every { mockDeliveryFacade.fetchActionForReportId(any()) } returns null // not used for an actionId
         every { mockDeliveryFacade.fetchAction(any()) } returns action
-        every { mockDeliveryFacade.findDetailedDeliveryHistory(any()) } returns returnBody
+        every { mockDeliveryFacade.findDetailedDeliveryHistory(any(), any()) } returns returnBody
         every { mockDeliveryFacade.checkAccessAuthorizationForAction(any(), any(), any()) } returns true
         response = function.getDeliveryDetails(mockRequest, goodActionId)
         assertThat(response.status).isEqualTo(HttpStatus.OK)
@@ -713,7 +713,7 @@ class DeliveryFunctionTests : Logging {
 
         every { mockDeliveryFacade.fetchActionForReportId(any()) } returns action
         every { mockDeliveryFacade.fetchAction(any()) } returns null // not used for a UUID
-        every { mockDeliveryFacade.findDetailedDeliveryHistory(any()) } returns returnBody
+        every { mockDeliveryFacade.findDetailedDeliveryHistory(any(), any()) } returns returnBody
         every { mockDeliveryFacade.checkAccessAuthorizationForAction(any(), any(), any()) } returns true
 
         val restCreds = mockk<RestCredential>()
@@ -814,7 +814,7 @@ class DeliveryFunctionTests : Logging {
 
         every { mockDeliveryFacade.fetchActionForReportId(any()) } returns action
         every { mockDeliveryFacade.fetchAction(any()) } returns null // not used for a UUID
-        every { mockDeliveryFacade.findDetailedDeliveryHistory(any()) } returns null
+        every { mockDeliveryFacade.findDetailedDeliveryHistory(any(), any()) } returns null
         every { mockDeliveryFacade.checkAccessAuthorizationForAction(any(), any(), any()) } returns true
 
         val restCreds = mockk<RestCredential>()


### PR DESCRIPTION
This PR updates fetching detailed delivery to count for actions that produce more than on report

Test Steps:
Follow these steps on main and they'll error, but on this branch they'll pass
1. Send a report through with at least two times from `ignore.ignore-fhir-e2e`
2. Wait for the items to get delivered
3. Find a report ID from the batch step going to the `ignore.FULL_ELR_FHIR` receiver
4. Run
```sh
curl --location 'http://localhost:7071/api/waters/report/afbeca26-8b1a-4a57-9749-8000c731e473/delivery' \
--header 'Authorization: Bearer dummy' \
```
For the success case, you should get back a single delivered item

## Changes
- Updates the findDetailedDeliveryHistory to individually retrieve the report and action if the requested id is a report id

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [x] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- [Fixes #issue](https://github.com/CDCgov/prime-reportstream/issues/14609)

## To Be Done
- https://github.com/CDCgov/prime-reportstream/issues/16191

## Specific Security-related subjects a reviewer should pay specific attention to
