### PR TITLE
 remove duplicate contents permission in release_to_github workflow

### DIFF
--- a/.github/workflows/release_to_github.yml
+++ b/.github/workflows/release_to_github.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   checks: write
-  contents: read
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
This PR ...

- Removed duplicate `contents: read` permission
- Kept `contents: write` permission  needed for deleting releases


## Related Issues
- Fixes workflow error in commit 6f8fd9b4f

