### PR TITLE
17343 add queuemessage to azure events

### DIFF
--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -644,8 +644,8 @@ class ActionHistory(
         reportFile.bodyUrl = blobInfo.blobUrl
 
         reportEventService.sendReportEvent(
-            childReport = reportFile,
             eventName = ReportStreamEventName.REPORT_SENT,
+            childReport = reportFile,
             pipelineStepName = TaskAction.send
         ) {
             parentReportId(header.reportFile.reportId)
@@ -722,8 +722,7 @@ class ActionHistory(
                             nextRetryTime?.let {
                                 ReportStreamEventProperties.NEXT_RETRY_TIME to
                                     DateTimeFormatter.ISO_DATE_TIME.format(it)
-                            },
-                            queueMessage?.let { ReportStreamEventProperties.QUEUE_MESSAGE to queueMessage }
+                            }
                         ).toMap()
                     )
                 }

--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -646,7 +646,7 @@ class ActionHistory(
         reportEventService.sendReportEvent(
             eventName = ReportStreamEventName.REPORT_SENT,
             childReport = reportFile,
-            pipelineStepName = TaskAction.send
+            pipelineStepName = TaskAction.send,
         ) {
             parentReportId(header.reportFile.reportId)
             params(
@@ -710,7 +710,7 @@ class ActionHistory(
                         )
                     )
                 )
-                reportEventService.sendItemEvent(eventName, report, TaskAction.send) {
+                reportEventService.sendItemEvent(eventName, report, TaskAction.send, queueMessage ?: "") {
                     trackingId(bundle)
                     parentReportId(itemLineage.parentReportId)
                     childItemIndex(itemLineage.childIndex)

--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -608,6 +608,7 @@ class ActionHistory(
         reportService: ReportService,
         transportType: String,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ) {
         if (isReportAlreadyTracked(sentReportId)) {
             error(
@@ -647,6 +648,7 @@ class ActionHistory(
             eventName = ReportStreamEventName.REPORT_SENT,
             childReport = reportFile,
             pipelineStepName = TaskAction.send,
+            queueMessage = queueMessage,
         ) {
             parentReportId(header.reportFile.reportId)
             params(
@@ -665,7 +667,7 @@ class ActionHistory(
             receiver,
             null,
             null,
-            null,
+            queueMessage,
             reportEventService,
             reportService
         )

--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -212,6 +212,7 @@ class SendFunction(
                         eventName = ReportStreamEventName.REPORT_LAST_MILE_FAILURE,
                         childReport = report,
                         pipelineStepName = TaskAction.send,
+                        queueMessage = message
                     ) {
                         params(
                             mapOf(
@@ -219,8 +220,7 @@ class SendFunction(
                                 ReportStreamEventProperties.RECEIVER_NAME to receiver.fullName,
                                 ReportStreamEventProperties.TRANSPORT_TYPE to receiver.transport.toString(),
                                 ReportStreamEventProperties.FILE_LENGTH to fileSize,
-                                ReportStreamEventProperties.FILENAME to externalFileName,
-                                ReportStreamEventProperties.QUEUE_MESSAGE to message
+                                ReportStreamEventProperties.FILENAME to externalFileName
                             )
                         )
                         if (parentReport != null) {

--- a/prime-router/src/main/kotlin/azure/SendFunction.kt
+++ b/prime-router/src/main/kotlin/azure/SendFunction.kt
@@ -117,7 +117,8 @@ class SendFunction(
                     actionHistory,
                     reportEventService,
                     workflowEngine.reportService,
-                    lineages
+                    lineages,
+                    message
                 )
                 if (nextRetry != null) {
                     nextRetryItems += nextRetry

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
@@ -1,5 +1,6 @@
 package gov.cdc.prime.router.azure.observability.event
 
+import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
@@ -19,6 +20,7 @@ import java.util.UUID
  * @param childBodyUrl the blob url of the outputted report
  * @param theTopic the topic that the report/item is part of
  * @param pipelineStepName the pipeline step producing the event
+ * @param queueMessage the azure queue message associated with this event
  *
  * Additional properties can be set for the event via an initializer
  * - [AbstractReportStreamEventBuilder.parentReportId] will configure the id of the inputted report
@@ -35,6 +37,7 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
     private val childBodyUrl: String,
     private val theTopic: Topic?,
     private val pipelineStepName: TaskAction,
+    private val queueMessage: QueueMessage,
 ) : Logging {
 
     constructor(
@@ -43,6 +46,7 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
         theName: ReportStreamEventName,
         report: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: QueueMessage,
     ) : this(
         reportEventService,
         azureEventService,
@@ -50,7 +54,8 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
         report.reportId,
         report.bodyUrl,
         report.schemaTopic,
-        pipelineStepName
+        pipelineStepName,
+        queueMessage
     )
 
     constructor(
@@ -59,6 +64,7 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
         theName: ReportStreamEventName,
         report: Report,
         pipelineStepName: TaskAction,
+        queueMessage: QueueMessage,
     ) : this(
         reportEventService,
         azureEventService,
@@ -66,7 +72,8 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
         report.id,
         report.bodyURL,
         report.schema.topic,
-        pipelineStepName
+        pipelineStepName,
+        queueMessage
     )
     var theParams: Map<ReportStreamEventProperties, Any> = emptyMap()
     var theParentReportId: UUID? = null
@@ -86,7 +93,8 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
             childBodyUrl,
             theParentReportId,
             pipelineStepName,
-            theTopic
+            theTopic,
+            queueMessage
         )
 
     fun send() {
@@ -119,6 +127,7 @@ open class ReportStreamReportEventBuilder(
     childBodyUrl: String,
     theTopic: Topic?,
     pipelineStepName: TaskAction,
+    queueMessage: QueueMessage,
 ) : AbstractReportStreamEventBuilder<ReportStreamReportEvent>(
     reportEventService,
     azureEventService,
@@ -126,7 +135,8 @@ open class ReportStreamReportEventBuilder(
     childReportId,
     childBodyUrl,
     theTopic,
-    pipelineStepName
+    pipelineStepName,
+    queueMessage
 ) {
 
     override fun buildEvent(): ReportStreamReportEvent = ReportStreamReportEvent(
@@ -151,6 +161,7 @@ open class ReportStreamItemEventBuilder(
     childBodyUrl: String,
     theTopic: Topic,
     pipelineStepName: TaskAction,
+    queueMessage: QueueMessage,
 ) : AbstractReportStreamEventBuilder<ReportStreamItemEvent>(
     reportEventService,
     azureEventService,
@@ -158,7 +169,8 @@ open class ReportStreamItemEventBuilder(
     childReportId,
     childBodyUrl,
     theTopic,
-    pipelineStepName
+    pipelineStepName,
+    queueMessage
 ) {
     private var theParentItemIndex = 1
     private var theChildIndex = 1
@@ -206,6 +218,7 @@ class ReportStreamReportProcessingErrorEventBuilder(
     childBodyUrl: String,
     theTopic: Topic?,
     pipelineStepName: TaskAction,
+    queueMessage: QueueMessage,
     private val error: String,
 ) : ReportStreamReportEventBuilder(
     reportEventService,
@@ -214,7 +227,8 @@ class ReportStreamReportProcessingErrorEventBuilder(
     childReportId,
     childBodyUrl,
     theTopic,
-    pipelineStepName
+    pipelineStepName,
+    queueMessage
 ) {
     override fun buildEvent(): ReportStreamReportEvent = ReportStreamReportEvent(
             getReportEventData(),
@@ -233,6 +247,7 @@ class ReportStreamItemProcessingErrorEventBuilder(
     childBodyUrl: String,
     theTopic: Topic,
     pipelineStepName: TaskAction,
+    queueMessage: QueueMessage,
     private val error: String,
 ) : ReportStreamItemEventBuilder(
     reportEventService,
@@ -241,7 +256,8 @@ class ReportStreamItemProcessingErrorEventBuilder(
     childReportId,
     childBodyUrl,
     theTopic,
-    pipelineStepName
+    pipelineStepName,
+    queueMessage
 ) {
     override fun buildEvent(): ReportStreamItemEvent = ReportStreamItemEvent(
             getReportEventData(),

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventBuilder.kt
@@ -1,6 +1,5 @@
 package gov.cdc.prime.router.azure.observability.event
 
-import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
@@ -37,7 +36,7 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
     private val childBodyUrl: String,
     private val theTopic: Topic?,
     private val pipelineStepName: TaskAction,
-    private val queueMessage: QueueMessage,
+    private val queueMessage: String,
 ) : Logging {
 
     constructor(
@@ -46,7 +45,7 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
         theName: ReportStreamEventName,
         report: ReportFile,
         pipelineStepName: TaskAction,
-        queueMessage: QueueMessage,
+        queueMessage: String,
     ) : this(
         reportEventService,
         azureEventService,
@@ -64,7 +63,7 @@ abstract class AbstractReportStreamEventBuilder<T : AzureCustomEvent>(
         theName: ReportStreamEventName,
         report: Report,
         pipelineStepName: TaskAction,
-        queueMessage: QueueMessage,
+        queueMessage: String,
     ) : this(
         reportEventService,
         azureEventService,
@@ -127,7 +126,7 @@ open class ReportStreamReportEventBuilder(
     childBodyUrl: String,
     theTopic: Topic?,
     pipelineStepName: TaskAction,
-    queueMessage: QueueMessage,
+    queueMessage: String = "",
 ) : AbstractReportStreamEventBuilder<ReportStreamReportEvent>(
     reportEventService,
     azureEventService,
@@ -161,7 +160,7 @@ open class ReportStreamItemEventBuilder(
     childBodyUrl: String,
     theTopic: Topic,
     pipelineStepName: TaskAction,
-    queueMessage: QueueMessage,
+    queueMessage: String = "",
 ) : AbstractReportStreamEventBuilder<ReportStreamItemEvent>(
     reportEventService,
     azureEventService,
@@ -218,7 +217,7 @@ class ReportStreamReportProcessingErrorEventBuilder(
     childBodyUrl: String,
     theTopic: Topic?,
     pipelineStepName: TaskAction,
-    queueMessage: QueueMessage,
+    queueMessage: String = "",
     private val error: String,
 ) : ReportStreamReportEventBuilder(
     reportEventService,
@@ -247,7 +246,7 @@ class ReportStreamItemProcessingErrorEventBuilder(
     childBodyUrl: String,
     theTopic: Topic,
     pipelineStepName: TaskAction,
-    queueMessage: QueueMessage,
+    queueMessage: String = "",
     private val error: String,
 ) : ReportStreamItemEventBuilder(
     reportEventService,

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventData.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventData.kt
@@ -3,6 +3,7 @@ package gov.cdc.prime.router.azure.observability.event
 import com.fasterxml.jackson.annotation.JsonKey
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.google.common.base.CaseFormat
+import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import java.time.OffsetDateTime
@@ -28,6 +29,7 @@ data class ReportEventData(
     val pipelineStepName: TaskAction,
     val timestamp: OffsetDateTime,
     val commitId: String,
+    val queueMessage: QueueMessage,
 )
 
 /**

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventData.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventData.kt
@@ -3,7 +3,6 @@ package gov.cdc.prime.router.azure.observability.event
 import com.fasterxml.jackson.annotation.JsonKey
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.google.common.base.CaseFormat
-import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import java.time.OffsetDateTime
@@ -19,6 +18,8 @@ import java.util.UUID
  * @param blobUrl the blob url for the outputted report
  * @param pipelineStepName the step that produced the outputted report
  * @param timestamp when the event occurred
+ * @param commitId the current git commit hash
+ * @param queueMessage the azure queue message
  */
 data class ReportEventData(
     val childReportId: UUID,
@@ -29,7 +30,7 @@ data class ReportEventData(
     val pipelineStepName: TaskAction,
     val timestamp: OffsetDateTime,
     val commitId: String,
-    val queueMessage: QueueMessage,
+    val queueMessage: String,
 )
 
 /**
@@ -75,7 +76,6 @@ enum class ReportStreamEventProperties {
     TARGET_FORMAT,
     RETRY_COUNT,
     NEXT_RETRY_TIME,
-    QUEUE_MESSAGE,
     ;
 
     @JsonKey

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventService.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventService.kt
@@ -262,7 +262,8 @@ class ReportStreamEventService(
             childReport.id,
             childReport.bodyURL,
             childReport.schema.topic,
-            pipelineStepName
+            pipelineStepName,
+            queueMessage
         ).apply(
             initializer
         )
@@ -288,7 +289,8 @@ class ReportStreamEventService(
             childReport.reportId,
             childReport.bodyUrl,
             childReport.schemaTopic,
-            pipelineStepName
+            pipelineStepName,
+            queueMessage
         ).apply(
             initializer
         )

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventService.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventService.kt
@@ -1,6 +1,5 @@
 package gov.cdc.prime.router.azure.observability.event
 
-import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.DatabaseAccess
@@ -36,6 +35,7 @@ interface IReportStreamEventService {
      * @param eventName the business event value from [ReportStreamEventName]
      * @param childReport the report that is getting emitted from the pipeline step
      * @param pipelineStepName the pipeline step that is emitting the event
+     * @param queueMessage the original azure queue message
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
@@ -43,6 +43,7 @@ interface IReportStreamEventService {
         eventName: ReportStreamEventName,
         childReport: Report,
         pipelineStepName: TaskAction,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
         initializer: ReportStreamReportEventBuilder.() -> Unit,
     )
@@ -53,6 +54,7 @@ interface IReportStreamEventService {
      * @param eventName the business event value from [ReportStreamEventName]
      * @param childReport the report that is getting emitted from the pipeline step
      * @param pipelineStepName the pipeline step that is emitting the event
+     * @param queueMessage the original azure queue message
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
@@ -60,6 +62,7 @@ interface IReportStreamEventService {
         eventName: ReportStreamEventName,
         childReport: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
         initializer: ReportStreamReportEventBuilder.() -> Unit,
     )
@@ -71,6 +74,7 @@ interface IReportStreamEventService {
      * @param childReport the report that is getting emitted from the pipeline step
      * @param pipelineStepName the pipeline step that is emitting the event
      * @param error the error description
+     * @param queueMessage the azure queue message associated with this event
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
@@ -79,7 +83,7 @@ interface IReportStreamEventService {
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
-        queueMessage: QueueMessage,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     )
@@ -91,6 +95,7 @@ interface IReportStreamEventService {
      * @param childReport the report that is getting emitted from the pipeline step
      * @param pipelineStepName the pipeline step that is emitting the event
      * @param error the error description
+     * @param queueMessage the azure queue message associated with this event
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
@@ -99,7 +104,7 @@ interface IReportStreamEventService {
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
-        queueMessage: QueueMessage,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     )
@@ -111,12 +116,14 @@ interface IReportStreamEventService {
      * @param childReport the report that is getting emitted from the pipeline step
      * @param pipelineStepName the pipeline step that is emitting the event
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
+     * @param queueMessage the azure queue message associated with this event
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
     fun sendItemEvent(
         eventName: ReportStreamEventName,
         childReport: Report,
         pipelineStepName: TaskAction,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
         initializer: ReportStreamItemEventBuilder.() -> Unit,
     )
@@ -128,12 +135,14 @@ interface IReportStreamEventService {
      * @param childReport the report that is getting emitted from the pipeline step
      * @param pipelineStepName the pipeline step that is emitting the event
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
+     * @param queueMessage the azure queue message associated with this event
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
     fun sendItemEvent(
         eventName: ReportStreamEventName,
         childReport: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
         initializer: ReportStreamItemEventBuilder.() -> Unit,
     )
@@ -154,8 +163,8 @@ interface IReportStreamEventService {
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
-        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     )
 
@@ -175,8 +184,8 @@ interface IReportStreamEventService {
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: String = "",
         shouldQueue: Boolean = false,
-        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     )
 
@@ -197,7 +206,7 @@ interface IReportStreamEventService {
         parentReportId: UUID?,
         pipelineStepName: TaskAction,
         topic: Topic?,
-        queueMessage: QueueMessage,
+        queueMessage: String = "",
     ): ReportEventData
 
     /**
@@ -242,6 +251,7 @@ class ReportStreamEventService(
         eventName: ReportStreamEventName,
         childReport: Report,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportEventBuilder.() -> Unit,
     ) {
@@ -267,6 +277,7 @@ class ReportStreamEventService(
         eventName: ReportStreamEventName,
         childReport: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportEventBuilder.() -> Unit,
     ) {
@@ -294,7 +305,7 @@ class ReportStreamEventService(
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
-        queueMessage: QueueMessage,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ) {
@@ -306,7 +317,8 @@ class ReportStreamEventService(
             childReport.bodyUrl,
             childReport.schemaTopic,
             pipelineStepName,
-            error
+            queueMessage,
+            error,
         ).apply(
             initializer
         )
@@ -323,7 +335,7 @@ class ReportStreamEventService(
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
-        queueMessage: QueueMessage,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ) {
@@ -335,6 +347,7 @@ class ReportStreamEventService(
             childReport.bodyURL,
             childReport.schema.topic,
             pipelineStepName,
+            queueMessage,
             error
         ).apply(
             initializer
@@ -351,6 +364,7 @@ class ReportStreamEventService(
         eventName: ReportStreamEventName,
         childReport: Report,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamItemEventBuilder.() -> Unit,
     ) {
@@ -361,7 +375,8 @@ class ReportStreamEventService(
             childReport.id,
             childReport.bodyURL,
             childReport.schema.topic,
-            pipelineStepName
+            pipelineStepName,
+            queueMessage
         ).apply(initializer)
 
         if (shouldQueue) {
@@ -375,6 +390,7 @@ class ReportStreamEventService(
         eventName: ReportStreamEventName,
         childReport: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamItemEventBuilder.() -> Unit,
     ) {
@@ -385,7 +401,8 @@ class ReportStreamEventService(
             childReport.reportId,
             childReport.bodyUrl,
             childReport.schemaTopic,
-            pipelineStepName
+            pipelineStepName,
+            queueMessage
         ).apply(initializer)
 
         if (shouldQueue) {
@@ -400,8 +417,8 @@ class ReportStreamEventService(
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: String,
         shouldQueue: Boolean,
-        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ) {
         val builder = ReportStreamItemProcessingErrorEventBuilder(
@@ -428,8 +445,8 @@ class ReportStreamEventService(
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: String,
         shouldQueue: Boolean,
-        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ) {
         val builder = ReportStreamItemProcessingErrorEventBuilder(
@@ -440,7 +457,7 @@ class ReportStreamEventService(
             childReport.bodyURL,
             childReport.schema.topic,
             pipelineStepName,
-            QueueMessage,
+            queueMessage,
             error
         ).apply(initializer)
 
@@ -457,7 +474,7 @@ class ReportStreamEventService(
         parentReportId: UUID?,
         pipelineStepName: TaskAction,
         topic: Topic?,
-        queueMessage: QueueMessage,
+        queueMessage: String,
     ): ReportEventData {
         val submittedReportIds = if (parentReportId != null) {
             reportService.getRootReports(parentReportId)

--- a/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventService.kt
+++ b/prime-router/src/main/kotlin/azure/observability/event/ReportStreamEventService.kt
@@ -1,5 +1,6 @@
 package gov.cdc.prime.router.azure.observability.event
 
+import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.Report
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.DatabaseAccess
@@ -78,6 +79,7 @@ interface IReportStreamEventService {
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: QueueMessage,
         shouldQueue: Boolean = false,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     )
@@ -97,6 +99,7 @@ interface IReportStreamEventService {
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: QueueMessage,
         shouldQueue: Boolean = false,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     )
@@ -143,6 +146,7 @@ interface IReportStreamEventService {
      * @param pipelineStepName the pipeline step that is emitting the event
      * @param error the error description
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
+     * @param queueMessage the original azure queue message
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
     fun sendItemProcessingError(
@@ -151,6 +155,7 @@ interface IReportStreamEventService {
         pipelineStepName: TaskAction,
         error: String,
         shouldQueue: Boolean = false,
+        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     )
 
@@ -162,6 +167,7 @@ interface IReportStreamEventService {
      * @param pipelineStepName the pipeline step that is emitting the event
      * @param error the error description
      * @param shouldQueue whether to send the event immediately or defer it to be sent later
+     * @param queueMessage the original azure queue message
      * @param initializer additional data to initialize the creation of the event. See [AbstractReportStreamEventBuilder]
      */
     fun sendItemProcessingError(
@@ -170,6 +176,7 @@ interface IReportStreamEventService {
         pipelineStepName: TaskAction,
         error: String,
         shouldQueue: Boolean = false,
+        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     )
 
@@ -181,6 +188,7 @@ interface IReportStreamEventService {
      * @param parentReportId the optional parent report id.  A report outputted from the ReportFunction will not have a parent
      * @param pipelineStepName the pipeline step that is generated the child report
      * @param topic the [Topic] that the report is in
+     * @param queueMessage the azure queue message associated with this event
      * @return [ReportEventData]
      */
     fun getReportEventData(
@@ -189,6 +197,7 @@ interface IReportStreamEventService {
         parentReportId: UUID?,
         pipelineStepName: TaskAction,
         topic: Topic?,
+        queueMessage: QueueMessage,
     ): ReportEventData
 
     /**
@@ -285,6 +294,7 @@ class ReportStreamEventService(
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: QueueMessage,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ) {
@@ -313,6 +323,7 @@ class ReportStreamEventService(
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: QueueMessage,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ) {
@@ -390,6 +401,7 @@ class ReportStreamEventService(
         pipelineStepName: TaskAction,
         error: String,
         shouldQueue: Boolean,
+        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ) {
         val builder = ReportStreamItemProcessingErrorEventBuilder(
@@ -400,6 +412,7 @@ class ReportStreamEventService(
             childReport.bodyUrl,
             childReport.schemaTopic,
             pipelineStepName,
+            queueMessage,
             error
         ).apply(initializer)
 
@@ -416,6 +429,7 @@ class ReportStreamEventService(
         pipelineStepName: TaskAction,
         error: String,
         shouldQueue: Boolean,
+        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ) {
         val builder = ReportStreamItemProcessingErrorEventBuilder(
@@ -426,6 +440,7 @@ class ReportStreamEventService(
             childReport.bodyURL,
             childReport.schema.topic,
             pipelineStepName,
+            QueueMessage,
             error
         ).apply(initializer)
 
@@ -442,6 +457,7 @@ class ReportStreamEventService(
         parentReportId: UUID?,
         pipelineStepName: TaskAction,
         topic: Topic?,
+        queueMessage: QueueMessage,
     ): ReportEventData {
         val submittedReportIds = if (parentReportId != null) {
             reportService.getRootReports(parentReportId)
@@ -457,7 +473,8 @@ class ReportStreamEventService(
             childBodyUrl,
             pipelineStepName,
             OffsetDateTime.now(),
-            Version.commitId
+            Version.commitId,
+            queueMessage
         )
     }
 

--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -18,6 +18,7 @@ import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import fhirengine.engine.CustomFhirPathFunctions
 import fhirengine.engine.CustomTranslationFunctions
+import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.ActionLogger
 import gov.cdc.prime.router.Hl7Configuration
 import gov.cdc.prime.router.Metadata
@@ -966,6 +967,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: QueueMessage,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -975,6 +977,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: QueueMessage,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -1001,6 +1004,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         pipelineStepName: TaskAction,
         error: String,
         shouldQueue: Boolean,
+        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
 

--- a/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
+++ b/prime-router/src/main/kotlin/cli/ProcessFhirCommands.kt
@@ -18,7 +18,6 @@ import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import fhirengine.engine.CustomFhirPathFunctions
 import fhirengine.engine.CustomTranslationFunctions
-import gov.cdc.prime.reportstream.shared.QueueMessage
 import gov.cdc.prime.router.ActionLogger
 import gov.cdc.prime.router.Hl7Configuration
 import gov.cdc.prime.router.Metadata
@@ -950,6 +949,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         eventName: ReportStreamEventName,
         childReport: Report,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -958,6 +958,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         eventName: ReportStreamEventName,
         childReport: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -967,7 +968,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
-        queueMessage: QueueMessage,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -977,7 +978,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
-        queueMessage: QueueMessage,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamReportProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -986,6 +987,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         eventName: ReportStreamEventName,
         childReport: Report,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamItemEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -994,6 +996,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         eventName: ReportStreamEventName,
         childReport: ReportFile,
         pipelineStepName: TaskAction,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamItemEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -1003,8 +1006,8 @@ class NoopReportStreamEventService : IReportStreamEventService {
         childReport: ReportFile,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: String,
         shouldQueue: Boolean,
-        queueMessage: QueueMessage,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
 
@@ -1013,6 +1016,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         childReport: Report,
         pipelineStepName: TaskAction,
         error: String,
+        queueMessage: String,
         shouldQueue: Boolean,
         initializer: ReportStreamItemProcessingErrorEventBuilder.() -> Unit,
     ): Unit = throw NotImplementedError()
@@ -1023,6 +1027,7 @@ class NoopReportStreamEventService : IReportStreamEventService {
         parentReportId: UUID?,
         pipelineStepName: TaskAction,
         topic: Topic?,
+        queueMessage: String,
     ): ReportEventData = throw NotImplementedError()
 
     override fun getItemEventData(

--- a/prime-router/src/main/kotlin/fhirengine/azure/FHIRFunctions.kt
+++ b/prime-router/src/main/kotlin/fhirengine/azure/FHIRFunctions.kt
@@ -248,7 +248,7 @@ class FHIRFunctions(
                 report,
                 fhirEngine.taskAction,
                 ex.message ?: "",
-                messageContent
+                messageContent.toString()
             ) {
                 params(mapOf(ReportStreamEventProperties.POISON_QUEUE_MESSAGE_ID to poisonQueueMessageId))
             }

--- a/prime-router/src/main/kotlin/fhirengine/azure/FHIRFunctions.kt
+++ b/prime-router/src/main/kotlin/fhirengine/azure/FHIRFunctions.kt
@@ -247,7 +247,8 @@ class FHIRFunctions(
                 ReportStreamEventName.PIPELINE_EXCEPTION,
                 report,
                 fhirEngine.taskAction,
-                ex.message ?: ""
+                ex.message ?: "",
+                messageContent
             ) {
                 params(mapOf(ReportStreamEventProperties.POISON_QUEUE_MESSAGE_ID to poisonQueueMessageId))
             }

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -385,6 +385,7 @@ class FHIRConverter(
                                 ReportStreamEventName.ITEM_ACCEPTED,
                                 report,
                                 TaskAction.convert,
+                                input.queueMessage,
                                 shouldQueue = true
                             ) {
                                 parentReportId(input.reportId)

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -108,7 +108,7 @@ class FHIRConverter(
         val blobURL: String,
         val blobDigest: String,
         val blobSubFolderName: String,
-        val queueMessage: QueueMessage,
+        val queueMessage: String,
     ) {
 
         companion object {
@@ -139,7 +139,7 @@ class FHIRConverter(
                     blobUrl,
                     blobDigest,
                     blobSubFolderName,
-                    message
+                    message.toString()
                 )
             }
 
@@ -193,7 +193,7 @@ class FHIRConverter(
                     blobUrl,
                     blobDigest,
                     blobSubFolderName,
-                    message
+                    message.toString()
                 )
             }
         }
@@ -310,8 +310,8 @@ class FHIRConverter(
                                     report,
                                     TaskAction.convert,
                                     processedItem.validationError!!.message,
-                                    shouldQueue = true,
-                                    input.queueMessage
+                                    input.queueMessage.toString(),
+                                    shouldQueue = true
                                 ) {
                                     parentReportId(input.reportId)
                                     parentItemIndex(itemIndex.toInt() + 1)
@@ -430,6 +430,7 @@ class FHIRConverter(
                     report,
                     TaskAction.convert,
                     "Submitted report was either empty or could not be parsed into HL7",
+                    input.queueMessage.toString()
                 ) {
                     parentReportId(input.reportId)
                     params(

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -310,7 +310,7 @@ class FHIRConverter(
                                     report,
                                     TaskAction.convert,
                                     processedItem.validationError!!.message,
-                                    input.queueMessage.toString(),
+                                    input.queueMessage,
                                     shouldQueue = true
                                 ) {
                                     parentReportId(input.reportId)
@@ -431,7 +431,7 @@ class FHIRConverter(
                     report,
                     TaskAction.convert,
                     "Submitted report was either empty or could not be parsed into HL7",
-                    input.queueMessage.toString()
+                    input.queueMessage
                 ) {
                     parentReportId(input.reportId)
                     params(

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRConverter.kt
@@ -99,6 +99,7 @@ class FHIRConverter(
      * @param schemaName the FHIR transform to apply
      * @param blobURL the URL for the blob to convert
      * @param blobDigest the digest of the blob contents
+     * @param queueMessage the original azure queue message
      */
     data class FHIRConvertInput(
         val reportId: UUID,
@@ -107,6 +108,7 @@ class FHIRConverter(
         val blobURL: String,
         val blobDigest: String,
         val blobSubFolderName: String,
+        val queueMessage: QueueMessage,
     ) {
 
         companion object {
@@ -136,7 +138,8 @@ class FHIRConverter(
                     schemaName,
                     blobUrl,
                     blobDigest,
-                    blobSubFolderName
+                    blobSubFolderName,
+                    message
                 )
             }
 
@@ -189,7 +192,8 @@ class FHIRConverter(
                     schemaName,
                     blobUrl,
                     blobDigest,
-                    blobSubFolderName
+                    blobSubFolderName,
+                    message
                 )
             }
         }
@@ -306,7 +310,8 @@ class FHIRConverter(
                                     report,
                                     TaskAction.convert,
                                     processedItem.validationError!!.message,
-                                    shouldQueue = true
+                                    shouldQueue = true,
+                                    input.queueMessage
                                 ) {
                                     parentReportId(input.reportId)
                                     parentItemIndex(itemIndex.toInt() + 1)
@@ -424,7 +429,7 @@ class FHIRConverter(
                     ReportStreamEventName.REPORT_NOT_PROCESSABLE,
                     report,
                     TaskAction.convert,
-                    "Submitted report was either empty or could not be parsed into HL7"
+                    "Submitted report was either empty or could not be parsed into HL7",
                 ) {
                     parentReportId(input.reportId)
                     params(

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRDestinationFilter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRDestinationFilter.kt
@@ -189,7 +189,8 @@ class FHIRDestinationFilter(
                     reportEventService.sendItemEvent(
                         eventName = ReportStreamEventName.ITEM_ROUTED,
                         childReport = report,
-                        pipelineStepName = TaskAction.destination_filter
+                        pipelineStepName = TaskAction.destination_filter,
+                        queueMessage = queueMessage.toString()
                     ) {
                         parentReportId(queueMessage.reportId)
                         params(
@@ -268,7 +269,8 @@ class FHIRDestinationFilter(
                 reportEventService.sendItemEvent(
                     eventName = ReportStreamEventName.ITEM_NOT_ROUTED,
                     childReport = report,
-                    pipelineStepName = TaskAction.destination_filter
+                    pipelineStepName = TaskAction.destination_filter,
+                    queueMessage = queueMessage.toString()
                 ) {
                     parentReportId(queueMessage.reportId)
                     trackingId(bundle)

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverEnrichment.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverEnrichment.kt
@@ -171,7 +171,8 @@ class FHIRReceiverEnrichment(
         reportEventService.sendItemEvent(
             eventName = ReportStreamEventName.ITEM_TRANSFORMED,
             childReport = report,
-            pipelineStepName = TaskAction.receiver_enrichment
+            pipelineStepName = TaskAction.receiver_enrichment,
+            queueMessage = queueMessage.toString()
         ) {
             parentReportId(queueMessage.reportId)
             params(

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverFilter.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRReceiverFilter.kt
@@ -474,7 +474,8 @@ class FHIRReceiverFilter(
                     reportEventService.sendItemEvent(
                         eventName = ReportStreamEventName.ITEM_FILTER_FAILED,
                         childReport = emptyReport,
-                        pipelineStepName = TaskAction.receiver_filter
+                        pipelineStepName = TaskAction.receiver_filter,
+                        queueMessage = queueMessage.toString()
                     ) {
                         parentReportId(queueMessage.reportId)
                         trackingId(bundle)

--- a/prime-router/src/main/kotlin/fhirengine/engine/FHIRTranslator.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/FHIRTranslator.kt
@@ -182,7 +182,8 @@ class FHIRTranslator(
         reportEventService.sendItemEvent(
             eventName = ReportStreamEventName.ITEM_TRANSFORMED,
             childReport = report,
-            pipelineStepName = TaskAction.translate
+            pipelineStepName = TaskAction.translate,
+            queueMessage = message.toString()
         ) {
             parentReportId(message.reportId)
             params(

--- a/prime-router/src/main/kotlin/fhirengine/engine/PrimeRouterQueueMessage.kt
+++ b/prime-router/src/main/kotlin/fhirengine/engine/PrimeRouterQueueMessage.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import gov.cdc.prime.reportstream.shared.QueueMessage
+import gov.cdc.prime.reportstream.shared.QueueMessage.Companion.mapper
 import gov.cdc.prime.router.Options
 import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.Topic
@@ -47,6 +48,7 @@ data class FhirConvertSubmissionQueueMessage(
 ) : ReportPipelineMessage(),
     QueueMessage.ReceiveInformation {
     override val messageQueueName = QueueMessage.Companion.elrSubmissionConvertQueueName
+    override fun toString(): String = mapper.writeValueAsString(this)
 }
 
 @JsonTypeName("convert")
@@ -59,6 +61,7 @@ data class FhirConvertQueueMessage(
     var schemaName: String = "",
 ) : ReportPipelineMessage() {
     override val messageQueueName = QueueMessage.Companion.elrConvertQueueName
+    override fun toString(): String = mapper.writeValueAsString(this)
 }
 
 @JsonTypeName("destination-filter")
@@ -70,6 +73,7 @@ data class FhirDestinationFilterQueueMessage(
     val topic: Topic,
 ) : ReportPipelineMessage() {
     override val messageQueueName = QueueMessage.Companion.elrDestinationFilterQueueName
+    override fun toString(): String = mapper.writeValueAsString(this)
 }
 
 @JsonTypeName("receiver-enrichment")
@@ -82,6 +86,7 @@ data class FhirReceiverEnrichmentQueueMessage(
     val receiverFullName: String,
 ) : ReportPipelineMessage() {
     override val messageQueueName = QueueMessage.Companion.elrReceiverEnrichmentQueueName
+    override fun toString(): String = mapper.writeValueAsString(this)
 }
 
 @JsonTypeName("receiver-filter")
@@ -94,6 +99,7 @@ data class FhirReceiverFilterQueueMessage(
     val receiverFullName: String,
 ) : ReportPipelineMessage() {
     override val messageQueueName = QueueMessage.Companion.elrReceiverFilterQueueName
+    override fun toString(): String = mapper.writeValueAsString(this)
 }
 
 @JsonTypeName("translate")
@@ -106,6 +112,7 @@ data class FhirTranslateQueueMessage(
     val receiverFullName: String,
 ) : ReportPipelineMessage() {
     override val messageQueueName = QueueMessage.Companion.elrTranslationQueueName
+    override fun toString(): String = mapper.writeValueAsString(this)
 }
 
 abstract class WithEventAction : PrimeRouterQueueMessage() {

--- a/prime-router/src/main/kotlin/transport/AS2Transport.kt
+++ b/prime-router/src/main/kotlin/transport/AS2Transport.kt
@@ -56,6 +56,7 @@ class AS2Transport(val metadata: Metadata? = null) :
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         // DevNote: This code is similar to the SFTP code in structure
         //
@@ -87,6 +88,7 @@ class AS2Transport(val metadata: Metadata? = null) :
                 reportService,
                 this::class.java.simpleName,
                 lineages,
+                queueMessage
             )
             actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
             null

--- a/prime-router/src/main/kotlin/transport/BlobStoreTransport.kt
+++ b/prime-router/src/main/kotlin/transport/BlobStoreTransport.kt
@@ -25,6 +25,7 @@ class BlobStoreTransport : ITransport {
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         val blobTransportType = transportType as BlobStoreTransportType
         val envVar: String = blobTransportType.containerName
@@ -52,6 +53,7 @@ class BlobStoreTransport : ITransport {
                 reportService,
                 this::class.java.simpleName,
                 lineages,
+                queueMessage
             )
             actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
             null

--- a/prime-router/src/main/kotlin/transport/EmailTransport.kt
+++ b/prime-router/src/main/kotlin/transport/EmailTransport.kt
@@ -37,6 +37,7 @@ class EmailTransport : ITransport {
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         val emailTransport = transportType as EmailTransportType
         val content = buildContent(header)

--- a/prime-router/src/main/kotlin/transport/GAENTransport.kt
+++ b/prime-router/src/main/kotlin/transport/GAENTransport.kt
@@ -84,6 +84,7 @@ class GAENTransport(val httpClient: HttpClient? = null) :
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         val gaenTransportInfo = transportType as GAENTransportType
         val reportId = header.reportFile.reportId
@@ -112,7 +113,13 @@ class GAENTransport(val httpClient: HttpClient? = null) :
 
             // Record the work in history and logs
             when (postResult) {
-                PostResult.SUCCESS -> recordFullSuccess(params, reportEventService, reportService, lineages)
+                PostResult.SUCCESS -> recordFullSuccess(
+                    params,
+                    reportEventService,
+                    reportService,
+                    lineages,
+                    queueMessage
+                )
                 PostResult.RETRY -> recordFailureWithRetry(params)
                 PostResult.FAIL -> recordFailure(params)
             }
@@ -134,6 +141,7 @@ class GAENTransport(val httpClient: HttpClient? = null) :
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ) {
         val msg = "${params.receiver.fullName}: Successful exposure notifications of ${params.comboId}"
         val history = params.actionHistory
@@ -150,7 +158,8 @@ class GAENTransport(val httpClient: HttpClient? = null) :
             reportEventService,
             reportService,
             this::class.java.simpleName,
-            lineages
+            lineages,
+            queueMessage
         )
         history.trackItemLineages(Report.createItemLineagesFromDb(params.header, params.sentReportId))
     }

--- a/prime-router/src/main/kotlin/transport/ITransport.kt
+++ b/prime-router/src/main/kotlin/transport/ITransport.kt
@@ -30,5 +30,6 @@ interface ITransport {
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems?
 }

--- a/prime-router/src/main/kotlin/transport/NullTransport.kt
+++ b/prime-router/src/main/kotlin/transport/NullTransport.kt
@@ -25,6 +25,7 @@ class NullTransport : ITransport {
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         if (header.content == null) error("No content for report ${header.reportFile.reportId}")
         val receiver = header.receiver ?: error("No receiver defined for report ${header.reportFile.reportId}")
@@ -40,7 +41,8 @@ class NullTransport : ITransport {
             reportEventService,
             reportService,
             this::class.java.simpleName,
-            lineages
+            lineages,
+            queueMessage
         )
         actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
         return null

--- a/prime-router/src/main/kotlin/transport/RESTTransport.kt
+++ b/prime-router/src/main/kotlin/transport/RESTTransport.kt
@@ -95,6 +95,7 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         val logger: Logger = context.logger
 
@@ -162,6 +163,7 @@ class RESTTransport(private val httpClient: HttpClient? = null) : ITransport {
                             reportService,
                             this::class.java.simpleName,
                             lineages,
+                            queueMessage
                         )
                         actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
                     } catch (t: Throwable) {

--- a/prime-router/src/main/kotlin/transport/SftpTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SftpTransport.kt
@@ -54,6 +54,7 @@ class SftpTransport :
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         val sftpTransportType = transportType as SFTPTransportType
 
@@ -81,6 +82,7 @@ class SftpTransport :
                 reportService,
                 this::class.java.simpleName,
                 lineages,
+                queueMessage
             )
             actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
             null

--- a/prime-router/src/main/kotlin/transport/SoapTransport.kt
+++ b/prime-router/src/main/kotlin/transport/SoapTransport.kt
@@ -158,6 +158,7 @@ class SoapTransport(private val httpClient: HttpClient? = null) : ITransport {
         reportEventService: IReportStreamEventService,
         reportService: ReportService,
         lineages: List<ItemLineage>?,
+        queueMessage: String,
     ): RetryItems? {
         // verify that we have a SOAP transport type for our parameters. I think if we ever fell
         // into this scenario with different parameters there's something seriously wrong in the system,
@@ -217,7 +218,8 @@ class SoapTransport(private val httpClient: HttpClient? = null) : ITransport {
                         reportEventService,
                         reportService,
                         this::class.java.simpleName,
-                        lineages
+                        lineages,
+                        queueMessage
                     )
                     actionHistory.trackItemLineages(Report.createItemLineagesFromDb(header, sentReportId))
                 }

--- a/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
@@ -414,7 +414,8 @@ class ActionHistoryTests {
             mockReportEventService,
             mockReportService,
             "",
-            lineages
+            lineages,
+            ""
         )
 
         // assert
@@ -449,7 +450,8 @@ class ActionHistoryTests {
                 mockReportEventService,
                 mockReportService,
                 "",
-                lineages
+                lineages,
+                ""
             )
         }
     }
@@ -543,7 +545,8 @@ class ActionHistoryTests {
             mockReportEventService,
             mockReportService,
             "",
-            lineages
+            lineages,
+            ""
         )
 
         val actionHistory2 = ActionHistory(TaskAction.receive)
@@ -557,7 +560,8 @@ class ActionHistoryTests {
             mockReportEventService,
             mockReportService,
             "",
-            lineages
+            lineages,
+            ""
         )
 
         // assert
@@ -916,7 +920,8 @@ class ActionHistoryTests {
             mockReportEventService,
             mockReportService,
             "",
-            lineages
+            lineages,
+            ""
         )
         val actionHistory2 = ActionHistory(TaskAction.receive)
         actionHistory2.action
@@ -930,7 +935,8 @@ class ActionHistoryTests {
             mockReportEventService,
             mockReportService,
             "",
-            lineages
+            lineages,
+            ""
         )
         assertThat(actionHistory1.reportsOut[uuid]).isNotNull()
         assertThat(actionHistory2.reportsOut[uuid2]).isNotNull()

--- a/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
@@ -379,12 +379,14 @@ class ActionHistoryTests {
             "http://blobUrl",
             TaskAction.send,
             OffsetDateTime.now(),
+            "",
             ""
         )
         every {
-            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         } returns Unit
-        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any()) } returns Unit
+        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any()) } returns
+            Unit
         mockkObject(Report)
         mockkObject(FhirTranscoder)
         every { FhirTranscoder.decode(any(), any()) } returns mockk<Bundle>()
@@ -432,8 +434,8 @@ class ActionHistoryTests {
         assertThat(reportFile.itemCount).isEqualTo(15)
         assertThat(actionHistory1.action.externalName).isEqualTo("filename1")
         verify(exactly = 1) {
-            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
-            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
+            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         }
         // not allowed to track the same report twice.
         assertFailure {
@@ -501,6 +503,7 @@ class ActionHistoryTests {
             "http://blobUrl",
             TaskAction.send,
             OffsetDateTime.now(),
+            "",
             ""
         )
         mockkObject(BlobAccess.Companion)
@@ -517,9 +520,10 @@ class ActionHistoryTests {
         every { anyConstructed<BundleDigestExtractor>().generateDigest(any()) } returns mockk<BundleDigest>()
         val header = mockk<WorkflowEngine.Header>()
         every {
-            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         } returns Unit
-        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any()) } returns Unit
+        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any()) } returns
+            Unit
         val inReportFile = mockk<ReportFile>()
         every { header.reportFile } returns inReportFile
         every { header.content } returns "".toByteArray()
@@ -564,8 +568,8 @@ class ActionHistoryTests {
         assertThat(actionHistory2.reportsOut[uuid]?.schemaName)
             .isEqualTo("STED/NESTED/STLTs/REALLY_LONG_STATE_NAME/REALLY_LONG_STATE_NAME")
         verify(exactly = 2) {
-            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
-            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
+            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         }
     }
 
@@ -594,7 +598,8 @@ class ActionHistoryTests {
         mockkConstructor(BundleDigestExtractor::class)
         every { anyConstructed<BundleDigestExtractor>().generateDigest(any()) } returns mockk<BundleDigest>()
 
-        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any()) } returns Unit
+        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any()) } returns
+            Unit
 
         // act
         val actionHistory1 = ActionHistory(TaskAction.receive)
@@ -612,7 +617,7 @@ class ActionHistoryTests {
 
         // assert
         verify(exactly = 2) {
-            mockReportEventService.sendItemEvent(eventName, reportFile, TaskAction.send, any(), any())
+            mockReportEventService.sendItemEvent(eventName, reportFile, TaskAction.send, any(), any(), any())
         }
     }
 
@@ -646,7 +651,7 @@ class ActionHistoryTests {
 
         // assert
         verify(exactly = 0) {
-            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         }
     }
 
@@ -675,7 +680,7 @@ class ActionHistoryTests {
 
         // assert
         verify(exactly = 0) {
-            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         }
     }
 
@@ -871,6 +876,7 @@ class ActionHistoryTests {
             "http://blobUrl",
             TaskAction.send,
             OffsetDateTime.now(),
+            "",
             ""
         )
         mockkObject(BlobAccess.Companion)
@@ -887,9 +893,10 @@ class ActionHistoryTests {
         every { anyConstructed<BundleDigestExtractor>().generateDigest(any()) } returns mockk<BundleDigest>()
         val header = mockk<WorkflowEngine.Header>()
         every {
-            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         } returns Unit
-        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any()) } returns Unit
+        every { mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any()) } returns
+            Unit
         val inReportFile = mockk<ReportFile>()
         every { header.reportFile } returns inReportFile
         every { header.content } returns "".toByteArray()
@@ -931,8 +938,8 @@ class ActionHistoryTests {
         assertContains(blobUrls[0], org.receivers[0].fullName)
         assertContains(blobUrls[1], org.receivers[1].fullName)
         verify(exactly = 2) {
-            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
-            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any())
+            mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
+            mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         }
     }
 

--- a/prime-router/src/test/kotlin/azure/FHIRFunctionsTests.kt
+++ b/prime-router/src/test/kotlin/azure/FHIRFunctionsTests.kt
@@ -8,7 +8,6 @@ import gov.cdc.prime.router.azure.observability.event.IReportStreamEventService
 import gov.cdc.prime.router.azure.observability.event.ReportStreamEventName
 import gov.cdc.prime.router.azure.observability.event.ReportStreamReportProcessingErrorEventBuilder
 import gov.cdc.prime.router.common.UniversalPipelineTestUtils
-import gov.cdc.prime.router.common.UniversalPipelineTestUtils.createFHIRFunctionsInstance
 import gov.cdc.prime.router.fhirengine.azure.FHIRFunctions
 import gov.cdc.prime.router.fhirengine.engine.FHIRConverter
 import gov.cdc.prime.router.metadata.LookupTable
@@ -87,6 +86,7 @@ class FHIRFunctionsTests {
                 any(),
                 any(),
                 any(),
+                any(),
                 capture(init)
             )
         } returns Unit
@@ -106,6 +106,7 @@ class FHIRFunctionsTests {
                 any<ReportFile>(),
                 TaskAction.convert,
                 "Error",
+                any(),
                 any(),
                 init.captured
             )

--- a/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
@@ -219,7 +219,14 @@ class SendFunctionTests {
         mockkConstructor(ActionHistory::class)
         mockkConstructor(ReportStreamEventService::class)
         every {
-            anyConstructed<ReportStreamEventService>().sendReportEvent(any(), any<ReportFile>(), any(), any(), any())
+            anyConstructed<ReportStreamEventService>().sendReportEvent(
+                any(),
+                any<ReportFile>(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
         } returns Unit
 
         every { anyConstructed<ActionHistory>().setActionType(TaskAction.send_error) } returns Unit
@@ -246,7 +253,7 @@ class SendFunctionTests {
                 ReportStreamEventName.ITEM_LAST_MILE_FAILURE, any(), any(), any(), any(), any(), any(), any(), any()
             )
             anyConstructed<ReportStreamEventService>().sendReportEvent(
-                ReportStreamEventName.REPORT_LAST_MILE_FAILURE, any<ReportFile>(), any(), any(), any()
+                ReportStreamEventName.REPORT_LAST_MILE_FAILURE, any<ReportFile>(), any(), any(), any(), any()
             )
         }
     }

--- a/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
+++ b/prime-router/src/test/kotlin/azure/SendFunctionTests.kt
@@ -131,7 +131,9 @@ class SendFunctionTests {
             val header = makeIgnoreDotCSVHeader()
             nextEvent = block(header, null, null)
         }
-        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }.returns(null)
+        every {
+            sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }.returns(null)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.azureEventService.trackEvent(any()) }.returns(Unit)
         every { workflowEngine.reportService.getRootReports(any()) } returns reportList
@@ -161,7 +163,9 @@ class SendFunctionTests {
             val header = makeIgnoreDotHL7NullHeader()
             nextEvent = block(header, null, null)
         }
-        every { nullTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }.returns(null)
+        every {
+            nullTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }.returns(null)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.azureEventService.trackEvent(any()) }.returns(Unit)
         every { workflowEngine.reportService.getRootReports(any()) } returns reportList
@@ -174,7 +178,7 @@ class SendFunctionTests {
         SendFunction(workflowEngine).run(event.toQueueMessage(), context)
 
         // Verify
-        verify { nullTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify { nullTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
         verify { workflowEngine.recordAction(match { it.action.actionName == TaskAction.send }) }
         assertThat(nextEvent).isNotNull()
         assertThat(nextEvent!!.eventAction).isEqualTo(Event.EventAction.NONE)
@@ -193,7 +197,9 @@ class SendFunctionTests {
             val header = makeIgnoreDotCSVHeader()
             nextEvent = block(header, null, null)
         }
-        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }.returns(null)
+        every {
+            sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }.returns(null)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.azureEventService.trackEvent(any()) }.returns(Unit)
         every { workflowEngine.reportService.getRootReports(any()) } returns reportList
@@ -238,7 +244,7 @@ class SendFunctionTests {
         }
         setupWorkflow()
         every {
-            sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }.returns(RetryToken.allItems)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.db } returns mockk<DatabaseAccess>(relaxed = true)
@@ -272,7 +278,7 @@ class SendFunctionTests {
             nextEvent = block(header, null, null)
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             .returns(RetryToken.allItems)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.db } returns mockk<DatabaseAccess>()
@@ -306,7 +312,7 @@ class SendFunctionTests {
             )
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             .returns(RetryToken.allItems)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.db } returns mockk<DatabaseAccess>()
@@ -343,7 +349,7 @@ class SendFunctionTests {
             )
         }
         setupWorkflow()
-        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+        every { sftpTransport.send(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
             .returns(RetryToken.allItems)
         every { workflowEngine.recordAction(any()) }.returns(Unit)
         every { workflowEngine.db } returns mockk<DatabaseAccess>(relaxed = true)

--- a/prime-router/src/test/kotlin/azure/observability/context/MDCUtilsTest.kt
+++ b/prime-router/src/test/kotlin/azure/observability/context/MDCUtilsTest.kt
@@ -95,6 +95,7 @@ class MDCUtilsTest {
                 "",
                 TaskAction.send,
                 OffsetDateTime.now(),
+                "",
                 ""
             ),
             mapOf(
@@ -123,6 +124,7 @@ class MDCUtilsTest {
                 "",
                 TaskAction.send,
                 OffsetDateTime.now(),
+                "",
                 ""
             ),
             ItemEventData(

--- a/prime-router/src/test/kotlin/azure/observability/event/ReportEventServiceTest.kt
+++ b/prime-router/src/test/kotlin/azure/observability/event/ReportEventServiceTest.kt
@@ -95,7 +95,8 @@ class ReportEventServiceTest {
                 "",
                 TaskAction.send,
                 OffsetDateTime.now(),
-                Version.commitId
+                Version.commitId,
+                ""
             ),
                 ReportEventData::timestamp
         )
@@ -139,7 +140,8 @@ class ReportEventServiceTest {
                 "",
                 TaskAction.send,
                 OffsetDateTime.now(),
-                Version.commitId
+                Version.commitId,
+                ""
             ),
                 ReportEventData::timestamp
         )

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRConverterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRConverterIntegrationTests.kt
@@ -485,7 +485,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    appendMessageQueueName(queueMessage, "elr-fhir-convert-submission")
+                    appendMessageQueueName(queueMessage, QueueMessage.Companion.elrSubmissionConvertQueueName)
                 ),
                 ReportEventData::timestamp
             )
@@ -653,7 +653,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    appendMessageQueueName(queueMessage, "elr-fhir-convert")
+                    appendMessageQueueName(queueMessage, QueueMessage.Companion.elrConvertQueueName)
                 ),
                 ReportEventData::timestamp
             )
@@ -841,7 +841,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    appendMessageQueueName(queueMessage, "elr-fhir-convert")
+                    appendMessageQueueName(queueMessage, QueueMessage.Companion.elrConvertQueueName)
                 ),
                 ReportEventData::timestamp
             )
@@ -979,7 +979,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    appendMessageQueueName(queueMessage, "elr-fhir-convert")
+                    appendMessageQueueName(queueMessage, QueueMessage.Companion.elrConvertQueueName)
                 ),
                 ReportEventData::timestamp
             )

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRConverterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRConverterIntegrationTests.kt
@@ -166,15 +166,15 @@ class FHIRConverterIntegrationTests {
         sender: Sender,
     ): String = """
         {
-            "type": "convert",
-            "reportId": "${report.id}",
-            "blobURL": "${report.bodyURL}",
-            "digest": "${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
-            "blobSubFolderName": "${sender.fullName}",
-            "topic": "${sender.topic.jsonVal}",
-            "schemaName": "${sender.schemaName}"
+        "type":"convert",
+        "reportId":"${report.id}",
+        "blobURL":"${report.bodyURL}",
+        "digest":"${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
+        "blobSubFolderName":"${sender.fullName}",
+        "topic":"${sender.topic.jsonVal}",
+        "schemaName":"${sender.schemaName}"
         }
-    """.trimIndent()
+        """.trimIndent().replace("\n", "")
 
     private fun generateFHIRConvertSubmissionQueueMessage(
         report: Report,
@@ -184,20 +184,25 @@ class FHIRConverterIntegrationTests {
         // TODO: something is wrong with the Jackson configuration as it should not require the type to parse this
         val headers = mapOf("client_id" to sender.fullName)
         val headersStringMap = headers.entries.joinToString(separator = ",\n") { (key, value) ->
-            """"$key": "$value""""
+            """"$key":"$value""""
         }
         val headersString = "[\"java.util.LinkedHashMap\",{$headersStringMap}]"
         return """
         {
-            "type": "receive-fhir",
-            "reportId": "${report.id}",
-            "blobURL": "${report.bodyURL}",
-            "digest": "${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
-            "blobSubFolderName": "${sender.fullName}",
-            "headers":$headersString
+        "type":"receive",
+        "reportId":"${report.id}",
+        "blobURL":"${report.bodyURL}",
+        "digest":"${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
+        "blobSubFolderName":"${sender.fullName}",
+        "headers":$headersString
         }
-    """.trimIndent()
+        """.trimIndent().replace("\n", "")
     }
+
+    private fun appendMessageQueueName(
+        queueMessage: String,
+        messageQueueName: String,
+    ): String = queueMessage.substringBeforeLast("}") + ",\"messageQueueName\":\"$messageQueueName\"}"
 
     @BeforeEach
     fun beforeEach() {
@@ -480,7 +485,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendMessageQueueName(queueMessage, "elr-fhir-convert-submission")
                 ),
                 ReportEventData::timestamp
             )
@@ -648,7 +653,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendMessageQueueName(queueMessage, "elr-fhir-convert")
                 ),
                 ReportEventData::timestamp
             )
@@ -836,7 +841,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendMessageQueueName(queueMessage, "elr-fhir-convert")
                 ),
                 ReportEventData::timestamp
             )
@@ -974,7 +979,7 @@ class FHIRConverterIntegrationTests {
                     TaskAction.convert,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendMessageQueueName(queueMessage, "elr-fhir-convert")
                 ),
                 ReportEventData::timestamp
             )

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRConverterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRConverterIntegrationTests.kt
@@ -479,7 +479,8 @@ class FHIRConverterIntegrationTests {
                     routedReports[1].bodyUrl,
                     TaskAction.convert,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp
             )
@@ -646,7 +647,8 @@ class FHIRConverterIntegrationTests {
                     routedReports[1].bodyUrl,
                     TaskAction.convert,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp
             )
@@ -833,7 +835,8 @@ class FHIRConverterIntegrationTests {
                     routedReports[1].bodyUrl,
                     TaskAction.convert,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp
             )
@@ -970,7 +973,8 @@ class FHIRConverterIntegrationTests {
                     "",
                     TaskAction.convert,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp
             )

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
@@ -148,7 +148,7 @@ class FHIRDestinationFilterIntegrationTests : Logging {
     private fun appendTestMessage(
         queueMessage: String,
     ): String = queueMessage.replace(",\"schemaName\":\"\"", "").substringBeforeLast("}") +
-            ",\"messageQueueName\":\"elr-fhir-destination-filter\"}"
+            ",\"messageQueueName\":\"${QueueMessage.Companion.elrDestinationFilterQueueName}\"}"
 
     @Test
     fun `should send valid FHIR report only to receivers listening to full-elr`() {

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRDestinationFilterIntegrationTests.kt
@@ -358,7 +358,8 @@ class FHIRDestinationFilterIntegrationTests : Logging {
                     routedReport.bodyUrl,
                     TaskAction.destination_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp
             )
@@ -465,7 +466,8 @@ class FHIRDestinationFilterIntegrationTests : Logging {
                 "",
                 TaskAction.destination_filter,
                 OffsetDateTime.now(),
-                Version.commitId
+                Version.commitId,
+                queueMessage
             ),
             ReportEventData::timestamp,
             ReportEventData::childReportId

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRReceiverFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRReceiverFilterIntegrationTests.kt
@@ -399,7 +399,8 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     "",
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp,
             )
@@ -581,7 +582,8 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     "",
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp,
             )
@@ -776,7 +778,8 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     "",
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp,
             )
@@ -915,7 +918,8 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     "",
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp,
             )
@@ -1201,7 +1205,8 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     "",
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    queueMessage
                 ),
                 ReportEventData::timestamp,
             )

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRReceiverFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRReceiverFilterIntegrationTests.kt
@@ -247,7 +247,7 @@ class FHIRReceiverFilterIntegrationTests : Logging {
     private fun appendTestMessage(
         queueMessage: String,
     ): String = queueMessage.substringBeforeLast("}") +
-            ",\"messageQueueName\":\"elr-fhir-receiver-filter\"}"
+            ",\"messageQueueName\":\"${QueueMessage.Companion.elrReceiverFilterQueueName}\"}"
 
     @Test
     fun `should send valid FHIR report filtered by condition filter`() {

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRReceiverFilterIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRReceiverFilterIntegrationTests.kt
@@ -227,22 +227,27 @@ class FHIRReceiverFilterIntegrationTests : Logging {
         )
     }
 
-    fun generateQueueMessage(
+    private fun generateQueueMessage(
         report: Report,
         blobContents: String,
         sender: Sender,
         receiverName: String,
     ): String = """
-            {
-                "type": "${TaskAction.receiver_filter.literal}",
-                "reportId": "${report.id}",
-                "blobURL": "${report.bodyURL}",
-                "digest": "${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
-                "blobSubFolderName": "${sender.fullName}",
-                "topic": "${sender.topic.jsonVal}",
-                "receiverFullName": "$receiverName" 
-            }
-        """.trimIndent()
+        {
+        "type":"${TaskAction.receiver_filter.literal}",
+        "reportId":"${report.id}",
+        "blobURL":"${report.bodyURL}",
+        "digest":"${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
+        "blobSubFolderName":"${sender.fullName}",
+        "topic":"${sender.topic.jsonVal}",
+        "receiverFullName":"$receiverName"
+        }
+        """.trimIndent().replace("\n", "")
+
+    private fun appendTestMessage(
+        queueMessage: String,
+    ): String = queueMessage.substringBeforeLast("}") +
+            ",\"messageQueueName\":\"elr-fhir-receiver-filter\"}"
 
     @Test
     fun `should send valid FHIR report filtered by condition filter`() {
@@ -400,7 +405,7 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendTestMessage(queueMessage)
                 ),
                 ReportEventData::timestamp,
             )
@@ -583,7 +588,7 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendTestMessage(queueMessage)
                 ),
                 ReportEventData::timestamp,
             )
@@ -779,7 +784,7 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendTestMessage(queueMessage)
                 ),
                 ReportEventData::timestamp,
             )
@@ -919,7 +924,7 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendTestMessage(queueMessage)
                 ),
                 ReportEventData::timestamp,
             )
@@ -1206,7 +1211,7 @@ class FHIRReceiverFilterIntegrationTests : Logging {
                     TaskAction.receiver_filter,
                     OffsetDateTime.now(),
                     Version.commitId,
-                    queueMessage
+                    appendTestMessage(queueMessage)
                 ),
                 ReportEventData::timestamp,
             )

--- a/prime-router/src/test/kotlin/fhirengine/azure/FHIRTranslatorIntegrationTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/azure/FHIRTranslatorIntegrationTests.kt
@@ -125,16 +125,16 @@ class FHIRTranslatorIntegrationTests : Logging {
         sender: Sender,
         receiverName: String,
     ): String = """
-            {
-                "type": "${TaskAction.translate.literal}",
-                "reportId": "${report.id}",
-                "blobURL": "${report.bodyURL}",
-                "digest": "${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
-                "blobSubFolderName": "${sender.fullName}",
-                "topic": "${sender.topic.jsonVal}",
-                "receiverFullName": "$receiverName" 
-            }
-        """.trimIndent()
+        {
+        "type":"${TaskAction.translate.literal}",
+        "reportId":"${report.id}",
+        "blobURL":"${report.bodyURL}",
+        "digest":"${BlobUtils.digestToString(BlobUtils.sha256Digest(blobContents.toByteArray()))}",
+        "blobSubFolderName":"${sender.fullName}",
+        "topic":"${sender.topic.jsonVal}",
+        "receiverFullName":"$receiverName" 
+        }
+        """.trimIndent().replace("\n", "")
 
     @Test
     fun `successfully translate for HL7 receiver when isSendOriginal is false`() {

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirConverterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirConverterTests.kt
@@ -733,7 +733,7 @@ class FhirConverterTests {
         @Test
         fun `should log an error and return no bundles if the message is empty`() {
             mockkObject(BlobAccess)
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "", "")
             val engine = spyk(makeFhirEngine(metadata, settings, TaskAction.process) as FHIRConverter)
             val actionLogger = ActionLogger()
             every { BlobAccess.downloadBlob(any(), any()) } returns ""
@@ -759,7 +759,15 @@ class FhirConverterTests {
             every { mockMessage.topic } returns Topic.FULL_ELR
             every { mockMessage.reportId } returns UUID.randomUUID()
             every { BlobAccess.downloadBlob(any(), any()) } returns simpleHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val bundles = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(bundles).isEmpty()
             assertThat(
@@ -775,7 +783,7 @@ class FhirConverterTests {
             val engine = spyk(makeFhirEngine(metadata, settings, TaskAction.process) as FHIRConverter)
             val actionLogger = ActionLogger()
             every { BlobAccess.downloadBlob(any(), any()) } returns "test,1,2"
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "", "")
             val bundles = engine.process(MimeFormat.CSV, input, actionLogger)
             assertThat(bundles).isEmpty()
             assertThat(actionLogger.errors.map { it.detail.message })
@@ -788,7 +796,7 @@ class FhirConverterTests {
             val engine = spyk(makeFhirEngine(metadata, settings, TaskAction.process) as FHIRConverter)
             val actionLogger = ActionLogger()
             every { BlobAccess.downloadBlob(any(), any()) } returns "{\"id\":}"
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "", "")
             val processedItems = engine.process(MimeFormat.FHIR, input, actionLogger)
             assertThat(processedItems).hasSize(1)
             assertThat(processedItems.first().bundle).isNull()
@@ -819,7 +827,15 @@ class FhirConverterTests {
             every { mockMessage.topic } returns Topic.FULL_ELR
             every { mockMessage.reportId } returns UUID.randomUUID()
             every { BlobAccess.downloadBlob(any(), any()) } returns "{\"id\":\"1\", \"resourceType\":\"Bundle\"}"
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val processedItems = engine.process(MimeFormat.FHIR, input, actionLogger)
             assertThat(processedItems).hasSize(1)
             assertThat(processedItems.first().bundle).isNull()
@@ -839,7 +855,15 @@ class FhirConverterTests {
             every {
                 BlobAccess.downloadBlob(any(), any())
             } returns unparseableHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val processedItems = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(processedItems).hasSize(1)
             assertThat(processedItems.first().bundle).isNull()
@@ -875,7 +899,15 @@ class FhirConverterTests {
             every {
                 BlobAccess.downloadBlob(any(), any())
             } returns simpleHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val processedItems = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(processedItems).hasSize(1)
             assertThat(processedItems.first().bundle).isNull()
@@ -905,7 +937,15 @@ class FhirConverterTests {
             every {
                 BlobAccess.downloadBlob(any(), any())
             } returns simpleHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val processedItems = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(processedItems).hasSize(1)
             assertThat(processedItems.first().bundle).isNull()
@@ -932,7 +972,15 @@ class FhirConverterTests {
             } returns """{\"id\":}
                 {"id":"1", "resourceType":"Bundle"}
             """.trimMargin()
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val processedItems = engine.process(MimeFormat.FHIR, input, actionLogger)
             assertThat(processedItems).hasSize(2)
             assertThat(actionLogger.errors.map { it.detail.message }).contains(
@@ -960,7 +1008,15 @@ class FhirConverterTests {
             every {
                 BlobAccess.downloadBlob(any(), any())
             } returns simpleHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val bundles = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(bundles).hasSize(1)
             assertThat(actionLogger.errors).isEmpty()
@@ -981,7 +1037,15 @@ class FhirConverterTests {
             every {
                 BlobAccess.downloadBlob(any(), any())
             } returns simpleHL7 + "\n" + simpleHL7 + "\n" + simpleHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val bundles = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(bundles).hasSize(3)
             assertThat(actionLogger.errors).isEmpty()
@@ -1003,7 +1067,15 @@ class FhirConverterTests {
             every {
                 BlobAccess.downloadBlob(any(), any())
             } returns simpleHL7
-            val input = FHIRConverter.FHIRConvertInput(UUID.randomUUID(), Topic.FULL_ELR, "", "", "", "")
+            val input = FHIRConverter.FHIRConvertInput(
+                UUID.randomUUID(),
+                Topic.FULL_ELR,
+                "",
+                "",
+                "",
+                "",
+                mockMessage.toString()
+            )
             val bundles = engine.process(MimeFormat.HL7, input, actionLogger)
             assertThat(bundles).hasSize(1)
             assertThat(actionLogger.errors).isEmpty()

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirDestinationFilterTests.kt
@@ -339,7 +339,8 @@ class FhirDestinationFilterTests {
                     "test",
                     TaskAction.destination_filter,
                     OffsetDateTime.now(),
-                    Version.commitId
+                    Version.commitId,
+                    message.toString()
                 ),
                 ReportEventData::timestamp,
             )
@@ -518,7 +519,8 @@ class FhirDestinationFilterTests {
                         "",
                         TaskAction.destination_filter,
                         OffsetDateTime.now(),
-                        Version.commitId
+                        Version.commitId,
+                        message.toString()
                     ),
                     ReportEventData::timestamp
                 )

--- a/prime-router/src/test/kotlin/fhirengine/engine/FhirTranslatorTests.kt
+++ b/prime-router/src/test/kotlin/fhirengine/engine/FhirTranslatorTests.kt
@@ -168,7 +168,7 @@ class FhirTranslatorTests {
         every { reportServiceMock.getRootReports(any()) } returns listOf(rootReport)
         every { reportServiceMock.getRootItemIndex(any(), any()) } returns 1
         every { BlobAccess.downloadBlobAsByteArray(any()) } returns "1".toByteArray(Charsets.UTF_8)
-        every { reportStreamEventService.sendItemEvent(any(), any<Report>(), any(), any(), any()) } returns Unit
+        every { reportStreamEventService.sendItemEvent(any(), any<Report>(), any(), any(), any(), any()) } returns Unit
 
         // act
         accessSpy.transact { txn ->
@@ -182,7 +182,7 @@ class FhirTranslatorTests {
             BlobAccess.Companion.uploadBlob(any(), any(), any())
             accessSpy.insertTask(any(), any(), any(), any(), any())
             actionHistory.trackActionReceiverInfo(any(), any())
-            reportStreamEventService.sendItemEvent(any(), any<Report>(), any(), any(), any())
+            reportStreamEventService.sendItemEvent(any(), any<Report>(), any(), any(), any(), any())
         }
     }
 
@@ -335,7 +335,7 @@ class FhirTranslatorTests {
         every { reportServiceMock.getRootReport(any()) } returns rootReport
         every { reportServiceMock.getRootReports(any()) } returns listOf(rootReport)
         every { reportServiceMock.getRootItemIndex(any(), any()) } returns 1
-        every { reportStreamEventService.sendItemEvent(any(), any<Report>(), any(), any(), any()) } returns Unit
+        every { reportStreamEventService.sendItemEvent(any(), any<Report>(), any(), any(), any(), any()) } returns Unit
 
         // act
         accessSpy.transact { txn ->

--- a/prime-router/src/testIntegration/kotlin/transport/AS2TransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/AS2TransportIntegrationTests.kt
@@ -128,7 +128,8 @@ class AS2TransportIntegrationTests {
                 actionHistory,
                 mockk<IReportStreamEventService>(relaxed = true),
                 mockk<ReportService>(relaxed = true),
-                listOf()
+                listOf(),
+                ""
             )
 
         assertThat(retryItems).isNull()
@@ -156,7 +157,8 @@ class AS2TransportIntegrationTests {
                 actionHistory,
                 mockk<IReportStreamEventService>(relaxed = true),
                 mockk<ReportService>(relaxed = true),
-                listOf()
+                listOf(),
+                "testQueue"
             )
 
         assertThat(retryItems).isSameInstanceAs(RetryToken.allItems)

--- a/prime-router/src/testIntegration/kotlin/transport/GAENTransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/GAENTransportIntegrationTests.kt
@@ -145,7 +145,8 @@ class GAENTransportIntegrationTests : TransportIntegrationTests() {
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         assertThat(retryItems).isNull()
@@ -179,7 +180,8 @@ class GAENTransportIntegrationTests : TransportIntegrationTests() {
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         assertThat(RetryToken.isAllItems(retryItems)).isTrue()
@@ -213,7 +215,8 @@ class GAENTransportIntegrationTests : TransportIntegrationTests() {
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         assertThat(retryItems).isNull()
@@ -248,7 +251,8 @@ class GAENTransportIntegrationTests : TransportIntegrationTests() {
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         assertThat(retryItems).isNull()

--- a/prime-router/src/testIntegration/kotlin/transport/RESTTransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/RESTTransportIntegrationTests.kt
@@ -318,7 +318,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -346,7 +347,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -372,7 +374,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -398,7 +401,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -424,7 +428,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNotNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -450,7 +455,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -476,7 +482,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -502,7 +509,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNotNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -528,7 +536,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNotNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -554,7 +563,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNotNull()
         assertThat(actionHistory.action.httpStatus).isNotNull()
@@ -577,7 +587,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNotNull()
     }
@@ -609,7 +620,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:
@@ -650,7 +662,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:
@@ -685,7 +698,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
     }
@@ -711,7 +725,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
     }
@@ -763,7 +778,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:
@@ -797,7 +813,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
     }
@@ -841,7 +858,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:
@@ -898,7 +916,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         assertThat(retryItems).isNull()
@@ -935,7 +954,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:
@@ -976,7 +996,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
     }
@@ -1037,7 +1058,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
     }
@@ -1092,7 +1114,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:
@@ -1145,7 +1168,8 @@ hnm8COa8Kr+bnTqzScpQuOfujHcFEtfcYUGfSS6HusxidwXx+lYi1A==
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // Then:

--- a/prime-router/src/testIntegration/kotlin/transport/SftpTransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/SftpTransportIntegrationTests.kt
@@ -179,7 +179,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // successful SFTP upload
@@ -222,7 +223,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // successful SFTP upload
@@ -265,7 +267,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // successful SFTP upload
@@ -291,7 +294,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // asserts that the initial null check works
@@ -324,7 +328,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // asserts that missing credentials will fail SFTP
@@ -365,7 +370,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // asserts that authentication error will result in error
@@ -399,7 +405,8 @@ class SftpTransportIntegrationTests : TransportIntegrationTests() {
             f.actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
 
         // asserts that invalid credential types will result in error

--- a/prime-router/src/testIntegration/kotlin/transport/SoapTransportIntegrationTests.kt
+++ b/prime-router/src/testIntegration/kotlin/transport/SoapTransportIntegrationTests.kt
@@ -131,7 +131,8 @@ class SoapTransportIntegrationTests : TransportIntegrationTests() {
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNull()
     }
@@ -153,7 +154,8 @@ class SoapTransportIntegrationTests : TransportIntegrationTests() {
             actionHistory,
             mockk<IReportStreamEventService>(relaxed = true),
             mockk<ReportService>(relaxed = true),
-            listOf()
+            listOf(),
+            ""
         )
         assertThat(retryItems).isNotNull()
     }

--- a/shared/src/main/kotlin/gov/cdc/prime/reportstream/shared/auth/AuthZService.kt
+++ b/shared/src/main/kotlin/gov/cdc/prime/reportstream/shared/auth/AuthZService.kt
@@ -1,6 +1,5 @@
 package gov.cdc.prime.reportstream.shared.auth
 
-import gov.cdc.prime.reportstream.shared.auth.jwt.OktaGroupsJWTConstants
 import gov.cdc.prime.reportstream.shared.auth.jwt.OktaGroupsJWTReader
 
 /**

--- a/shared/src/test/kotlin/gov/cdc/prime/reportstream/shared/auth/AuthZServiceTest.kt
+++ b/shared/src/test/kotlin/gov/cdc/prime/reportstream/shared/auth/AuthZServiceTest.kt
@@ -1,8 +1,6 @@
 package gov.cdc.prime.reportstream.shared.auth
 
-import gov.cdc.prime.reportstream.shared.auth.jwt.OktaGroupsJWT
 import gov.cdc.prime.reportstream.shared.auth.jwt.OktaGroupsJWTReader
-import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -43,5 +41,4 @@ class AuthZServiceTest {
             false
         )
     }
-
 }


### PR DESCRIPTION
This PR updates Azure events to emit the Azure queue message when available.

Test Steps:
1. Search the logs in `pdhtest-appinsights` to look for `ITEM_TRANSFORMED` or `ITEM_NOT_ROUTED` events to see samples of queue messages being included.

## Changes
- Structure of Azure events changed to include `queueMessage` as a top level item within `customDimensions`.
- Various pipeline steps adjusted to emit queueMessage when available.
- Adjustments to allow serialization of queue messages.

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [x] Added tests?

## Linked Issues
- Fixes #17343