### PR TITLE
Update sonarcloud.yml - remove refs to tj-actions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -46,19 +46,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2
+      #- name: Get branch name
+        #id: branch-name
+        #uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2
         
-      - name: "Get changed files with yaml"
-        id: changed-files-yaml
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
-        with:
-          files_yaml: |
-            frontend:
-              - 'frontend-react/**'
-            backend:
-              - 'prime-router/**'
+      #- name: "Get changed files with yaml"
+        #id: changed-files-yaml
+        #uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
+        #with:
+        #  files_yaml: |
+        #    frontend:
+        #      - 'frontend-react/**'
+        #    backend:
+        #      - 'prime-router/**'
 
       - name: Set up JDK 17
         if: steps.changed-files-yaml.outputs.backend_any_changed == 'true' || steps.branch-name.outputs.is_default == 'true'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,7 +49,16 @@ jobs:
       - name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v8
-    
+
+      - name: "Get changed files with yaml"
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            frontend:
+              - 'frontend-react/**'
+            backend:
+              - 'prime-router/**'
 
       - name: Set up JDK 17
         if: steps.changed-files-yaml.outputs.backend_any_changed == 'true' 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -46,9 +46,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      #- name: Get branch name
-        #id: branch-name
-        #uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v8
     
 
       - name: Set up JDK 17

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,19 +49,10 @@ jobs:
       #- name: Get branch name
         #id: branch-name
         #uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2
-        
-      #- name: "Get changed files with yaml"
-        #id: changed-files-yaml
-        #uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
-        #with:
-        #  files_yaml: |
-        #    frontend:
-        #      - 'frontend-react/**'
-        #    backend:
-        #      - 'prime-router/**'
+    
 
       - name: Set up JDK 17
-        if: steps.changed-files-yaml.outputs.backend_any_changed == 'true' || steps.branch-name.outputs.is_default == 'true'
+        if: steps.changed-files-yaml.outputs.backend_any_changed == 'true' 
         uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73
         with:
           java-version: "17"


### PR DESCRIPTION

This PR comments out the sections in the SonarCloud workflow that use tj-actions


