### PR TITLE
Update GH Action Slack URL

### DIFF
--- a/.github/workflows/alert_PD_schedule_Slack.yml
+++ b/.github/workflows/alert_PD_schedule_Slack.yml
@@ -131,7 +131,6 @@ jobs:
           "${{ env.Schedules_oncallSchedule_3_ScheduleName }}"
           ❗"Now": *"${{ env.Schedules_oncallSchedule_3_OnCallPersonName }}"*
         icon-emoji: ':alarm_clock:'
-        channel:  ${{ env.channel }}
         webhook-url: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK_URL }}
         color: good
 

--- a/.github/workflows/alert_PD_schedule_Slack.yml
+++ b/.github/workflows/alert_PD_schedule_Slack.yml
@@ -1,8 +1,9 @@
 name: Find next person on call
-on: workflow_dispatch
+on:
+  schedule:
+    - cron: "7 13 * * Tue-Fri"  #UTC-5
+    - cron: "7 13 * * Mon"  #UTC-5
 
-env:
-  channel: cdc-reportstream-devsecops-new
 jobs:
   pre_job:
     name: Pre Job
@@ -128,6 +129,5 @@ jobs:
           "${{ env.Schedules_oncallSchedule_3_ScheduleName }}"
           ❗"Now": *"${{ env.Schedules_oncallSchedule_3_OnCallPersonName }}"*
         icon-emoji: ':alarm_clock:'
-        webhook-url: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK_URL }}
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_NAVA_ENGINEERING_NEW_CHANNEL }}
         color: good
-

--- a/.github/workflows/alert_PD_schedule_Slack.yml
+++ b/.github/workflows/alert_PD_schedule_Slack.yml
@@ -1,8 +1,5 @@
 name: Find next person on call
-on:
-  schedule:
-    - cron: "7 13 * * Tue-Fri"  #UTC-5
-    - cron: "7 13 * * Mon"  #UTC-5
+on: workflow_dispatch
 
 env:
   channel: cdc-reportstream-devsecops-new

--- a/.github/workflows/alert_PD_schedule_Slack.yml
+++ b/.github/workflows/alert_PD_schedule_Slack.yml
@@ -4,6 +4,8 @@ on:
     - cron: "7 13 * * Tue-Fri"  #UTC-5
     - cron: "7 13 * * Mon"  #UTC-5
 
+env:
+  channel: cdc-reportstream-engineering-new
 jobs:
   pre_job:
     name: Pre Job
@@ -11,7 +13,7 @@ jobs:
     outputs:
       IsMonday: ${{ steps.IsMonday.outputs.IsMonday }}
       WeekDay: ${{ steps.WeekDay.outputs.IsWeekDay }}
-      
+
     steps:
       - name: "Check out changes"
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
@@ -20,67 +22,67 @@ jobs:
         if: github.event_name == 'schedule' && github.event.schedule == '7 13 * * Mon'
         shell: bash
         run: echo "IsMonday=true" >> $GITHUB_OUTPUT
-      
+
       - name: IsWeekDay
         id: WeekDay
         if: github.event_name == 'schedule' && github.event.schedule == '7 13 * * Tue-Fri'
         shell: bash
         run: echo "IsWeekDay=true" >> $GITHUB_OUTPUT
-  
+
   PDAlert_Monday:
     name: PD Alert for Monday
     needs: pre_job
     if: ${{ needs.pre_job.outputs.IsMonday == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Check Out Changes
-      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-      with:
-        fetch-depth: 0
-      
-    - name: Get PD oncall schedule
-      id: PD
-      shell: pwsh
-      run: |
-        ./.github/scripts/PagerDutyAlerts/TriggerPDApi.ps1 -PD_KEY "${{ secrets.PD_ROTATION_SLACK_NOTIFICATION }}" -ScheduleIds "${{ secrets.PD_ReportStream_ScheduleId }}"
-    
-    - name: Get PD onCall Details
-      id: PDOnCall
-      shell: pwsh
-      run: | 
-        echo  "${env:PDSchedules}" >> PDSchedules.json
+      - name: Check Out Changes
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+        with:
+          fetch-depth: 0
 
-    - name: JSON to variables
-      uses: antifree/json-to-variables@8de3c6b94715a24fe65f29640b4e292a4add22a3
-      with:
-        filename: 'PDSchedules.json'
-        prefix: Schedules  
+      - name: Get PD oncall schedule
+        id: PD
+        shell: pwsh
+        run: |
+          ./.github/scripts/PagerDutyAlerts/TriggerPDApi.ps1 -PD_KEY "${{ secrets.PD_ROTATION_SLACK_NOTIFICATION }}" -ScheduleIds "${{ secrets.PD_ReportStream_ScheduleId }}"
 
-    - name: Slack Notification
-      uses: ./.github/actions/notifications
-      with:
-        method: slack
-        title: Pagerduty On-Call
-        message: |
-          "${{ env.Schedules_oncallSchedule_0_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_0_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_0_Until }}"\`
-          🔸"Next": *"${{ env.Schedules_oncallSchedule_0_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_0_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_0_NextUntil }}"\`
-          
-          "${{ env.Schedules_oncallSchedule_1_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_1_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_1_Until }}"\`
-          🔸"Next": *"${{ env.Schedules_oncallSchedule_1_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_1_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_1_NextUntil }}"\`
-          
-          "${{ env.Schedules_oncallSchedule_2_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_2_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_2_Until }}"\`
-          🔸"Next": *"${{ env.Schedules_oncallSchedule_2_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_2_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_2_NextUntil }}"\`
-          
-          "${{ env.Schedules_oncallSchedule_3_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_3_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_3_Until }}"\`
-          🔸"Next": *"${{ env.Schedules_oncallSchedule_3_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_3_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_3_NextUntil }}"\`
-        icon-emoji: ':alarm_clock:'
-        channel:  ${{ env.channel }}
-        webhook-url: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK_URL }}
-        color: good
+      - name: Get PD onCall Details
+        id: PDOnCall
+        shell: pwsh
+        run: |
+          echo  "${env:PDSchedules}" >> PDSchedules.json
+
+      - name: JSON to variables
+        uses: antifree/json-to-variables@8de3c6b94715a24fe65f29640b4e292a4add22a3
+        with:
+          filename: 'PDSchedules.json'
+          prefix: Schedules
+
+      - name: Slack Notification
+        uses: ./.github/actions/notifications
+        with:
+          method: slack
+          title: Pagerduty On-Call
+          message: |
+            "${{ env.Schedules_oncallSchedule_0_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_0_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_0_Until }}"\`
+            🔸"Next": *"${{ env.Schedules_oncallSchedule_0_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_0_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_0_NextUntil }}"\`
+            
+            "${{ env.Schedules_oncallSchedule_1_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_1_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_1_Until }}"\`
+            🔸"Next": *"${{ env.Schedules_oncallSchedule_1_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_1_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_1_NextUntil }}"\`
+            
+            "${{ env.Schedules_oncallSchedule_2_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_2_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_2_Until }}"\`
+            🔸"Next": *"${{ env.Schedules_oncallSchedule_2_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_2_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_2_NextUntil }}"\`
+            
+            "${{ env.Schedules_oncallSchedule_3_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_3_OnCallPersonName }}"* : _until_ \`"${{ env.Schedules_oncallSchedule_3_Until }}"\`
+            🔸"Next": *"${{ env.Schedules_oncallSchedule_3_NextPersonName }}"* : \`"${{ env.Schedules_oncallSchedule_3_NextFrom }}"\` _until_ \`"${{ env.Schedules_oncallSchedule_3_NextUntil }}"\`
+          icon-emoji: ':alarm_clock:'
+          channel:  ${{ env.channel }}
+          webhook-url: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK_URL }}
+          color: good
 
   PDAlert_WeekDays:
     name: PD Alert for WeekDays
@@ -88,46 +90,47 @@ jobs:
     if: ${{ needs.pre_job.outputs.WeekDay == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Check Out Changes
-      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-      with:
-        fetch-depth: 0
-      
-    - name: Get PD oncall schedule
-      id: PD
-      shell: pwsh
-      run: |
-        ./.github/scripts/PagerDutyAlerts/TriggerPDApi.ps1 -PD_KEY "${{ secrets.PD_ROTATION_SLACK_NOTIFICATION }}" -ScheduleIds "${{ secrets.PD_ReportStream_ScheduleId }}"
-    
-    - name: Get PD onCall Details
-      id: PDOnCall
-      shell: pwsh
-      run: | 
-        echo  "${env:PDSchedules}" >> PDSchedules.json
+      - name: Check Out Changes
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+        with:
+          fetch-depth: 0
 
-    - name: JSON to variables
-      uses: antifree/json-to-variables@8de3c6b94715a24fe65f29640b4e292a4add22a3
-      with:
-        filename: 'PDSchedules.json'
-        prefix: Schedules  
+      - name: Get PD oncall schedule
+        id: PD
+        shell: pwsh
+        run: |
+          ./.github/scripts/PagerDutyAlerts/TriggerPDApi.ps1 -PD_KEY "${{ secrets.PD_ROTATION_SLACK_NOTIFICATION }}" -ScheduleIds "${{ secrets.PD_ReportStream_ScheduleId }}"
 
-    - name: Slack Notification
-      uses: ./.github/actions/notifications
-      with:
-        method: slack
-        title: PagerDuty On-Call
-        message: |
-          "${{ env.Schedules_oncallSchedule_0_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_0_OnCallPersonName }}"*
+      - name: Get PD onCall Details
+        id: PDOnCall
+        shell: pwsh
+        run: |
+          echo  "${env:PDSchedules}" >> PDSchedules.json
 
-          "${{ env.Schedules_oncallSchedule_1_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_1_OnCallPersonName }}"*
+      - name: JSON to variables
+        uses: antifree/json-to-variables@8de3c6b94715a24fe65f29640b4e292a4add22a3
+        with:
+          filename: 'PDSchedules.json'
+          prefix: Schedules
 
-          "${{ env.Schedules_oncallSchedule_2_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_2_OnCallPersonName }}"*
-
-          "${{ env.Schedules_oncallSchedule_3_ScheduleName }}"
-          ❗"Now": *"${{ env.Schedules_oncallSchedule_3_OnCallPersonName }}"*
-        icon-emoji: ':alarm_clock:'
-        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_NAVA_ENGINEERING_NEW_CHANNEL }}
-        color: good
+      - name: Slack Notification
+        uses: ./.github/actions/notifications
+        with:
+          method: slack
+          title: PagerDuty On-Call
+          message: |
+            "${{ env.Schedules_oncallSchedule_0_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_0_OnCallPersonName }}"*
+            
+            "${{ env.Schedules_oncallSchedule_1_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_1_OnCallPersonName }}"*
+            
+            "${{ env.Schedules_oncallSchedule_2_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_2_OnCallPersonName }}"*
+            
+            "${{ env.Schedules_oncallSchedule_3_ScheduleName }}"
+            ❗"Now": *"${{ env.Schedules_oncallSchedule_3_OnCallPersonName }}"*
+          icon-emoji: ':alarm_clock:'
+          channel:  ${{ env.channel }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_NAVA_ENGINEERING_NEW_CHANNEL }}
+          color: good


### PR DESCRIPTION
This PR updates the PagerDuty slack notification workflow to match the slack URL with the team to fix the "404 not found" error.

Test Steps:
1. I had Nava generate a new Slack URL that is tied to the following Nava owned channel: `cdc-reportstream-engineering-new`
2. I installed ACT locally and ran the following simplified version of the workflow from the root of the repo via `act -j PDAlert_WeekDays`
```
name: Find next person on call
on:
  schedule:
    - cron: "7 13 * * Tue-Fri"  #UTC-5
    - cron: "7 13 * * Mon"  #UTC-5

env:
  channel: cdc-reportstream-devsecops-new
jobs:

  PDAlert_WeekDays:
    name: PD Alert for WeekDays
    runs-on: ubuntu-latest
    steps:
    - name: Check Out Changes
      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
      with:
        fetch-depth: 0

    - name: Slack Notification
      uses: ./.github/actions/notifications
      with:
        method: slack
        title: PagerDuty On-Call
        message: 'Arnej Testing PDAlert_WeekDays locally'
        icon-emoji: ':alarm_clock:'
        channel:  'cdc-reportstream-engineering-new'
        webhook-url: 'NEW URL IS HARDCODED HERE'
        color: good
```
3. I confirmed this was able to successfully send a notification to slack:
![Screenshot 2025-04-01 at 11 52 53 AM](https://github.com/user-attachments/assets/905f2092-504b-490b-858d-6254a6cdd7fc)
4. I confirmed that if the channel does not match what channel the webhook-url was generated for, the workflow returns a "404 not found" error, the same thing we are seeing in production.

## Changes
- Generated a new webhook URL for `cdc-reportstream-engineering-new` channel and updated the pagerduty schedule workflow to use it.
- Created the following GitHub secret to be referenced by the aforementioned Workflow: `SLACK_WEBHOOK_URL_NAVA_ENGINEERING_NEW_CHANNEL`