### PR TITLE
Flexion/jgilmore/16196-add-environment-variable-for-default-encoding

### DIFF
--- a/operations/app/terraform/modules/function_app/locals.tf
+++ b/operations/app/terraform/modules/function_app/locals.tf
@@ -19,6 +19,7 @@ locals {
     "RS_OKTA_ClientId" = var.RS_OKTA_clientId
     "ETOR_TI_baseurl"  = var.etor_ti_base_url
     "cdctiautomated"   = var.cdctiautomated_sa
+    "JAVA_OPTS"        = var.JAVA_OPTS
     # Manage client secrets via a Key Vault
     "CREDENTIAL_STORAGE_METHOD" = "AZURE"
     "CREDENTIAL_KEY_VAULT_NAME" = var.client_config_key_vault_name

--- a/operations/app/terraform/modules/function_app/~inputs.tf
+++ b/operations/app/terraform/modules/function_app/~inputs.tf
@@ -93,6 +93,7 @@ variable "etor_ti_base_url" {}
 variable "cdctiautomated_sa" {
   default = ""
 }
+variable "JAVA_OPTS" {}
 
 variable "subnets" {
   description = "A set of all available subnet combinations"

--- a/operations/app/terraform/vars/demo/locals.tf
+++ b/operations/app/terraform/vars/demo/locals.tf
@@ -17,6 +17,7 @@ locals {
     RS_okta_redirect_url  = "https://prime-data-hub-XXXXXXX.azurefd.net/download"
     RS_OKTA_scope         = "reportstream_dev"
     etor_ti_base_url      = "https://cdcti-stg-api.azurewebsites.net"
+    JAVA_OPTS             = "-Dfile.encoding=UTF-8"
   }
   key_vault = {
     app_config_kv_name    = "pdh${local.init.environment}-appconfig${local.init.random_id}"

--- a/operations/app/terraform/vars/demo/main.tf
+++ b/operations/app/terraform/vars/demo/main.tf
@@ -183,6 +183,7 @@ module "function_app" {
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
   etor_ti_base_url                  = local.init.etor_ti_base_url
+  JAVA_OPTS                         = local.init.JAVA_OPTS
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/prod/locals.tf
+++ b/operations/app/terraform/vars/prod/locals.tf
@@ -16,7 +16,7 @@ locals {
     storage_queue_name    = ["process"]
     sftp_container_module = false
     etor_ti_base_url      = "https://cdcti-prd-api.azurewebsites.net"
-
+    JAVA_OPTS             = "-Dfile.encoding=UTF-8"
   }
   key_vault = {
     app_config_kv_name    = "pdh${local.init.environment}-appconfig"

--- a/operations/app/terraform/vars/prod/main.tf
+++ b/operations/app/terraform/vars/prod/main.tf
@@ -161,6 +161,7 @@ module "function_app" {
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
   etor_ti_base_url                  = local.init.etor_ti_base_url
+  JAVA_OPTS                         = local.init.JAVA_OPTS
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/staging/locals.tf
+++ b/operations/app/terraform/vars/staging/locals.tf
@@ -16,6 +16,7 @@ locals {
     storage_queue_name    = ["process", "batch", "batch-poison", "elr-fhir-convert", "process-poison", "send", "send-poison", "elr-fhir-convert", "elr-fhir-convert-poison", "elr-fhir-route", "elr-fhir-translate", "elr-fhir-translate-poison", "process-elr"]
     sftp_container_module = true
     etor_ti_base_url      = "https://cdcti-stg-api.azurewebsites.net"
+    JAVA_OPTS             = "-Dfile.encoding=UTF-8"
   }
   key_vault = {
     app_config_kv_name    = "pdh${local.init.environment}-appconfig"

--- a/operations/app/terraform/vars/staging/main.tf
+++ b/operations/app/terraform/vars/staging/main.tf
@@ -161,6 +161,7 @@ module "function_app" {
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
   etor_ti_base_url                  = local.init.etor_ti_base_url
   cdctiautomated_sa                 = data.azurerm_key_vault_secret.cdctiautomated_sa.value
+  JAVA_OPTS                         = local.init.JAVA_OPTS
 }
 
 module "front_door" {

--- a/operations/app/terraform/vars/test/locals.tf
+++ b/operations/app/terraform/vars/test/locals.tf
@@ -16,6 +16,7 @@ locals {
     storage_queue_name    = ["process"]
     sftp_container_module = true
     etor_ti_base_url      = "https://cdcti-stg-api.azurewebsites.net"
+    JAVA_OPTS             = "-Dfile.encoding=UTF-8"
   }
   key_vault = {
     app_config_kv_name    = "pdh${local.init.environment}-app-config"

--- a/operations/app/terraform/vars/test/main.tf
+++ b/operations/app/terraform/vars/test/main.tf
@@ -164,6 +164,7 @@ module "function_app" {
   RS_OKTA_clientId                  = data.azurerm_key_vault_secret.RS_OKTA_clientId.value
   RS_OKTA_authKey                   = data.azurerm_key_vault_secret.RS_OKTA_authKey.value
   etor_ti_base_url                  = local.init.etor_ti_base_url
+  JAVA_OPTS                         = local.init.JAVA_OPTS
 }
 
 module "front_door" {


### PR DESCRIPTION
This PR Adds Environment variable "JAVA_OPTS" with value ""-Dfile.encoding=UTF-8" to all environments so the deployed environments are consistent with local environments which have the JAVA_OPTS set in prime-router/local.settings.json

Test Steps:
1. Deploy to demo1
2. submit file with special characters to waters/reports endpoint

## Changes
- Add Environment variable "JAVA_OPTS" with value ""-Dfile.encoding=UTF-8" to all env terraform files
## Checklist

### Testing
- [x ] Tested locally?
- [x ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?

