### PR TITLE
quick fix for deliveries query for ELIMS reports

### DIFF
--- a/prime-router/src/main/kotlin/history/azure/DatabaseDeliveryAccess.kt
+++ b/prime-router/src/main/kotlin/history/azure/DatabaseDeliveryAccess.kt
@@ -46,11 +46,15 @@ class DatabaseDeliveryAccess(
         val org = BaseEngine.settingsProviderSingleton.findOrganization(organization)
 
         var filter = if (org?.featureFlags?.contains("ELIMS_DATA") == true) {
-                REPORT_FILE.NEXT_ACTION.isNull
-                    .and(REPORT_FILE.TRANSPORT_PARAMS.isNotNull)
-                    .and(REPORT_FILE.TRANSPORT_RESULT.notLike("%downloadedBy%"))
-                    .and(REPORT_FILE.SCHEMA_TOPIC.equalIgnoreCase(Topic.ELR_ELIMS.jsonVal))
-                    .and(REPORT_FILE.RECEIVING_ORG.eq(organization))
+            REPORT_FILE.NEXT_ACTION.eq(TaskAction.send)
+                .and(REPORT_FILE.SCHEMA_TOPIC.notEqualIgnoreCase(Topic.ELR_ELIMS.jsonVal))
+                .or(
+                    REPORT_FILE.NEXT_ACTION.isNull
+                        .and(REPORT_FILE.TRANSPORT_PARAMS.isNotNull)
+                        .and(REPORT_FILE.TRANSPORT_RESULT.notLike("%downloadedBy%"))
+                        .and(REPORT_FILE.SCHEMA_TOPIC.equalIgnoreCase(Topic.ELR_ELIMS.jsonVal))
+            )
+            .and(REPORT_FILE.RECEIVING_ORG.eq(organization))
         } else {
             REPORT_FILE.NEXT_ACTION.eq(TaskAction.send)
                 .and(REPORT_FILE.RECEIVING_ORG.eq(organization))

--- a/prime-router/src/test/kotlin/history/azure/HistoryDatabaseAccessTests.kt
+++ b/prime-router/src/test/kotlin/history/azure/HistoryDatabaseAccessTests.kt
@@ -47,10 +47,18 @@ class HistoryDatabaseAccessTests {
     fun `test organizationFilter with feature flag`() {
         var conditionExpected = """
             (
-              "public"."report_file"."next_action" is null
-              and "public"."report_file"."transport_params" is not null
-              and "public"."report_file"."transport_result" not like '%downloadedBy%'
-              and lower(cast("public"."report_file"."schema_topic" as varchar)) = lower('elr-elims')
+              (
+                (
+                  "public"."report_file"."next_action" = 'send'
+                  and lower(cast("public"."report_file"."schema_topic" as varchar)) <> lower('elr-elims')
+                )
+                or (
+                  "public"."report_file"."next_action" is null
+                  and "public"."report_file"."transport_params" is not null
+                  and "public"."report_file"."transport_result" not like '%downloadedBy%'
+                  and lower(cast("public"."report_file"."schema_topic" as varchar)) = lower('elr-elims')
+                )
+              )
               and "public"."report_file"."receiving_org" = 'test'
               and "public"."report_file"."receiving_org_svc" = 'test'
             )


### PR DESCRIPTION
Quick followup to #17120 which is for ticket #16865 
This PR fixes a small error with the deliveries query that was affecting the daily data page when filtered by "ELR_ELIMS"

Test Steps:
1. *Include steps to test these changes*

## Changes
- *Include a comprehensive list of changes in this PR*
- *(For web UI changes) Include screenshots/video of changes*

## Checklist

### Testing
- [ ] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #16865

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- #issue

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints?
    - new endpoint A
    - new endpoint B
- Does this PR include changes in authentication and/or authorization of existing endpoints?
- Does this change introduce new dependencies that need vetting?
- Does this change require changes to our infrastructure?
- Does logging contain sensitive data?
- Does this PR include or remove any sensitive information itself?

If you answered '_yes_' to any of the questions above, conduct a detailed Review that addresses at least:

- What are the potential security threats and mitigations? Please list the _STRIDE_ threats and how they are mitigated
    - **S**poofing (faking authenticity)
        - Threat _T_, which could be achieved by _A_, is mitigated by _M_
    - **T**ampering (influence or sabotage the integrity of information, data, or system)
    - **R**epudiation (the ability to dispute the origin or originator of an action)
    - **I**nformation disclosure (data made available to entities who should not have it)
    - **D**enial of service (make a resource unavailable)
    - **E**levation of Privilege (reduce restrictions that apply or gain privileges one should not have)
- Have you ensured logging does not contain sensitive data?
- Have you received any additional approvals needed for this change?
