### PR TITLE
16059 -Unskips a last mile failures page user flow/smoke test

### DIFF
--- a/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
@@ -35,66 +35,69 @@ const test = baseTest.extend<LastMileFailuresPageFixtures>({
     },
 });
 
-test.describe("Last Mile Failure page",
+test.describe(
+    "Last Mile Failure page",
     {
         tag: "@smoke",
-    }, () => {
-    test.describe("admin user", () => {
-        test.use({ storageState: "e2e/.auth/admin.json" });
+    },
+    () => {
+        test.describe("admin user", () => {
+            test.use({ storageState: "e2e/.auth/admin.json" });
 
-        test.describe("'Filter'", () => {
-            test("table has expected data when filtering by 'ReportId'", async ({ lastMileFailuresPage }) => {
-                const reportId = await tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(1).innerText();
-                await lastMileFailuresPage.filterFormInputs.filter.input.fill(reportId);
-                const isReportIdReturned = await lastMileFailuresPage.testReportId(
-                    reportId,
+            test.describe("'Filter'", () => {
+                test("table has expected data when filtering by 'ReportId'", async ({ lastMileFailuresPage }) => {
+                    const reportId = await tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(1).innerText();
+                    await lastMileFailuresPage.filterFormInputs.filter.input.fill(reportId);
+                    const isReportIdReturned = await lastMileFailuresPage.testReportId(reportId);
+                    expect(isReportIdReturned).toBe(true);
+                });
+            });
+
+            test.describe("'Days to show' filter", () => {
+                test.beforeEach(async ({ lastMileFailuresPage }) => {
+                    await lastMileFailuresPage.filterFormInputs.daysToShow.input.fill("200");
+                    await lastMileFailuresPage.page.locator(".usa-table tbody").waitFor({ state: "visible" });
+                });
+
+                test("table has correct headers", async ({ lastMileFailuresPage }) => {
+                    await expect(lastMileFailuresPage.page.locator(".column-header-text").nth(0)).toHaveText(
+                        /Failed At/,
+                    );
+                    await expect(lastMileFailuresPage.page.locator(".column-header-text").nth(1)).toHaveText(
+                        /ReportId/,
+                    );
+                    await expect(lastMileFailuresPage.page.locator(".column-header-text").nth(2)).toHaveText(
+                        /Receiver/,
+                    );
+                });
+
+                test("table column 'Failed At' has expected data", async ({ lastMileFailuresPage, isMockDisabled }) => {
+                    test.skip(!isMockDisabled, "Mocks are ENABLED, test");
+                    const areDatesInRange = await lastMileFailuresPage.tableColumnDateTimeInRange(200);
+                    expect(areDatesInRange).toBe(true);
+                });
+            });
+
+            test("table column 'ReportId' will open a modal with report details", async ({ lastMileFailuresPage }) => {
+                const reportId = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(1);
+                const reportIdCell = await reportId.innerText();
+                await reportId.click();
+
+                const modal = lastMileFailuresPage.page.getByTestId("modalWindow").nth(0);
+                await expect(modal).toContainText(`Report ID:${reportIdCell}`);
+            });
+
+            test("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage }) => {
+                const receiver = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(2);
+                const receiverCell = await receiver.getByRole("link").innerText();
+                const orgName = receiverCell.slice(0, receiverCell.indexOf("."));
+                const receiverName = receiverCell.slice(receiverCell.indexOf(".") + 1);
+                await receiver.click();
+
+                await expect(lastMileFailuresPage.page).toHaveURL(
+                    `/admin/orgreceiversettings/org/${orgName}/receiver/${receiverName}/action/edit`,
                 );
-                expect(isReportIdReturned).toBe(true);
             });
         });
-
-        test.describe("'Days to show' filter", () => {
-            test.beforeEach(async ({ lastMileFailuresPage }) => {
-                await lastMileFailuresPage.filterFormInputs.daysToShow.input.fill("200");
-                await lastMileFailuresPage.page.locator(".usa-table tbody").waitFor({ state: "visible" });
-            });
-
-            test("table has correct headers", async ({ lastMileFailuresPage }) => {
-                await expect(lastMileFailuresPage.page.locator(".column-header-text").nth(0)).toHaveText(/Failed At/);
-                await expect(lastMileFailuresPage.page.locator(".column-header-text").nth(1)).toHaveText(/ReportId/);
-                await expect(lastMileFailuresPage.page.locator(".column-header-text").nth(2)).toHaveText(/Receiver/);
-            });
-
-            test("table column 'Failed At' has expected data", async ({ lastMileFailuresPage, isMockDisabled }) => {
-                test.skip(!isMockDisabled, "Mocks are ENABLED, test");
-                const areDatesInRange = await lastMileFailuresPage.tableColumnDateTimeInRange(
-                    200,
-                );
-                expect(areDatesInRange).toBe(true);
-            });
-        });
-
-        test("table column 'ReportId' will open a modal with report details", async ({ lastMileFailuresPage }) => {
-            const reportId = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(1);
-            const reportIdCell = await reportId.innerText();
-            await reportId.click();
-
-            const modal = lastMileFailuresPage.page.getByTestId("modalWindow").nth(0);
-            await expect(modal).toContainText(`Report ID:${reportIdCell}`);
-        });
-
-        test.skip("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage, isMockDisabled }) => {
-            test.skip(!isMockDisabled, "Mocks are ENABLED, skipping test");
-            const receiver = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(2);
-            const receiverCell = await receiver.getByRole("link").innerText();
-            const orgName = receiverCell.slice(0,receiverCell.indexOf("."))
-            const receiverName = receiverCell.slice(receiverCell.indexOf(".") + 1)
-            await receiver.click();
-
-            await expect(lastMileFailuresPage.page).toHaveURL(
-                `/admin/orgreceiversettings/org/${orgName}/receiver/${receiverName}/action/edit`,
-            );
-        });
-    });
     },
 );

--- a/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
@@ -92,7 +92,7 @@ test.describe(
                 const receiverCell = await receiver.getByRole("link").innerText();
                 const orgName = receiverCell.slice(0, receiverCell.indexOf("."));
                 const receiverName = receiverCell.slice(receiverCell.indexOf(".") + 1);
-                await receiver.click();
+                await receiver.getByRole("link").click();
 
                 await expect(lastMileFailuresPage.page).toHaveURL(
                     `/admin/orgreceiversettings/org/${orgName}/receiver/${receiverName}/action/edit`,

--- a/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
+++ b/frontend-react/e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts
@@ -87,7 +87,11 @@ test.describe(
                 await expect(modal).toContainText(`Report ID:${reportIdCell}`);
             });
 
-            test("table column 'Receiver' will open receiver edit page", async ({ lastMileFailuresPage }) => {
+            test.skip("table column 'Receiver' will open receiver edit page", async ({
+                lastMileFailuresPage,
+                isMockDisabled,
+            }) => {
+                test.skip(!isMockDisabled, "Mocks are ENABLED, skipping test");
                 const receiver = tableRows(lastMileFailuresPage.page).nth(0).locator("td").nth(2);
                 const receiverCell = await receiver.getByRole("link").innerText();
                 const orgName = receiverCell.slice(0, receiverCell.indexOf("."));


### PR DESCRIPTION
This PR ...

Unskips a last mile failures page user flow test 

Test Steps:
1. When running locally
`yarn run test:e2e-smoke e2e/spec/chromium-only/authenticated/last-mile-failures-page-user-flow.spec.ts`

## Changes
- unskipped a skipped test

## Checklist

### Testing
- [x] Tested locally?
- [ ] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [ ] Added tests?

## Linked Issues
- Fixes #16059 
