### PR TITLE
Add java_opts with UTF-8 encoding

### DIFF
--- a/operations/app/functions/admin/host.json
+++ b/operations/app/functions/admin/host.json
@@ -1,5 +1,8 @@
 {
   "version": "2.0",
+  "Values": {
+    "JAVA_OPTS": "-Dfile.encoding=UTF-8"
+  },
   "logging": {
     "applicationInsights": {
       "samplingSettings": {


### PR DESCRIPTION
This PR adds UTF-8 encoding to the JAVA_OPTS in operations/app/functions/admin/host.json
