### PR TITLE
add tf storage timeouts

### DIFF
--- a/.github/workflows/deploy_terraform.yml
+++ b/.github/workflows/deploy_terraform.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   pre_job:
     name: Set Build Environment
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ needs.pre_job.outputs.env_name }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
   confirm_changes:
     name: Check Terraform Stats - ${{ needs.pre_job.outputs.env_name }}
     if: ${{ needs.pre_job.outputs.tf_change == 'true' }}
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ needs.pre_job.outputs.env_name }}
       cancel-in-progress: true
     needs:
@@ -60,7 +60,7 @@ jobs:
 
   approve_deploy:
     name: Approve Deploy - ${{ needs.pre_job.outputs.env_name }}
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ needs.pre_job.outputs.env_name }}
       cancel-in-progress: true
     needs:
@@ -75,7 +75,7 @@ jobs:
 
   run_deploy:
     name: Run Deploy - ${{ needs.pre_job.outputs.env_name }}
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ needs.pre_job.outputs.env_name }}
       cancel-in-progress: true
     needs:
@@ -108,4 +108,7 @@ jobs:
       - name: Run Terraform
         run: |
           terraform init -input=false
-          terraform apply -input=false -no-color -lock-timeout=600s -auto-approve
+          terraform validate
+          terraform fmt -recursive
+          terraform plan -out ${{ needs.pre_job.outputs.env_name }}-tf.plan
+          terraform apply -input=false -no-color -lock-timeout=600s -auto-approve ${{ needs.pre_job.outputs.env_name }}-tf.plan

--- a/.github/workflows/deploy_terraform.yml
+++ b/.github/workflows/deploy_terraform.yml
@@ -111,4 +111,4 @@ jobs:
           terraform validate
           terraform fmt -recursive
           terraform plan -out ${{ needs.pre_job.outputs.env_name }}-tf.plan
-          terraform apply -input=false -no-color -lock-timeout=600s -auto-approve ${{ needs.pre_job.outputs.env_name }}-tf.plan
+          # terraform apply -input=false -no-color -lock-timeout=600s -auto-approve ${{ needs.pre_job.outputs.env_name }}-tf.plan

--- a/operations/app/terraform/modules/storage/main.tf
+++ b/operations/app/terraform/modules/storage/main.tf
@@ -36,6 +36,13 @@ resource "azurerm_storage_account" "storage_account" {
   tags = {
     environment = var.environment
   }
+
+  timeouts {
+    create = var.timeout_create
+    read   = var.timeout_read
+    delete = var.timeout_delete
+    update = var.timeout_update
+  }
 }
 
 resource "azurerm_storage_queue" "storage_queue" {

--- a/operations/app/terraform/modules/storage/~inputs.tf
+++ b/operations/app/terraform/modules/storage/~inputs.tf
@@ -59,3 +59,28 @@ variable "storage_queue_name" {
   type        = list(string)
   default     = ["proces"]
 }
+
+# TF timeouts for storage operations
+variable "timeout_create" {
+  description = "Timeout for create operations"
+  type        = string
+  default     = "60m" # module default 60m
+}
+
+variable "timeout_read" {
+  description = "Timeout for read operations"
+  type        = string
+  default     = "615m" # module default 5m
+}
+
+variable "timeout_update" {
+  description = "Timeout for update operations"
+  type        = string
+  default     = "60m" # module default 60m
+}
+
+variable "timeout_delete" {
+  description = "Timeout for delete operations"
+  type        = string
+  default     = "60m" # module default 60m
+}


### PR DESCRIPTION
This PR 
- adds terraform timeouts for `azurerm_storage_account` resource
- adds additional terraform sanity checks before running `terraform apply` in deploy action

Test Steps:
1. Run deployment via automation

## Linked Issues
- Fixes #16241 

