### PR TITLE
switch dnsmasq Dockerfile to wolfi to resolve cves

### DIFF
--- a/operations/dnsmasq/Dockerfile
+++ b/operations/dnsmasq/Dockerfile
@@ -1,20 +1,14 @@
-FROM ubuntu:24.04
+FROM cgr.dev/chainguard/wolfi-base:latest
 
-# Latest patches
-RUN apt-get update && apt-get upgrade -y
 
-# Install dnsmasq and explicitly update perl to the patched version
-RUN apt-get install -y dnsmasq perl=5.38.2-3.2ubuntu0.1
+RUN apk update && \
+    apk add --no-cache dnsmasq
 
 # Expose the DNS port
 EXPOSE 53/udp
 
-# Place the environment's config in the config directory
 ARG AZ_ENV
 COPY config /tmp/config
-RUN cp -r /tmp/config/${AZ_ENV}/. /etc/dnsmasq.d/
-
-# Remove the unused configs
-RUN rm -r /tmp/config
+RUN cp -r /tmp/config/${AZ_ENV}/. /etc/dnsmasq.d/ && rm -r /tmp/config
 
 ENTRYPOINT ["dnsmasq", "-k"]


### PR DESCRIPTION
This PR resolves CVEs baked into ubuntu

> DOCKER_HOST=unix:///Users/matts/.docker/run/docker.sock trivy image --severity=HIGH,CRITICAL,MEDIUM,LOW --ignore-unfixed dnsmasq:matts-3
> 
> 2025-05-07T15:08:26-07:00       INFO    [vuln] Vulnerability scanning is enabled
> 2025-05-07T15:08:26-07:00       INFO    [secret] Secret scanning is enabled
> 2025-05-07T15:08:26-07:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
> 2025-05-07T15:08:26-07:00       INFO    [secret] Please see also https://trivy.dev/v0.61/docs/scanner/secret#recommendation for faster secret detection
> 2025-05-07T15:08:26-07:00       INFO    Detected OS     family="wolfi" version="20230201"
> 2025-05-07T15:08:26-07:00       INFO    [wolfi] Detecting vulnerabilities...    pkg_num=16
> 2025-05-07T15:08:26-07:00       INFO    Number of language-specific files       num=0
> 
> Report Summary
> 
> ┌──────────────────────────────────┬───────┬─────────────────┬─────────┐
> │              Target              │ Type  │ Vulnerabilities │ Secrets │
> ├──────────────────────────────────┼───────┼─────────────────┼─────────┤
> │ dnsmasq:matts-3 (wolfi 20230201) │ wolfi │        0        │    -    │
> └──────────────────────────────────┴───────┴─────────────────┴─────────┘
> Legend:
> - '-': Not scanned
> - '0': Clean (no security findings detected)
> 