### PR TITLE
Disable Admin Receiver Status Page / functions correctly / filters / result message @smoke test

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/receiver-status-page-user-flow.spec.ts
@@ -192,7 +192,7 @@ test.describe(
                     expect(defaultReceiversStatusRowsCount).toBe(adminReceiverStatusPage.timePeriodData.length);
                 });
 
-                test("result message", async ({ adminReceiverStatusPage }) => {
+                test.skip("result message", async ({ adminReceiverStatusPage }) => {
                     await adminReceiverStatusPage.statusContainer.waitFor({ state: "visible" });
 
                     // get first entry's result from all-fail receiver's first day -> third time period


### PR DESCRIPTION
Fixes #17268

This PR temporarily disables the Admin Receiver Status Page › functions correctly › filters › result message smoke test until a solution is found.