### PR TITLE
[17330] Log test result interpretations in Azure Event.

### DIFF
--- a/prime-router/src/main/kotlin/azure/observability/event/AzureEventUtils.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/AzureEventUtils.kt
@@ -23,10 +23,8 @@ object AzureEventUtils {
     fun getObservationSummaries(
         observations: List<Observation>,
     ): List<ObservationSummary> = observations.map { observation ->
-            ObservationSummary(
-                observation.code.coding.map(TestSummary::fromCoding),
-            )
-        }
+        ObservationSummary.fromObservation(observation)
+    }
 
     /**
      * For tracking the Message ID, we need the bundle.identifier value and system.

--- a/prime-router/src/main/kotlin/azure/observability/event/ObservationSummary.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ObservationSummary.kt
@@ -1,11 +1,29 @@
 package gov.cdc.prime.router.azure.observability.event
 
+import org.hl7.fhir.r4.model.Observation
+
 /**
  * An observation can include multiple mapped conditions to be queried
  */
-data class ObservationSummary(val testSummary: List<TestSummary> = emptyList()) {
+data class ObservationSummary(
+    val testSummary: List<TestSummary> = emptyList(),
+    val interpretations: List<CodeSummary> = emptyList(),
+) {
 
     companion object {
         val EMPTY = ObservationSummary(emptyList())
+        fun fromObservation(observation: Observation): ObservationSummary {
+            val summaries = mutableListOf<TestSummary>()
+            val interpretations = mutableListOf<CodeSummary>()
+            observation.interpretation.forEach { concept ->
+                (
+                    concept.coding.forEach { interpretations.add(CodeSummary.fromCoding(it)) }
+                    )
+            }
+            observation.code.coding.forEach { codingCode ->
+                summaries.add(TestSummary.fromCoding(codingCode))
+            }
+            return ObservationSummary(summaries, interpretations)
+        }
     }
 }

--- a/prime-router/src/main/kotlin/azure/observability/event/ObservationSummary.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ObservationSummary.kt
@@ -16,9 +16,7 @@ data class ObservationSummary(
             val summaries = mutableListOf<TestSummary>()
             val interpretations = mutableListOf<CodeSummary>()
             observation.interpretation.forEach { concept ->
-                (
-                    concept.coding.forEach { interpretations.add(CodeSummary.fromCoding(it)) }
-                    )
+                (concept.coding.forEach { interpretations.add(CodeSummary.fromCoding(it)) })
             }
             observation.code.coding.forEach { codingCode ->
                 summaries.add(TestSummary.fromCoding(codingCode))

--- a/prime-router/src/test/kotlin/azure/observability/bundleDigest/FhirPathBundleDigestExtractorStrategyTests.kt
+++ b/prime-router/src/test/kotlin/azure/observability/bundleDigest/FhirPathBundleDigestExtractorStrategyTests.kt
@@ -10,6 +10,7 @@ import gov.cdc.prime.router.azure.observability.event.TestSummary
 import gov.cdc.prime.router.fhirengine.translation.hl7.utils.CustomContext
 import org.hl7.fhir.r4.model.Address
 import org.hl7.fhir.r4.model.Bundle
+import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.MessageHeader
@@ -51,14 +52,21 @@ class FhirPathBundleDigestExtractorStrategyTests {
                         ObservationSummary(
                             testSummary = listOf(
                                 TestSummary(
-                                conditions = listOf(
-                                    CodeSummary(system = "Unknown", code = "Unknown", display = "Unknown")
+                                    conditions = listOf(
+                                        CodeSummary(system = "Unknown", code = "Unknown", display = "Unknown")
+                                    )
                                 )
-                            )
+                            ),
+                            interpretations = listOf(
+                                CodeSummary(
+                                    system = "http://snomed.info/sct",
+                                    code = "260385009",
+                                    display = "Negative"
+                                )
                             )
                         )
                     ),
-                                listOf("VA"), listOf("MD"), listOf("DC"), "ORU_R01"
+                    listOf("VA"), listOf("MD"), listOf("DC"), "ORU_R01"
                 )
             )
     }
@@ -156,6 +164,15 @@ class FhirPathBundleDigestExtractorStrategyTests {
         extension.setValue(Coding())
         coding.extension = listOf(extension)
         observation.code.coding = listOf(coding)
+
+        val interpretation = CodeableConcept()
+        val interpretationCoding = Coding()
+        interpretationCoding.system = "http://snomed.info/sct"
+        interpretationCoding.code = "260385009"
+        interpretationCoding.display = "Negative"
+        interpretation.addCoding(interpretationCoding)
+        observation.interpretation = listOf(interpretation)
+
         bundle.addEntry().resource = observation
     }
 }

--- a/prime-router/src/test/kotlin/azure/observability/event/AzureEventUtilsTest.kt
+++ b/prime-router/src/test/kotlin/azure/observability/event/AzureEventUtilsTest.kt
@@ -56,28 +56,32 @@ class AzureEventUtilsTest {
                         "12345",
                         "Covid 19 Test"
                     )
-                )
+                ),
+                listOf(CodeSummary(system = "http://terminology.hl7.org/CodeSystem/v2-0078", code = "N", display = "Normal"))
             ),
             ObservationSummary(
                 listOf(
                     TestSummary(
                         testPerformedCode = "95418-0",
                     )
-                )
+                ),
+                emptyList()
             ),
             ObservationSummary(
                 listOf(
                     TestSummary(
                         testPerformedSystem = loincSystem
                     )
-                )
+                ),
+                emptyList()
             ),
             ObservationSummary(
                 listOf(
                     TestSummary(
                         testPerformedDisplay = "SARS-CoV-2 (COVID-19) N gene [Presence] in Saliva (oral fluid) by Nucleic acid amplification using CDC primer-probe set N1"
                     )
-                )
+                ),
+                emptyList()
             ),
             ObservationSummary(
                 listOf(
@@ -85,7 +89,8 @@ class AzureEventUtilsTest {
                         testPerformedCode = "95419-8",
                         testPerformedSystem = loincSystem
                     )
-                )
+                ),
+                emptyList()
             )
         )
         val actual = AzureEventUtils.getObservationSummaries(bundle)

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
@@ -374,6 +374,13 @@ class FhirDestinationFilterTests {
                                         loincSystem,
                                         "94558-4",
                                     )
+                                ),
+                                listOf(
+                                    CodeSummary(
+                                        system = "http://terminology.hl7.org/CodeSystem/v2-0078",
+                                        code = "N",
+                                        display = "Normal"
+                                    )
                                 )
                             ),
                             ObservationSummary(
@@ -536,6 +543,13 @@ class FhirDestinationFilterTests {
                                             ),
                                             loincSystem,
                                             "94558-4",
+                                        )
+                                    ),
+                                    listOf(
+                                        CodeSummary(
+                                            system = "http://terminology.hl7.org/CodeSystem/v2-0078",
+                                            code = "N",
+                                            display = "Normal"
                                         )
                                     )
                                 ),


### PR DESCRIPTION
This PR adds Observation.interpretation information to the bundle digest information logged in Azure Events.

Test Steps:
1. Submit a Report (e.g., c2sense in staging has some HL7 messages that would work) that has lab interpretation information (i.e., information in OBX8 segment) and observe the event(s) that are logged (either in your local console if you're running the app or via [appinsights](https://github.com/CDCgov/prime-reportstream/blob/73f12902351ef0968231e6039cca2336a71672ee/prime-router/docs/observability/local-dev-setup.md)).

## Changes
- See [this](https://github.com/CDCgov/prime-reportstream/pull/17534/files).

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

## Linked Issues
- N/A

## To Be Done
*Create GitHub issues to track the work remaining, if any*
- N/A

## Specific Security-related subjects a reviewer should pay specific attention to
- N/A