### PR TITLE
[17603] Fix incomplete History API response.

### DIFF
--- a/prime-router/src/main/kotlin/history/SubmissionHistory.kt
+++ b/prime-router/src/main/kotlin/history/SubmissionHistory.kt
@@ -283,6 +283,8 @@ class DetailedSubmissionHistory(
                         )
                     )
                 } else {
+                    existingDestination.filteredReportRows?.addAll(filteredReportRows)
+                    existingDestination.filteredReportItems?.addAll(filteredReportItems)
                     existingDestination.sentReports.addAll(sentReports)
                     existingDestination.downloadedReports.addAll(downloadedReports)
                     if (report.nextActionAt != null) {

--- a/prime-router/src/test/kotlin/history/SubmissionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/history/SubmissionHistoryTests.kt
@@ -21,6 +21,7 @@ import gov.cdc.prime.router.ReportStreamFilterResult
 import gov.cdc.prime.router.ReportStreamFilterType
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
+import gov.cdc.prime.router.fhirengine.engine.FHIRReceiverFilter
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.Test
@@ -1130,6 +1131,81 @@ class SubmissionHistoryTests {
         testWaitingToDeliver.enrichWithSummary()
         testWaitingToDeliver.run {
             assertThat(overallStatus).isEqualTo(DetailedSubmissionHistory.Status.WAITING_TO_DELIVER)
+        }
+    }
+
+    @Test
+    fun `test DetailedSubmissionHistory (verify filtered rows or filtered items in destination)`() {
+        val reports = listOf(
+            DetailedReport(
+                UUID.fromString("e88ff2ba-0fea-4ce7-9bc2-0febb06a029d"),
+                "recvOrg1",
+                "recvSvc1",
+                null,
+                null,
+                Topic.FULL_ELR,
+                "externalName1",
+                null,
+                null,
+                1,
+                null,
+                true,
+                null,
+                null,
+                null
+            ),
+            DetailedReport(
+                UUID.fromString("e959a724-234d-4d2f-850f-a931813dff62"),
+                "recvOrg1",
+                "recvSvc1",
+                null,
+                null,
+                Topic.FULL_ELR,
+                "externalName1",
+                null,
+                null,
+                0,
+                null,
+                true,
+                null,
+                null,
+                null
+            ),
+        ).toMutableList()
+        val filterResult = ReportStreamFilterResult(
+            receiverName = "recvOrg1",
+            originalCount = 1,
+            filterName = "filterName",
+            filterArgs = emptyList(),
+            filteredTrackingElement = "filterTrackingElement",
+            filterType = "QUALITY_FILTER",
+            filteredObservationDetails = null,
+            scope = ActionLogScope.report,
+        )
+        val logDetail = FHIRReceiverFilter.ReceiverItemFilteredActionLogDetail(
+            filter = "filter",
+            filterType = "QUALITY_FILTER",
+            receiverOrg = "recvOrg1",
+            receiverName = "recvSvc1",
+        )
+        val logs = listOf(
+            DetailedActionLog(
+                ActionLogScope.report, UUID.fromString("e959a724-234d-4d2f-850f-a931813dff62"), null, null,
+                ActionLogLevel.filter, filterResult
+            ),
+            DetailedActionLog(
+                ActionLogScope.item, null, null, null,
+                ActionLogLevel.warning, logDetail
+            ),
+        ).toMutableList()
+        val testFiltersInDestinations = DetailedSubmissionHistory(
+            1, TaskAction.receive, OffsetDateTime.now(),
+            HttpStatus.OK.value(), reports, logs
+        )
+        testFiltersInDestinations.run {
+            assertThat(destinations.count()).isEqualTo(1)
+            assertThat(destinations[0].filteredReportRows?.count()).isEqualTo(1)
+            assertThat(destinations[0].filteredReportItems?.count()).isEqualTo(1)
         }
     }
 }


### PR DESCRIPTION
This PR addresses a bug where information did not appear in the history API response.

From the user story in [Zenhub](https://app.zenhub.com/workspaces/platform-6182b02547c1130010f459db/issues/gh/cdcgov/prime-reportstream/17603):

The bug is not limited to multiple receiving organizations. It occurs for any number of receivers in the DetailedSubmissionHistory initializer (init) when it is looping through reports (List of DetailedReport). filterLogs is the result of filtering logs (List of DetailedActionLog) based on the filter type of filter and the reportIds matching. filterReportRows and filterReportItems are constructed from that result. In the event that the list of destinations does not already contain an entry for the receiving organization then a new destination (including the filteredReportRows and filteredReportItems lists) is created and added to the list. The bug occurs in the case where the first report for an organization has no filter types in the DetailedActionLog (logs) list. Its destination is built with empty lists (filteredReportRows and filteredReportItems ) which are never appended to with subsequent reports. The fix should be simply appending to the filtered lists (filteredReportRows and filteredReportItems ) for an existing destination in the else (already exists) clause:

```
                    existingDestination.filteredReportRows?.addAll(filteredReportRows)
                    existingDestination.filteredReportItems?.addAll(filteredReportItems)

```

Test Steps:
The easiest way to test locally is via the “test DetailedSubmissionHistory (verify filtered rows or filtered items in destination)” unit test in SubmissionHistoryTests.kt.  If you comment out the following two lines (286:287) in SubmissionHistory.kt and run the test it should fail.

                    existingDestination.filteredReportRows?.addAll(filteredReportRows)
                    existingDestination.filteredReportItems?.addAll(filteredReportItems)

If you uncomment the code and re-run the test it should complete successfully.


If you’re in the mood for a more substantial local test:

1. Check out this branch of the code.
2. Modify organizations.xml by creating two new organizations.  Copy development to a new org (e.g., bill1) and retain the first sender (dev-elims) and the first receiver (DEV_FULL_ELR).
3. Rename the sender bill1-sender and the sender’s organizationName to bill1.
4. Rename the receiver bill1_receiver, the externalName to bill1 FULL_ELR Development, and the receiver’s organizationName to bill1.
5. Copy the bill1 organization to make the second new one and rename all the bill1 references to bill2.
6. Delete the sender in the bill2 organization.
7. Build the application and start it up.
8. Identify a candidate ELR HL7 message (I chose “Single HL7 Full ELR” from the Postman collection).
9. POST the message with the “client” header value set to “bill1.bill1-sender”.  (You should receive a 201 response.)
10. Copy the “reportId” value and use it in the history api call (e.g., http://localhost:7071/api/waters/report/f12f80df-ff68-4e5c-adaa-317f997e225e/history/).

The output should look similar to this:

```
{
    "id": "f12f80df-ff68-4e5c-adaa-317f997e225e",
    "submissionId": 4345,
    "overallStatus": "Not Delivering",
    "timestamp": "2025-03-26T18:24:53.617Z",
    "plannedCompletionAt": null,
    "actualCompletionAt": null,
    "sender": "bill1.bill1-sender",
    "reportItemCount": 1,
    "errorCount": 0,
    "warningCount": 8,
    "httpStatus": 201,
    "destinations": [
        {
            "organization": "bill2 FOR DEVELOPMENT PURPOSES ONLY",
            "organization_id": "bill2",
            "service": "bill2_receiver",
            "itemCount": 0,
            "itemCountBeforeQualityFiltering": 1,
            "filteredReportRows": [
                "        For bill2.bill2_receiver, filter Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0\nBundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0\nBundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'\nBundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'[] filtered out item 1234d1d1-95fe-462c-8ac6-46728dba581c. \n        Filter Type: QUALITY_FILTER Filter Args: [] \n        Filtered Observation Details: null "
            ],
            "filteredReportItems": [
                {
                    "filterType": "QUALITY_FILTER",
                    "filterName": "Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0\nBundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0\nBundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'\nBundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'",
                    "filteredTrackingElement": "1234d1d1-95fe-462c-8ac6-46728dba581c",
                    "filterArgs": [],
                    "message": "        For bill2.bill2_receiver, filter Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0\nBundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0\nBundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'\nBundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'[] filtered out item 1234d1d1-95fe-462c-8ac6-46728dba581c. \n        Filter Type: QUALITY_FILTER Filter Args: [] \n        Filtered Observation Details: null "
                }
            ],
            "sentReports": [],
            "downloadedReports": []
        },
        {
            "organization": "bill1 FOR DEVELOPMENT PURPOSES ONLY",
            "organization_id": "bill1",
            "service": "bill1_receiver",
            "itemCount": 0,
            "itemCountBeforeQualityFiltering": 1,
            "filteredReportRows": [
                "        For bill1.bill1_receiver, filter Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0\nBundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0\nBundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'\nBundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'[] filtered out item 1234d1d1-95fe-462c-8ac6-46728dba581c. \n        Filter Type: QUALITY_FILTER Filter Args: [] \n        Filtered Observation Details: null "
            ],
            "filteredReportItems": [
                {
                    "filterType": "QUALITY_FILTER",
                    "filterName": "Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0\nBundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0\nBundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'\nBundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'",
                    "filteredTrackingElement": "1234d1d1-95fe-462c-8ac6-46728dba581c",
                    "filterArgs": [],
                    "message": "        For bill1.bill1_receiver, filter Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0\nBundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0\nBundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'\nBundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'[] filtered out item 1234d1d1-95fe-462c-8ac6-46728dba581c. \n        Filter Type: QUALITY_FILTER Filter Args: [] \n        Filtered Observation Details: null "
                }
            ],
            "sentReports": [],
            "downloadedReports": []
        }
    ],
    "actionName": "receive",
    "externalName": null,
    "reportId": "f12f80df-ff68-4e5c-adaa-317f997e225e",
    "topic": "full-elr",
    "bodyFormat": "",
    "errors": [],
    "warnings": [
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill1.bill1_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill1.bill1_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill1.bill1_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill1.bill1_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill2.bill2_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(DiagnosticReport).result.resolve().where(method.empty() or value.coding.code.empty()).count() = 0",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill2.bill2_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(ServiceRequest).performer.resolve().identifier.value.getIdType() = 'CLIA'",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill2.bill2_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(ServiceRequest).requester.resolve().organization.resolve().identifier.value.getIdType() = 'CLIA'",
            "errorCode": "UNKNOWN"
        },
        {
            "scope": "item",
            "indices": [
                1
            ],
            "trackingIds": [
                "1234d1d1-95fe-462c-8ac6-46728dba581c"
            ],
            "message": "Item was not routed to bill2.bill2_receiver because it did not pass the QUALITY_FILTER. Item failed on: Bundle.entry.resource.ofType(Specimen).where(type.empty()).count() = 0",
            "errorCode": "UNKNOWN"
        }
    ],
    "destinationCount": 0,
    "fileName": ""
}
```



## Changes
- See [changes](https://github.com/CDCgov/prime-reportstream/pull/17683/files).

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [x] Added tests?

### Process
N/A

## Linked Issues
N/A

## To Be Done
N/A

## Specific Security-related subjects a reviewer should pay specific attention to
N/A