### PR TITLE
Finish validation of the new dockerization of FE to eliminate 404 error

### DIFF
--- a/frontend-react/nginx.conf
+++ b/frontend-react/nginx.conf
@@ -12,6 +12,13 @@ http {
         index index.html index.htm;
         try_files $uri /index.html; # Pass all non-files to our react app
     }
+
+    # For internal use (deployed environments should be redirecting /api before the request reaches here)
+    location /api {
+      proxy_ssl_server_name on;
+      proxy_set_header Host staging.prime.cdc.gov;
+      proxy_pass https://staging.prime.cdc.gov;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #17435

This PR adds proxying to the staging api through the /api url for the docker nginx server. This is for internal use only (running locally), as in deployed environments this redirection is handled at a higher level so our nginx server is never queried at this url in practice.