### PR TITLE
16059 Removed skip from last mile failure test

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
@@ -83,8 +83,7 @@ test.describe("Last Mile Failure page",
             await expect(modal).toContainText(`Report ID:${reportIdCell}`);
         });
 
-        test.skip("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage, isMockDisabled }) => {
-            test.skip(!isMockDisabled, "Mocks are ENABLED, skipping test");
+        test("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage }) => {
             const receiver = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(2);
             const receiverCell = await receiver.getByRole("link").innerText();
             const orgName = receiverCell.slice(0,receiverCell.indexOf("."))


### PR DESCRIPTION
This PR ...

Unskips a last mile failures page user flow test 

Test Steps:
1. Run e2e on the Last Mile Failure page smoke test (will happen as part of the checks for this PR)

## Changes
- unskipped a skipped test

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [ ] Added tests?

## Linked Issues
- Fixes #16059
