### PR TITLE
Adding some missing transforms from azure and fixing Message Testing API

### DIFF
--- a/prime-router/settings/organizations.yml
+++ b/prime-router/settings/organizations.yml
@@ -1161,7 +1161,7 @@
       conditionFilter:
         # Accept all conditions except Covid results in the LIVD look up table
         # Covid flows through the Covid pipeline
-        - "%resource.livdTableLookup('Component').contains('coronavirus').not()"
+        - "%resource.interpretation.coding.code = 'A' and (%resource.code.coding.extension('https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code').value.where(code  in ('840539006')).exists())"
       timing:
         operation: MERGE
         numberPerDay: 1440 # Every minute

--- a/prime-router/src/main/kotlin/azure/ReportFunction.kt
+++ b/prime-router/src/main/kotlin/azure/ReportFunction.kt
@@ -192,7 +192,7 @@ class ReportFunction(
                     null
                 }
                 val bundle = if (result.bundle != null) {
-                    result.bundle.toString()
+                    FhirTranscoder.encode(result.bundle!!)
                 } else {
                     null
                 }

--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -260,7 +260,7 @@ class ProcessFhirCommands : CliktCommand(
 
         val senderSchemaName = when {
             senderSchema != null -> senderSchema
-            senderSchemaParam != null -> senderSchemaParam
+            isCli && senderSchemaParam != null -> senderSchemaParam
             else -> null
         }
 
@@ -272,7 +272,7 @@ class ProcessFhirCommands : CliktCommand(
             receiver != null && receiver.enrichmentSchemaNames.isNotEmpty() -> {
                 receiver.enrichmentSchemaNames.joinToString(",")
             }
-            enrichmentSchemaNames != null -> enrichmentSchemaNames
+            isCli && enrichmentSchemaNames != null -> enrichmentSchemaNames
             else -> null
         }
 
@@ -470,19 +470,19 @@ class ProcessFhirCommands : CliktCommand(
         }
 
         val receiverTransformSchemaName = when {
-            receiver != null && receiver.schemaName.isNotEmpty() -> receiver.enrichmentSchemaNames.joinToString(",")
-            receiverSchema != null -> receiverSchema
+            receiver != null && receiver.schemaName.isNotEmpty() -> receiver.schemaName
+            isCli && receiverSchema != null -> receiverSchema
             else -> null
         }
 
         if (receiverTransformSchemaName != null) {
             val message = FhirToHl7Converter(
-                receiverSchema!!,
+                receiverTransformSchemaName,
                 BlobAccess.BlobContainerMetadata.build("metadata", Environment.get().storageEnvVar),
                 context = FhirToHl7Context(
                     CustomFhirPathFunctions(),
                     config = HL7TranslationConfig(
-                        hl7Configuration,
+                        hl7Configuration = hl7Configuration,
                         receiver
                     ),
                     translationFunctions = CustomTranslationFunctions(),

--- a/prime-router/src/main/resources/metadata/fhir_transforms/senders/SimpleReport/simple-report-sender-transform.yml
+++ b/prime-router/src/main/resources/metadata/fhir_transforms/senders/SimpleReport/simple-report-sender-transform.yml
@@ -6,6 +6,10 @@ constants:
   patient: 'Bundle.entry.resource.ofType(Patient)'
   specimen: 'Bundle.entry.resource.ofType(Specimen)'
 elements:
+  - name: sender-identifier
+    resource: 'Bundle.entry.resource.ofType(MessageHeader)'
+    bundleProperty: '%resource.extension("https://reportstream.cdc.gov/fhir/StructureDefinition/sender-id").value[x]'
+    value: [ '"SimpleReport"' ]
 
   # MSH
   - name: sending-application-target-msh3-extension

--- a/prime-router/src/main/resources/metadata/hl7_mapping/receivers/STLTs/PA/PA-receiver-transform.yml
+++ b/prime-router/src/main/resources/metadata/hl7_mapping/receivers/STLTs/PA/PA-receiver-transform.yml
@@ -62,3 +62,6 @@ elements:
     condition: '%resource.value[x].coding[0].code = "UNK" or %resource.value.coding[0].code = "ASKU"'
     value: [ '"U"' ]
     hl7Spec: [ '%{PID}-10-1' ]
+
+  - name: observation-result-with-aoe
+    resource: "Bundle.entry.resource.ofType(Observation).where(code.coding.extension('https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code').value.where(code in ('AOE')).exists().not())"


### PR DESCRIPTION
This PR fixes some bugs on the message testing API and adds some transforms that were missing from azure.

**If you are suggesting a fix for a currently exploitable issue, please disclose the issue to the prime-reportstream team directly outside of GitHub instead of filing a PR, so we may immediately patch the affected systems before a disclosure. See [SECURITY.md/Reporting a Vulnerability](https://github.com/CDCgov/prime-reportstream/blob/main/SECURITY.md#reporting-a-vulnerability) for more information.**

Test Steps:
1. Use this postman collection to test changes to API
[Message Testing.postman_collection.json](https://github.com/user-attachments/files/18088024/Message.Testing.postman_collection.json)


## Changes
- Fixes message testing API

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [ ] Added tests?
