### PR TITLE
Update 0023-condition-to-code-mapping.md to correct broken Diagram

### DIFF
--- a/prime-router/docs/design/proposals/0023-condition-to-code-mapping/0023-condition-to-code-mapping.md
+++ b/prime-router/docs/design/proposals/0023-condition-to-code-mapping/0023-condition-to-code-mapping.md
@@ -19,7 +19,7 @@ The below items are not covered in this proposal.
 
 Overview Diagram
 
-![Code to Condition Overview Diagram](C:\Users\James.Gilmore\Documents\GitHub\PRIME\prime-reportstream\prime-router\docs\design\proposals\0023-condition-to-code-mapping\code-to-condtion-overview.png)
+![Code to Condition Overview Diagram](https://github.com/CDCgov/prime-reportstream/blob/main/prime-router/docs/design/proposals/0023-condition-to-code-mapping/code-to-condtion-overview.png)
 
 ### Creating Observation Mapping Table
 


### PR DESCRIPTION
Correcting path to diagram for _code-to-condtion-overview.png_ that was pointing to a local location (C:\...)

This PR **only** updates documentation 

Test Steps:
N/A

## Changes
-change to readme file
