### PR TITLE
Disabled end of file newline rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -61,6 +61,7 @@ ktlint_standard_property-naming = disabled
 ktlint_standard_enum-entry-name-case = disabled
 ktlint_standard_function-naming = disabled
 ktlint_standard_filename = disabled
+ktlint_standard_final-newline = disabled
 
 [{*.har,*.jsb2,*.jsb3,*.json,*.fhir,.babelrc,.eslintrc,.stylelintrc,bowerrc,jest.config}]
 indent_size = 2


### PR DESCRIPTION
This PR disables the ktlint rule while requires that no newline be present at the end of a file. This is an issue because the github code editor automatically adds a trailing new line to files it touches. 

Test Steps:
1. Build passes

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [ ] Added tests?

### Process
- [ ] Are there licensing issues with any new dependencies introduced?
- [ ] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?
