### PR TITLE
Add time flexibility to Daily Data "onLoad / table has correct headers" Smoke Test

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/daily-data-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/daily-data-page-user-flow.spec.ts
@@ -88,6 +88,7 @@ test.describe(
                     });
 
                     test("table has correct headers", async ({ dailyDataPage }) => {
+                        await dailyDataPage.page.locator(".usa-table tbody").waitFor({ state: "visible" });
                         await expect(dailyDataPage.page.locator(".usa-table th").nth(0)).toHaveText(/Report ID/);
                         await expect(dailyDataPage.page.locator(".usa-table th").nth(1)).toHaveText(/Time received/);
                         await expect(dailyDataPage.page.locator(".usa-table th").nth(2)).toHaveText(


### PR DESCRIPTION
Fixes #17206

This PR adds an additional await for the table to load before the rest of the actual checks in order to be more flexible on load time.