### PR TITLE
Add checks: write permission to GitHub workflow

### DIFF
--- a/.github/workflows/release_to_github.yml
+++ b/.github/workflows/release_to_github.yml
@@ -6,6 +6,10 @@ on:
       - main
       - production
 
+permissions:
+  checks: write
+  contents: write
+
 concurrency: ${{ github.ref }}-gh-release
 
 jobs:


### PR DESCRIPTION

# Add checks: write permission to GitHub workflow

This PR adds the `checks: write` permission to the GitHub workflow to resolve the 403 error when creating check runs for test results. This is necessary for the workflow to properly create and update check runs during the build process.