### PR TITLE
Add GitHub workflow permissions for check runs

### DIFF
--- a/.github/workflows/release_to_azure.yml
+++ b/.github/workflows/release_to_azure.yml
@@ -1,5 +1,9 @@
-
 name: Release to Azure
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
## Changes
- Added `permissions` block to `.github/workflows/release_to_azure.yml` with:
  - `checks: write` - Allows creating and updating check runs
  - `contents: read` - Allows reading repository contents
  - `pull-requests: write` - Allows updating pull requests

## Context
The workflow was encountering a 403 Forbidden error when trying to create check runs for test results. This was happening because the workflow didn't have the necessary permissions to create check runs. By default, GitHub Actions workflows have limited permissions, and we need to explicitly grant the required permissions.

