### PR TITLE
13598 address database varchar size limits

### DIFF
--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -19,7 +19,6 @@ import gov.cdc.prime.router.ReportId
 import gov.cdc.prime.router.Sender
 import gov.cdc.prime.router.Topic
 import gov.cdc.prime.router.azure.ActionHistory.ReceivedReportSenderParameters.Companion.removeExcludedParameters
-import gov.cdc.prime.router.azure.db.Tables.ACTION
 import gov.cdc.prime.router.azure.db.enums.TaskAction
 import gov.cdc.prime.router.azure.db.tables.pojos.Action
 import gov.cdc.prime.router.azure.db.tables.pojos.CovidResultMetadata
@@ -303,30 +302,24 @@ class ActionHistory(
      */
     fun trackActionParams(actionParams: String) {
         if (actionParams.isEmpty()) return
-        val tmp = if (action.actionParams.isNullOrBlank()) actionParams else "${action.actionParams}, $actionParams"
-        // truncate if data is longer than maximum length of db column
-        val max = ACTION.ACTION_PARAMS.dataType.length()
-        // truncate if needed
-        action.actionParams = if (max > 0) {
-            tmp.take(max)
-        } else {
-            tmp
-        }
+        action.actionParams =
+            if (action.actionParams.isNullOrBlank()) {
+                actionParams
+            } else {
+                "${action.actionParams}, $actionParams"
+            }
     }
 
     /**
      * Always appends
      */
     fun trackActionResult(actionResult: String) {
-        val tmp = if (action.actionResult.isNullOrBlank()) actionResult else "${action.actionResult}, $actionResult"
-        // truncate if data is longer than maximum length of db column
-        val max = ACTION.ACTION_RESULT.dataType.length()
-        // truncate if needed
-        action.actionResult = if (max > 0) {
-            tmp.take(max)
-        } else {
-            tmp
-        }
+        action.actionResult =
+            if (action.actionResult.isNullOrBlank()) {
+                actionResult
+            } else {
+                "${action.actionResult}, $actionResult"
+            }
     }
 
     /**
@@ -368,16 +361,8 @@ class ActionHistory(
         if (clientParam.isNotBlank()) {
             try {
                 val (sendingOrg, sendingOrgClient) = Sender.parseFullName(clientParam)
-                action.sendingOrg = if (ACTION.SENDING_ORG.dataType.length() > 0) {
-                    sendingOrg.take(ACTION.SENDING_ORG.dataType.length())
-                } else {
-                    sendingOrg
-                }
-                action.sendingOrgClient = if (ACTION.SENDING_ORG_CLIENT.dataType.length() > 0) {
-                    sendingOrgClient.take(ACTION.SENDING_ORG_CLIENT.dataType.length())
-                } else {
-                    sendingOrgClient
-                }
+                action.sendingOrg = sendingOrg
+                action.sendingOrgClient = sendingOrgClient
             } catch (e: Exception) {
                 logger.warn(
                     "Exception tracking sender: ${e.localizedMessage} ${e.stackTraceToString()}"

--- a/prime-router/src/main/kotlin/azure/ActionHistory.kt
+++ b/prime-router/src/main/kotlin/azure/ActionHistory.kt
@@ -40,9 +40,6 @@ import gov.cdc.prime.router.fhirengine.utils.FhirTranscoder
 import gov.cdc.prime.router.report.ReportService
 import io.ktor.http.HttpStatusCode
 import org.apache.logging.log4j.kotlin.Logging
-import org.jooq.impl.SQLDataType
-import java.net.URI
-import java.net.URISyntaxException
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
@@ -307,10 +304,14 @@ class ActionHistory(
     fun trackActionParams(actionParams: String) {
         if (actionParams.isEmpty()) return
         val tmp = if (action.actionParams.isNullOrBlank()) actionParams else "${action.actionParams}, $actionParams"
-        // kluge to get the max size of the varchar
+        // truncate if data is longer than maximum length of db column
         val max = ACTION.ACTION_PARAMS.dataType.length()
         // truncate if needed
-        action.actionParams = tmp.chunked(size = max)[0]
+        action.actionParams = if (max > 0) {
+            tmp.take(max)
+        } else {
+            tmp
+        }
     }
 
     /**
@@ -318,13 +319,13 @@ class ActionHistory(
      */
     fun trackActionResult(actionResult: String) {
         val tmp = if (action.actionResult.isNullOrBlank()) actionResult else "${action.actionResult}, $actionResult"
+        // truncate if data is longer than maximum length of db column
         val max = ACTION.ACTION_RESULT.dataType.length()
-        // max is 0 for the CLOB type. we're using CLOB for the action_result now because we want
-        // bigly strings, not just small sad 2048 strings
-        action.actionResult = if (ACTION.ACTION_RESULT.dataType == SQLDataType.CLOB && max == 0) {
-            tmp
+        // truncate if needed
+        action.actionResult = if (max > 0) {
+            tmp.take(max)
         } else {
-            tmp.chunked(size = max)[0]
+            tmp
         }
     }
 
@@ -367,8 +368,16 @@ class ActionHistory(
         if (clientParam.isNotBlank()) {
             try {
                 val (sendingOrg, sendingOrgClient) = Sender.parseFullName(clientParam)
-                action.sendingOrg = sendingOrg.take(ACTION.SENDING_ORG.dataType.length())
-                action.sendingOrgClient = sendingOrgClient.take(ACTION.SENDING_ORG_CLIENT.dataType.length())
+                action.sendingOrg = if (ACTION.SENDING_ORG.dataType.length() > 0) {
+                    sendingOrg.take(ACTION.SENDING_ORG.dataType.length())
+                } else {
+                    sendingOrg
+                }
+                action.sendingOrgClient = if (ACTION.SENDING_ORG_CLIENT.dataType.length() > 0) {
+                    sendingOrgClient.take(ACTION.SENDING_ORG_CLIENT.dataType.length())
+                } else {
+                    sendingOrgClient
+                }
             } catch (e: Exception) {
                 logger.warn(
                     "Exception tracking sender: ${e.localizedMessage} ${e.stackTraceToString()}"
@@ -436,7 +445,7 @@ class ActionHistory(
         reportFile.nextAction = report.nextAction
         reportFile.sendingOrg = source.organization
         reportFile.sendingOrgClient = source.client
-        reportFile.schemaName = trimSchemaNameToMaxLength(report.schema.name)
+        reportFile.schemaName = report.schema.name
         reportFile.schemaTopic = report.schema.topic
         reportFile.bodyUrl = blobInfo.blobUrl
         reportFile.bodyFormat = blobInfo.format.toString()
@@ -488,7 +497,7 @@ class ActionHistory(
         reportFile.nextAction = TaskAction.send
         reportFile.receivingOrg = receiver.organizationName
         reportFile.receivingOrgSvc = receiver.name
-        reportFile.schemaName = trimSchemaNameToMaxLength(report.schema.name)
+        reportFile.schemaName = report.schema.name
         reportFile.schemaTopic = report.schema.topic
         reportFile.bodyUrl = blobInfo.blobUrl
         reportFile.bodyFormat = blobInfo.format.toString()
@@ -521,7 +530,7 @@ class ActionHistory(
         reportFile.reportId = report.id
         reportFile.receivingOrg = receiver.organizationName
         reportFile.receivingOrgSvc = receiver.name
-        reportFile.schemaName = trimSchemaNameToMaxLength(report.schema.name)
+        reportFile.schemaName = report.schema.name
         reportFile.schemaTopic = report.schema.topic
         reportFile.itemCount = report.itemCount
         reportFile.bodyFormat = report.bodyFormat.toString()
@@ -549,7 +558,7 @@ class ActionHistory(
         val reportFile = ReportFile()
 
         reportFile.reportId = report.id
-        reportFile.schemaName = trimSchemaNameToMaxLength(report.schema.name)
+        reportFile.schemaName = report.schema.name
         reportFile.schemaTopic = report.schema.topic
         reportFile.itemCountBeforeQualFilter = report.itemCountBeforeQualFilter
 
@@ -633,7 +642,7 @@ class ActionHistory(
         reportFile.reportId = sentReportId
         reportFile.receivingOrg = receiver.organizationName
         reportFile.receivingOrgSvc = receiver.name
-        reportFile.schemaName = trimSchemaNameToMaxLength(receiver.schemaName)
+        reportFile.schemaName = receiver.schemaName
         reportFile.schemaTopic = receiver.topic
         reportFile.externalName = filename
         action.externalName = filename
@@ -755,7 +764,7 @@ class ActionHistory(
         reportFile.reportId = externalReportId // child report
         reportFile.receivingOrg = parentReportFile.receivingOrg
         reportFile.receivingOrgSvc = parentReportFile.receivingOrgSvc
-        reportFile.schemaName = trimSchemaNameToMaxLength(parentReportFile.schemaName)
+        reportFile.schemaName = parentReportFile.schemaName
         reportFile.schemaTopic = parentReportFile.schemaTopic
         reportFile.externalName = parentReportFile.externalName
         action.externalName = parentReportFile.externalName
@@ -876,21 +885,6 @@ class ActionHistory(
     }
 
     companion object : Logging {
-
-        // The schema_name column only support 63 characters
-        // If the schemaName is a URI grab the path and then take the last 63
-        // otherwise just take the last 63
-        // TODO: #13598
-        fun trimSchemaNameToMaxLength(schemaName: String?): String? {
-            if (schemaName == null) {
-                return schemaName
-            }
-            return try {
-                URI(schemaName).path.replace(".yml", "").takeLast(63)
-            } catch (ex: URISyntaxException) {
-                schemaName.takeLast(63)
-            }
-        }
 
         /**
          * Get rid of this once we have moved away from the old Task table.  In the meantime,

--- a/prime-router/src/main/kotlin/common/AzureHttpUtils.kt
+++ b/prime-router/src/main/kotlin/common/AzureHttpUtils.kt
@@ -1,7 +1,6 @@
 package gov.cdc.prime.router.common
 
 import com.microsoft.azure.functions.HttpRequestMessage
-import gov.cdc.prime.router.azure.db.Tables
 
 /**
  * Utility object that provides methods for handling Azure HTTP requests.
@@ -16,12 +15,9 @@ object AzureHttpUtils {
      * @param request The HTTP request message from which to extract the sender's IP address.
      * @return The sender's IP address as a [String], or `null` if not found.
      */
-    fun getSenderIP(request: HttpRequestMessage<*>): String? = (
-            (
-                request.headers["x-forwarded-for"]?.split(",")
-                    ?.firstOrNull()
-                )?.take(Tables.ACTION.SENDER_IP.dataType.length()) ?: request.headers["x-azure-clientip"]
-            )
+    fun getSenderIP(request: HttpRequestMessage<*>): String? =
+        (request.headers["x-forwarded-for"]?.split(",")?.firstOrNull())
+            ?: request.headers["x-azure-clientip"]
 
     /**
      * Retrieves the sender's IP address from a map of HTTP headers.
@@ -29,10 +25,7 @@ object AzureHttpUtils {
      * @param headers A map of HTTP headers from which to extract the sender's IP address.
      * @return The sender's IP address as a [String], or `null` if not found.
      */
-    fun getSenderIP(headers: Map<String, String>): String? = (
-            (
-                headers["x-forwarded-for"]?.split(",")
-                    ?.firstOrNull()
-                )?.take(Tables.ACTION.SENDER_IP.dataType.length()) ?: headers["x-azure-clientip"]
-            )
+    fun getSenderIP(headers: Map<String, String>): String? =
+        (headers["x-forwarded-for"]?.split(",")?.firstOrNull())
+            ?: headers["x-azure-clientip"]
 }

--- a/prime-router/src/main/resources/db/migration/V75__extend_character_limits.sql
+++ b/prime-router/src/main/resources/db/migration/V75__extend_character_limits.sql
@@ -1,0 +1,183 @@
+/*
+ * The Flyway tool applies this migration to create the database.
+ *
+ * Follow this style guide https://about.gitlab.com/handbook/business-ops/data-team/platform/sql-style-guide/
+ *
+ * Copy a version of this comment into the next migration
+ *
+ */
+
+/*
+ * Extend length of character limited fields that are in danger of being exceeded in production.
+ * Online documentation on the PostgreSQL website recommends limits only be set if there is an application reason
+ * to do so: https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_varchar.28n.29_by_default
+ * In most cases, the previously defined limits were arbitrary and had no solid application requirement
+ * for being limited to a certain length.
+ */
+
+/* Columns used by materialized views cannot be altered, so we have to drop the view first. */
+
+/* Clean up any existing structures for the view that exist now */
+DROP INDEX IF EXISTS idx_vw_livid_manufacturer;
+DROP INDEX IF EXISTS idx_vw_livid_model;
+DROP INDEX IF EXISTS idx_vw_livid_test_performed_loinc_code;
+DROP INDEX IF EXISTS idx_vw_livid_test_orderd_loinc_code;
+DROP INDEX IF EXISTS idx_vw_livid_otc;
+
+/* Remove the view */
+DROP MATERIALIZED VIEW IF EXISTS vw_livd_table;
+
+
+ALTER TABLE action
+ALTER COLUMN action_params TYPE VARCHAR, --previously VARCHAR(2048)
+ALTER COLUMN sender_ip TYPE VARCHAR, -- previously VARCHAR(39)
+ALTER COLUMN sending_org TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN sending_org_client TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN receiving_org TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN receiving_org_svc TYPE VARCHAR; -- previously VARCHAR(63)
+
+ALTER TABLE action_log
+ALTER COLUMN tracking_id TYPE VARCHAR; -- previously VARCHAR(128)
+
+ALTER TABLE email_schedule
+ALTER COLUMN created_by TYPE VARCHAR; -- previously VARCHAR(63)
+
+ALTER TABLE item_lineage
+ALTER COLUMN tracking_id TYPE VARCHAR, -- previously VARCHAR(128)
+ALTER COLUMN transport_result TYPE VARCHAR; -- previously VARCHAR(512)
+
+ALTER TABLE jti_cache
+ALTER COLUMN jti TYPE VARCHAR; -- previously VARCHAR(128)
+
+ALTER TABLE lookup_table_version
+ALTER COLUMN table_name TYPE VARCHAR, -- previously VARCHAR(512)
+ALTER COLUMN created_by TYPE VARCHAR; -- previously VARCHAR(63)
+
+ALTER TABLE report_file
+ALTER COLUMN sending_org TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN sending_org_client TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN receiving_org TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN receiving_org_svc TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN transport_params TYPE VARCHAR, -- previously VARCHAR(512)
+ALTER COLUMN schema_name TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN schema_topic TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN body_url TYPE VARCHAR, -- previously VARCHAR(2048)
+ALTER COLUMN external_name TYPE VARCHAR, -- previously VARCHAR(2048)
+ALTER COLUMN body_format TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN downloaded_by TYPE VARCHAR; -- previously VARCHAR(63)
+
+ALTER TABLE setting
+ALTER COLUMN name TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN created_by TYPE VARCHAR; -- previously VARCHAR(63)
+
+ALTER TABLE task
+ALTER COLUMN schema_name TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN receiver_name TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN body_format TYPE VARCHAR, -- previously VARCHAR(63)
+ALTER COLUMN body_url TYPE VARCHAR; -- previously VARCHAR(2048)
+
+/*
+ * Recreate the view. It is better to do a drop and recreate. CREATE OR REPLACE could fail
+ * if the shape of the data is different. Wanting this to be idempotent, and given the fact
+ * that it's a view, it's okay to just drop it and rebuild it.
+ */
+CREATE MATERIALIZED VIEW vw_livd_table
+AS
+SELECT
+    r.lookup_table_row_id
+     , r.lookup_table_version_id
+     , r.row_num
+     , r.data->>'Manufacturer'                        as "manufacturer"
+     , r.data->>'Model'                               as "model"
+     , r.data->>'Vendor Analyte Name'                 as "vendor_analyte_name"
+     , r.data->>'Vendor Specimen Description'         as "vendor_specimen_description"
+     , r.data->>'Vendor Result Description'           as "vendor_result_description"
+     , r.data->>'Test Performed LOINC Code'           as "test_performed_loinc_code"
+     , r.data->>'Test Performed LOINC Long Name'      as "test_performed_loinc_long_name"
+     , r.data->>'Test Ordered LOINC Code'             as "test_ordered_loinc_code"
+     , r.data->>'Test Ordered LOINC Long Name'        as "test_orderd_loinc_long_name"
+     , r.data->>'Vendor Comment'                      as "vendor_comment"
+     , r.data->>'Vendor Analyte Code'                 as "vendor_analyte_code"
+     , r.data->>'Vendor Reference ID'                 as "vendor_reference_id"
+     , r.data->>'Testkit Name ID'                     as "testkit_name_id"
+     , r.data->>'Testkit Name ID Type'                as "testkit_name_id_type"
+     , r.data->>'Equipment UID'                       as "equipment_uid"
+     , r.data->>'Equipment UID Type'                  as "equipment_uid_type"
+     , r.data->>'Component'                           as "component"
+     , r.data->>'Property'                            as "property"
+     , r.data->>'Time'                                as "time"
+     , r.data->>'System'                              as "system"
+     , r.data->>'Scale'                               as "scale"
+     , r.data->>'Method'                              as "method"
+     , r.data->>'Publication Version ID'              as "publication_version_id"
+     , r.data->>'LOINC Version ID'                    as "loinc_version_id"
+     , r.data->>'Saliva'                              as "saliva"
+     , r.data->>'Pooling'                             as "pooling"
+     , r.data->>'Screening'                           as "screening"
+     , r.data->>'Test Type'                           as "test_type"
+     , r.data->>'CLIAComplexity'                      as "clia_complexity"
+     , r.data->>'Fingerstick'                         as "fingerstick"
+     , r.data->>'Test Method'                         as "test_method"
+     , r.data->>'Multi-analyte'                       as "multi-analyte"
+     , r.data->>'Collection Kit'                      as "collection_kit"
+     , r.data->>'Serial Testing'                      as "serial_testing"
+     , r.data->>'Home Collection'                     as "home_collection"
+     , r.data->>'Serial Screening'                    as "serial_screening"
+     , r.data->>'Authorized Settings'                 as "authorized_settings"
+     , r.data->>'Quantitative Result'                 as "quantitative_result"
+     , r.data->>'Direct to Consumer (DTC)'            as "direct_to_consumer"
+     , r.data->>'Non-prescription Testing'            as "non-prescription_testing"
+     , r.data->>'Prescription Home Testing'           as "prescription_home_testing"
+     , r.data->>'Visual or Instrument Read'           as "visual_or_instrument_read"
+     , r.data->>'Show All Home Testing Rows'          as "show_all_home_testing_rows"
+     , r.data->>'Single or Multiple Targets'          as "single_or_multiple_targets"
+     , r.data->>'Telehealth Proctor Supervised'       as "telehealth_proctor_supervised"
+     , r.data->>'Pooled Serial Screening - Swab'      as "Pooled_serial_screening_swab"
+     , r.data->>'Pooled Serial Screening - Media'     as "pooled_serial_screening_media"
+     , r.data->>'Over the Counter (OTC) Home Testing' as "over_the_counter_home_testing"
+     -- additional fields we add for our own needs
+     , r.data->>'is_otc'                              as "is_otc"
+     , r.data->>'is_home'                             as "is_home"
+     , r.data->>'is_serial'                           as "is_serial"
+     , r.data->>'is_unproctored'                      as "is_unproctored"
+     , r.data->>'fda_ref'                             as "fda_ref"
+     , r.data->>'fda_authorization'                   as "fda_authorization"
+     , r.data->>'processing_mode_code'                as "processing_mode_code"
+FROM
+    lookup_table_row r
+        JOIN lookup_table_version v ON r.lookup_table_version_id = v.lookup_table_version_id
+        and upper(v.table_name) = 'LIVD-SARS-COV-2'
+ORDER BY
+        r.data->>'Manufacturer'
+       , r.data->>'Model'
+       , r.data->>'Equipment UID'
+       , r.row_num
+;
+
+/* Create all our views */
+CREATE INDEX idx_vw_livid_manufacturer on vw_livd_table(manufacturer);
+CREATE INDEX idx_vw_livid_model on vw_livd_table(model);
+CREATE INDEX idx_vw_livid_test_performed_loinc_code on vw_livd_table(test_performed_loinc_code);
+CREATE INDEX idx_vw_livid_test_ordered_loinc_code on vw_livd_table(test_ordered_loinc_code);
+CREATE INDEX idx_vw_livid_otc on vw_livd_table(is_otc, is_home, is_serial, is_unproctored);
+
+/*
+ Create a void function to safely refresh materialized views
+ */
+CREATE OR REPLACE FUNCTION refresh_materialized_views(table_name VARCHAR(256)) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+    DECLARE
+        view_exists integer;
+    BEGIN
+        /* Check to see what table we're updating */
+        IF upper(table_name) = 'LIVD-SARS-COV-2' THEN
+            /* Look to see if the livd materialized view exists */
+            SELECT COUNT(*) INTO view_exists FROM pg_matviews WHERE matviewname ILIKE 'vw_livd_table';
+            /* Refresh the view if it exists */
+            IF view_exists > 0 THEN
+                REFRESH MATERIALIZED VIEW vw_livd_table;
+            END IF;
+        END IF;
+    END;
+$$;

--- a/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
+++ b/prime-router/src/test/kotlin/azure/ActionHistoryTests.kt
@@ -567,10 +567,10 @@ class ActionHistoryTests {
         // assert
         assertThat(actionHistory1.reportsOut[uuid]).isNotNull()
         assertThat(actionHistory1.reportsOut[uuid]?.schemaName)
-            .isEqualTo("g/receivers/STLTs/REALLY_LONG_STATE_NAME/REALLY_LONG_STATE_NAME")
+            .isEqualTo(longNameWithClasspath)
         assertThat(actionHistory2.reportsOut[uuid]).isNotNull()
         assertThat(actionHistory2.reportsOut[uuid]?.schemaName)
-            .isEqualTo("STED/NESTED/STLTs/REALLY_LONG_STATE_NAME/REALLY_LONG_STATE_NAME")
+            .isEqualTo(longNameWithoutClasspath)
         verify(exactly = 2) {
             mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
             mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
@@ -947,13 +947,6 @@ class ActionHistoryTests {
             mockReportEventService.sendReportEvent(any(), any<ReportFile>(), any(), any(), any(), any())
             mockReportEventService.sendItemEvent(any(), any<ReportFile>(), any(), any(), any(), any())
         }
-    }
-
-    @Test
-    fun `test trimSchemaNameToMaxLength malformed URI`() {
-        val longMalformedURI = ":very_very:_long_name//with a badly formed URI that causes a parse exception"
-        val trimmed = ActionHistory.trimSchemaNameToMaxLength((longMalformedURI))
-        assertThat(trimmed).isEqualTo("ong_name//with a badly formed URI that causes a parse exception")
     }
 
     @Test


### PR DESCRIPTION
This PR extends the length of the `report_file`.`schema_name` column so longer strings can be stored and removes temporary code that truncates the data to be stored in this column. It additionally extends the length of many other varchar columns throughout the database.

Test Steps:
1. Run `clean` followed by `package` to apply db migrations and run tests.
2. Confirm the database has been updated by running the following query and verifying the value is null:
```
SELECT character_maximum_length 
FROM information_schema.columns 
WHERE table_schema = 'public' 
AND table_name  = 'report_file' 
AND column_name  = 'schema_name';
```

## Changes
- Add migration to alter size of `report_file`.`schema_name` and many other varchar database columns
- Remove temporary code to truncate schema name prior to inserting to database
- Fix actionHistory to correctly handle varchar columns without a size limit
- Add and update tests

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [x] Added tests?

## Linked Issues
- #9576
- #13598