### PR TITLE
[16141] Amending new folder name.

### DIFF
--- a/prime-router/src/main/kotlin/azure/BlobAccess.kt
+++ b/prime-router/src/main/kotlin/azure/BlobAccess.kt
@@ -145,11 +145,12 @@ class BlobAccess : Logging {
          */
         internal fun directoryForAction(action: Event.EventAction?): String =
 
-         when (action) {
+        when (action) {
             Event.EventAction.RECEIVE -> "receive"
             Event.EventAction.BATCH -> "batch"
             Event.EventAction.PROCESS -> "process"
             Event.EventAction.DESTINATION_FILTER -> "destination-filter"
+            Event.EventAction.RECEIVER_ENRICHMENT -> "receiver-enrichment"
             Event.EventAction.RECEIVER_FILTER -> "receiver-filter"
             Event.EventAction.ROUTE -> "route"
             Event.EventAction.TRANSLATE -> "translate"


### PR DESCRIPTION
This PR amends a missing item from the main PR for this [receiver enrichment PR](https://github.com/CDCgov/prime-reportstream/pull/16854).  The utility class that facilitates the uploading of BLOBs maps event actions to folder structure inside of Azure.  This simple change updates that mapping for "receiver-enrichment" (see attached screenshot of the updated report folder/directory structure in Azure Storage Explorer).
![blob-folder](https://github.com/user-attachments/assets/9a7d551f-fa47-49e8-92ad-c9dc9e0dd452)


