### PR TITLE
Revert "16059 Removed skip from last mile failure test"

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
@@ -83,7 +83,8 @@ test.describe("Last Mile Failure page",
             await expect(modal).toContainText(`Report ID:${reportIdCell}`);
         });
 
-        test("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage }) => {
+        test.skip("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage, isMockDisabled }) => {
+            test.skip(!isMockDisabled, "Mocks are ENABLED, skipping test");
             const receiver = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(2);
             const receiverCell = await receiver.getByRole("link").innerText();
             const orgName = receiverCell.slice(0,receiverCell.indexOf("."))


### PR DESCRIPTION
Reverts CDCgov/prime-reportstream#17975.
Seems like a timing issue happening on the staging server that needs to be revisited.