### PR TITLE
Changed FHIR transform schema validation to string comparison

### DIFF
--- a/.github/actions/build-backend/action.yml
+++ b/.github/actions/build-backend/action.yml
@@ -95,9 +95,14 @@ runs:
           --subscription 7d1e3999-6577-4cd5-b296-f518e5c8e677 -o tsv)
           ./prime validateSchemas --schema-type="HL7" --blob-store-connect="$bsc" --blob-store-container="metadata"
           ./prime validateSchemas --schema-type="FHIR" --blob-store-connect="$bsc" --blob-store-container="metadata"
-          az storage account network-rule remove -g prime-data-hub-staging --account-name pdhstagingstorageaccount \
-          --ip-address ${{ steps.runner_ip.outputs.ip-address }} --output none;
         shell: bash
+
+    - name: Remove GitHub action storage account IP whitelist
+      if: always() # This should happen even on a failure
+      run: |
+        az storage account network-rule remove -g prime-data-hub-staging --account-name pdhstagingstorageaccount \
+        --ip-address ${{ steps.runner_ip.outputs.ip-address }} --output none
+      shell: bash
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/linux@82082dac68ad6a19d980f8ce817e108b9f496c2a

--- a/prime-router/src/main/kotlin/fhirengine/translation/hl7/FhirTransformer.kt
+++ b/prime-router/src/main/kotlin/fhirengine/translation/hl7/FhirTransformer.kt
@@ -11,6 +11,7 @@ import gov.cdc.prime.router.fhirengine.translation.hl7.schema.fhirTransform.fhir
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.CustomContext
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirBundleUtils
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.FhirPathUtils
+import gov.cdc.prime.router.fhirengine.utils.FhirTranscoder
 import gov.cdc.prime.router.fhirengine.utils.deleteResource
 import org.apache.logging.log4j.Level
 import org.hl7.fhir.exceptions.FHIRException
@@ -67,7 +68,7 @@ class FhirTransformer(
     )
 
     override fun checkForEquality(converted: Bundle, expectedOutput: Bundle): Boolean {
-        return converted.equalsDeep(expectedOutput)
+        return FhirTranscoder.encode(converted).trim() == FhirTranscoder.encode(expectedOutput).trim()
     }
 
     /**


### PR DESCRIPTION
This PR updates FHIR transform schema validation to compare FHIR bundle strings instead of using equalsDeep

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/master/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. Run this command against staging ```./prime validateSchemas
--schema-type="FHIR"
--blob-store-connect={AZURE_KEY}
--blob-store-container="metadata ```
2. Verify all schemas are valid

## Changes
- Updated FHIR transform schema validation to string comparison

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`? 
- [ ] Added tests?
