### PR TITLE
add dev mode that removes browser overlays

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -49,6 +49,7 @@
   "scripts": {
     "postinstall": "scripts/postinstall.sh",
     "dev": "vite",
+    "dev:disable:overlays": "DISABLE_OVERLAYS=1 vite",
     "preview": "vite preview --mode preview",
     "preview:csp": "yarn run preview --mode csp",
     "preview:test": "yarn run preview --mode test",

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig(async ({ mode }) => {
     const port = getPort(mode);
     const backendUrl = env.VITE_BACKEND_URL ?? createBackendUrl(mode);
     const proxyUrl = env.PROXY_URL ?? createProxyUrl(mode);
+    const disableOverlays = !!process.env.DISABLE_OVERLAYS;
 
     return {
         define: {
@@ -81,6 +82,7 @@ export default defineConfig(async ({ mode }) => {
             }),
             svgr(),
             checker({
+                overlay: !disableOverlays,
                 typescript: true,
                 eslint: {
                     lintCommand: 'eslint "./src/**/*[!.test][!.stories].{ts,tsx}"',


### PR DESCRIPTION
This PR adds a local dev mode that removes the TS error/warning overlays which can get quite annoying when early development is riddled with TS errors.