### PR TITLE
Add wait for status dashboard container visibility for Receiver Status Page / functions correctly / filters / result message

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
@@ -193,6 +193,8 @@ test.describe(
                 });
 
                 test("result message", async ({ adminReceiverStatusPage }) => {
+                    await adminReceiverStatusPage.statusContainer.waitFor({ state: "visible" });
+
                     // get first entry's result from all-fail receiver's first day -> third time period
                     const receiverI = 0;
                     const dayI = 0;


### PR DESCRIPTION
Fixes #17262

This PR adds a wait for proof of rendering on page before moving forward with a smoke test for receiver status.