### PR TITLE
fix: update as2-lib dependency to 5.1.6

### DIFF
--- a/prime-router/build.gradle.kts
+++ b/prime-router/build.gradle.kts
@@ -941,7 +941,7 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql:11.8.1")
     implementation("org.commonmark:commonmark:0.24.0")
     implementation("com.google.guava:guava:33.4.8-jre")
-    implementation("com.helger.as2:as2-lib:5.1.5")
+    implementation("com.helger.as2:as2-lib:5.1.6")
     implementation("org.bouncycastle:bcprov-jdk15to18:1.81")
     implementation("org.bouncycastle:bcprov-jdk18on:1.81")
     implementation("org.bouncycastle:bcmail-jdk15to18:1.81")


### PR DESCRIPTION
This PR updates com.helger.as2:as2-lib from 5.1.5 to 5.1.6.

## Changes
- Updated `com.helger.as2:as2-lib` dependency from 5.1.5 to 5.1.6 in `prime-router/build.gradle.kts`

## Checklist

### Testing
- [x] Tested locally?
- [x] Ran `./prime test` or `./gradlew testSmoke` against local Docker ReportStream container?
- [ ] (For Changes to /frontend-react/...) Ran `npm run lint:write`?
- [ ] Added tests?

### Process
- [x] Are there licensing issues with any new dependencies introduced?
- [x] Includes a summary of what a code reviewer should test/verify?
- [ ] Updated the release notes?
- [ ] Database changes are submitted as a separate PR?
- [ ] DevOps team has been notified if PR requires ops support?

## Linked Issues
- Fixes #18502

## Specific Security-related subjects a reviewer should pay specific attention to
- Does this PR introduce new endpoints? **No**
- Does this PR include changes in authentication and/or authorization of existing endpoints? **No**
- Does this change introduce new dependencies that need vetting? **No** - This is a version update of existing dependency
- Does this change require changes to our infrastructure? **No**
- Does logging contain sensitive data? **No**
- Does this PR include or remove any sensitive information itself? **No**