### PR TITLE
bump GET timeout to 60m

### DIFF
--- a/operations/app/terraform/modules/storage/main.tf
+++ b/operations/app/terraform/modules/storage/main.tf
@@ -196,6 +196,13 @@ resource "azurerm_storage_account" "storage_public" {
   tags = {
     environment = var.environment
   }
+
+  timeouts {
+    create = var.timeout_create
+    read   = var.timeout_read
+    delete = var.timeout_delete
+    update = var.timeout_update
+  }
 }
 
 resource "azurerm_storage_share" "gh_locks" {
@@ -250,6 +257,13 @@ resource "azurerm_storage_account" "storage_partner" {
 
   tags = {
     environment = var.environment
+  }
+
+  timeouts {
+    create = var.timeout_create
+    read   = var.timeout_read
+    delete = var.timeout_delete
+    update = var.timeout_update
   }
 }
 

--- a/operations/app/terraform/modules/storage/~inputs.tf
+++ b/operations/app/terraform/modules/storage/~inputs.tf
@@ -70,7 +70,7 @@ variable "timeout_create" {
 variable "timeout_read" {
   description = "Timeout for read operations"
   type        = string
-  default     = "615m" # module default 5m
+  default     = "60m" # module default 5m
 }
 
 variable "timeout_update" {


### PR DESCRIPTION
This PR 
- fixes timeout for read, setting it to 60m
- adds timeouts to other `azurerm_storage_account` resources