### PR TITLE
Remove Apple Silicon check from cleanslate.sh

### DIFF
--- a/prime-router/cleanslate.sh
+++ b/prime-router/cleanslate.sh
@@ -18,11 +18,6 @@ TAKE_OWNERSHIP=0
 PROFILE=amd64
 SERVICES=() # empty list means all services for docker-compose
 BUILD_SERVICES=()
-if [ "$(uname -m)" = "arm64" ] && [[ $(uname -av) == *"Darwin"* ]]; then
-  PROFILE=apple_silicon
-  SERVICES=(sftp azurite vault) # Only these services are M1 compatible
-  BUILD_SERVICES=(postgresql)
-fi
 
 function usage() {
   cat <<EOF


### PR DESCRIPTION
This PR removes the check for Apple Silicon from `cleanslate.sh`.  For a few years now, x86, x86_64, and amd64 architecture Docker images run just fine through Rosetta 2 emulation.  We've run all the images in ReportStream on Apple Silicon Macs without any problems for years.  This check can be removed.

Test Steps:
Run `cleanslate.sh` on an Apple Silicon Mac.

## Changes
- Removed the Apple Silicon check from `cleanslate.sh` that made it only build a few services.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [x] Added tests?

### Process
- [x] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [x] Updated the release notes?
- [x] Database changes are submitted as a separate PR?
- [x] DevOps team has been notified if PR requires ops support?

## Linked Issues

_None._

## To Be Done

_None._