### PR TITLE
Add contents: write permission for deleting releases

### DIFF
--- a/.github/workflows/release_to_github.yml
+++ b/.github/workflows/release_to_github.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   checks: write
   contents: read
+  contents: write
   pull-requests: write
 
 concurrency: ${{ github.ref }}-gh-release


### PR DESCRIPTION
This PR ...

## Changes
 adds the `contents: write` permission to the `release_to_github.yml` workflow to allow the `delete-older-releases` action to delete releases and tags. The workflow now has:

- `checks: write` - for test results
- `contents: read` - for reading files
- `contents: write` - for deleting releases
- `pull-requests: write` - for PR status

## Impact
This change should resolve the "Resource not accessible by integration" error when the workflow tries to delete older releases.

## Testing
- [ ] Verify that the workflow can successfully delete older releases
- [ ] Confirm that the release deletion step completes without permission errors